### PR TITLE
Fix build failure from Google Fonts dependency and remove stale backup references

### DIFF
--- a/jsmkc-app/jest.config.ts
+++ b/jsmkc-app/jest.config.ts
@@ -49,7 +49,7 @@ const customJestConfig: Config = {
     '^.+\\.module\\.(css|sass|scss)$',
   ],
   testMatch: ['**/__tests__/**/*.test.ts', '**/__tests__/**/*.test.tsx'],
-  testPathIgnorePatterns: ['/node_modules/', '/e2e/', 'src\\.bak/', '__tests__\\.bak/', '__tests__/debug-', '__tests__/mock-debug'],
+  testPathIgnorePatterns: ['/node_modules/', '/e2e/', '__tests__/debug-', '__tests__/mock-debug'],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load Next.js config which is async

--- a/jsmkc-app/package-lock.json
+++ b/jsmkc-app/package-lock.json
@@ -19,6 +19,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dotenv": "^16.4.7",
+        "geist": "^1.5.1",
         "isomorphic-dompurify": "^2.35.0",
         "lucide-react": "^0.562.0",
         "next": "^16.1.4",
@@ -7262,6 +7263,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/geist": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/geist/-/geist-1.5.1.tgz",
+      "integrity": "sha512-mAHZxIsL2o3ZITFaBVFBnwyDOw+zNLYum6A6nIjpzCGIO8QtC3V76XF2RnZTyLx1wlDTmMDy8jg3Ib52MIjGvQ==",
+      "license": "SIL OPEN FONT LICENSE",
+      "peerDependencies": {
+        "next": ">=13.2.0"
       }
     },
     "node_modules/generator-function": {

--- a/jsmkc-app/package.json
+++ b/jsmkc-app/package.json
@@ -28,6 +28,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dotenv": "^16.4.7",
+    "geist": "^1.5.1",
     "isomorphic-dompurify": "^2.35.0",
     "lucide-react": "^0.562.0",
     "next": "^16.1.4",

--- a/jsmkc-app/src/app/globals.css
+++ b/jsmkc-app/src/app/globals.css
@@ -39,7 +39,7 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
 
-  /* Typography fonts loaded via next/font/google */
+  /* Typography fonts loaded via geist package (next/font/local) */
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 

--- a/jsmkc-app/src/app/layout.tsx
+++ b/jsmkc-app/src/app/layout.tsx
@@ -3,7 +3,7 @@
  *
  * This is the top-level layout for the entire JSMKC application.
  * It provides:
- * 1. HTML document structure with font loading (Geist Sans + Mono)
+ * 1. HTML document structure with locally-bundled Geist fonts (Sans + Mono)
  * 2. Global metadata (title, description) for SEO
  * 3. NextAuth SessionProvider for client-side session access
  * 4. Shared navigation header with authentication-aware UI
@@ -20,29 +20,12 @@
  * children in SessionProvider for client-side session hooks.
  */
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 import Link from "next/link";
 import "./globals.css";
 import { auth, signOut } from "@/lib/auth";
 import { SessionProvider } from "next-auth/react";
-
-/**
- * Geist Sans - Primary sans-serif font for body text and UI.
- * Assigned to CSS variable --font-geist-sans for Tailwind consumption.
- */
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-/**
- * Geist Mono - Monospace font for code blocks, technical data,
- * and time/score displays where alignment matters.
- */
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 /**
  * Page metadata for SEO and browser tab display.
@@ -76,7 +59,7 @@ export default async function RootLayout({
         {/* Additional head content can be added here (favicon, meta tags, etc.) */}
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${GeistSans.variable} ${GeistMono.variable} antialiased`}
       >
         {/* SessionProvider makes the session available to all client components via useSession() */}
         <SessionProvider>

--- a/jsmkc-app/tsconfig.json
+++ b/jsmkc-app/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "src.bak", "__tests__.bak"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Switch layout.tsx from next/font/google to the geist npm package for local font
bundling, eliminating network dependency at build time. Remove stale src.bak and
__tests__.bak references from tsconfig.json and jest.config.ts.

https://claude.ai/code/session_017wFzdr5x7PhLorkwEojT7L