### PR TITLE
Remove TypeScript `any` types and improve type safety

### DIFF
--- a/jsmkc-app/src/app/api/tournaments/[id]/bm/export/route.ts
+++ b/jsmkc-app/src/app/api/tournaments/[id]/bm/export/route.ts
@@ -6,13 +6,13 @@ const { GET } = createExportHandlers({
   matchModel: 'bMMatch',
   eventCode: 'BM',
   qualificationHeaders: ['Rank', 'Player Name', 'Nickname', 'Matches', 'Wins', 'Ties', 'Losses', 'Win Rounds', 'Loss Rounds', 'Points', 'Score'],
-  qualificationRowMapper: (q: any, index: number) => [
+  qualificationRowMapper: (q, index) => [
     String(index + 1), q.player.name, q.player.nickname,
     String(q.mp), String(q.wins), String(q.ties), String(q.losses),
     String(q.winRounds), String(q.lossRounds), String(q.points), String(q.score),
   ],
   matchHeaders: ['Match #', 'Stage', 'Player 1', 'Player 2', 'Score 1', 'Score 2', 'Completed'],
-  matchRowMapper: (m: any) => [
+  matchRowMapper: (m) => [
     String(m.matchNumber), m.stage,
     `${m.player1.name} (${m.player1.nickname})`,
     `${m.player2.name} (${m.player2.nickname})`,

--- a/jsmkc-app/src/app/api/tournaments/[id]/gp/export/route.ts
+++ b/jsmkc-app/src/app/api/tournaments/[id]/gp/export/route.ts
@@ -6,13 +6,13 @@ const { GET } = createExportHandlers({
   matchModel: 'gPMatch',
   eventCode: 'GP',
   qualificationHeaders: ['Rank', 'Player Name', 'Nickname', 'Matches', 'Wins', 'Ties', 'Losses', 'Driver Points', 'Score'],
-  qualificationRowMapper: (q: any, index: number) => [
+  qualificationRowMapper: (q, index) => [
     String(index + 1), q.player.name, q.player.nickname,
     String(q.mp), String(q.wins), String(q.ties), String(q.losses),
     String(q.points), String(q.score),
   ],
   matchHeaders: ['Match #', 'Stage', 'Cup', 'Player 1', 'Player 2', 'Points 1', 'Points 2', 'Completed'],
-  matchRowMapper: (m: any) => [
+  matchRowMapper: (m) => [
     String(m.matchNumber), m.stage, m.cup || '-',
     `${m.player1.name} (${m.player1.nickname})`,
     `${m.player2.name} (${m.player2.nickname})`,

--- a/jsmkc-app/src/app/api/tournaments/[id]/mr/export/route.ts
+++ b/jsmkc-app/src/app/api/tournaments/[id]/mr/export/route.ts
@@ -6,13 +6,13 @@ const { GET } = createExportHandlers({
   matchModel: 'mRMatch',
   eventCode: 'MR',
   qualificationHeaders: ['Rank', 'Player Name', 'Nickname', 'Matches', 'Wins', 'Ties', 'Losses', 'Points', 'Score'],
-  qualificationRowMapper: (q: any, index: number) => [
+  qualificationRowMapper: (q, index) => [
     String(index + 1), q.player.name, q.player.nickname,
     String(q.mp), String(q.wins), String(q.ties), String(q.losses),
     String(q.points), String(q.score),
   ],
   matchHeaders: ['Match #', 'Stage', 'Player 1', 'Player 2', 'Score 1', 'Score 2', 'Completed'],
-  matchRowMapper: (m: any) => [
+  matchRowMapper: (m) => [
     String(m.matchNumber), m.stage,
     `${m.player1.name} (${m.player1.nickname})`,
     `${m.player2.name} (${m.player2.nickname})`,

--- a/jsmkc-app/src/app/auth/signin/page.tsx
+++ b/jsmkc-app/src/app/auth/signin/page.tsx
@@ -89,7 +89,7 @@ export default function SignInPage() {
     } catch (error) {
       /* Log structured error for debugging while showing generic message to user */
       const metadata = error instanceof Error ? { message: error.message, stack: error.stack } : { error };
-      logger.error('Player login error', metadata as any)
+      logger.error('Player login error', metadata)
       setPlayerError('An error occurred during login')
     } finally {
       setIsLoading(false)

--- a/jsmkc-app/src/app/players/page.tsx
+++ b/jsmkc-app/src/app/players/page.tsx
@@ -137,7 +137,7 @@ export default function PlayersPage() {
       }
     } catch (err) {
       const metadata = err instanceof Error ? { message: err.message, stack: err.stack } : { error: err };
-      logger.error("Failed to fetch players:", metadata as any);
+      logger.error("Failed to fetch players:", metadata);
     } finally {
       setLoading(false);
     }
@@ -187,7 +187,7 @@ export default function PlayersPage() {
       }
     } catch (err) {
       const metadata = err instanceof Error ? { message: err.message, stack: err.stack } : { error: err };
-      logger.error("Failed to create player:", metadata as any);
+      logger.error("Failed to create player:", metadata);
       setError("Failed to create player");
     }
   };
@@ -215,7 +215,7 @@ export default function PlayersPage() {
       }
     } catch (err) {
       const metadata = err instanceof Error ? { message: err.message, stack: err.stack } : { error: err };
-      logger.error("Failed to update player:", metadata as any);
+      logger.error("Failed to update player:", metadata);
       setError("Failed to update player");
     }
   };
@@ -237,7 +237,7 @@ export default function PlayersPage() {
       }
     } catch (err) {
       const metadata = err instanceof Error ? { message: err.message, stack: err.stack } : { error: err };
-      logger.error("Failed to delete player:", metadata as any);
+      logger.error("Failed to delete player:", metadata);
     }
   };
 

--- a/jsmkc-app/src/app/profile/page.tsx
+++ b/jsmkc-app/src/app/profile/page.tsx
@@ -98,7 +98,7 @@ export default function ProfilePage() {
                         setLinkedPlayer(myPlayer)
                     }
                 }
-            } catch (error) {
+            } catch {
                 /* Silently handle fetch errors - the user will see an empty state */
             } finally {
                 setLoading(false)

--- a/jsmkc-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/jsmkc-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -203,7 +203,7 @@ export default function BattleModeFinals({
     } catch (err) {
       /* Log the error with structured metadata for debugging */
       const metadata = err instanceof Error ? { message: err.message, stack: err.stack } : { error: err };
-      logger.error("Failed to create bracket:", metadata as any);
+      logger.error("Failed to create bracket:", metadata);
       alert("Failed to create bracket");
     } finally {
       setCreating(false);
@@ -263,7 +263,7 @@ export default function BattleModeFinals({
       }
     } catch (err) {
       const metadata = err instanceof Error ? { message: err.message, stack: err.stack } : { error: err };
-      logger.error("Failed to update score:", metadata as any);
+      logger.error("Failed to update score:", metadata);
       alert("Failed to update score");
     }
   };

--- a/jsmkc-app/src/app/tournaments/[id]/gp/page.tsx
+++ b/jsmkc-app/src/app/tournaments/[id]/gp/page.tsx
@@ -219,7 +219,7 @@ export default function GrandPrixPage({
       }
     } catch (err) {
       const metadata = err instanceof Error ? { message: err.message, stack: err.stack } : { error: err };
-      logger.error("Failed to setup:", metadata as any);
+      logger.error("Failed to setup:", metadata);
     }
   };
 
@@ -291,7 +291,7 @@ export default function GrandPrixPage({
       }
     } catch (err) {
       const metadata = err instanceof Error ? { message: err.message, stack: err.stack } : { error: err };
-      logger.error("Failed to update match:", metadata as any);
+      logger.error("Failed to update match:", metadata);
     }
   };
 
@@ -328,7 +328,7 @@ export default function GrandPrixPage({
       document.body.removeChild(a);
     } catch (err) {
       const metadata = err instanceof Error ? { message: err.message, stack: err.stack } : { error: err };
-      logger.error("Failed to export:", metadata as any);
+      logger.error("Failed to export:", metadata);
     } finally {
       setExporting(false);
     }

--- a/jsmkc-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/jsmkc-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -205,7 +205,7 @@ export default function MatchRaceFinals({
       }
     } catch (err) {
       const metadata = err instanceof Error ? { message: err.message, stack: err.stack } : { error: err };
-      logger.error("Failed to create bracket:", metadata as any);
+      logger.error("Failed to create bracket:", metadata);
       alert("Failed to create bracket");
     } finally {
       setCreating(false);
@@ -300,7 +300,7 @@ export default function MatchRaceFinals({
       }
     } catch (err) {
       const metadata = err instanceof Error ? { message: err.message, stack: err.stack } : { error: err };
-      logger.error("Failed to update match:", metadata as any);
+      logger.error("Failed to update match:", metadata);
       alert("Failed to update match");
     }
   };

--- a/jsmkc-app/src/app/tournaments/[id]/page.tsx
+++ b/jsmkc-app/src/app/tournaments/[id]/page.tsx
@@ -110,7 +110,7 @@ export default function TournamentDetailPage({
       }
     } catch (err) {
       const metadata = err instanceof Error ? { message: err.message, stack: err.stack } : { error: err };
-      logger.error("Failed to fetch tournament:", metadata as any);
+      logger.error("Failed to fetch tournament:", metadata);
     } finally {
       setLoading(false);
     }
@@ -140,7 +140,7 @@ export default function TournamentDetailPage({
       }
     } catch (err) {
       const metadata = err instanceof Error ? { message: err.message, stack: err.stack } : { error: err };
-      logger.error("Failed to update status:", metadata as any);
+      logger.error("Failed to update status:", metadata);
     }
   };
 

--- a/jsmkc-app/src/components/ErrorBoundary.tsx
+++ b/jsmkc-app/src/components/ErrorBoundary.tsx
@@ -211,7 +211,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, { hasErro
       message: error.message,
       stack: error.stack,
       componentStack: errorInfo.componentStack
-    } as any);
+    });
 
     /** Invoke the optional external error handler (e.g., Sentry, analytics) */
     if (this.props.onError) {

--- a/jsmkc-app/src/components/tournament/export-button.tsx
+++ b/jsmkc-app/src/components/tournament/export-button.tsx
@@ -149,7 +149,7 @@ export function ExportButton({
        * for better UX in a future iteration.
        */
       const metadata = error instanceof Error ? { message: error.message, stack: error.stack } : { error };
-      logger.error("Export failed", metadata as any);
+      logger.error("Export failed", metadata);
     }
   };
 

--- a/jsmkc-app/src/lib/api-factories/export-route.ts
+++ b/jsmkc-app/src/lib/api-factories/export-route.ts
@@ -3,15 +3,35 @@ import prisma from '@/lib/prisma';
 import { createCSV } from '@/lib/excel';
 import { createLogger } from '@/lib/logger';
 
+interface ExportPlayer {
+  name: string;
+  nickname: string;
+}
+
+export interface ExportQualification {
+  player: ExportPlayer;
+  [key: string]: unknown;
+}
+
+export interface ExportMatch {
+  matchNumber: number;
+  stage: string;
+  player1: ExportPlayer;
+  player2: ExportPlayer;
+  completed: boolean;
+  cup?: string;
+  [key: string]: unknown;
+}
+
 export interface ExportConfig {
   loggerName: string;
   qualificationModel: string;
   matchModel: string;
   eventCode: string;
   qualificationHeaders: string[];
-  qualificationRowMapper: (q: any, index: number) => string[];
+  qualificationRowMapper: (q: ExportQualification, index: number) => string[];
   matchHeaders: string[];
-  matchRowMapper: (m: any) => string[];
+  matchRowMapper: (m: ExportMatch) => string[];
 }
 
 export function createExportHandlers(config: ExportConfig) {

--- a/jsmkc-app/src/lib/client-logger.ts
+++ b/jsmkc-app/src/lib/client-logger.ts
@@ -18,7 +18,7 @@ export interface LoggerOptions {
 
 interface LogMetadata extends Record<string, unknown> {
   timestamp?: string;
-  service: string;
+  service?: string;
 }
 
 // Silent test logger to avoid noise in test output

--- a/package.json
+++ b/package.json
@@ -1,6 +1,3 @@
 {
-  "dependencies": {
-    "@types/redis": "^4.0.10",
-    "redis": "^5.10.0"
-  }
+  "private": true
 }


### PR DESCRIPTION
## Summary
This PR removes unnecessary `any` type assertions throughout the codebase and introduces proper TypeScript interfaces for better type safety and code maintainability.

## Key Changes

### Type Safety Improvements
- **Export route handlers**: Introduced `ExportQualification` and `ExportMatch` interfaces to replace `any` types in qualification and match row mappers across all tournament export routes (BM, GP, MR)
- **Logger calls**: Removed `as any` type assertions from error metadata logging in 10+ files, relying on proper type inference instead
- **Error handling**: Simplified error catch blocks by removing unused error parameters where appropriate (e.g., `profile/page.tsx`)

### Interface Definitions
Added new interfaces in `lib/api-factories/export-route.ts`:
- `ExportPlayer`: Defines player object structure with name and nickname
- `ExportQualification`: Extends qualification data with player reference
- `ExportMatch`: Extends match data with player references and match details

### Configuration Updates
- Updated `ExportConfig` interface to use the new typed interfaces instead of `any`
- Made `service` property optional in `LogMetadata` interface for flexibility

### Dependency Cleanup
- Removed unused Redis dependencies (`redis` and `@types/redis`) from package.json

## Benefits
- Improved IDE autocomplete and type checking
- Better documentation through explicit interfaces
- Reduced technical debt from type assertions
- Easier maintenance and refactoring in the future

https://claude.ai/code/session_01My724yRzxJikh8iwGQWRtz