### PR TITLE
Fix time parsing and round completion logic in Time Attack

### DIFF
--- a/jsmkc-app/__tests__/app/api/tournaments/[id]/ta/standings/route.test.ts
+++ b/jsmkc-app/__tests__/app/api/tournaments/[id]/ta/standings/route.test.ts
@@ -346,13 +346,13 @@ describe('GET /api/tournaments/[id]/ta/standings', () => {
         { params: Promise.resolve({ id: 't1' }) }
       );
 
-      // Note: Source uses `e.totalTime ? ...` which is falsy for 0.
-      // So totalTime = 0 produces formattedTime = '-', not '0:00'.
+      // Source uses `e.totalTime != null` which correctly treats 0 as a valid time.
+      // So totalTime = 0 produces formattedTime = '0:00', not '-'.
       expect(NextResponse.json).toHaveBeenCalledWith(
         expect.objectContaining({
           entries: expect.arrayContaining([
             expect.objectContaining({
-              formattedTime: '-',
+              formattedTime: '0:00',
             }),
           ]),
         })

--- a/jsmkc-app/__tests__/lib/ta/time-utils.test.ts
+++ b/jsmkc-app/__tests__/lib/ta/time-utils.test.ts
@@ -23,33 +23,22 @@ import {
 describe('TA Time Utils', () => {
   describe('timeToMs', () => {
     it('should convert valid time string M:SS.mmm to milliseconds', () => {
-        expect(timeToMs('1:23.456')).toBe(83456);
-        expect(timeToMs('12:34.567')).toBe(754567);
-        expect(timeToMs('59:59.999')).toBe(3599999);
-      });
-
-      it('should convert valid time string MM:SS.mmm to milliseconds', () => {
-        expect(timeToMs('1:23.456')).toBe(83456);
-        expect(timeToMs('12:34.567')).toBe(754567);
-        expect(timeToMs('59:59.999')).toBe(3599999);
-      });
-
-    it('should convert valid time string MM:SS.mmm to milliseconds', () => {
       expect(timeToMs('1:23.456')).toBe(83456);
+      expect(timeToMs('12:34.567')).toBe(754567);
       expect(timeToMs('59:59.999')).toBe(3599999);
     });
 
-    it('should handle milliseconds with 1 digit padding', () => {
-      expect(timeToMs('1:23.4')).toBe(83004);
-      expect(timeToMs('1:23.45')).toBe(83045);
+    it('should right-pad milliseconds with 1 digit to 3 digits', () => {
+      // '1:23.4' -> .4 is padded to .400 -> 1*60000 + 23*1000 + 400 = 83400
+      expect(timeToMs('1:23.4')).toBe(83400);
     });
 
-    it('should handle milliseconds with 2 digit padding', () => {
-      expect(timeToMs('1:23.4')).toBe(83004);
-      expect(timeToMs('1:23.45')).toBe(83045);
+    it('should right-pad milliseconds with 2 digits to 3 digits', () => {
+      // '1:23.45' -> .45 is padded to .450 -> 1*60000 + 23*1000 + 450 = 83450
+      expect(timeToMs('1:23.45')).toBe(83450);
     });
 
-    it('should handle milliseconds with 3 digit padding', () => {
+    it('should keep 3-digit milliseconds as-is', () => {
       expect(timeToMs('1:23.456')).toBe(83456);
     });
 

--- a/jsmkc-app/src/app/api/tournaments/[id]/ta/standings/route.ts
+++ b/jsmkc-app/src/app/api/tournaments/[id]/ta/standings/route.ts
@@ -99,7 +99,7 @@ export async function GET(
         playerNickname: e.player.nickname,
         totalTime: e.totalTime,
         // Format total time as M:SS for display (simplified format without ms)
-        formattedTime: e.totalTime ? `${Math.floor(e.totalTime / 60000)}:${((e.totalTime % 60000) / 1000).toFixed(0).padStart(2, '0')}` : '-',
+        formattedTime: e.totalTime != null ? `${Math.floor(e.totalTime / 60000)}:${((e.totalTime % 60000) / 1000).toFixed(0).padStart(2, '0')}` : '-',
         lives: e.lives,
         eliminated: e.eliminated,
       })),

--- a/jsmkc-app/src/app/tournaments/[id]/overall-ranking/page.tsx
+++ b/jsmkc-app/src/app/tournaments/[id]/overall-ranking/page.tsx
@@ -63,7 +63,7 @@ interface PlayerRanking {
   gpFinalsPoints: number;
   /* Total tournament points (max 12000) */
   totalPoints: number;
-  overallRank: number;
+  overallRank: number | null;
 }
 
 /** API response structure for the overall ranking endpoint */
@@ -164,14 +164,16 @@ export default function OverallRankingPage({
    * Format a rank number with ordinal suffix (1st, 2nd, 3rd, 4th, etc.)
    * Handles special cases for 11th, 12th, 13th which use "th" not "st/nd/rd"
    */
-  const formatRank = (rank: number): string => {
+  const formatRank = (rank: number | null): string => {
+    if (rank === null) return "-";
     const suffixes = ["th", "st", "nd", "rd"];
     const v = rank % 100;
     return rank + (suffixes[(v - 20) % 10] || suffixes[v] || suffixes[0]);
   };
 
   /** Get badge styling variant based on rank position */
-  const getRankBadgeVariant = (rank: number): "default" | "secondary" | "outline" => {
+  const getRankBadgeVariant = (rank: number | null): "default" | "secondary" | "outline" => {
+    if (rank === null) return "outline";
     if (rank === 1) return "default";
     if (rank <= 3) return "secondary";
     return "outline";

--- a/jsmkc-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/jsmkc-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -364,7 +364,7 @@ export default function TimeAttackFinals({
     if (!firstEntry) return COURSE_INFO.map((c) => ({ course: c.abbr, completed: false }));
     return COURSE_INFO.map((c) => ({
       course: c.abbr,
-      completed: entries.every((e) => !e.eliminated && e.times?.[c.abbr]),
+      completed: entries.filter((e) => !e.eliminated).every((e) => e.times?.[c.abbr]),
     }));
   };
 

--- a/jsmkc-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/jsmkc-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -362,10 +362,13 @@ export default function TimeAttackFinals({
   const getCourseProgress = (): Array<{ course: string; completed: boolean }> => {
     const firstEntry = entries.find((e) => e.times);
     if (!firstEntry) return COURSE_INFO.map((c) => ({ course: c.abbr, completed: false }));
-    return COURSE_INFO.map((c) => ({
-      course: c.abbr,
-      completed: entries.filter((e) => !e.eliminated).every((e) => e.times?.[c.abbr]),
-    }));
+    return COURSE_INFO.map((c) => {
+      const active = entries.filter((e) => !e.eliminated);
+      return {
+        course: c.abbr,
+        completed: active.length > 0 && active.every((e) => e.times?.[c.abbr]),
+      };
+    });
   };
 
   // === Derived State ===

--- a/jsmkc-app/src/app/tournaments/[id]/ta/revival-1/page.tsx
+++ b/jsmkc-app/src/app/tournaments/[id]/ta/revival-1/page.tsx
@@ -251,10 +251,13 @@ export default function RevivalRound1({
   const getCourseProgress = (): Array<{ course: string; completed: boolean }> => {
     const firstEntry = entries.find((e) => e.times);
     if (!firstEntry) return COURSE_INFO.map((c) => ({ course: c.abbr, completed: false }));
-    return COURSE_INFO.map((c) => ({
-      course: c.abbr,
-      completed: entries.filter((e) => !e.eliminated).every((e) => e.times?.[c.abbr]),
-    }));
+    return COURSE_INFO.map((c) => {
+      const active = entries.filter((e) => !e.eliminated);
+      return {
+        course: c.abbr,
+        completed: active.length > 0 && active.every((e) => e.times?.[c.abbr]),
+      };
+    });
   };
 
   // === Derived State ===
@@ -340,7 +343,7 @@ export default function RevivalRound1({
       </div>
 
       {/* Round Complete Banner */}
-      {isComplete && activeEntries.length === 1 && (
+      {isComplete && (
         <Card className="border-green-500 bg-green-500/10">
           <CardContent className="py-6 text-center">
             <div className="text-4xl mb-2">✓</div>

--- a/jsmkc-app/src/app/tournaments/[id]/ta/revival-1/page.tsx
+++ b/jsmkc-app/src/app/tournaments/[id]/ta/revival-1/page.tsx
@@ -253,7 +253,7 @@ export default function RevivalRound1({
     if (!firstEntry) return COURSE_INFO.map((c) => ({ course: c.abbr, completed: false }));
     return COURSE_INFO.map((c) => ({
       course: c.abbr,
-      completed: entries.every((e) => !e.eliminated && e.times?.[c.abbr]),
+      completed: entries.filter((e) => !e.eliminated).every((e) => e.times?.[c.abbr]),
     }));
   };
 
@@ -261,7 +261,7 @@ export default function RevivalRound1({
   const activeEntries = entries.filter((e) => !e.eliminated);
   const eliminatedEntries = entries.filter((e) => e.eliminated);
   // Round is complete when only survivors remain (or fewer)
-  const isComplete = activeEntries.length <= 1 && entries.length > 0;
+  const isComplete = activeEntries.length <= 4 && entries.length > 0;
 
   // === Loading State ===
   if (loading) {

--- a/jsmkc-app/src/app/tournaments/[id]/ta/revival-2/page.tsx
+++ b/jsmkc-app/src/app/tournaments/[id]/ta/revival-2/page.tsx
@@ -233,10 +233,13 @@ export default function RevivalRound2({
   const getCourseProgress = (): Array<{ course: string; completed: boolean }> => {
     const firstEntry = entries.find((e) => e.times);
     if (!firstEntry) return COURSE_INFO.map((c) => ({ course: c.abbr, completed: false }));
-    return COURSE_INFO.map((c) => ({
-      course: c.abbr,
-      completed: entries.filter((e) => !e.eliminated).every((e) => e.times?.[c.abbr]),
-    }));
+    return COURSE_INFO.map((c) => {
+      const active = entries.filter((e) => !e.eliminated);
+      return {
+        course: c.abbr,
+        completed: active.length > 0 && active.every((e) => e.times?.[c.abbr]),
+      };
+    });
   };
 
   // === Derived State ===
@@ -321,7 +324,7 @@ export default function RevivalRound2({
       </div>
 
       {/* Round Complete Banner */}
-      {isComplete && activeEntries.length === 1 && (
+      {isComplete && (
         <Card className="border-green-500 bg-green-500/10">
           <CardContent className="py-6 text-center">
             <div className="text-4xl mb-2">✓</div>

--- a/jsmkc-app/src/app/tournaments/[id]/ta/revival-2/page.tsx
+++ b/jsmkc-app/src/app/tournaments/[id]/ta/revival-2/page.tsx
@@ -235,14 +235,14 @@ export default function RevivalRound2({
     if (!firstEntry) return COURSE_INFO.map((c) => ({ course: c.abbr, completed: false }));
     return COURSE_INFO.map((c) => ({
       course: c.abbr,
-      completed: entries.every((e) => !e.eliminated && e.times?.[c.abbr]),
+      completed: entries.filter((e) => !e.eliminated).every((e) => e.times?.[c.abbr]),
     }));
   };
 
   // === Derived State ===
   const activeEntries = entries.filter((e) => !e.eliminated);
   const eliminatedEntries = entries.filter((e) => e.eliminated);
-  const isComplete = activeEntries.length <= 1 && entries.length > 0;
+  const isComplete = activeEntries.length <= 4 && entries.length > 0;
 
   // === Loading State ===
   if (loading) {

--- a/jsmkc-app/src/lib/points/overall-ranking.ts
+++ b/jsmkc-app/src/lib/points/overall-ranking.ts
@@ -20,15 +20,12 @@
  * and persistence functions (saving/loading from the TournamentPlayerScore table).
  *
  * Database dependency: The TournamentPlayerScore model must exist in the Prisma schema.
- * The ExtendedPrismaClient type is intentionally `any` because this model may not
- * be generated yet during development cycles.
+ * The ExtendedPrismaClient type aliases PrismaClient from @prisma/client.
  */
 
-// Note: After running `npx prisma migrate dev` and `npx prisma generate`,
-// the TournamentPlayerScore model will be available on the Prisma client.
-// Using `any` until the model is fully generated and type-safe.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ExtendedPrismaClient = any;
+import { PrismaClient } from "@prisma/client";
+
+type ExtendedPrismaClient = PrismaClient;
 
 /**
  * Shape of a qualification entry from the database for BM/MR/GP modes.
@@ -52,6 +49,7 @@ interface TTEntryRecord {
   totalTime: number | null;
 }
 
+import { createLogger } from "@/lib/logger";
 import {
   calculateTAQualificationPoints,
   TAQualificationPointsResult,
@@ -63,6 +61,8 @@ import {
 } from "./qualification-points";
 import { getFinalsPoints } from "./finals-points";
 import { timeToMs } from "@/lib/ta/time-utils";
+
+const logger = createLogger("overall-ranking");
 
 /**
  * Aggregated tournament score for a single player.
@@ -90,8 +90,10 @@ export interface PlayerTournamentScore {
 
   // Sum of all 8 point categories (max 12000)
   totalPoints: number;
-  // Tournament-wide rank (1-based, with ties)
-  overallRank: number;
+  // Tournament-wide rank (1-based, with ties). Null if not yet calculated.
+  overallRank: number | null;
+  // Timestamp of last DB update (only present when loaded from DB via getOverallRankings)
+  updatedAt?: string;
 }
 
 /**
@@ -327,10 +329,17 @@ export async function getTAFinalsPositions(
 /**
  * Determine BM/MR/GP finals positions from bracket results.
  *
- * SIMPLIFIED IMPLEMENTATION: Currently uses qualification ranking as a proxy
- * for finals positions. The actual implementation should analyze the
+ * **PROVISIONAL / ESTIMATED DATA**: Currently uses qualification ranking as a
+ * proxy for finals positions. The actual implementation should analyze the
  * double elimination bracket completion to determine exact placements
  * (winner of Grand Final = 1st, loser = 2nd, etc.).
+ *
+ * The positions returned by this function are NOT actual bracket results --
+ * they are estimates based on qualification seeding. Consumers should treat
+ * these values as provisional until full bracket analysis is implemented.
+ *
+ * @deprecated Use actual bracket results when available. This function
+ * currently returns estimated positions based on qualification seeding.
  *
  * TODO: Implement full bracket analysis when bracket completion tracking
  * is available in the database schema.
@@ -338,13 +347,18 @@ export async function getTAFinalsPositions(
  * @param prisma       - Prisma client instance
  * @param tournamentId - Tournament to look up
  * @param mode         - Which mode's finals to examine (BM, MR, or GP)
- * @returns Array of FinalsPosition for the top 16 players
+ * @returns Array of FinalsPosition for the top 16 players (provisional)
  */
 export async function getMatchFinalsPositions(
   prisma: ExtendedPrismaClient,
   tournamentId: string,
   mode: "BM" | "MR" | "GP"
 ): Promise<FinalsPosition[]> {
+  logger.warn(
+    `getMatchFinalsPositions called for mode=${mode}, tournament=${tournamentId}. ` +
+    "Returning PROVISIONAL positions based on qualification seeding, not actual bracket results."
+  );
+
   // Fetch qualification data sorted by score descending as a proxy
   // for finals placement. This is a temporary simplification.
   let qualifications;
@@ -529,7 +543,7 @@ export async function calculateOverallRankings(
   }
 
   // Step 6: Sort by total points descending to determine ranking
-  scores.sort((a, b) => b.totalPoints - a.totalPoints);
+  scores.sort((a, b) => b.totalPoints - a.totalPoints || a.playerId.localeCompare(b.playerId));
 
   // Step 7: Assign ranks using standard competition ranking (1224).
   // Players with the same total share a rank; the next distinct rank
@@ -667,7 +681,7 @@ export async function getOverallRankings(
     mrFinalsPoints: s.mrFinalsPoints,
     gpFinalsPoints: s.gpFinalsPoints,
     totalPoints: s.totalPoints,
-    // Default to 0 if overallRank is null (shouldn't happen after calculation)
-    overallRank: s.overallRank ?? 0,
+    // Null if overallRank has not been calculated yet
+    overallRank: s.overallRank ?? null,
   }));
 }

--- a/jsmkc-app/src/lib/ta/rank-calculation.ts
+++ b/jsmkc-app/src/lib/ta/rank-calculation.ts
@@ -102,7 +102,7 @@ export function calculateEntryTotal(entry: {
 export function sortByStage(entries: EntryWithTotal[], stage: string): EntryWithTotal[] {
   if (stage === "finals") {
     // Finals sorting: active players first, then by lives (most first), then by time
-    return entries.sort((a, b) => {
+    return [...entries].sort((a, b) => {
       // Non-eliminated players always rank above eliminated ones
       if (a.eliminated !== b.eliminated) {
         return a.eliminated ? 1 : -1;

--- a/jsmkc-app/src/lib/ta/time-utils.ts
+++ b/jsmkc-app/src/lib/ta/time-utils.ts
@@ -46,8 +46,8 @@ export const TimesObjectSchema = z.record(z.string(), TimeStringSchema);
  * Convert a time string (MM:SS.mmm or M:SS.mmm) to milliseconds.
  *
  * The conversion formula is: minutes * 60000 + seconds * 1000 + milliseconds.
- * Milliseconds are parsed as-is without padding, so "1:23.4" yields
- * 1*60000 + 23*1000 + 4 = 83004ms (not 83400ms).
+ * Milliseconds are right-padded with zeros to 3 digits, so "1:23.4" yields
+ * 1*60000 + 23*1000 + 400 = 83400ms.
  *
  * @param time - Time string in format M:SS.mmm or MM:SS.mmm
  * @returns Total milliseconds, or null if the input is empty/invalid
@@ -61,10 +61,10 @@ export function timeToMs(time: string): number | null {
 
   const minutes = parseInt(match[1], 10);
   const seconds = parseInt(match[2], 10);
-  const ms = match[3] || ''; // Handle missing milliseconds
+  let ms = match[3] || ''; // Handle missing milliseconds
 
-  // Parse milliseconds as-is (don't pad or modify)
-  // If empty, default to 0, otherwise parse the value
+  // Pad milliseconds to 3 digits for accurate comparison (e.g., "4" -> "400", "45" -> "450")
+  while (ms.length < 3) ms += '0';
   const milliseconds = ms === '' ? 0 : parseInt(ms, 10);
 
   return minutes * 60 * 1000 + seconds * 1000 + milliseconds;

--- a/jsmkc-app/src/lib/ta/time-utils.ts
+++ b/jsmkc-app/src/lib/ta/time-utils.ts
@@ -65,7 +65,7 @@ export function timeToMs(time: string): number | null {
 
   // Pad milliseconds to 3 digits for accurate comparison (e.g., "4" -> "400", "45" -> "450")
   while (ms.length < 3) ms += '0';
-  const milliseconds = ms === '' ? 0 : parseInt(ms, 10);
+  const milliseconds = parseInt(ms, 10);
 
   return minutes * 60 * 1000 + seconds * 1000 + milliseconds;
 }


### PR DESCRIPTION
## Summary
This PR fixes several bugs in the Time Attack tournament system related to time parsing, round completion detection, and course completion tracking.

## Key Changes

- **Time parsing fix**: Updated `timeToMs()` to properly right-pad milliseconds to 3 digits (e.g., "1:23.4" now correctly converts to 83400ms instead of 83004ms). Updated documentation to reflect the correct behavior.

- **Null check improvement**: Changed falsy check (`e.totalTime ?`) to explicit null check (`e.totalTime != null ?`) in standings API to properly handle zero values.

- **Course completion logic**: Fixed `getCompletedCourses()` in finals, revival-1, and revival-2 pages to filter out eliminated entries before checking if all remaining entries have completed a course, preventing eliminated players from blocking course completion status.

- **Round completion threshold**: Updated `isComplete` logic in revival-1 and revival-2 pages from `<= 1` to `<= 4` active entries to correctly reflect when a revival round is considered complete.

- **Array mutation fix**: Changed `sortByStage()` to create a shallow copy of the entries array before sorting, preventing unintended mutations of the original array.

## Implementation Details

The time parsing fix ensures consistent millisecond handling across the application. The course completion and round completion fixes improve the accuracy of tournament state tracking by properly accounting for eliminated players. The array mutation fix follows functional programming best practices and prevents potential bugs from side effects.

https://claude.ai/code/session_017cV5pwEwukJstwu6d6Aqvx