### PR TITLE
[Security] Fix IDOR 脆弱性：match-detail-route GET handler に tournamentId 連携を追加

### DIFF
--- a/smkc-score-app/src/lib/api-factories/match-detail-route.ts
+++ b/smkc-score-app/src/lib/api-factories/match-detail-route.ts
@@ -93,8 +93,9 @@ export function createMatchDetailHandlers(config: MatchDetailConfig) {
     const { matchId } = await params;
 
     try {
+      const { id: tournamentId, matchId } = await params;
       const match = await model(prisma).findUnique({
-        where: { id: matchId },
+        where: { id: matchId, tournamentId },
         include: { player1: true, player2: true },
       });
 


### PR DESCRIPTION
## 問題

`src/lib/api-factories/match-detail-route.ts` の GET handler で matchId のみでマッチを取得しており、URL パスの `tournamentId` との整合性を検証していない。

## セキュリティリスク

- 攻撃者が他の大会のマッチ ID を推測/総当たりすることで、認証なしにアクセス可能
- 大会関係者のみが知るべきマッチ情報の情報漏洩
- マッチの存在確認による列挙攻撃

## 修正内容

- `params` から `tournamentId` を取得
- Prisma の WHERE 句に `tournamentId` を追加して整合性を検証
- マッチが見つからない場合は 404 エラーを返す

## 影響範囲

- BM/MR/GP 全てのマッチ詳細 API
