### PR TITLE
fix: invalidate standings cache after rankOverride update (#319)

### DIFF
--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -22,6 +22,7 @@ import { EventTypeConfig } from '@/lib/event-types/types';
 import { CupMismatchError } from '@/lib/event-types/gp-config';
 import { resolveTournamentId } from '@/lib/tournament-identifier';
 import { checkQualificationConfirmed } from '@/lib/qualification-confirmed-check';
+import { invalidate } from '@/lib/standings-cache';
 import {
   generateRoundRobinSchedule,
   getByeMatchData,
@@ -527,6 +528,9 @@ export function createQualificationHandlers(config: EventTypeConfig) {
             rankOverrideAt: rankOverride != null ? new Date() : null,
           },
         });
+
+        // Invalidate standings cache so the rank change takes effect immediately
+        await invalidate(tournamentId, 'qualification');
 
         logger.info('Rank override updated', {
           tournamentId,


### PR DESCRIPTION
## Summary

When admin updates `rankOverride` via PATCH endpoint, the standings cache was not invalidated, causing stale rank data to be shown for up to 5 minutes (cache TTL).

## Changes

- Import `invalidate` from `@/lib/standings-cache`
- Call `invalidate(tournamentId, 'qualification')` after rankOverride update

## Test plan

- [ ] Deploy to production
- [ ] Run E2E tests: `node e2e/tc-all.js`
- [ ] Verify rankOverride changes take effect immediately

Fixes #319