### PR TITLE
fix: parallelize BYE recipient stats update (#318)

### DIFF
--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -300,8 +300,9 @@ export function createQualificationHandlers(config: EventTypeConfig) {
        * BYE matches are auto-completed on creation, so the player's win
        * must be reflected in standings right away — not deferred until
        * their first real match is submitted via PUT.
+       * Use Promise.all for parallel execution to reduce latency.
        */
-      for (const playerId of byeRecipientIds) {
+      await Promise.all([...byeRecipientIds].map(async (playerId) => {
         const byeMatches = await matchModel(prisma).findMany({
           where: {
             tournamentId,
@@ -319,7 +320,7 @@ export function createQualificationHandlers(config: EventTypeConfig) {
           where: { tournamentId, playerId },
           data: stats.qualificationData,
         });
-      }
+      }));
 
       /* Audit logging if configured */
       if (config.auditAction && currentSession) {


### PR DESCRIPTION
## Summary

Replace sequential for-loop with `Promise.all` for BYE recipient stats updates. Reduces latency from O(N) sequential queries to O(1) parallel.

## Changes

- Change `for (const playerId of byeRecipientIds)` to `await Promise.all([...byeRecipientIds].map(async (playerId) => ...))`

## Test plan

- [ ] Deploy to production
- [ ] Run E2E tests: `node e2e/tc-all.js`

Fixes #318