### PR TITLE
fix: add match existence check before tvNumber update (#317)

### DIFF
--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -555,10 +555,17 @@ export function createQualificationHandlers(config: EventTypeConfig) {
       }
 
       /*
-       * Verify the match belongs to this tournament before updating.
+       * Verify the match exists and belongs to this tournament before updating.
        * Prevents IDOR: an admin could otherwise modify matches in other tournaments
        * by guessing/enumerating matchIds.
        */
+      const existingMatch = await matchModel(prisma).findFirst({
+        where: { id: matchId, tournamentId },
+      });
+      if (!existingMatch) {
+        return createErrorResponse('Match not found', 404, 'NOT_FOUND');
+      }
+
       const match = await matchModel(prisma).update({
         where: { id: matchId, tournamentId },
         data: { tvNumber: tvNumber ?? null },


### PR DESCRIPTION
## Summary

Add match existence check before tvNumber update in PATCH handler. Previously the code claimed to verify match ownership but just ran update directly, causing P2025 errors to surface as 500.

## Changes

- Add `findFirst` to check match existence before update
- Return 404 if match not found

## Test plan

- [ ] Deploy to production
- [ ] Run E2E tests: `node e2e/tc-all.js`

Fixes #317