### PR TITLE
ci: enable auto-merge for every non-draft PR

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,12 +56,11 @@ jobs:
 
             Write the review body in Japanese. Keep it focused on actionable findings.
 
-      # Opt-in auto-merge: only PRs labeled `auto-merge` get auto-merged.
-      # `--auto` waits for required status checks defined in branch protection.
-      - name: Enable auto-merge (opt-in via label)
+      # Auto-merge every non-draft PR. `--auto` waits for required status checks
+      # and approving reviews defined in branch protection before merging.
+      - name: Enable auto-merge
         if: |
           success() &&
-          contains(github.event.pull_request.labels.*.name, 'auto-merge') &&
           github.event.pull_request.draft == false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `claude-code-review.yml` の auto-merge ステップから `auto-merge` ラベル opt-in 条件を削除
- 今後は non-draft PR すべてで `gh pr merge --auto --squash` が走る

## Why
Branch protection で「1件 approve + 必須チェック成功」が既に担保されているので、ラベル opt-in は二重ゲートで、実際 #328 がラベル無しのためマージされず停滞していた。

## Test plan
- [ ] このPR自身がマージ後に auto-merge で消化されること（メタテスト）