### PR TITLE
fix: add tournamentId validation to qualification-route PUT updateMatch (#327)

### DIFF
--- a/smkc-score-app/src/lib/event-types/types.ts
+++ b/smkc-score-app/src/lib/event-types/types.ts
@@ -20,7 +20,7 @@ export type MatchResult = {
 /** Parsed PUT request body for qualification match updates */
 export type QualificationPutData = {
   matchId: string;
-  tournamentId?: string;
+  tournamentId: string;
   score1?: number;
   score2?: number;
   points1?: number;


### PR DESCRIPTION
## Summary
- Add `tournamentId` to `QualificationPutData` type (optional, injected by route)
- qualification-route.ts injects `tournamentId` into putData before calling updateMatch
- All updateMatch implementations (BM/MR/GP) now include `tournamentId` in Prisma where clause

## Test plan
- [x] E2E tests pass (45/45)
- [x] TypeScript compiles without new errors

Fixes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)