### PR TITLE
fix(e2e): demote tournament to draft before DELETE in cleanup

### DIFF
--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -1347,7 +1347,7 @@ async function deletePlayer(p, id) {
       log('TC-315', 'FAIL', e.message);
     } finally {
       if (tc315TournamentId) {
-        await page.evaluate(async u => fetch(u, { method: 'DELETE' }), `/api/tournaments/${tc315TournamentId}`);
+        await deleteTournament(page, tc315TournamentId);
       }
     }
   }
@@ -1547,7 +1547,7 @@ async function deletePlayer(p, id) {
       log('TC-316', 'FAIL', e.message);
     } finally {
       if (tc316TournamentId) {
-        await page.evaluate(async u => fetch(u, { method: 'DELETE' }), `/api/tournaments/${tc316TournamentId}`).catch(() => {});
+        await deleteTournament(page, tc316TournamentId);
       }
     }
   }
@@ -1692,16 +1692,13 @@ async function deletePlayer(p, id) {
       log('TC-321', 'FAIL', err instanceof Error ? err.message : 'BM match view-only test failed');
     } finally {
       if (tc321TournamentId) {
-        await page.evaluate(async (u) => { await fetch(u, { method: 'DELETE' }); },
-          `/api/tournaments/${tc321TournamentId}`).catch(() => {});
+        await deleteTournament(page, tc321TournamentId);
       }
       if (tc321Player1Id) {
-        await page.evaluate(async (u) => { await fetch(u, { method: 'DELETE' }); },
-          `/api/players/${tc321Player1Id}`).catch(() => {});
+        await deletePlayer(page, tc321Player1Id);
       }
       if (tc321Player2Id) {
-        await page.evaluate(async (u) => { await fetch(u, { method: 'DELETE' }); },
-          `/api/players/${tc321Player2Id}`).catch(() => {});
+        await deletePlayer(page, tc321Player2Id);
       }
     }
   }
@@ -1847,16 +1844,13 @@ async function deletePlayer(p, id) {
     } finally {
       if (tc322PlayerBrowser) await tc322PlayerBrowser.close().catch(() => {});
       if (tc322TournamentId) {
-        await page.evaluate(async (u) => { await fetch(u, { method: 'DELETE' }); },
-          `/api/tournaments/${tc322TournamentId}`).catch(() => {});
+        await deleteTournament(page, tc322TournamentId);
       }
       if (tc322Player1Id) {
-        await page.evaluate(async (u) => { await fetch(u, { method: 'DELETE' }); },
-          `/api/players/${tc322Player1Id}`).catch(() => {});
+        await deletePlayer(page, tc322Player1Id);
       }
       if (tc322Player2Id) {
-        await page.evaluate(async (u) => { await fetch(u, { method: 'DELETE' }); },
-          `/api/players/${tc322Player2Id}`).catch(() => {});
+        await deletePlayer(page, tc322Player2Id);
       }
     }
   }
@@ -1999,12 +1993,10 @@ async function deletePlayer(p, id) {
       log('TC-323', 'FAIL', err instanceof Error ? err.message : 'BM tie warning flow failed');
     } finally {
       if (tc323TournamentId) {
-        await page.evaluate(async (u) => { await fetch(u, { method: 'DELETE' }); },
-          `/api/tournaments/${tc323TournamentId}`).catch(() => {});
+        await deleteTournament(page, tc323TournamentId);
       }
       for (const id of tc323PlayerIds) {
-        await page.evaluate(async (u) => { await fetch(u, { method: 'DELETE' }); },
-          `/api/players/${id}`).catch(() => {});
+        await deletePlayer(page, id);
       }
     }
   }

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -63,8 +63,17 @@ async function deletePlayer(page, id) {
   await page.evaluate(async (url) => { await fetch(url, { method: 'DELETE' }); }, `/api/players/${id}`).catch(() => {});
 }
 
-/** Helper: delete a tournament via API */
+/** Helper: delete a tournament via API.
+ *  DELETE /api/tournaments/:id only accepts status='draft', so we demote first. */
 async function deleteTournament(page, id) {
+  if (!id) return;
+  await page.evaluate(async (url) => {
+    await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'draft' }),
+    });
+  }, `/api/tournaments/${id}`).catch(() => {});
   await page.evaluate(async (url) => { await fetch(url, { method: 'DELETE' }); }, `/api/tournaments/${id}`).catch(() => {});
 }
 


### PR DESCRIPTION
## Summary
E2E cleanup (finally ブロック) が `DELETE /api/tournaments/:id` を直叩きしていたため、アクティブ化されたテスト用トーナメントが毎回リークしていた。該当 API は `status='draft'` のレコードしか削除しないため、PUT で draft に降格してから DELETE を叩くよう修正する。

## Why re-submission
この修正は `cb1852c` として fix/318-bye-recipient-stats-parallel に commit 済みだったが、該当ブランチが #326 として別内容で squash-merge されたため、cleanup 修正だけが取り残されて main に入らなかった。実機確認で今朝時点で24件の孤立トーナメント + 多数の孤立プレイヤーを検出したため再提出。

## Why player cleanup が直ったわけ
`/api/players/:id` DELETE は「どのトーナメントにも登録されていないこと」を前提とする。トーナメント削除が直前に失敗すると FK 違反で player DELETE も 409 になり連鎖リーク、という構造。トーナメント削除さえ通れば player は cascade で未登録化されるので、player 側のコードは変更不要。

## Scope
- `smkc-score-app/e2e/tc-all.js`: TC-315/316/321/322/323 の finally ブロックを既存の `deleteTournament()` / `deletePlayer()` helper に置換（直叩きの DELETE を廃止）
- `smkc-score-app/e2e/tc-mr.js`: `deleteTournament()` helper 本体を「PUT draft → DELETE」順に修正
- `tc-bm.js` は対象外（ユーザーが意図的に保持した状態）

## Test plan
- [x] `node --check` 通過
- [ ] Merge → デプロイ後の E2E loop (cb1062c9) が完走し、/api/tournaments の孤立が増えないことを確認
- [ ] 同時に現在の24件の孤立データを手動削除（別作業で実施中）

Ref: `cb1852c` (original orphaned commit on fix/318-bye-recipient-stats-parallel)