### PR TITLE
fix: qualifications POST DELETE+CREATE atomic pattern (#315)

### DIFF
--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -175,9 +175,19 @@ export function createQualificationHandlers(config: EventTypeConfig) {
         return handleValidationError('Players array is required', 'players');
       }
 
-      /* Clear existing qualification data for fresh setup */
-      await qualModel(prisma).deleteMany({ where: { tournamentId } });
-      await matchModel(prisma).deleteMany({ where: { tournamentId, stage: 'qualification' } });
+      /*
+       * Collect existing record IDs before DELETE to enable safe delete-first-then-create pattern.
+       * D1 does not support prisma.$transaction, so we collect IDs first, then create new records,
+       * then delete old records by ID (not by tournamentId which would also delete new records).
+       */
+      const existingQualificationIds = await qualModel(prisma).findMany({
+        where: { tournamentId },
+        select: { id: true },
+      });
+      const existingMatchIds = await matchModel(prisma).findMany({
+        where: { tournamentId, stage: 'qualification' },
+        select: { id: true },
+      });
 
       /* Create qualification records for each player */
       const qualifications = await Promise.all(
@@ -344,6 +354,21 @@ export function createQualificationHandlers(config: EventTypeConfig) {
             action: config.auditAction,
           });
         }
+      }
+
+      /*
+       * Delete old records after all creates succeed — preserves new records.
+       * Uses ID-based deletion (not tournamentId) to avoid deleting newly created records.
+       */
+      if (existingQualificationIds.length > 0) {
+        await qualModel(prisma).deleteMany({
+          where: { id: { in: existingQualificationIds.map(q => q.id) } },
+        });
+      }
+      if (existingMatchIds.length > 0) {
+        await matchModel(prisma).deleteMany({
+          where: { id: { in: existingMatchIds.map(m => m.id) } },
+        });
       }
 
       return NextResponse.json(


### PR DESCRIPTION
## Summary

Fix for #315: qualifications DELETE + CREATE は atomic transaction が必要です

### Problem

`qualification-route.ts` POST handler deleted all existing qualification data before creating new records. If CREATE failed partway through, all data was lost.

### Solution

D1 does not support `prisma.$transaction`, so we use the **collect-ID-then-delete** pattern:

1. Collect existing record IDs before any DELETE
2. Create new records first
3. Delete old records by ID (not by tournamentId — which would also delete newly created records)

### Changes

- `smkc-score-app/src/lib/api-factories/qualification-route.ts`
  - Added `existingQualificationIds` and `existingMatchIds` collection before any mutation
  - Moved DELETE to after all CREATE operations succeed
  - DELETE uses ID-based filtering to preserve new records

### Testing

- Manual verification of the POST handler flow
- E2E tests should continue to pass

Closes #315