### PR TITLE
refactor(e2e): rebuild full-workflow suite for 28 players + add GP suite

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -190,6 +190,21 @@
   2. 全て `"error": "Forbidden"` を返すことを確認
 - **期待結果**: 全エンドポイントで統一された "Forbidden" メッセージ
 
+## TC-108: Players API ページネーション
+- **URL**: /api/players, /players
+- **authRequired**: false
+- **背景**: コミット 0269c8f で Players ページがページネーション化された。
+  `page`/`limit` クエリで分割取得し `{ data, meta: { total, page, limit, totalPages } }` を返す契約。
+  デフォルト limit=50、最大 100。
+- **手順**:
+  1. `/api/players?page=1&limit=10` を GET し、`data` が10件以下、`meta.page=1`, `meta.limit=10`,
+     `meta.total>=data.length`, `meta.totalPages=Math.ceil(total/10)` であることを確認
+  2. `/api/players?page=2&limit=10` を GET し、1ページ目と異なる ID のレコードが返ること
+     （または total<=10 で空配列）
+  3. `/api/players?page=1&limit=200` を GET → 200 を要求しても `meta.limit<=100` にクランプされること
+  4. `/players` ページを開き、プレイヤー数が既定 limit (50) を超える場合にページャー UI が出ること
+- **期待結果**: ページネーションが API/UI 双方で機能し、limit クランプが効いている
+
 ## TC-201: 各モードページのデータ読み込み確認
 - **URL**: /tournaments/[id]/ta, /bm, /mr, /gp
 - **authRequired**: true (admin)
@@ -220,40 +235,6 @@
   2. 「トーナメントが見つかりません」が表示されないこと
   3. 「総合ランキング」タイトルが表示されること
 - **期待結果**: ランキングページがレイアウトごと正常表示される
-
----
-
-## フルワークフローテスト
-
-## TC-401: MR予選グループ設定→スコア入力→順位表確認
-- **URL**: /tournaments/[id]/mr
-- **authRequired**: true (admin)
-- **手順**:
-  1. MR予選ページで「グループ設定」をクリック
-  2. 4名以上のプレイヤーを選択、グループAに割り当て
-  3. 「グループ作成」をクリック → ダイアログが閉じること
-  4. 順位表タブにプレイヤーが表示されること
-  5. 試合一覧タブに試合が作成されていること
-  6. 任意の試合でスコア入力 → 保存成功
-  7. 順位表に結果が反映されること
-  8. **クリーンアップ**: グループ編集で再作成（データリセット）
-- **期待結果**: グループ作成→スコア入力→順位表反映の一連のフローが正常動作
-
-## TC-402: GP予選グループ設定→スコア入力→順位表確認
-- **URL**: /tournaments/[id]/gp
-- **authRequired**: true (admin)
-- **手順**:
-  1. GP予選ページで「グループ設定」をクリック
-  2. 4名以上のプレイヤーを選択、グループAに割り当て
-  3. 「グループ作成」をクリック → ダイアログが閉じること
-  4. 順位表タブにプレイヤーが表示されること
-  5. 試合一覧タブに試合が作成されていること（カップ割り当て付き）
-  6. 任意の試合でカップ選択 → 5コースが固定順で自動入力されること
-  7. 各レースの順位（1-8）を入力 → 保存成功
-  8. 順位表にドライバーズポイントが反映されること
-  9. 必要に応じて管理者が合計ポイントのみ手動修正できること
-  10. **クリーンアップ**: グループ編集で再作成（データリセット）
-- **期待結果**: グループ作成→カップ選択→コース自動入力→順位入力→順位表反映の一連のフローが正常動作
 
 ---
 
@@ -381,6 +362,13 @@
   6. 作成したトーナメントを削除する
 - **期待結果**: 奇数人数でも POST 201、グループ設定成功、アラートなし
 
+## BM フルワークフロー設計方針
+- **予選プレイヤー数**: 28名（4グループ × 7名、7はオッドのため各グループに BYE が混在）
+- **予選試合数**: 7名RR = 21試合 × 4グループ = **84試合**（API一括投入）
+- **決勝**: 上位8名でダブルイリミネーション (17試合)
+- **決勝形式**: best-of-9 (first-to-5)、`score1 + score2 ≦ 9` で一方が `5` に到達した時点で勝者確定
+- 単発の participant テスト (TC-322/501/502/507/508/509) は 2 名のみで設置（高速フィードバック用）
+
 ## TC-501: BMプレイヤーログインからスコア入力・送信まで
 - **URL**: /auth/signin -> /tournaments/[temp-id]/bm/participant
 - **authRequired**: true (player)
@@ -410,59 +398,55 @@
   8. 一時トーナメントと一時プレイヤーを削除する
 - **期待結果**: 2-2の引き分けスコアが正常に送信・保存される
 
-## TC-503: BM決勝ブラケット生成とスコア入力
+## TC-503: BM予選28名フル + 決勝ブラケット生成・1試合スコア入力
 - **URL**: /tournaments/[temp-id]/bm/finals
 - **authRequired**: true (admin)
 - **手順**:
-  1. 管理者セッションで一時トーナメントとプレイヤー8名を作成する
-  2. BMグループ設定を行い、全予選マッチのスコアをAPIで入力して完了させる
-  3. `/tournaments/[temp-id]/bm/finals` を開き、「Generate Bracket」ボタンをクリックする
-  4. 確認ダイアログで「Top 8」を選択し、「Generate」をクリックする
-  5. ダブルイリミネーションブラケットが表示されることを確認する（QF 4試合が表示）
-  6. QF Match #1 をクリックし、スコア入力ダイアログが開くことを確認する
-  7. score1=5, score2=2（best-of-9）を入力し「Save Score」をクリックする
-  8. ブラケットが更新され、勝者がWinners Bracket次ラウンドに、敗者がLosers Bracketに移動することを確認する
-  9. 一時トーナメントと一時プレイヤーを削除する
-- **期待結果**: ブラケット生成、スコア入力、勝敗によるブラケット進行が正常に動作する
+  1. 管理者セッションで一時トーナメントとプレイヤー **28名** を作成する
+  2. BMグループ設定を 4グループ × 7名 (snake-draft) に登録（奇数なのでBYE発生）
+  3. 全予選マッチ（21試合 × 4 = 84試合）のスコアを API で 3-1 入力し completed にする
+  4. `POST /api/tournaments/[id]/bm/finals` `{ topN: 8 }` でブラケット生成（17試合）
+  5. M1 に 3-0 で PUT → 400 拒否（best-of-9 なので first-to-5 必須）
+  6. M1 に 5-0 で PUT → 200 受理、勝者→M5、敗者→M8 にルーティングされること
+  7. クリーンアップ（トーナメント `status='draft'` に降格 → DELETE → プレイヤー DELETE）
+- **期待結果**: 28名予選→上位8名抽出→決勝ブラケットの全フローが正常動作
 
-## TC-504: BM決勝ブラケットリセット
+## TC-504: BM決勝ブラケットリセット（28名予選後）
 - **URL**: /tournaments/[temp-id]/bm/finals
 - **authRequired**: true (admin)
 - **手順**:
-  1. TC-503と同様にブラケットを生成し、一部スコアを入力する
-  2. 「Reset Bracket」ボタンをクリックする
-  3. 確認ダイアログで「Reset」をクリックする
-  4. ブラケットが再生成され、入力済みスコアがリセットされることを確認する
-  5. 一時トーナメントと一時プレイヤーを削除する
-- **期待結果**: ブラケットリセットが正常に機能し、全マッチがpending状態に戻る
+  1. TC-503同様に 28名予選 + 決勝ブラケット生成
+  2. M1 に 5-0 で PUT
+  3. ブラケット生成 API を再 POST（=「Reset Bracket」UI 動作と同等）
+  4. 全 17 マッチが `completed=false` の pending 状態に戻ること
+  5. クリーンアップ
+- **期待結果**: ブラケットリセットで全マッチが未完了状態に戻る
 
-## TC-505: BM決勝 Grand Final → チャンピオン決定
+## TC-505: BM Grand Final → チャンピオン決定（28名予選後）
 - **URL**: /tournaments/[temp-id]/bm/finals
 - **authRequired**: true (admin)
 - **手順**:
-  1. 管理者セッションで一時トーナメントとプレイヤー8名を作成する
-  2. BMグループ設定→全予選マッチ完了→ブラケット生成する
-  3. 全ブラケットマッチ（Winners QF〜Grand Final）のスコアをAPIで入力する
-     - Winners Bracket: QF(1-4), SF(5-6), WF(7)
-     - Losers Bracket: L_R1(8-9), L_R2(10-11), L_R3(12-13), LSF(14), LF(15)
-     - Grand Final(16): best-of-9
-  4. Grand FinalでWinners側が勝った場合、チャンピオンカードが表示されることを確認する
-  5. チャンピオンのニックネームが正しく表示されることを確認する
-  6. 進行バッジが「Tournament Complete」を示すことを確認する
-  7. 一時トーナメントと一時プレイヤーを削除する
+  1. 28名予選 + 決勝ブラケット生成（TC-503同様）
+  2. M1〜M16 を P1 win 5-0 で API 連続入力
+     - Winners: QF(1-4), SF(5-6), WF(7)
+     - Losers : L_R1(8-9), L_R2(10-11), L_R3(12-13), LSF(14), LF(15)
+     - Grand Final: M16 (best-of-9)
+  3. M16 で Winners 側勝者 (P1) が 5-0 で勝つ
+  4. `/bm/finals` ページの `body.innerText` にチャンピオンの nickname と "Champion/チャンピオン/優勝" のいずれかが含まれること
+  5. クリーンアップ
 - **期待結果**: 全マッチ完了後にチャンピオンが正しく決定・表示される
 
-## TC-506: BM決勝 Grand Final Reset Match
+## TC-506: BM Grand Final Reset Match（28名予選後）
 - **URL**: /tournaments/[temp-id]/bm/finals
 - **authRequired**: true (admin)
-- **背景**: Grand FinalでLosers側が勝った場合、Reset Match（17試合目）が発生する
+- **背景**: Grand Final で Losers 側が勝った場合、Reset Match (M17) が発生する
 - **手順**:
-  1. TC-505と同様に全マッチを進め、Grand Final(16)でLosers側勝者が勝つようにスコアを入力する
-  2. Grand Final Reset(17)マッチがブラケットに出現することを確認する
-  3. Reset Matchのスコアを入力する
-  4. チャンピオンが正しく決定されることを確認する
-  5. 一時トーナメントと一時プレイヤーを削除する
-- **期待結果**: Grand Final Resetが正しくトリガーされ、最終勝者がチャンピオンとなる
+  1. TC-505 同様に M1〜M15 を P1 win 5-0 で消化
+  2. M16 (Grand Final) で Losers 側勝者 (P2) が 0-5 で勝つようにスコア入力
+  3. M17 (Grand Final Reset) が出現し両プレイヤーが populate されること
+  4. M17 にスコア入力（L-side 勝者を勝たせる）→ completed
+  5. クリーンアップ
+- **期待結果**: Grand Final Reset が正しくトリガーされ、最終勝者がチャンピオンとなる
 
 ## TC-507: BM二重報告 — 双方一致で自動確定
 - **URL**: /tournaments/[temp-id]/bm/participant
@@ -512,25 +496,26 @@
 
 ### 設計方針
 - BMテスト(TC-5xx)と対称に構成。BMとの差異（決勝がレース形式、コース割当あり）以外は同じシナリオ
-- 予選プレイヤー数: 12名（3グループ×4名）
-- シード入力・推奨グループ数・自動振り分けをカバー
-- プレイヤー側の試合リストからの「スコア入力」リンクテスト(TC-307相当)はMRでは不要
+- **予選プレイヤー数**: 28名（4グループ × 7名、奇数のためBYEあり）
+- **予選試合数**: 7名RR = 21試合 × 4グループ = **84試合**
+- **決勝形式**: best-of-5 races (first-to-3)、5レース分のコース選択+勝者選択
+- 単発の participant テスト (TC-602/603/608/609/610/611/612) は 2 名のみで設置
 
-## TC-601: MR予選フルフロー（12名、シード、推奨グループ、自動振り分け）
+## TC-601: MR予選フルフロー（28名、シード、4グループ snake-draft）
 - **URL**: /tournaments/[temp-id]/mr
 - **authRequired**: true (admin)
 - **手順**:
-  1. 管理者セッションで一時トーナメントと12名のプレイヤーを作成する
-  2. MR予選グループ設定APIで12名をシード1〜12で登録、3グループ（A/B/C × 4名）に自動振り分けする
-     - シードはsnake配分: A=[1,6,7,12], B=[2,5,8,11], C=[3,4,9,10]
-  3. APIレスポンスでグループごとに4名が割り当てられていることを確認する
-  4. 各グループの全試合（4名RR = 6試合 × 3グループ = 18試合）のスコアをAPIで入力する
-     - score1+score2=4 のルールを遵守（例: 3-1, 2-2, 4-0 等）
-  5. MR予選ページを開き、順位表に全12名が表示されることを確認する
-  6. 各グループの順位表がscore desc → points descで正しくソートされていることを確認する
-  7. コース割当がランダムシャッフルされていることを確認する（rounds配列にcourse情報あり）
-  8. 一時トーナメントと一時プレイヤーを削除する
-- **期待結果**: 12名3グループのMR予選がシード・自動振り分けで正しく設定・実行・集計される
+  1. 管理者セッションで一時トーナメントと **28名** のプレイヤーを作成
+  2. MR予選グループ設定APIで28名をシード1〜28で登録、4グループ（A/B/C/D × 7名）に snake-draft で自動振り分け
+     - boustrophedon: row r = floor(i/4), col = i%4 (even row) / 3-i%4 (odd row)
+  3. APIレスポンスで各グループに7名が割り当てられていることを確認
+  4. 各グループの全試合（7名RR = 21試合 × 4グループ = 84試合）のスコアを API で入力
+     - score1+score2=4 のルール（例: 3-1, 2-2, 4-0 等）。test スコアパターンは循環使用
+  5. MR予選ページを開き、順位表に全28名が表示されること
+  6. 各グループの順位表が score desc → points desc で正しくソートされていること
+  7. コース割当がランダムシャッフルされていること（rounds配列にcourse情報あり）
+  8. クリーンアップ
+- **期待結果**: 28名4グループのMR予選がシード・自動振り分けで正しく設定・実行・集計される
 
 ## TC-602: MR予選プレイヤーログインからスコア入力・送信まで
 - **URL**: /auth/signin -> /tournaments/[temp-id]/mr/participant
@@ -559,60 +544,56 @@
   6. 一時トーナメントと一時プレイヤーを削除する
 - **期待結果**: 2-2の引き分けスコアがバリデーションを通過し正常に保存される
 
-## TC-604: MR決勝ブラケット生成とスコア入力
+## TC-604: MR予選28名フル + 決勝ブラケット生成 + race-format UI スコア入力
 - **URL**: /tournaments/[temp-id]/mr/finals
 - **authRequired**: true (admin)
 - **手順**:
-  1. 管理者セッションで一時トーナメントとプレイヤー8名を作成する
-  2. MRグループ設定を行い、全予選マッチのスコアをAPIで入力して完了させる
-  3. `/tournaments/[temp-id]/mr/finals` を開き、「Generate Bracket」ボタンをクリックする
-  4. 確認ダイアログで「Top 8」を選択し、「Generate」をクリックする
-  5. ダブルイリミネーションブラケットが表示されることを確認する（QF 4試合が表示）
-  6. QF Match #1 をクリックし、スコア入力ダイアログが開くことを確認する
-  7. **MR固有**: レーステーブルでコース選択＋勝者選択を行う。P1が3勝（best-of-5でfirst-to-3）になるよう入力
-  8. 「Save Result」をクリックする
-  9. ブラケットが更新され、勝者がWinners Bracket次ラウンドに、敗者がLosers Bracketに移動することを確認する
-  10. 一時トーナメントと一時プレイヤーを削除する
-- **期待結果**: MR決勝ブラケット生成、レース形式スコア入力、勝敗によるブラケット進行が正常に動作する
+  1. 管理者セッションで一時トーナメントと **28名** のプレイヤーを作成
+  2. MR予選グループ設定 (4グループ × 7名) → 全 84 試合を API で 3-1 入力
+  3. `/mr/finals` を開き、「Generate Bracket」→「Top 8」→「Generate」をクリック
+  4. ダブルイリミネーションブラケットが生成されること（17試合）
+  5. M1 に対して 3-3 を API PUT → 400 拒否（first-to-3 なのでどちらか一方が 3 必須）
+  6. M1 ダイアログを UI で開き、各レースのコース選択＋勝者選択で P1 3勝にして「Save」
+  7. 勝者が M5、敗者が M8 に移動していること（routing）
+  8. クリーンアップ
+- **期待結果**: 28名予選→Top 8抽出→MR決勝ブラケット生成→ race-format スコア入力→ routing が全て正常動作
 
-## TC-605: MR決勝ブラケットリセット
+## TC-605: MR決勝ブラケットリセット（28名予選後）
 - **URL**: /tournaments/[temp-id]/mr/finals
 - **authRequired**: true (admin)
 - **手順**:
-  1. TC-604と同様にブラケットを生成し、一部スコアを入力する
-  2. 「Reset Bracket」ボタンをクリックする
-  3. 確認ダイアログで「Reset」をクリックする
-  4. ブラケットが再生成され、入力済みスコアがリセットされることを確認する
-  5. 一時トーナメントと一時プレイヤーを削除する
-- **期待結果**: ブラケットリセットが正常に機能し、全マッチがpending状態に戻る
+  1. TC-604 と同様に 28名予選 + ブラケット生成
+  2. M1 に 3-0 で API PUT
+  3. ブラケット生成 API を再 POST（=「Reset Bracket」UI 動作と同等）
+  4. 全 17 マッチが pending 状態に戻ること
+  5. クリーンアップ
+- **期待結果**: ブラケットリセットで全マッチが未完了状態に戻る
 
-## TC-606: MR決勝 Grand Final → チャンピオン決定
+## TC-606: MR Grand Final → チャンピオン決定（28名予選後）
 - **URL**: /tournaments/[temp-id]/mr/finals
 - **authRequired**: true (admin)
 - **手順**:
-  1. 管理者セッションで一時トーナメントとプレイヤー8名を作成する
-  2. MRグループ設定→全予選マッチ完了→ブラケット生成する
-  3. 全ブラケットマッチ（Winners QF〜Grand Final）のスコアをAPIで入力する
-     - Winners Bracket: QF(1-4), SF(5-6), WF(7)
-     - Losers Bracket: L_R1(8-9), L_R2(10-11), L_R3(12-13), LSF(14), LF(15)
-     - Grand Final(16): **MR固有** best-of-5レース（first-to-3）
-  4. Grand FinalでWinners側が勝った場合、チャンピオンカードが表示されることを確認する
-  5. チャンピオンのニックネームが正しく表示されることを確認する
-  6. 進行バッジが「Tournament Complete」を示すことを確認する
-  7. 一時トーナメントと一時プレイヤーを削除する
+  1. 28名予選 + 決勝ブラケット生成
+  2. M1〜M16 を P1 win 3-0 で API 連続入力
+     - Winners: QF(1-4), SF(5-6), WF(7)
+     - Losers : L_R1(8-9), L_R2(10-11), L_R3(12-13), LSF(14), LF(15)
+     - Grand Final: M16 (best-of-5 races, first-to-3)
+  3. M16 で Winners 側勝者 (P1) が 3-0 で勝つ
+  4. `/mr/finals` ページの `body.innerText` にチャンピオンの nickname と "Champion/チャンピオン/優勝" のいずれかが含まれること
+  5. クリーンアップ
 - **期待結果**: 全マッチ完了後にチャンピオンが正しく決定・表示される
 
-## TC-607: MR決勝 Grand Final Reset Match
+## TC-607: MR Grand Final Reset Match（28名予選後）
 - **URL**: /tournaments/[temp-id]/mr/finals
 - **authRequired**: true (admin)
-- **背景**: Grand FinalでLosers側が勝った場合、Reset Match（17試合目）が発生する
+- **背景**: Grand Final で Losers 側が勝った場合、Reset Match (M17) が発生する
 - **手順**:
-  1. TC-606と同様に全マッチを進め、Grand Final(16)でLosers側勝者が勝つようにスコアを入力する
-  2. Grand Final Reset(17)マッチがブラケットに出現することを確認する
-  3. Reset Matchのスコアを入力する（MR形式のレース入力）
-  4. チャンピオンが正しく決定されることを確認する
-  5. 一時トーナメントと一時プレイヤーを削除する
-- **期待結果**: Grand Final Resetが正しくトリガーされ、最終勝者がチャンピオンとなる
+  1. TC-606 と同様に M1〜M15 を P1 win 3-0 で消化
+  2. M16 で Losers 側勝者 (P2) が 0-3 で勝つようにスコア入力
+  3. M17 (Grand Final Reset) が出現し両プレイヤーが populate されること
+  4. M17 にスコア入力（L-side 勝者を勝たせる）→ completed
+  5. クリーンアップ
+- **期待結果**: Grand Final Reset が正しくトリガーされ、最終勝者がチャンピオンとなる
 
 ## TC-608: MR二重報告 — 双方一致で自動確定
 - **URL**: /tournaments/[temp-id]/mr/participant
@@ -688,6 +669,202 @@
 
 ---
 
+## GP (Grand Prix) フルワークフローテスト
+
+### 設計方針
+- BM/MR と対称に構成。GP 固有: 1試合 = 5レース（カップ単位）、各レースで position 1〜8 を入力 →
+  driver points (1st=9, 2nd=6, 3rd=3, 4th=1, 5th〜=0) に換算
+- **予選プレイヤー数**: 28名（4グループ × 7名）
+- **予選試合数**: 7名RR × 4 = 84試合。各試合は 5 races の `{ course, position1, position2 }` 配列で送信
+- **決勝**: 上位8名でダブルイリミネーション (17試合)。各試合は API PUT `{ score1, score2 }` で
+  `points1/points2` を直接指定。`targetWins=3` のため score1 >= 3 XOR score2 >= 3 が必要
+- 単発の participant テスト (TC-702/707/708) は 2 名のみで設置
+
+## TC-701: GP予選フルフロー（28名、シード、4グループ）
+- **URL**: /tournaments/[temp-id]/gp
+- **authRequired**: true (admin)
+- **手順**:
+  1. 管理者セッションで一時トーナメントと28名のプレイヤーを作成
+  2. GP予選グループ設定APIで28名をシード1〜28で登録、4グループ × 7 名に snake-draft で振り分け
+  3. APIレスポンスで各グループに7名が割り当てられていること
+  4. 各試合（合計84試合）について、5レース分の `races: [{ course, position1, position2 }]` を
+     管理者 PUT (`{ matchId, cup, races }`) で投入し completed にする
+  5. 順位表で driver points DESC → match score DESC でソートされていること
+  6. クリーンアップ
+- **期待結果**: 28名4グループのGP予選がシード・自動振り分け・driver points換算で正しく集計される
+
+## TC-702: GPプレイヤーログインから 5-race 送信
+- **URL**: /auth/signin -> /tournaments/[temp-id]/gp/participant
+- **authRequired**: true (player)
+- **手順**:
+  1. 管理者セッションで一時トーナメントとプレイヤー2名を作成（`dualReportEnabled=false`）
+  2. GP予選グループ設定で2名のpendingマッチを生成（カップ自動割当付き）
+  3. 別の一時ブラウザでP1としてログインし `/api/.../gp/match/:id/report` に
+     `{ reportingPlayer: 1, races: [...5 entries with position1=1, position2=5...] }` を POST
+  4. レスポンスに `autoConfirmed: true` が含まれること（`dualReportEnabled=false` のため即時確定）
+  5. 管理者APIでマッチが completed、`points1=45, points2=0` で保存されていること
+  6. クリーンアップ
+- **期待結果**: GP participant 入力で5レース順位送信→driver points換算→永続化が動作
+
+## TC-703: GP予選28名フル + 決勝ブラケット生成・1試合スコア入力
+- **URL**: /tournaments/[temp-id]/gp/finals
+- **authRequired**: true (admin)
+- **手順**:
+  1. 28名予選 + 全予選マッチ完了（TC-701同様）
+  2. `POST /api/.../gp/finals { topN: 8 }` でブラケット生成（17試合）
+  3. M1 に `{ score1: 9, score2: 0 }` で API PUT → 200 受理（targetWins=3、9 >= 3 XOR 0 < 3）
+  4. 勝者→M5、敗者→M8 にルーティングされること
+  5. クリーンアップ
+- **期待結果**: 28名予選→上位8名→GP決勝ブラケット生成・スコア入力・進行が正常動作
+
+## TC-704: GP決勝ブラケットリセット（28名予選後）
+- **URL**: /tournaments/[temp-id]/gp/finals
+- **authRequired**: true (admin)
+- **手順**:
+  1. TC-703と同様にブラケット生成 → M1 に 9-0 入力
+  2. ブラケット生成 API を再 POST（=「Reset Bracket」UI 動作と同等）
+  3. 全 17 マッチが pending 状態に戻ること
+  4. クリーンアップ
+- **期待結果**: ブラケットリセットで全マッチが未完了状態に戻る
+
+## TC-705: GP Grand Final → チャンピオン決定（28名予選後）
+- **URL**: /tournaments/[temp-id]/gp/finals
+- **authRequired**: true (admin)
+- **手順**:
+  1. 28名予選 + 決勝ブラケット生成
+  2. M1〜M16 を P1 win 9-0 で API 連続入力
+  3. M16 (Grand Final) で Winners 側勝者 (P1) が 9-0 で勝つ
+  4. `/gp/finals` ページの `body.innerText` にチャンピオンの nickname と "Champion/チャンピオン/優勝" が含まれること
+  5. クリーンアップ
+- **期待結果**: 全マッチ完了後にチャンピオンが正しく決定・表示される
+
+## TC-706: GP Grand Final Reset Match（28名予選後）
+- **URL**: /tournaments/[temp-id]/gp/finals
+- **authRequired**: true (admin)
+- **背景**: Grand Final で Losers 側が勝った場合、Reset Match (M17) が発生する
+- **手順**:
+  1. TC-705 同様に M1〜M15 を P1 win 9-0 で消化
+  2. M16 で L-side 勝者 (P2) が 0-9 で勝つようにスコア入力
+  3. M17 が出現し両プレイヤーが populate されること
+  4. M17 にスコア入力（L-side 勝者を勝たせる）→ completed
+  5. クリーンアップ
+- **期待結果**: Grand Final Reset が正しくトリガーされ、最終勝者がチャンピオンとなる
+
+## TC-707: GP二重報告 — 双方一致で自動確定
+- **URL**: /tournaments/[temp-id]/gp/participant
+- **authRequired**: true (player × 2)
+- **手順**:
+  1. `dualReportEnabled=true` のトーナメントとプレイヤー2名を作成
+  2. GPグループ設定でpendingマッチを生成
+  3. P1 が `races=[各レース position1=1, position2=5]` を送信 → `waitingFor: player2`
+  4. P2 が同じ `races` を送信 → `autoConfirmed: true` で confirmed
+  5. 管理者APIでマッチが completed、`points1=45, points2=0`
+  6. クリーンアップ
+- **期待結果**: 双方一致で GP マッチが自動確定される
+
+## TC-708: GP二重報告 — 不一致でmismatch検出
+- **URL**: /tournaments/[temp-id]/gp/participant
+- **authRequired**: true (player × 2)
+- **手順**:
+  1. `dualReportEnabled=true` のトーナメントとプレイヤー2名を作成
+  2. GPグループ設定でpendingマッチを生成
+  3. P1 が race position 1-vs-5 で送信、P2 が race position 5-vs-1 で送信（不一致）
+  4. レスポンスに `mismatch: true` が含まれ、マッチは completed=false のまま
+  5. 管理者 PUT (`{ matchId, cup, races }`) で確定 → completed=true
+  6. クリーンアップ
+- **期待結果**: 不一致時はマッチが未完了のまま管理者レビュー待ちになる
+
+## TC-709: GP決勝 — 非管理者のスコア入力拒否
+- **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)
+- **authRequired**: true (player — 管理者ではない)
+- **背景**: 決勝は putRequiresAuth: true で管理者のみ
+- **手順**:
+  1. 28名予選 + 決勝ブラケット生成
+  2. 一般プレイヤーとしてログインし、決勝APIにPUT
+  3. HTTP 403 Forbidden が返ること
+  4. クリーンアップ
+- **期待結果**: GP 決勝スコア入力は管理者のみ許可、プレイヤーは 403 拒否
+
+---
+
+## TT (Time Trial / TA) フルワークフローテスト  *(scenario only — 実装は別タスク)*
+
+### 設計方針
+- **エントリー数**: 28名（TA はグループ分けなし、全員が同一プールでタイムを競う）
+- **コース数**: 1 ラウンド = 20 コース（cycle、no-repeat until all used）
+- **フェーズ**: 予選 → Phase 1 (17〜24位の8→4) → Phase 2 (1〜16位の16→4) → Phase 3 (決勝、最大16名のノックアウト)
+- **タイ処理**: 同タイムは平均ポイント按分、per-course 線形補間（50pt 上限）
+- **スコア**: `qualification-scoring.ts` で算出（合計値だけ floor、per-course は double-floor しない）
+
+## TC-801: TA予選フルフロー（28名、20コース）
+- **URL**: /tournaments/[temp-id]/ta
+- **authRequired**: true (admin)
+- **手順**:
+  1. 一時トーナメント + プレイヤー28名 + TA 予選 entry 作成
+  2. 各プレイヤーに 20 コース分の time を API でランダム入力
+  3. 順位表が `qualification-scoring.ts` の per-course 線形補間 + 平均按分で算出されていること
+  4. floor は合計値のみ（per-course の double-floor になっていないこと）
+  5. クリーンアップ
+- **期待結果**: 28名のTA予選順位がスコア式どおりに集計される
+
+## TC-802: TAプレイヤーログインからタイム入力
+- **URL**: /auth/signin -> /tournaments/[temp-id]/ta/participant
+- **authRequired**: true (player)
+- **手順**:
+  1. 一時トーナメント + プレイヤー1名 + entry 作成
+  2. 一時ブラウザでログイン → `/ta/participant`
+  3. 自分の20コース分のタイムを順次入力・送信
+  4. 順位表に反映されること
+  5. クリーンアップ
+- **期待結果**: 参加者UIから自分の予選タイムを入力できる
+
+## TC-803: TAペア機能 + パートナー編集
+- **URL**: /api/tournaments/[temp-id]/ta + /ta/participant
+- **authRequired**: true (player)
+- **手順**:
+  1. プレイヤー2名でTAエントリー
+  2. `set_partner` でペア結成
+  3. P1 がログインし P2 のタイムを編集 → 成功
+  4. 逆方向 (P2 → P1) も成功
+  5. クリーンアップ
+- **期待結果**: ペアが双方向にタイム編集可能（TC-318 と重複しないよう統合検討）
+
+## TC-804: TA予選確定 → Phase 1 開始
+- **URL**: /api/tournaments/[temp-id]/ta/phases (POST `promote_phase1`)
+- **authRequired**: true (admin)
+- **手順**:
+  1. 28名予選完了
+  2. `promote_phase1` を送信 → 17〜24位の8名が Phase 1 へ抽出
+  3. Phase 1 ラウンドが開始されること
+  4. プレイヤー側で予選タイム編集が disabled になること（TC-312 既存の確認）
+  5. クリーンアップ
+- **期待結果**: Phase 1 開始でノックアウト枠が確定し、予選タイムロックが効く
+
+## TC-805: TA Phase 2 → 上位16名のノックアウト
+- **URL**: /api/tournaments/[temp-id]/ta/phases (POST `promote_phase2`)
+- **authRequired**: true (admin)
+- **手順**:
+  1. Phase 1 のラウンド結果を入力
+  2. `promote_phase2` を送信 → 1〜16位の枠がノックアウトに進む
+  3. 各プレイヤーが Phase 2 ラウンドのタイムを送信
+  4. 順位/勝ち上がりが正しく更新されること
+  5. クリーンアップ
+- **期待結果**: Phase 2 が正しく進行する
+
+## TC-806: TA Phase 3 → 決勝ラウンドとチャンピオン決定
+- **URL**: /api/tournaments/[temp-id]/ta/phases (POST `promote_phase3`) + /ta/finals
+- **authRequired**: true (admin)
+- **手順**:
+  1. Phase 2 完了
+  2. `promote_phase3` で決勝（最大16名）を開始
+  3. 決勝の各ラウンドのタイムを入力 → 上位者が勝ち上がる
+  4. 最終ラウンドでチャンピオンが決定し UI 表示されること
+  5. 「直前ラウンドを取り消す」ボタンで再入力できる（TC-314 と整合）
+  6. クリーンアップ
+- **期待結果**: TA決勝がフェーズ3で完結し、チャンピオン表示まで通る
+
+---
+
 ## E2Eテスト実行ガイド
 
 ### セッション管理（重要）
@@ -699,9 +876,30 @@
 - TC-304（観覧者メッセージ）も同様に `https` で認証なしHTMLを取得して確認
 
 ### スクリプト構成
-- `e2e/tc-all.js` — 全TCを1つのスクリプトで実行（セッション維持）
-- `e2e/tc-bm.js` — BM専用テスト（TC-322, TC-323）
-- `e2e/tc-mr.js` — MR専用テスト（TC-601〜TC-610）
+- `e2e/tc-all.js` — 全TCを1つのスクリプトで実行（セッション維持）。
+  自身のインライン TC（TC-001〜TC-324 の基本機能・回帰系）を実行後、
+  child process で `tc-bm.js` → `tc-mr.js` → `tc-gp.js` を逐次呼ぶ。
+- `e2e/tc-bm.js` — BM 専用（TC-322 訂正、TC-501〜TC-509）
+- `e2e/tc-mr.js` — MR 専用 + 共通系（TC-601〜TC-612）
+- `e2e/tc-gp.js` — GP 専用（TC-701〜TC-709）
+
+**TC ID 命名ルール**:
+- TC-0xx: 公開ページ表示・ナビゲーション
+- TC-1xx: 認証必須の基本機能（プレイヤーCRUD・ページネーション等）
+- TC-2xx: データ読み込みとレンダリング
+- TC-3xx: リグレッション・補助機能テスト（既存issue由来）
+- TC-4xx: **欠番**（旧「軽量フルワークフロー」を廃止し、フル版に集約）
+- TC-5xx: BMフルワークフロー（28名予選 + 決勝）
+- TC-6xx: MRフルワークフロー（28名予選 + 決勝）+ MR/GP共通の決勝/予選ロック検証
+- TC-7xx: GPフルワークフロー（28名予選 + 決勝）
+- TC-8xx: TT(TA)フルワークフロー（28名予選 + フェーズ1〜3 決勝）— **scenario only**
+
+**欠番 / リネーム履歴**:
+- 旧 TC-323 (`tc-bm.js` のBM決勝ブラケット生成) → **TC-503** にリネーム
+  （tc-all.js TC-323 と内容衝突していたため）
+- 旧 tc-all.js TC-323 (BM tie warning banner) → **TC-324** にリネーム
+- TC-323 は欠番（再利用しないこと）
+- TC-401〜TC-404 は廃止（軽量フルワークフローおよびGPダイアログUIチェック）
 
 ### ページ中身の確認ルール（重要）
 E2Eテストでは以下を必ず確認すること：

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -1,0 +1,581 @@
+/**
+ * Shared E2E helpers used by tc-bm.js, tc-mr.js, tc-gp.js (and optionally tc-all.js).
+ *
+ * Design notes:
+ * - Every API helper runs inside an admin-session Playwright page via page.evaluate
+ *   so the admin cookie is forwarded automatically.
+ * - Tournament cleanup uses the demote-to-draft → DELETE pattern because
+ *   DELETE /api/tournaments/:id only accepts status='draft'.
+ * - apiPutQualScore retries transient 5xx with backoff (D1 occasionally 503s under load).
+ * - 28-player setups return a `cleanup` closure so callers always do `try { ... } finally { cleanup() }`
+ *   without needing to know which IDs were created. The closure is also called
+ *   internally if setup throws partway through, so partial state never leaks.
+ */
+const { chromium } = require('playwright');
+
+const BASE = process.env.E2E_BASE_URL || 'https://smkc.bluemoon.works';
+const NAV_WAIT_MS = 8000;
+
+function makeResults() {
+  /* Each TC suite owns its own results array. */
+  return [];
+}
+
+function makeLog(results) {
+  return function log(tc, status, detail = '') {
+    const icon = status === 'PASS' ? '✅' : status === 'SKIP' ? '⏭️' : '❌';
+    console.log(`${icon} [${tc}] ${status}${detail ? ' — ' + detail : ''}`);
+    results.push({ tc, status, detail });
+  };
+}
+
+async function nav(page, path) {
+  let lastError;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      await page.goto(BASE + path, { waitUntil: 'domcontentloaded', timeout: 30000 });
+      await page.waitForTimeout(NAV_WAIT_MS);
+      return;
+    } catch (err) {
+      lastError = err;
+      if (attempt === 2) throw err;
+      await page.waitForTimeout(3000);
+    }
+  }
+  throw lastError;
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/* ───────── Player / Tournament CRUD ───────── */
+
+async function apiCreatePlayer(page, name, nickname) {
+  const res = await page.evaluate(async (d) => {
+    const r = await fetch('/api/players', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(d),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, { name, nickname, country: 'JP' });
+  const id = res.b?.data?.player?.id ?? null;
+  const password = res.b?.data?.temporaryPassword ?? null;
+  if (res.s !== 201 || !id) throw new Error(`Failed to create player ${nickname} (${res.s})`);
+  return { id, nickname, password };
+}
+
+async function apiCreateTournament(page, name, opts = {}) {
+  const res = await page.evaluate(async (d) => {
+    const r = await fetch('/api/tournaments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(d),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, { name, date: new Date().toISOString(), ...opts });
+  const id = res.b?.data?.id ?? null;
+  if (res.s !== 201 || !id) throw new Error(`Failed to create tournament (${res.s})`);
+  return id;
+}
+
+async function apiDeletePlayer(page, id) {
+  if (!id) return;
+  await page.evaluate(async (u) => { await fetch(u, { method: 'DELETE' }); },
+    `/api/players/${id}`).catch(() => {});
+}
+
+/** DELETE /api/tournaments/:id only accepts status='draft'.
+ *  Demote first, then DELETE. Both calls are best-effort. */
+async function apiDeleteTournament(page, id) {
+  if (!id) return;
+  await page.evaluate(async (u) => {
+    await fetch(u, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'draft' }),
+    });
+  }, `/api/tournaments/${id}`).catch(() => {});
+  await page.evaluate(async (u) => { await fetch(u, { method: 'DELETE' }); },
+    `/api/tournaments/${id}`).catch(() => {});
+}
+
+/* ───────── Snake-draft helpers ─────────
+ * 28 players (or fewer) into 4 groups (A/B/C/D × 7) using boustrophedon
+ * to keep top-seed clustering low. */
+
+const GROUP_LETTERS = ['A', 'B', 'C', 'D'];
+
+function snakeDraft28(playerIds) {
+  return playerIds.map((playerId, i) => {
+    const row = Math.floor(i / 4);
+    const col = row % 2 === 0 ? (i % 4) : (3 - (i % 4));
+    return { playerId, group: GROUP_LETTERS[col], seeding: i + 1 };
+  });
+}
+
+/* ───────── Player credentials login (separate browser context) ─────────
+ * Use a fresh non-persistent browser so the admin's persistent profile stays
+ * untouched. Caller must close the returned browser. */
+
+async function loginPlayerBrowser(nickname, password) {
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+  const page = await context.newPage();
+  await nav(page, '/auth/signin');
+  await page.locator('#nickname').fill(nickname);
+  await page.locator('#password').fill(password);
+  await page.getByRole('button', { name: /ログイン|Login/ }).click();
+  await page.waitForURL((u) => u.pathname === '/tournaments', { timeout: 15000 });
+  await page.waitForTimeout(1000);
+  return { browser, context, page };
+}
+
+/* ───────── Retry wrapper for transient API failures ─────────
+ * D1 occasionally returns 5xx under burst load. Retry idempotent operations
+ * (PUT score input is safe to retry — it sets a final state, not an increment).
+ * 2 retries with 1s/3s backoff = ~4s worst case before giving up. */
+
+async function withRetry(fn, { attempts = 3, label = 'op' } = {}) {
+  let lastError;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const result = await fn();
+      const status = result?.s;
+      /* Retry only on server-side transient failures (5xx) and 429.
+       * 4xx (client errors) are deterministic — bail immediately so the test
+       * surfaces the validation issue instead of looping. */
+      if (status && status >= 500) {
+        lastError = new Error(`${label}: server returned ${status}`);
+      } else if (status === 429) {
+        lastError = new Error(`${label}: rate limited (429)`);
+      } else {
+        return result;
+      }
+    } catch (err) {
+      lastError = err;
+    }
+    if (i < attempts - 1) {
+      const backoffMs = 1000 * Math.pow(3, i); // 1s, 3s
+      await new Promise((r) => setTimeout(r, backoffMs));
+    }
+  }
+  throw lastError;
+}
+
+/* ───────── BM helpers ───────── */
+
+async function apiSetupBmGroup(page, tournamentId, players) {
+  return page.evaluate(async ([url, body]) => {
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/bm`, { players }]);
+}
+
+async function apiFetchBm(page, tournamentId) {
+  return page.evaluate(async (u) => {
+    const r = await fetch(u);
+    const j = await r.json().catch(() => ({}));
+    return j.data || j;
+  }, `/api/tournaments/${tournamentId}/bm`);
+}
+
+async function apiPutBmQualScore(page, tournamentId, matchId, score1, score2) {
+  return withRetry(() => page.evaluate(async ([url, body]) => {
+    const r = await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/bm`, { matchId, score1, score2 }]),
+  { label: `BM qual PUT ${matchId}` });
+}
+
+async function apiSetBmFinalsScore(page, tournamentId, matchId, score1, score2) {
+  return withRetry(() => page.evaluate(async ([url, body]) => {
+    const r = await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/bm/finals`, { matchId, score1, score2 }]),
+  { label: `BM finals PUT ${matchId}` });
+}
+
+async function apiGenerateBmFinals(page, tournamentId, topN = 8) {
+  return withRetry(() => page.evaluate(async ([url, body]) => {
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/bm/finals`, { topN }]),
+  { label: `BM finals POST` });
+}
+
+async function apiFetchBmFinalsMatches(page, tournamentId) {
+  const json = await page.evaluate(async (u) => {
+    const r = await fetch(`${u}?ts=${Date.now()}`, { cache: 'no-store' });
+    return r.json().catch(() => ({}));
+  }, `/api/tournaments/${tournamentId}/bm/finals`);
+  /* BM uses 'grouped' GET style. Fall back to grouped arrays if `matches` is absent. */
+  const arr = json.matches || [
+    ...(json.winnersMatches || []),
+    ...(json.losersMatches || []),
+    ...(json.grandFinalMatches || []),
+  ];
+  return arr.slice().sort((a, b) => (a.matchNumber || 0) - (b.matchNumber || 0));
+}
+
+/** 28-player BM setup with built-in cleanup closure. Throws on failure
+ *  *after* invoking cleanup so partial data never leaks to production. */
+async function setupBm28PlayerFinals(adminPage, label, opts = {}) {
+  const stamp = Date.now();
+  const playerIds = [];
+  const nicknames = [];
+  let tournamentId = null;
+
+  const cleanup = async () => {
+    await apiDeleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await apiDeletePlayer(adminPage, id);
+  };
+
+  try {
+    for (let i = 1; i <= 28; i++) {
+      const p = await apiCreatePlayer(
+        adminPage,
+        `E2E BM ${label} P${i}`,
+        `e2e_bm${label}_${stamp}_${i}`,
+      );
+      playerIds.push(p.id);
+      nicknames.push(p.nickname);
+    }
+    tournamentId = await apiCreateTournament(adminPage, `E2E BM ${label} ${stamp}`, opts);
+    const setup = await apiSetupBmGroup(adminPage, tournamentId, snakeDraft28(playerIds));
+    if (setup.s !== 201) {
+      throw new Error(`BM 28-player setup failed (${setup.s}): ${JSON.stringify(setup.b).slice(0, 200)}`);
+    }
+
+    /* 7-player RR per group = 21 non-BYE matches × 4 groups = 84 PUTs.
+     * 3-1 satisfies sum=4 and yields a deterministic seed order in standings. */
+    const data = await apiFetchBm(adminPage, tournamentId);
+    const matches = (data.matches || []).filter((m) => !m.isBye && !m.completed);
+    for (const m of matches) {
+      const res = await apiPutBmQualScore(adminPage, tournamentId, m.id, 3, 1);
+      if (res.s !== 200) {
+        throw new Error(`BM qual put failed (${res.s}) match=${m.id}: ${JSON.stringify(res.b).slice(0, 200)}`);
+      }
+    }
+    return { tournamentId, playerIds, nicknames, cleanup };
+  } catch (err) {
+    await cleanup();
+    throw err;
+  }
+}
+
+/* ───────── MR helpers ───────── */
+
+async function apiSetupMrGroup(page, tournamentId, players) {
+  return page.evaluate(async ([url, body]) => {
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/mr`, { players }]);
+}
+
+async function apiFetchMr(page, tournamentId) {
+  return page.evaluate(async (u) => {
+    const r = await fetch(u);
+    const j = await r.json().catch(() => ({}));
+    return j.data || j;
+  }, `/api/tournaments/${tournamentId}/mr`);
+}
+
+async function apiPutMrQualScore(page, tournamentId, matchId, score1, score2) {
+  return withRetry(() => page.evaluate(async ([url, body]) => {
+    const r = await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/mr`, { matchId, score1, score2 }]),
+  { label: `MR qual PUT ${matchId}` });
+}
+
+async function apiGenerateMrFinals(page, tournamentId, topN = 8) {
+  return withRetry(() => page.evaluate(async ([url, body]) => {
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/mr/finals`, { topN }]),
+  { label: `MR finals POST` });
+}
+
+async function apiSetMrFinalsScore(page, tournamentId, matchId, score1, score2) {
+  return withRetry(() => page.evaluate(async ([url, body]) => {
+    const r = await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/mr/finals`, { matchId, score1, score2 }]),
+  { label: `MR finals PUT ${matchId}` });
+}
+
+async function apiFetchMrFinalsMatches(page, tournamentId) {
+  const json = await page.evaluate(async (u) => {
+    const r = await fetch(`${u}?ts=${Date.now()}`, { cache: 'no-store' });
+    return r.json().catch(() => ({}));
+  }, `/api/tournaments/${tournamentId}/mr/finals`);
+  return (json.matches || []).slice().sort((a, b) => (a.matchNumber || 0) - (b.matchNumber || 0));
+}
+
+async function setupMr28PlayerFinals(adminPage, label, opts = {}) {
+  const stamp = Date.now();
+  const playerIds = [];
+  const nicknames = [];
+  let tournamentId = null;
+
+  const cleanup = async () => {
+    await apiDeleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await apiDeletePlayer(adminPage, id);
+  };
+
+  try {
+    for (let i = 1; i <= 28; i++) {
+      const p = await apiCreatePlayer(
+        adminPage,
+        `E2E MR ${label} P${i}`,
+        `e2e_mr${label}_${stamp}_${i}`,
+      );
+      playerIds.push(p.id);
+      nicknames.push(p.nickname);
+    }
+    tournamentId = await apiCreateTournament(adminPage, `E2E MR ${label} ${stamp}`, opts);
+    const setup = await apiSetupMrGroup(adminPage, tournamentId, snakeDraft28(playerIds));
+    if (setup.s !== 201) {
+      throw new Error(`MR 28-player setup failed (${setup.s}): ${JSON.stringify(setup.b).slice(0, 200)}`);
+    }
+
+    const data = await apiFetchMr(adminPage, tournamentId);
+    const matches = (data.matches || []).filter((m) => !m.isBye && !m.completed);
+    for (const m of matches) {
+      const res = await apiPutMrQualScore(adminPage, tournamentId, m.id, 3, 1);
+      if (res.s !== 200) {
+        throw new Error(`MR qual put failed (${res.s}) match=${m.id}: ${JSON.stringify(res.b).slice(0, 200)}`);
+      }
+    }
+    return { tournamentId, playerIds, nicknames, cleanup };
+  } catch (err) {
+    await cleanup();
+    throw err;
+  }
+}
+
+/* ───────── GP helpers ─────────
+ * GP qualification PUT contract: { matchId, cup, races[5] } where each race is
+ * { course, position1, position2 } and positions ≠ each other (except both 0). */
+
+const TOTAL_GP_RACES = 5;
+
+/** P1 finishes 1st in every race (driver pts 9 × 5 = 45), P2 finishes 5th (0 × 5 = 0). */
+function makeRacesP1Wins() {
+  const races = [];
+  for (let i = 0; i < TOTAL_GP_RACES; i++) {
+    races.push({ course: `course${i + 1}`, position1: 1, position2: 5 });
+  }
+  return races;
+}
+
+/** P2 wins instead — used for mismatch test. */
+function makeRacesP2Wins() {
+  const races = [];
+  for (let i = 0; i < TOTAL_GP_RACES; i++) {
+    races.push({ course: `course${i + 1}`, position1: 5, position2: 1 });
+  }
+  return races;
+}
+
+async function apiSetupGpGroup(page, tournamentId, players) {
+  return page.evaluate(async ([url, body]) => {
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/gp`, { players }]);
+}
+
+async function apiFetchGp(page, tournamentId) {
+  return page.evaluate(async (u) => {
+    const r = await fetch(u);
+    const j = await r.json().catch(() => ({}));
+    return j.data || j;
+  }, `/api/tournaments/${tournamentId}/gp`);
+}
+
+async function apiPutGpQualScore(page, tournamentId, matchId, cup, races) {
+  return withRetry(() => page.evaluate(async ([url, body]) => {
+    const r = await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/gp`, { matchId, cup, races }]),
+  { label: `GP qual PUT ${matchId}` });
+}
+
+async function apiSetGpFinalsScore(page, tournamentId, matchId, score1, score2) {
+  return withRetry(() => page.evaluate(async ([url, body]) => {
+    const r = await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/gp/finals`, { matchId, score1, score2 }]),
+  { label: `GP finals PUT ${matchId}` });
+}
+
+async function apiGenerateGpFinals(page, tournamentId, topN = 8) {
+  return withRetry(() => page.evaluate(async ([url, body]) => {
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/gp/finals`, { topN }]),
+  { label: `GP finals POST` });
+}
+
+/** GP finals uses 'paginated' GET style: { data, meta, totalPages }.
+ *  Aggregate up to 5 pages of 50 entries (17 finals matches always fit in 1 page). */
+async function apiFetchGpFinalsMatches(page, tournamentId) {
+  const all = [];
+  for (let p = 1; p <= 5; p++) {
+    const json = await page.evaluate(async ([u, pp]) => {
+      const r = await fetch(`${u}?page=${pp}&limit=50&ts=${Date.now()}`, { cache: 'no-store' });
+      return r.json().catch(() => ({}));
+    }, [`/api/tournaments/${tournamentId}/gp/finals`, p]);
+    const data = json.data || [];
+    if (data.length === 0) break;
+    all.push(...data);
+    const totalPages = json.totalPages || 1;
+    if (p >= totalPages) break;
+  }
+  return all.slice().sort((a, b) => (a.matchNumber || 0) - (b.matchNumber || 0));
+}
+
+async function setupGp28PlayerFinals(adminPage, label, opts = {}) {
+  const stamp = Date.now();
+  const playerIds = [];
+  const nicknames = [];
+  let tournamentId = null;
+
+  const cleanup = async () => {
+    await apiDeleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await apiDeletePlayer(adminPage, id);
+  };
+
+  try {
+    for (let i = 1; i <= 28; i++) {
+      const p = await apiCreatePlayer(
+        adminPage,
+        `E2E GP ${label} P${i}`,
+        `e2e_gp${label}_${stamp}_${i}`,
+      );
+      playerIds.push(p.id);
+      nicknames.push(p.nickname);
+    }
+    tournamentId = await apiCreateTournament(adminPage, `E2E GP ${label} ${stamp}`, opts);
+    const setup = await apiSetupGpGroup(adminPage, tournamentId, snakeDraft28(playerIds));
+    if (setup.s !== 201) {
+      throw new Error(`GP 28-player setup failed (${setup.s}): ${JSON.stringify(setup.b).slice(0, 200)}`);
+    }
+
+    /* GP qualification matches each carry a pre-assigned cup. Use the assigned
+     * cup as-is in the PUT (the validator rejects cup mismatches per §7.4). */
+    const data = await apiFetchGp(adminPage, tournamentId);
+    const matches = (data.matches || []).filter((m) => !m.isBye && !m.completed);
+    for (const m of matches) {
+      if (!m.cup) continue;
+      const res = await apiPutGpQualScore(adminPage, tournamentId, m.id, m.cup, makeRacesP1Wins());
+      if (res.s !== 200) {
+        throw new Error(`GP qual put failed (${res.s}) match=${m.id}: ${JSON.stringify(res.b).slice(0, 200)}`);
+      }
+    }
+    return { tournamentId, playerIds, nicknames, cleanup };
+  } catch (err) {
+    await cleanup();
+    throw err;
+  }
+}
+
+module.exports = {
+  /* config */
+  BASE,
+  NAV_WAIT_MS,
+  TOTAL_GP_RACES,
+  GROUP_LETTERS,
+  /* logging / nav */
+  makeResults,
+  makeLog,
+  nav,
+  escapeRegex,
+  /* CRUD */
+  apiCreatePlayer,
+  apiCreateTournament,
+  apiDeletePlayer,
+  apiDeleteTournament,
+  /* draft */
+  snakeDraft28,
+  /* player browser */
+  loginPlayerBrowser,
+  /* retry */
+  withRetry,
+  /* BM */
+  apiSetupBmGroup,
+  apiFetchBm,
+  apiPutBmQualScore,
+  apiSetBmFinalsScore,
+  apiGenerateBmFinals,
+  apiFetchBmFinalsMatches,
+  setupBm28PlayerFinals,
+  /* MR */
+  apiSetupMrGroup,
+  apiFetchMr,
+  apiPutMrQualScore,
+  apiGenerateMrFinals,
+  apiSetMrFinalsScore,
+  apiFetchMrFinalsMatches,
+  setupMr28PlayerFinals,
+  /* GP */
+  makeRacesP1Wins,
+  makeRacesP2Wins,
+  apiSetupGpGroup,
+  apiFetchGp,
+  apiPutGpQualScore,
+  apiSetGpFinalsScore,
+  apiGenerateGpFinals,
+  apiFetchGpFinalsMatches,
+  setupGp28PlayerFinals,
+};

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -1360,87 +1360,8 @@ async function deletePlayer(p, id) {
   }
   log('TC-307', tc307 ? 'PASS' : 'FAIL');
 
-  // TC-401: MR group setup + standings verification
-  await nav(page, `/tournaments/${TID}/mr`);
-  t = await vis(page);
-  const mrHasGroups = t.includes('Group A') || t.includes('グループ A');
-  const mrHasStandings = mrHasGroups && (t.includes('MP') || t.includes('試合数'));
-  log('TC-401', mrHasGroups && mrHasStandings ? 'PASS' : 'FAIL',
-    !mrHasGroups ? 'No groups' : !mrHasStandings ? 'No standings' : '');
-
-  // TC-402: GP group setup + standings verification
-  await nav(page, `/tournaments/${TID}/gp`);
-  t = await vis(page);
-  const gpHasGroups = t.includes('Group A') || t.includes('グループ A');
-  const gpHasStandings = gpHasGroups && (t.includes('MP') || t.includes('試合数'));
-  log('TC-402', gpHasGroups && gpHasStandings ? 'PASS' : 'FAIL',
-    !gpHasGroups ? 'No groups' : !gpHasStandings ? 'No standings' : '');
-
-  // TC-403: GP admin dialog exposes manual total-score correction
-  await nav(page, `/tournaments/${TID}/gp`);
-  const gpMatchesTab = page.getByRole('tab', { name: /試合|Matches/ });
-  if (await gpMatchesTab.count() > 0) {
-    await gpMatchesTab.click();
-    await page.waitForTimeout(1000);
-  }
-  const gpEditButtons = page.locator('tbody button').filter({ hasText: /編集|Edit/ });
-  const gpEnterButtons = page.locator('tbody button').filter({ hasText: /結果入力|Enter Result/ });
-  const gpActionBtn = await gpEditButtons.count() > 0 ? gpEditButtons.first() : gpEnterButtons.first();
-  if (await gpActionBtn.count() > 0) {
-    await gpActionBtn.click();
-    await page.waitForTimeout(2000);
-    const dialogText = await page.locator('[role="dialog"]').last().innerText();
-    const hasManualScoreUi =
-      dialogText.includes('合計ポイントを手動修正') ||
-      dialogText.includes('Manual Total Score');
-    log('TC-403', hasManualScoreUi ? 'PASS' : 'FAIL');
-    await page.keyboard.press('Escape');
-    await page.waitForTimeout(1000);
-  } else {
-    log('TC-403', 'SKIP', 'No GP edit button');
-  }
-
-  // TC-404: GP admin dialog allows 8th-place input
-  await nav(page, `/tournaments/${TID}/gp`);
-  if (await gpMatchesTab.count() > 0) {
-    await gpMatchesTab.click();
-    await page.waitForTimeout(1000);
-  }
-  const gpActionBtnForPosition = await gpEditButtons.count() > 0 ? gpEditButtons.first() : gpEnterButtons.first();
-  if (await gpActionBtnForPosition.count() > 0) {
-    await gpActionBtnForPosition.click();
-    await page.waitForTimeout(2000);
-    const dialog = page.locator('[role="dialog"]').last();
-    if (await dialog.locator('[role="combobox"]').count() < 3) {
-      const cupSelect = dialog.locator('[role="combobox"]').first();
-      if (await cupSelect.count() > 0) {
-        await cupSelect.click();
-        await page.waitForTimeout(1000);
-        const firstCupOption = page.locator('[role="option"]').first();
-        if (await firstCupOption.count() > 0) {
-          await firstCupOption.click();
-          await page.waitForTimeout(1000);
-        }
-      }
-    }
-    const positionSelect = dialog.locator('[role="combobox"]').nth(2);
-    if (await positionSelect.count() > 0) {
-      await positionSelect.click();
-      await page.waitForTimeout(1000);
-      const hasEighthOption = await page.locator('[role="option"]').filter({ hasText: /8位|8th/ }).count();
-      log('TC-404', hasEighthOption > 0 ? 'PASS' : 'FAIL');
-      await page.keyboard.press('Escape');
-      await page.waitForTimeout(1000);
-      await page.keyboard.press('Escape');
-      await page.waitForTimeout(1000);
-    } else {
-      log('TC-404', 'SKIP', 'No GP position select');
-      await page.keyboard.press('Escape');
-      await page.waitForTimeout(1000);
-    }
-  } else {
-    log('TC-404', 'SKIP', 'No GP result button');
-  }
+  // TC-401/402/403/404 (旧「軽量フルワークフロー」と GP ダイアログUI checks) は廃止。
+  // 機能カバレッジは tc-bm.js / tc-mr.js / tc-gp.js の 28人フルワークフロー (TC-5xx/6xx/7xx) に集約。
 
   // TC-316: Tiebreaker warning suppressed at group setup (mp=0), shown after tie match
   // Regression test for #filterActiveTiedIds: at mp=0 all players share 0-0 scores,
@@ -1703,159 +1624,9 @@ async function deletePlayer(p, id) {
     }
   }
 
-  // TC-322: BM participant can correct a submitted score
-  // Creates a draft temp tournament (so cleanup remains allowed), submits a BM score
-  // as a player, then uses the completed-match correction UI to change 3-1 -> 2-2.
-  {
-    let tc322TournamentId = null;
-    let tc322Player1Id = null;
-    let tc322Player2Id = null;
-    let tc322PlayerBrowser = null;
-    try {
-      const stamp = Date.now();
-      const tc322P1Nick = `e2e_bmc1_${stamp}`;
-      const tc322P2Nick = `e2e_bmc2_${stamp}`;
+  // TC-322 (BM participant correction) は tc-bm.js が担当。tc-all.js 末尾の child process で実行される。
 
-      const p1 = await page.evaluate(async (d) => {
-        const r = await fetch('/api/players', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, { name: 'E2E BM Correct P1', nickname: tc322P1Nick, country: 'JP' });
-      tc322Player1Id = p1.b?.data?.player?.id ?? null;
-      const tc322Password = p1.b?.data?.temporaryPassword ?? null;
-
-      const p2 = await page.evaluate(async (d) => {
-        const r = await fetch('/api/players', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, { name: 'E2E BM Correct P2', nickname: tc322P2Nick, country: 'JP' });
-      tc322Player2Id = p2.b?.data?.player?.id ?? null;
-
-      if (p1.s !== 201 || p2.s !== 201 || !tc322Player1Id || !tc322Player2Id || !tc322Password) {
-        throw new Error('Failed to create BM correction players');
-      }
-
-      const tournament = await page.evaluate(async (d) => {
-        const r = await fetch('/api/tournaments', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, {
-        name: `E2E BM Correction ${stamp}`,
-        date: new Date().toISOString(),
-        dualReportEnabled: false,
-      });
-      tc322TournamentId = tournament.b?.data?.id ?? null;
-      if (tournament.s !== 201 || !tc322TournamentId) {
-        throw new Error('Failed to create BM correction tournament');
-      }
-
-      const setup = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [
-        `/api/tournaments/${tc322TournamentId}/bm`,
-        {
-          players: [
-            { playerId: tc322Player1Id, group: 'A' },
-            { playerId: tc322Player2Id, group: 'A' },
-          ],
-        },
-      ]);
-      if (setup.s !== 201) throw new Error(`BM setup failed (${setup.s})`);
-
-      const initialBm = await page.evaluate(async (u) => {
-        const r = await fetch(u);
-        const j = await r.json().catch(() => ({}));
-        return j.data || j;
-      }, `/api/tournaments/${tc322TournamentId}/bm`);
-      const match = (initialBm.matches || []).find(m => !m.isBye);
-      if (!match) throw new Error('No non-BYE BM match found');
-
-      const p1Label = match.player1.nickname;
-      const p2Label = match.player2.nickname;
-
-      tc322PlayerBrowser = await chromium.launch({ headless: false });
-      const playerContext = await tc322PlayerBrowser.newContext({ viewport: { width: 1280, height: 720 } });
-      const playerPage = await playerContext.newPage();
-
-      await nav(playerPage, '/auth/signin');
-      await playerPage.locator('#nickname').fill(tc322P1Nick);
-      await playerPage.locator('#password').fill(tc322Password);
-      await playerPage.getByRole('button', { name: /ログイン|Login/ }).click();
-      await playerPage.waitForURL((url) => url.pathname === '/tournaments', { timeout: 15000 });
-      await playerPage.waitForTimeout(1000);
-
-      await nav(playerPage, `/tournaments/${tc322TournamentId}/bm/participant`);
-
-      for (let i = 0; i < 3; i++) {
-        await playerPage.getByRole('button', { name: new RegExp(`${p1Label} \\+1`) }).click();
-      }
-      await playerPage.getByRole('button', { name: new RegExp(`${p2Label} \\+1`) }).click();
-
-      playerPage.once('dialog', async (dialog) => {
-        await dialog.accept();
-      });
-      await playerPage.getByRole('button', { name: /スコア送信|Submit Scores/ }).click();
-      await playerPage.waitForFunction(() => {
-        const text = document.body.innerText;
-        return text.includes('スコアを修正') || text.includes('Correct Score');
-      }, null, { timeout: 15000 });
-
-      await playerPage.getByRole('button', { name: /スコアを修正|Correct Score/ }).click();
-      await playerPage.getByRole('button', { name: new RegExp(`${p1Label} -1`) }).click();
-      await playerPage.getByRole('button', { name: new RegExp(`${p2Label} \\+1`) }).click();
-
-      playerPage.once('dialog', async (dialog) => {
-        await dialog.accept();
-      });
-      await playerPage.getByRole('button', { name: /修正を送信|Submit Correction/ }).click();
-      await playerPage.waitForTimeout(3000);
-
-      const correctedBm = await page.evaluate(async (u) => {
-        const r = await fetch(u);
-        const j = await r.json().catch(() => ({}));
-        return j.data || j;
-      }, `/api/tournaments/${tc322TournamentId}/bm`);
-      const correctedMatch = (correctedBm.matches || []).find(m => m.id === match.id);
-      const correctionPersisted =
-        correctedMatch?.completed === true &&
-        correctedMatch.score1 === 2 &&
-        correctedMatch.score2 === 2;
-
-      log('TC-322', correctionPersisted ? 'PASS' : 'FAIL',
-        correctionPersisted ? ''
-        : !correctedMatch ? 'Corrected match not found'
-        : `completed=${correctedMatch.completed} score=${correctedMatch.score1}-${correctedMatch.score2}`);
-    } catch (err) {
-      log('TC-322', 'FAIL', err instanceof Error ? err.message : 'BM correction flow failed');
-    } finally {
-      if (tc322PlayerBrowser) await tc322PlayerBrowser.close().catch(() => {});
-      if (tc322TournamentId) {
-        await deleteTournament(page, tc322TournamentId);
-      }
-      if (tc322Player1Id) {
-        await deletePlayer(page, tc322Player1Id);
-      }
-      if (tc322Player2Id) {
-        await deletePlayer(page, tc322Player2Id);
-      }
-    }
-  }
-
-  // TC-323: BM tie warning banner disappears after admin sets rankOverride
+  // TC-324: BM tie warning banner disappears after admin sets rankOverride
   // Creates 3 players, sets up BM qualification, submits all matches as 2-2 ties
   // to force identical standings, then verifies:
   //   (a) tie warning banner appears on the standings tab
@@ -1985,12 +1756,12 @@ async function deletePlayer(p, id) {
         await page.locator('text=Tied ranks detected').count();
       const hasBannerAfter = bannerAfter > 0;
 
-      log('TC-323', hasBannerBefore && !hasBannerAfter ? 'PASS' : 'FAIL',
+      log('TC-324', hasBannerBefore && !hasBannerAfter ? 'PASS' : 'FAIL',
         !hasBannerBefore ? 'Tie warning banner never appeared (expected tie from 2-2 draws)'
         : hasBannerAfter ? 'Tie warning banner still visible after setting rankOverride on N-1 players'
         : '');
     } catch (err) {
-      log('TC-323', 'FAIL', err instanceof Error ? err.message : 'BM tie warning flow failed');
+      log('TC-324', 'FAIL', err instanceof Error ? err.message : 'BM tie warning flow failed');
     } finally {
       if (tc323TournamentId) {
         await deleteTournament(page, tc323TournamentId);
@@ -2001,28 +1772,39 @@ async function deletePlayer(p, id) {
     }
   }
 
-  // ===== MR Tests (tc-mr.js) — run as child process =====
-  console.log('\n========== Running MR Tests ==========');
-  const { execSync } = require('child_process');
-  let mrFailed = false;
-  try {
-    // tc-mr.js runs its own browser instance; close ours first to avoid conflicts
-    await browser.close();
-    const mrOutput = execSync('node e2e/tc-mr.js', {
-      cwd: __dirname.replace(/\/e2e$/, ''),
+  // ===== Mode-specific child-process suites =====
+  // tc-bm.js / tc-mr.js / tc-gp.js each spawn their own Playwright browser, so we
+  // must close the persistent profile here first to release the lock. Run them
+  // sequentially (not in parallel) for the same reason.
+  //
+  // Use spawnSync + stdio: 'inherit' (instead of execSync which buffers and
+  // truncates at 1MB by default). The 28-player full workflows produce too
+  // much console output to safely buffer; inheriting stdio also gives the
+  // operator real-time visibility instead of waiting for the child to finish.
+  // We rely on the child's exit code (non-zero ⇒ failure) for pass/fail
+  // tracking, since the buffered "FAIL:" string parser can't see inherited output.
+  const { spawnSync } = require('child_process');
+  const projectRoot = __dirname.replace(/\/e2e$/, '');
+  await browser.close();
+
+  function runChildScript(label, script) {
+    console.log(`\n========== Running ${label} (${script}) ==========`);
+    const result = spawnSync('node', [script], {
+      cwd: projectRoot,
       env: { ...process.env, E2E_BASE_URL: BASE },
-      timeout: 600000,
-      encoding: 'utf-8',
+      timeout: 1800000, // 30 min: 28-player full workflows take several minutes each
+      stdio: 'inherit',
     });
-    console.log(mrOutput);
-    if (mrOutput.includes('FAIL:') && !mrOutput.includes('FAIL: 0')) {
-      mrFailed = true;
+    if (result.error) {
+      console.error(`[${label}] spawn error:`, result.error.message);
+      return true;
     }
-  } catch (err) {
-    console.log(err.stdout || '');
-    console.error(err.stderr || err.message);
-    mrFailed = true;
+    return result.status !== 0;
   }
+
+  const bmFailed = runChildScript('BM Tests', 'e2e/tc-bm.js');
+  const mrFailed = runChildScript('MR Tests', 'e2e/tc-mr.js');
+  const gpFailed = runChildScript('GP Tests', 'e2e/tc-gp.js');
 
   // ===== Summary =====
   console.log('\n========== SUMMARY (tc-all.js inline tests) ==========');
@@ -2031,7 +1813,9 @@ async function deletePlayer(p, id) {
   const sk = results.filter(r => r.s === 'SKIP').length;
   console.log(`PASS: ${p} | FAIL: ${f} | SKIP: ${sk} | Total: ${results.length}`);
   if (f > 0) results.filter(r => r.s === 'FAIL').forEach(r => console.log(`  ❌ [${r.tc}] ${r.d}`));
+  if (bmFailed) console.log('  ⚠️  BM tests (tc-bm.js) had failures — see output above');
   if (mrFailed) console.log('  ⚠️  MR tests (tc-mr.js) had failures — see output above');
+  if (gpFailed) console.log('  ⚠️  GP tests (tc-gp.js) had failures — see output above');
 
-  process.exit((f > 0 || mrFailed) ? 1 : 0);
+  process.exit((f > 0 || bmFailed || mrFailed || gpFailed) ? 1 : 0);
 })();

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -1,46 +1,154 @@
 /**
- * E2E BM focused tests.
+ * E2E BM (Battle Mode) tests.
  *
- * Uses Playwright persistent profile at /tmp/playwright-smkc-profile.
- * Admin session must already exist in the profile (Discord OAuth).
+ * Coverage:
+ *   TC-501  BM participant single-match submission (UI, 2 players)
+ *   TC-502  BM participant draw 2-2 (UI, 2 players)
+ *   TC-507  BM dual report — agreement → autoConfirmed (2 players)
+ *   TC-508  BM dual report — mismatch (2 players)
+ *   TC-509  BM dual report — previousReports panel (2 players)
+ *   TC-322  BM participant correction (UI, 2 players)
+ *   TC-503  28-player full qualification + finals bracket gen + first-to-5 routing
+ *   TC-504  28-player full + finals bracket reset
+ *   TC-505  28-player full + Grand Final → champion
+ *   TC-506  28-player full + Grand Final Reset Match (M17)
  *
- * Run: npm run e2e:bm  (from smkc-score-app/)
+ * Setup:
+ *   - Uses Playwright persistent profile at /tmp/playwright-smkc-profile.
+ *   - The profile must already hold a Discord OAuth admin session.
+ *   - Player-credential tests open separate non-persistent browser contexts so
+ *     the admin session is never disturbed.
+ *
+ * Cleanup (every test):
+ *   - 28-player setup helpers return a `cleanup` closure; callers always call
+ *     it in `finally`. The helpers also self-cleanup on partial failure so
+ *     production never leaks tournaments/players.
+ *
+ * Run: node e2e/tc-bm.js  (from smkc-score-app/)  or:  npm run e2e:bm
  */
 const { chromium } = require('playwright');
+const {
+  makeResults, makeLog, nav, escapeRegex,
+  apiCreatePlayer, apiCreateTournament, apiDeletePlayer, apiDeleteTournament,
+  apiSetupBmGroup, apiFetchBm, apiPutBmQualScore,
+  apiSetBmFinalsScore, apiGenerateBmFinals, apiFetchBmFinalsMatches,
+  setupBm28PlayerFinals, loginPlayerBrowser,
+} = require('./lib/common');
 
-const BASE = process.env.E2E_BASE_URL || 'https://smkc.bluemoon.works';
-const WAIT = 8000;
-const results = [];
+const results = makeResults();
+const log = makeLog(results);
 
-function log(tc, s, d = '') {
-  console.log(`${s === 'PASS' ? '✅' : s === 'SKIP' ? '⏭️' : '❌'} [${tc}] ${s}${d ? ' — ' + d : ''}`);
-  results.push({ tc, s, d });
-}
+/* ───────── TC-501: BM participant single-match submission (UI) ───────── */
+async function runTc501(adminPage) {
+  let tournamentId = null;
+  const playerIds = [];
+  let playerBrowser = null;
+  try {
+    const stamp = Date.now();
+    const p1 = await apiCreatePlayer(adminPage, 'E2E BM 501 P1', `e2e_bm501_p1_${stamp}`);
+    const p2 = await apiCreatePlayer(adminPage, 'E2E BM 501 P2', `e2e_bm501_p2_${stamp}`);
+    playerIds.push(p1.id, p2.id);
 
-async function nav(page, path) {
-  let lastError;
-  for (let attempt = 1; attempt <= 2; attempt++) {
-    try {
-      await page.goto(BASE + path, { waitUntil: 'domcontentloaded', timeout: 30000 });
-      await page.waitForTimeout(WAIT);
-      return;
-    } catch (err) {
-      lastError = err;
-      if (attempt === 2) throw err;
-      await page.waitForTimeout(3000);
+    tournamentId = await apiCreateTournament(adminPage, `E2E BM 501 ${stamp}`, { dualReportEnabled: false });
+    const setup = await apiSetupBmGroup(adminPage, tournamentId, [
+      { playerId: p1.id, group: 'A' },
+      { playerId: p2.id, group: 'A' },
+    ]);
+    if (setup.s !== 201) throw new Error(`BM setup failed (${setup.s})`);
+
+    const initial = await apiFetchBm(adminPage, tournamentId);
+    const match = (initial.matches || []).find((m) => !m.isBye);
+    if (!match) throw new Error('No non-BYE match found');
+
+    const ctx = await loginPlayerBrowser(p1.nickname, p1.password);
+    playerBrowser = ctx.browser;
+    await nav(ctx.page, `/tournaments/${tournamentId}/bm/participant`);
+
+    const p1Label = match.player1.nickname;
+    const p2Label = match.player2.nickname;
+    /* Increment via UI: P1 +3 then P2 +1 → 3-1 */
+    for (let i = 0; i < 3; i++) {
+      await ctx.page.getByRole('button', { name: new RegExp(`${escapeRegex(p1Label)} \\+1`) }).click();
     }
+    await ctx.page.getByRole('button', { name: new RegExp(`${escapeRegex(p2Label)} \\+1`) }).click();
+    ctx.page.once('dialog', (d) => d.accept());
+    await ctx.page.getByRole('button', { name: /スコア送信|Submit Scores/ }).click();
+    await ctx.page.waitForTimeout(3000);
+
+    const after = await apiFetchBm(adminPage, tournamentId);
+    const updated = (after.matches || []).find((m) => m.id === match.id);
+    const ok = updated?.completed === true && updated.score1 === 3 && updated.score2 === 1;
+    log('TC-501', ok ? 'PASS' : 'FAIL',
+      ok ? '' : `completed=${updated?.completed} score=${updated?.score1}-${updated?.score2}`);
+  } catch (err) {
+    log('TC-501', 'FAIL', err instanceof Error ? err.message : 'BM 501 failed');
+  } finally {
+    if (playerBrowser) await playerBrowser.close().catch(() => {});
+    await apiDeleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await apiDeletePlayer(adminPage, id);
   }
-  throw lastError;
 }
 
-function escapeRegex(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+/* ───────── TC-502: BM participant draw 2-2 (UI) ─────────
+ * Per §4.1, 2-2 is a valid score (each player scores 1 draw point). */
+async function runTc502(adminPage) {
+  let tournamentId = null;
+  const playerIds = [];
+  let playerBrowser = null;
+  try {
+    const stamp = Date.now();
+    const p1 = await apiCreatePlayer(adminPage, 'E2E BM 502 P1', `e2e_bm502_p1_${stamp}`);
+    const p2 = await apiCreatePlayer(adminPage, 'E2E BM 502 P2', `e2e_bm502_p2_${stamp}`);
+    playerIds.push(p1.id, p2.id);
+
+    tournamentId = await apiCreateTournament(adminPage, `E2E BM 502 ${stamp}`, { dualReportEnabled: false });
+    const setup = await apiSetupBmGroup(adminPage, tournamentId, [
+      { playerId: p1.id, group: 'A' },
+      { playerId: p2.id, group: 'A' },
+    ]);
+    if (setup.s !== 201) throw new Error(`BM setup failed (${setup.s})`);
+
+    const initial = await apiFetchBm(adminPage, tournamentId);
+    const match = (initial.matches || []).find((m) => !m.isBye);
+    if (!match) throw new Error('No non-BYE match found');
+
+    const ctx = await loginPlayerBrowser(p1.nickname, p1.password);
+    playerBrowser = ctx.browser;
+    await nav(ctx.page, `/tournaments/${tournamentId}/bm/participant`);
+
+    const p1Label = match.player1.nickname;
+    const p2Label = match.player2.nickname;
+    /* 2-2: alternate +1 P1, +1 P2 twice each */
+    for (let i = 0; i < 2; i++) {
+      await ctx.page.getByRole('button', { name: new RegExp(`${escapeRegex(p1Label)} \\+1`) }).click();
+      await ctx.page.getByRole('button', { name: new RegExp(`${escapeRegex(p2Label)} \\+1`) }).click();
+    }
+    const submitBtn = ctx.page.getByRole('button', { name: /スコア送信|Submit Scores/ });
+    const enabledBefore = await submitBtn.isEnabled();
+    ctx.page.once('dialog', (d) => d.accept());
+    await submitBtn.click();
+    await ctx.page.waitForTimeout(3000);
+
+    const after = await apiFetchBm(adminPage, tournamentId);
+    const updated = (after.matches || []).find((m) => m.id === match.id);
+    const ok = enabledBefore && updated?.completed === true && updated.score1 === 2 && updated.score2 === 2;
+    log('TC-502', ok ? 'PASS' : 'FAIL',
+      ok ? '' :
+      !enabledBefore ? 'Submit button disabled — 2-2 should be valid per §4.1'
+      : `completed=${updated?.completed} score=${updated?.score1}-${updated?.score2}`);
+  } catch (err) {
+    log('TC-502', 'FAIL', err instanceof Error ? err.message : 'BM 502 failed');
+  } finally {
+    if (playerBrowser) await playerBrowser.close().catch(() => {});
+    await apiDeleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await apiDeletePlayer(adminPage, id);
+  }
 }
 
+/* ───────── TC-322: BM participant correction (UI) ─────────
+ * Submit 3-1, then use the "Correct Score" UI to flip to 2-2 and confirm
+ * the change persists via admin-side API fetch. */
 async function runTc322(adminPage) {
-  // TC-322: BM participant can correct a submitted score.
-  // Creates a draft temp tournament (so cleanup remains allowed), submits a BM score
-  // as a player, then uses the completed-match correction UI to change 3-1 -> 2-2.
   let tournamentId = null;
   let player1Id = null;
   let player2Id = null;
@@ -51,88 +159,31 @@ async function runTc322(adminPage) {
     const player1Nick = `e2e_bmc1_${stamp}`;
     const player2Nick = `e2e_bmc2_${stamp}`;
 
-    const p1 = await adminPage.evaluate(async (d) => {
-      const r = await fetch('/api/players', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(d),
-      });
-      return { s: r.status, b: await r.json().catch(() => ({})) };
-    }, { name: 'E2E BM Correct P1', nickname: player1Nick, country: 'JP' });
-    player1Id = p1.b?.data?.player?.id ?? null;
-    const playerPassword = p1.b?.data?.temporaryPassword ?? null;
+    const p1 = await apiCreatePlayer(adminPage, 'E2E BM Correct P1', player1Nick);
+    const p2 = await apiCreatePlayer(adminPage, 'E2E BM Correct P2', player2Nick);
+    player1Id = p1.id;
+    player2Id = p2.id;
+    const playerPassword = p1.password;
+    if (!playerPassword) throw new Error('No temp password for player 1');
 
-    const p2 = await adminPage.evaluate(async (d) => {
-      const r = await fetch('/api/players', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(d),
-      });
-      return { s: r.status, b: await r.json().catch(() => ({})) };
-    }, { name: 'E2E BM Correct P2', nickname: player2Nick, country: 'JP' });
-    player2Id = p2.b?.data?.player?.id ?? null;
-
-    if (p1.s !== 201 || p2.s !== 201 || !player1Id || !player2Id || !playerPassword) {
-      throw new Error('Failed to create BM correction players');
-    }
-
-    const tournament = await adminPage.evaluate(async (d) => {
-      const r = await fetch('/api/tournaments', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(d),
-      });
-      return { s: r.status, b: await r.json().catch(() => ({})) };
-    }, {
-      name: `E2E BM Correction ${stamp}`,
-      date: new Date().toISOString(),
-      dualReportEnabled: false,
-    });
-    tournamentId = tournament.b?.data?.id ?? null;
-    if (tournament.s !== 201 || !tournamentId) {
-      throw new Error('Failed to create BM correction tournament');
-    }
-
-    const setup = await adminPage.evaluate(async ([url, data]) => {
-      const r = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-      return { s: r.status, b: await r.json().catch(() => ({})) };
-    }, [
-      `/api/tournaments/${tournamentId}/bm`,
-      {
-        players: [
-          { playerId: player1Id, group: 'A' },
-          { playerId: player2Id, group: 'A' },
-        ],
-      },
+    tournamentId = await apiCreateTournament(adminPage, `E2E BM Correction ${stamp}`,
+      { dualReportEnabled: false });
+    const setup = await apiSetupBmGroup(adminPage, tournamentId, [
+      { playerId: player1Id, group: 'A' },
+      { playerId: player2Id, group: 'A' },
     ]);
     if (setup.s !== 201) throw new Error(`BM setup failed (${setup.s})`);
 
-    const initialBm = await adminPage.evaluate(async (url) => {
-      const r = await fetch(url);
-      const j = await r.json().catch(() => ({}));
-      return j.data || j;
-    }, `/api/tournaments/${tournamentId}/bm`);
+    const initialBm = await apiFetchBm(adminPage, tournamentId);
     const match = (initialBm.matches || []).find((m) => !m.isBye);
     if (!match) throw new Error('No non-BYE BM match found');
 
     const p1Label = match.player1.nickname;
     const p2Label = match.player2.nickname;
 
-    playerBrowser = await chromium.launch({ headless: false });
-    const playerContext = await playerBrowser.newContext({ viewport: { width: 1280, height: 720 } });
-    const playerPage = await playerContext.newPage();
-
-    await nav(playerPage, '/auth/signin');
-    await playerPage.locator('#nickname').fill(player1Nick);
-    await playerPage.locator('#password').fill(playerPassword);
-    await playerPage.getByRole('button', { name: /ログイン|Login/ }).click();
-    await playerPage.waitForURL((url) => url.pathname === '/tournaments', { timeout: 15000 });
-    await playerPage.waitForTimeout(1000);
-
+    const ctx = await loginPlayerBrowser(player1Nick, playerPassword);
+    playerBrowser = ctx.browser;
+    const playerPage = ctx.page;
     await nav(playerPage, `/tournaments/${tournamentId}/bm/participant`);
 
     for (let i = 0; i < 3; i++) {
@@ -140,229 +191,491 @@ async function runTc322(adminPage) {
     }
     await playerPage.getByRole('button', { name: new RegExp(`${escapeRegex(p2Label)} \\+1`) }).click();
 
-    playerPage.once('dialog', async (dialog) => {
-      await dialog.accept();
-    });
+    playerPage.once('dialog', (d) => d.accept());
     await playerPage.getByRole('button', { name: /スコア送信|Submit Scores/ }).click();
+    /* Wait for correction affordance (= match completed and re-rendered). */
     await playerPage.waitForFunction(() => {
       const text = document.body.innerText;
       return text.includes('スコアを修正') || text.includes('Correct Score');
     }, null, { timeout: 15000 });
 
+    /* Open correction UI and flip to 2-2. */
     await playerPage.getByRole('button', { name: /スコアを修正|Correct Score/ }).click();
     await playerPage.getByRole('button', { name: new RegExp(`${escapeRegex(p1Label)} -1`) }).click();
     await playerPage.getByRole('button', { name: new RegExp(`${escapeRegex(p2Label)} \\+1`) }).click();
 
-    playerPage.once('dialog', async (dialog) => {
-      await dialog.accept();
-    });
+    playerPage.once('dialog', (d) => d.accept());
     await playerPage.getByRole('button', { name: /修正を送信|Submit Correction/ }).click();
     await playerPage.waitForTimeout(3000);
 
-    const correctedBm = await adminPage.evaluate(async (url) => {
-      const r = await fetch(url);
-      const j = await r.json().catch(() => ({}));
-      return j.data || j;
-    }, `/api/tournaments/${tournamentId}/bm`);
+    const correctedBm = await apiFetchBm(adminPage, tournamentId);
     const correctedMatch = (correctedBm.matches || []).find((m) => m.id === match.id);
-    const correctionPersisted =
+    const ok =
       correctedMatch?.completed === true &&
       correctedMatch.score1 === 2 &&
       correctedMatch.score2 === 2;
 
-    log('TC-322', correctionPersisted ? 'PASS' : 'FAIL',
-      correctionPersisted ? ''
-      : !correctedMatch ? 'Corrected match not found'
+    log('TC-322', ok ? 'PASS' : 'FAIL',
+      ok ? '' :
+      !correctedMatch ? 'Corrected match not found'
       : `completed=${correctedMatch.completed} score=${correctedMatch.score1}-${correctedMatch.score2}`);
   } catch (err) {
     log('TC-322', 'FAIL', err instanceof Error ? err.message : 'BM correction flow failed');
   } finally {
     if (playerBrowser) await playerBrowser.close().catch(() => {});
-    if (tournamentId) {
-      await adminPage.evaluate(async (url) => { await fetch(url, { method: 'DELETE' }); },
-        `/api/tournaments/${tournamentId}`).catch(() => {});
-    }
-    if (player1Id) {
-      await adminPage.evaluate(async (url) => { await fetch(url, { method: 'DELETE' }); },
-        `/api/players/${player1Id}`).catch(() => {});
-    }
-    if (player2Id) {
-      await adminPage.evaluate(async (url) => { await fetch(url, { method: 'DELETE' }); },
-        `/api/players/${player2Id}`).catch(() => {});
-    }
+    await apiDeleteTournament(adminPage, tournamentId);
+    await apiDeletePlayer(adminPage, player1Id);
+    await apiDeletePlayer(adminPage, player2Id);
   }
 }
 
-async function runTc323(adminPage) {
-  // TC-323: BM finals bracket generation and first-to-5 score progression.
-  // Creates a draft temp tournament with 8 BM qualifiers, generates the finals
-  // bracket through the UI, verifies 3-0 is rejected, then saves 5-0 and checks
-  // winner/loser routing.
-  let tournamentId = null;
-  const playerIds = [];
-
+/* ───────── TC-503: 28-player full + finals bracket gen + first-to-5 routing ─────────
+ * Validates: 84 quals succeed, top-8 bracket (17 matches), first-to-5 rejection
+ * of 3-0, 5-0 acceptance with M1 winner→M5 / loser→M8 routing. */
+async function runTc503(adminPage) {
+  let setup = null;
   try {
-    const stamp = Date.now();
-    for (let i = 1; i <= 8; i++) {
-      const player = await adminPage.evaluate(async (d) => {
-        const r = await fetch('/api/players', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, {
-        name: `E2E BM Final P${i}`,
-        nickname: `e2e_bmf_${stamp}_${i}`,
-        country: 'JP',
-      });
-      const playerId = player.b?.data?.player?.id ?? null;
-      if (player.s !== 201 || !playerId) {
-        throw new Error(`Failed to create BM finals player ${i}`);
-      }
-      playerIds.push(playerId);
-    }
+    setup = await setupBm28PlayerFinals(adminPage, '503');
 
-    const tournament = await adminPage.evaluate(async (d) => {
-      const r = await fetch('/api/tournaments', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(d),
-      });
-      return { s: r.status, b: await r.json().catch(() => ({})) };
-    }, {
-      name: `E2E BM Finals ${stamp}`,
-      date: new Date().toISOString(),
-      dualReportEnabled: false,
-    });
-    tournamentId = tournament.b?.data?.id ?? null;
-    if (tournament.s !== 201 || !tournamentId) {
-      throw new Error('Failed to create BM finals tournament');
-    }
+    const gen = await apiGenerateBmFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
 
-    const setup = await adminPage.evaluate(async ([url, ids]) => {
-      const r = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          players: ids.map((playerId, index) => ({
-            playerId,
-            group: 'A',
-            seeding: index + 1,
-          })),
-        }),
-      });
-      return { s: r.status, b: await r.json().catch(() => ({})) };
-    }, [`/api/tournaments/${tournamentId}/bm`, playerIds]);
-    if (setup.s !== 201) throw new Error(`BM setup failed (${setup.s})`);
+    const matches = await apiFetchBmFinalsMatches(adminPage, setup.tournamentId);
+    const m1 = matches.find((m) => m.matchNumber === 1);
+    if (!m1) throw new Error('Bracket missing match 1');
 
-    await nav(adminPage, `/tournaments/${tournamentId}/bm/finals`);
-    await adminPage.getByRole('button', { name: /Generate finals bracket/i }).click();
-    await adminPage.getByRole('button', { name: /生成 \(8 players\)|Generate \(8 players\)/ }).click();
-    await adminPage.waitForFunction(() => {
-      const text = document.body.innerText;
-      return text.includes('0 / 17') && (text.includes('M1') || text.includes('Match 1'));
-    }, null, { timeout: 20000 });
+    /* BM finals = best-of-9, first-to-5. 3-0 must be rejected. */
+    const reject = await apiSetBmFinalsScore(adminPage, setup.tournamentId, m1.id, 3, 0);
+    const firstToFiveRejected = reject.s === 400;
 
-    const generated = await adminPage.evaluate(async (url) => {
-      const r = await fetch(url);
-      return r.json().catch(() => ({}));
-    }, `/api/tournaments/${tournamentId}/bm/finals`);
-    const matches = generated.matches || [];
-    const match1 = matches.find((m) => m.matchNumber === 1);
-    if (!match1) throw new Error('Generated bracket is missing match 1');
+    /* 5-0 valid → routing into M5 (winner) and M8 (loser). */
+    const valid = await apiSetBmFinalsScore(adminPage, setup.tournamentId, m1.id, 5, 0);
+    if (valid.s !== 200) throw new Error(`Valid 5-0 put failed (${valid.s})`);
 
-    const invalidFirstToThree = await adminPage.evaluate(async ([url, matchId]) => {
-      const r = await fetch(url, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ matchId, score1: 3, score2: 0 }),
-      });
-      return { s: r.status, b: await r.json().catch(() => ({})) };
-    }, [`/api/tournaments/${tournamentId}/bm/finals`, match1.id]);
+    const after = await apiFetchBmFinalsMatches(adminPage, setup.tournamentId);
+    const updated = after.find((m) => m.id === m1.id);
+    const winnerTarget = after.find((m) => m.matchNumber === 5);
+    const loserTarget = after.find((m) => m.matchNumber === 8);
+    const bracketCount = after.length === 17;
+    const scoreSaved = updated?.completed === true && updated.score1 === 5 && updated.score2 === 0;
+    const winnerRouted = [winnerTarget?.player1Id, winnerTarget?.player2Id].includes(m1.player1Id);
+    const loserRouted = [loserTarget?.player1Id, loserTarget?.player2Id].includes(m1.player2Id);
 
-    await adminPage.locator(`[aria-label^="Match 1:"]`).first().click();
-    await adminPage.getByLabel(`${match1.player1.nickname} score`).fill('5');
-    await adminPage.getByLabel(`${match1.player2.nickname} score`).fill('0');
-    await adminPage.getByRole('button', { name: /スコア保存|Save Score/ }).click();
-
-    let updated = null;
-    const routingDeadline = Date.now() + 20000;
-    while (Date.now() < routingDeadline) {
-      updated = await adminPage.evaluate(async (url) => {
-        const r = await fetch(`${url}?ts=${Date.now()}`, { cache: 'no-store' });
-        return r.json().catch(() => ({}));
-      }, `/api/tournaments/${tournamentId}/bm/finals`);
-
-      const polledMatches = updated.matches || [];
-      const match = polledMatches.find((m) => m.id === match1.id);
-      const winnerTarget = polledMatches.find((m) => m.matchNumber === 5);
-      const loserTarget = polledMatches.find((m) => m.matchNumber === 8);
-      const scoreSaved = match?.completed === true && match.score1 === 5 && match.score2 === 0;
-      const winnerRouted = [winnerTarget?.player1Id, winnerTarget?.player2Id].includes(match1.player1Id);
-      const loserRouted = [loserTarget?.player1Id, loserTarget?.player2Id].includes(match1.player2Id);
-      if (scoreSaved && winnerRouted && loserRouted) break;
-
-      await adminPage.waitForTimeout(500);
-    }
-    const updatedMatches = updated.matches || [];
-    const updatedMatch1 = updatedMatches.find((m) => m.id === match1.id);
-    const winnerTarget = updatedMatches.find((m) => m.matchNumber === 5);
-    const loserTarget = updatedMatches.find((m) => m.matchNumber === 8);
-
-    const bracketGenerated =
-      updatedMatches.length === 17 &&
-      (updated.winnersMatches || []).length === 7 &&
-      (updated.losersMatches || []).length === 8 &&
-      (updated.grandFinalMatches || []).length === 2;
-    const firstToThreeRejected = invalidFirstToThree.s === 400;
-    const scoreSaved =
-      updatedMatch1?.completed === true &&
-      updatedMatch1.score1 === 5 &&
-      updatedMatch1.score2 === 0;
-    const winnerRouted = [winnerTarget?.player1Id, winnerTarget?.player2Id].includes(match1.player1Id);
-    const loserRouted = [loserTarget?.player1Id, loserTarget?.player2Id].includes(match1.player2Id);
-    const routed = winnerRouted && loserRouted;
-
-    log('TC-323',
-      bracketGenerated && firstToThreeRejected && scoreSaved && routed ? 'PASS' : 'FAIL',
-      !bracketGenerated ? `Unexpected bracket counts: matches=${updatedMatches.length} winners=${(updated.winnersMatches || []).length} losers=${(updated.losersMatches || []).length} gf=${(updated.grandFinalMatches || []).length}`
-      : !firstToThreeRejected ? `3-0 was not rejected (${invalidFirstToThree.s})`
-      : !scoreSaved ? `Score not saved: ${updatedMatch1?.score1}-${updatedMatch1?.score2} completed=${updatedMatch1?.completed}`
-      : !routed ? `Routing mismatch: m1=${match1.player1Id}/${match1.player2Id} m5=${winnerTarget?.player1Id}/${winnerTarget?.player2Id} m8=${loserTarget?.player1Id}/${loserTarget?.player2Id}`
+    const ok = bracketCount && firstToFiveRejected && scoreSaved && winnerRouted && loserRouted;
+    log('TC-503', ok ? 'PASS' : 'FAIL',
+      !bracketCount ? `bracket size=${after.length} (expected 17)`
+      : !firstToFiveRejected ? `3-0 not rejected (status=${reject.s})`
+      : !scoreSaved ? `score not saved: ${updated?.score1}-${updated?.score2} completed=${updated?.completed}`
+      : !winnerRouted || !loserRouted ? `routing mismatch w=${winnerRouted} l=${loserRouted}`
       : '');
   } catch (err) {
-    log('TC-323', 'FAIL', err instanceof Error ? err.message : 'BM finals flow failed');
+    log('TC-503', 'FAIL', err instanceof Error ? err.message : 'BM 503 failed');
   } finally {
-    if (tournamentId) {
-      await adminPage.evaluate(async (url) => { await fetch(url, { method: 'DELETE' }); },
-        `/api/tournaments/${tournamentId}`).catch(() => {});
-    }
-    for (const playerId of playerIds) {
-      await adminPage.evaluate(async (url) => { await fetch(url, { method: 'DELETE' }); },
-        `/api/players/${playerId}`).catch(() => {});
-    }
+    if (setup) await setup.cleanup();
   }
 }
 
-(async () => {
-  const browser = await chromium.launchPersistentContext(
-    '/tmp/playwright-smkc-profile',
-    { headless: false, viewport: { width: 1280, height: 720 } }
-  );
-  const page = browser.pages()[0] || await browser.newPage();
+/* ───────── TC-504: BM finals bracket reset (28-player setup) ─────────
+ * Re-POST to /finals (same endpoint UI's Reset button calls) regenerates
+ * the bracket with all matches pending. */
+async function runTc504(adminPage) {
+  let setup = null;
+  try {
+    setup = await setupBm28PlayerFinals(adminPage, '504');
 
-  await nav(page, '/');
-  await runTc322(page);
-  await runTc323(page);
+    const gen = await apiGenerateBmFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
 
-  console.log('\n========== SUMMARY ==========');
-  const p = results.filter((r) => r.s === 'PASS').length;
-  const f = results.filter((r) => r.s === 'FAIL').length;
-  const sk = results.filter((r) => r.s === 'SKIP').length;
-  console.log(`PASS: ${p} | FAIL: ${f} | SKIP: ${sk} | Total: ${results.length}`);
-  if (f > 0) results.filter((r) => r.s === 'FAIL').forEach((r) => console.log(`  ❌ [${r.tc}] ${r.d}`));
+    const before = await apiFetchBmFinalsMatches(adminPage, setup.tournamentId);
+    const m1 = before.find((m) => m.matchNumber === 1);
+    if (!m1) throw new Error('Match 1 missing');
+    const score = await apiSetBmFinalsScore(adminPage, setup.tournamentId, m1.id, 5, 0);
+    if (score.s !== 200) throw new Error(`Score put failed (${score.s})`);
 
-  await browser.close();
-  process.exit(f > 0 ? 1 : 0);
-})();
+    const completedBefore = (await apiFetchBmFinalsMatches(adminPage, setup.tournamentId))
+      .filter((m) => m.completed).length;
+    if (completedBefore < 1) throw new Error('Pre-reset score not persisted');
+
+    const reset = await apiGenerateBmFinals(adminPage, setup.tournamentId, 8);
+    if (reset.s !== 200 && reset.s !== 201) throw new Error(`Bracket reset failed (${reset.s})`);
+
+    const after = await apiFetchBmFinalsMatches(adminPage, setup.tournamentId);
+    const completedAfter = after.filter((m) => m.completed).length;
+    const ok = completedBefore >= 1 && completedAfter === 0 && after.length === 17;
+    log('TC-504', ok ? 'PASS' : 'FAIL',
+      ok ? '' : `before=${completedBefore} after=${completedAfter} total=${after.length}`);
+  } catch (err) {
+    log('TC-504', 'FAIL', err instanceof Error ? err.message : 'BM 504 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-505: BM Grand Final → champion (28-player full) ─────────
+ * Drives M1..M16 with player1 sweeping 5-0 each so seeds propagate
+ * deterministically. Winners-side champion takes the GF; the champion
+ * banner on /bm/finals must show the expected nickname. */
+async function runTc505(adminPage) {
+  let setup = null;
+  try {
+    setup = await setupBm28PlayerFinals(adminPage, '505');
+    const { tournamentId, playerIds, nicknames } = setup;
+
+    const gen = await apiGenerateBmFinals(adminPage, tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    for (let mn = 1; mn <= 16; mn++) {
+      const matches = await apiFetchBmFinalsMatches(adminPage, tournamentId);
+      const match = matches.find((m) => m.matchNumber === mn);
+      if (!match || !match.player1Id || !match.player2Id) {
+        throw new Error(`Match ${mn} not ready (p1=${match?.player1Id} p2=${match?.player2Id})`);
+      }
+      const res = await apiSetBmFinalsScore(adminPage, tournamentId, match.id, 5, 0);
+      if (res.s !== 200) throw new Error(`Match ${mn} put failed (${res.s})`);
+    }
+
+    const matches = await apiFetchBmFinalsMatches(adminPage, tournamentId);
+    const m16 = matches.find((m) => m.matchNumber === 16);
+    const expectedChampionId = m16?.player1Id;
+    if (!expectedChampionId) throw new Error('GF (M16) missing player1');
+    const championNickname = nicknames[playerIds.indexOf(expectedChampionId)];
+
+    await nav(adminPage, `/tournaments/${tournamentId}/bm/finals`);
+    const pageText = await adminPage.locator('body').innerText();
+    const championShown = pageText.includes(championNickname) &&
+      (pageText.includes('Champion') || pageText.includes('チャンピオン') || pageText.includes('優勝'));
+    const m16Ok = m16.completed === true && m16.score1 === 5 && m16.score2 === 0;
+
+    log('TC-505', m16Ok && championShown ? 'PASS' : 'FAIL',
+      !m16Ok ? `M16 not completed: score=${m16?.score1}-${m16?.score2}`
+      : !championShown ? `Champion banner missing nickname ${championNickname}`
+      : '');
+  } catch (err) {
+    log('TC-505', 'FAIL', err instanceof Error ? err.message : 'BM 505 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-506: BM Grand Final Reset Match (M17) ─────────
+ * If the L-side champion wins the GF, M17 is generated. Force this by
+ * scoring M16 0-5. */
+async function runTc506(adminPage) {
+  let setup = null;
+  try {
+    setup = await setupBm28PlayerFinals(adminPage, '506');
+    const { tournamentId } = setup;
+
+    const gen = await apiGenerateBmFinals(adminPage, tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    /* M1..M15: player1 wins 5-0 */
+    for (let mn = 1; mn <= 15; mn++) {
+      const matches = await apiFetchBmFinalsMatches(adminPage, tournamentId);
+      const match = matches.find((m) => m.matchNumber === mn);
+      if (!match || !match.player1Id || !match.player2Id) throw new Error(`Match ${mn} not ready`);
+      const res = await apiSetBmFinalsScore(adminPage, tournamentId, match.id, 5, 0);
+      if (res.s !== 200) throw new Error(`Match ${mn} put failed (${res.s})`);
+    }
+
+    /* M16: P2 (L-side champion) wins 0-5 → triggers M17 */
+    let matches = await apiFetchBmFinalsMatches(adminPage, tournamentId);
+    const m16 = matches.find((m) => m.matchNumber === 16);
+    if (!m16 || !m16.player1Id || !m16.player2Id) throw new Error('M16 not ready');
+    const expectedResetChampionId = m16.player2Id;
+    const m16Res = await apiSetBmFinalsScore(adminPage, tournamentId, m16.id, 0, 5);
+    if (m16Res.s !== 200) throw new Error(`M16 put failed (${m16Res.s})`);
+
+    matches = await apiFetchBmFinalsMatches(adminPage, tournamentId);
+    const m17 = matches.find((m) => m.matchNumber === 17);
+    if (!m17) throw new Error('M17 not generated');
+    const m17Populated = !!m17.player1Id && !!m17.player2Id;
+
+    /* Play M17. The L-side champion's slot may be P1 or P2 depending on routing. */
+    const m17ScoreP1Wins = m17.player1Id === expectedResetChampionId;
+    const m17Res = await apiSetBmFinalsScore(adminPage, tournamentId, m17.id,
+      m17ScoreP1Wins ? 5 : 0,
+      m17ScoreP1Wins ? 0 : 5);
+    if (m17Res.s !== 200) throw new Error(`M17 put failed (${m17Res.s})`);
+
+    const finalMatches = await apiFetchBmFinalsMatches(adminPage, tournamentId);
+    const finalM17 = finalMatches.find((m) => m.matchNumber === 17);
+    const m17Completed = finalM17?.completed === true;
+
+    log('TC-506', m17Populated && m17Completed ? 'PASS' : 'FAIL',
+      !m17Populated ? `M17 not populated p1=${m17.player1Id} p2=${m17.player2Id}`
+      : !m17Completed ? 'M17 not completed'
+      : '');
+  } catch (err) {
+    log('TC-506', 'FAIL', err instanceof Error ? err.message : 'BM 506 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-507: BM dual report — agreement → autoConfirmed ───────── */
+async function runTc507(adminPage) {
+  let tournamentId = null;
+  const playerIds = [];
+  const browsers = [];
+  try {
+    const stamp = Date.now();
+    const p1 = await apiCreatePlayer(adminPage, 'E2E BM 507 P1', `e2e_bm507_p1_${stamp}`);
+    const p2 = await apiCreatePlayer(adminPage, 'E2E BM 507 P2', `e2e_bm507_p2_${stamp}`);
+    playerIds.push(p1.id, p2.id);
+
+    tournamentId = await apiCreateTournament(adminPage, `E2E BM 507 ${stamp}`, { dualReportEnabled: true });
+    const setup = await apiSetupBmGroup(adminPage, tournamentId, [
+      { playerId: p1.id, group: 'A' },
+      { playerId: p2.id, group: 'A' },
+    ]);
+    if (setup.s !== 201) throw new Error(`BM setup failed (${setup.s})`);
+
+    const data = await apiFetchBm(adminPage, tournamentId);
+    const match = (data.matches || []).find((m) => !m.isBye);
+    if (!match) throw new Error('No non-BYE match');
+
+    /* P1 reports 3-1 → response should include waitingFor=player2 */
+    const ctx1 = await loginPlayerBrowser(p1.nickname, p1.password);
+    browsers.push(ctx1.browser);
+    const r1 = await ctx1.page.evaluate(async ([u, body]) => {
+      const r = await fetch(u, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [
+      `/api/tournaments/${tournamentId}/bm/match/${match.id}/report`,
+      { reportingPlayer: 1, score1: 3, score2: 1 },
+    ]);
+    const r1WaitingForP2 = r1.s === 200 &&
+      (r1.b?.data?.waitingFor === 'player2' || r1.b?.waitingFor === 'player2');
+
+    const mid = await apiFetchBm(adminPage, tournamentId);
+    const midMatch = (mid.matches || []).find((m) => m.id === match.id);
+    const midOk = midMatch?.completed === false &&
+      midMatch.player1ReportedScore1 === 3 &&
+      midMatch.player1ReportedScore2 === 1;
+
+    /* P2 reports identical 3-1 → autoConfirmed */
+    const ctx2 = await loginPlayerBrowser(p2.nickname, p2.password);
+    browsers.push(ctx2.browser);
+    const r2 = await ctx2.page.evaluate(async ([u, body]) => {
+      const r = await fetch(u, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [
+      `/api/tournaments/${tournamentId}/bm/match/${match.id}/report`,
+      { reportingPlayer: 2, score1: 3, score2: 1 },
+    ]);
+    const autoConfirmed = r2.s === 200 &&
+      (r2.b?.data?.autoConfirmed === true || r2.b?.autoConfirmed === true);
+
+    const finalData = await apiFetchBm(adminPage, tournamentId);
+    const finalMatch = (finalData.matches || []).find((m) => m.id === match.id);
+    const persisted = finalMatch?.completed === true &&
+      finalMatch.score1 === 3 && finalMatch.score2 === 1;
+
+    const ok = r1WaitingForP2 && midOk && autoConfirmed && persisted;
+    log('TC-507', ok ? 'PASS' : 'FAIL',
+      !r1WaitingForP2 ? `P1 missing waitingFor (status=${r1.s})`
+      : !midOk ? `mid state wrong: completed=${midMatch?.completed} reportedP1=${midMatch?.player1ReportedScore1}-${midMatch?.player1ReportedScore2}`
+      : !autoConfirmed ? `P2 missing autoConfirmed (status=${r2.s})`
+      : !persisted ? `final not persisted: ${finalMatch?.score1}-${finalMatch?.score2}`
+      : '');
+  } catch (err) {
+    log('TC-507', 'FAIL', err instanceof Error ? err.message : 'BM 507 failed');
+  } finally {
+    for (const b of browsers) await b.close().catch(() => {});
+    await apiDeleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await apiDeletePlayer(adminPage, id);
+  }
+}
+
+/* ───────── TC-508: BM dual report — mismatch ─────────
+ * P1 reports 3-1, P2 reports 1-3 → mismatch flag, match stays incomplete.
+ * Admin then resolves via PUT /api/tournaments/:id/bm. */
+async function runTc508(adminPage) {
+  let tournamentId = null;
+  const playerIds = [];
+  const browsers = [];
+  try {
+    const stamp = Date.now();
+    const p1 = await apiCreatePlayer(adminPage, 'E2E BM 508 P1', `e2e_bm508_p1_${stamp}`);
+    const p2 = await apiCreatePlayer(adminPage, 'E2E BM 508 P2', `e2e_bm508_p2_${stamp}`);
+    playerIds.push(p1.id, p2.id);
+
+    tournamentId = await apiCreateTournament(adminPage, `E2E BM 508 ${stamp}`, { dualReportEnabled: true });
+    const setup = await apiSetupBmGroup(adminPage, tournamentId, [
+      { playerId: p1.id, group: 'A' },
+      { playerId: p2.id, group: 'A' },
+    ]);
+    if (setup.s !== 201) throw new Error(`BM setup failed (${setup.s})`);
+
+    const data = await apiFetchBm(adminPage, tournamentId);
+    const match = (data.matches || []).find((m) => !m.isBye);
+    if (!match) throw new Error('No non-BYE match');
+
+    const ctx1 = await loginPlayerBrowser(p1.nickname, p1.password);
+    browsers.push(ctx1.browser);
+    await ctx1.page.evaluate(async ([u, body]) => {
+      await fetch(u, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }, [
+      `/api/tournaments/${tournamentId}/bm/match/${match.id}/report`,
+      { reportingPlayer: 1, score1: 3, score2: 1 },
+    ]);
+
+    const ctx2 = await loginPlayerBrowser(p2.nickname, p2.password);
+    browsers.push(ctx2.browser);
+    /* P2 disagrees: 1-3 instead of 3-1 → mismatch */
+    const r2 = await ctx2.page.evaluate(async ([u, body]) => {
+      const r = await fetch(u, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [
+      `/api/tournaments/${tournamentId}/bm/match/${match.id}/report`,
+      { reportingPlayer: 2, score1: 1, score2: 3 },
+    ]);
+    const mismatchFlag = r2.s === 200 &&
+      (r2.b?.data?.mismatch === true || r2.b?.mismatch === true);
+
+    const mid = await apiFetchBm(adminPage, tournamentId);
+    const midMatch = (mid.matches || []).find((m) => m.id === match.id);
+    const stillIncomplete = midMatch?.completed === false;
+
+    /* Admin overrides via qualification PUT */
+    const adminPut = await apiPutBmQualScore(adminPage, tournamentId, match.id, 3, 1);
+    const finalData = await apiFetchBm(adminPage, tournamentId);
+    const finalMatch = (finalData.matches || []).find((m) => m.id === match.id);
+    const adminConfirmed = adminPut.s === 200 && finalMatch?.completed === true;
+
+    const ok = mismatchFlag && stillIncomplete && adminConfirmed;
+    log('TC-508', ok ? 'PASS' : 'FAIL',
+      !mismatchFlag ? `mismatch flag missing (status=${r2.s})`
+      : !stillIncomplete ? 'match auto-completed despite mismatch'
+      : !adminConfirmed ? `admin PUT failed (${adminPut.s}) or not completed`
+      : '');
+  } catch (err) {
+    log('TC-508', 'FAIL', err instanceof Error ? err.message : 'BM 508 failed');
+  } finally {
+    for (const b of browsers) await b.close().catch(() => {});
+    await apiDeleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await apiDeletePlayer(adminPage, id);
+  }
+}
+
+/* ───────── TC-509: BM dual report — previousReports panel ─────────
+ * After P1 reports, P2 visiting /bm/participant should see P1's submission
+ * in a "Previous Reports" / "過去の報告" / "既に報告" section. */
+async function runTc509(adminPage) {
+  let tournamentId = null;
+  const playerIds = [];
+  const browsers = [];
+  try {
+    const stamp = Date.now();
+    const p1 = await apiCreatePlayer(adminPage, 'E2E BM 509 P1', `e2e_bm509_p1_${stamp}`);
+    const p2 = await apiCreatePlayer(adminPage, 'E2E BM 509 P2', `e2e_bm509_p2_${stamp}`);
+    playerIds.push(p1.id, p2.id);
+
+    tournamentId = await apiCreateTournament(adminPage, `E2E BM 509 ${stamp}`, { dualReportEnabled: true });
+    const setup = await apiSetupBmGroup(adminPage, tournamentId, [
+      { playerId: p1.id, group: 'A' },
+      { playerId: p2.id, group: 'A' },
+    ]);
+    if (setup.s !== 201) throw new Error(`BM setup failed (${setup.s})`);
+
+    const data = await apiFetchBm(adminPage, tournamentId);
+    const match = (data.matches || []).find((m) => !m.isBye);
+    if (!match) throw new Error('No non-BYE match');
+
+    /* P1 reports first */
+    const ctx1 = await loginPlayerBrowser(p1.nickname, p1.password);
+    browsers.push(ctx1.browser);
+    await ctx1.page.evaluate(async ([u, body]) => {
+      await fetch(u, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }, [
+      `/api/tournaments/${tournamentId}/bm/match/${match.id}/report`,
+      { reportingPlayer: 1, score1: 3, score2: 1 },
+    ]);
+
+    /* P2 opens participant page and should see P1's report. */
+    const ctx2 = await loginPlayerBrowser(p2.nickname, p2.password);
+    browsers.push(ctx2.browser);
+    await nav(ctx2.page, `/tournaments/${tournamentId}/bm/participant`);
+    const pageText = await ctx2.page.locator('body').innerText();
+
+    /* Either an English or Japanese label may appear; accept the common variants. */
+    const labelShown = pageText.includes('Previous Reports') ||
+      pageText.includes('過去の報告') ||
+      pageText.includes('既に報告');
+    const scoreShown = /3\s*[-−]\s*1/.test(pageText);
+
+    log('TC-509', labelShown && scoreShown ? 'PASS' : 'FAIL',
+      !labelShown ? 'Previous Reports section not found in page text'
+      : !scoreShown ? `P1 report (3-1) not visible — page snippet: ${pageText.slice(0, 200)}`
+      : '');
+  } catch (err) {
+    log('TC-509', 'FAIL', err instanceof Error ? err.message : 'BM 509 failed');
+  } finally {
+    for (const b of browsers) await b.close().catch(() => {});
+    await apiDeleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await apiDeletePlayer(adminPage, id);
+  }
+}
+
+module.exports = {
+  runTc501, runTc502, runTc322, runTc503, runTc504, runTc505, runTc506,
+  runTc507, runTc508, runTc509,
+};
+
+if (require.main === module) {
+  (async () => {
+    const browser = await chromium.launchPersistentContext(
+      '/tmp/playwright-smkc-profile',
+      { headless: false, viewport: { width: 1280, height: 720 } },
+    );
+    const page = browser.pages()[0] || await browser.newPage();
+
+    await nav(page, '/');
+
+    /* Light single-match tests first (fast feedback) */
+    await runTc501(page);
+    await runTc502(page);
+    await runTc507(page);
+    await runTc508(page);
+    await runTc509(page);
+    await runTc322(page);
+
+    /* Heavy 28-player full-workflow tests last */
+    await runTc503(page);
+    await runTc504(page);
+    await runTc505(page);
+    await runTc506(page);
+
+    console.log('\n========== BM TEST SUMMARY ==========');
+    const p = results.filter((r) => r.status === 'PASS').length;
+    const f = results.filter((r) => r.status === 'FAIL').length;
+    const sk = results.filter((r) => r.status === 'SKIP').length;
+    console.log(`PASS: ${p} | FAIL: ${f} | SKIP: ${sk} | Total: ${results.length}`);
+    if (f > 0) results.filter((r) => r.status === 'FAIL')
+      .forEach((r) => console.log(`  ❌ [${r.tc}] ${r.detail}`));
+
+    await browser.close();
+    process.exit(f > 0 ? 1 : 0);
+  })();
+}

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -1,0 +1,522 @@
+/**
+ * E2E GP (Grand Prix) tests.
+ *
+ * Coverage:
+ *   TC-701  28-player full qualification (4 groups × 7, snake-draft)
+ *   TC-702  GP player login + participant 5-race submission
+ *   TC-703  28-player full + finals bracket gen + first race score (routing)
+ *   TC-704  GP finals bracket reset
+ *   TC-705  GP Grand Final → champion
+ *   TC-706  GP Grand Final Reset Match (M17)
+ *   TC-707  GP dual report — agreement → autoConfirmed
+ *   TC-708  GP dual report — mismatch
+ *   TC-709  GP finals admin-only enforcement (403)
+ *
+ * Setup:
+ *   - Uses Playwright persistent profile at /tmp/playwright-smkc-profile.
+ *   - Admin Discord OAuth session must already exist in the profile.
+ *
+ * Run: node e2e/tc-gp.js  (from smkc-score-app/)  or:  npm run e2e:gp
+ */
+const { chromium } = require('playwright');
+const {
+  makeResults, makeLog, nav,
+  apiCreatePlayer, apiCreateTournament, apiDeletePlayer, apiDeleteTournament,
+  apiSetupGpGroup, apiFetchGp, apiPutGpQualScore,
+  apiSetGpFinalsScore, apiGenerateGpFinals, apiFetchGpFinalsMatches,
+  setupGp28PlayerFinals, makeRacesP1Wins, makeRacesP2Wins,
+  loginPlayerBrowser,
+} = require('./lib/common');
+
+const results = makeResults();
+const log = makeLog(results);
+
+/* ───────── TC-701: 28-player full qualification ───────── */
+async function runTc701(adminPage) {
+  let setup = null;
+  try {
+    setup = await setupGp28PlayerFinals(adminPage, '701');
+    const data = await apiFetchGp(adminPage, setup.tournamentId);
+
+    const groupCounts = { A: 0, B: 0, C: 0, D: 0 };
+    for (const q of (data.qualifications || [])) {
+      if (q.group in groupCounts) groupCounts[q.group]++;
+    }
+    const groupedOk = groupCounts.A === 7 && groupCounts.B === 7 && groupCounts.C === 7 && groupCounts.D === 7;
+    const matches = (data.matches || []).filter((m) => !m.isBye);
+    const matchesOk = matches.length === 84;
+    const allCompleted = matches.every((m) => m.completed);
+    const standingsOk = (data.qualifications || []).length >= 28;
+
+    const ok = groupedOk && matchesOk && allCompleted && standingsOk;
+    log('TC-701', ok ? 'PASS' : 'FAIL',
+      !groupedOk ? `groups: A=${groupCounts.A} B=${groupCounts.B} C=${groupCounts.C} D=${groupCounts.D}`
+      : !matchesOk ? `matches=${matches.length} expected=84`
+      : !allCompleted ? `not all completed`
+      : !standingsOk ? `standings count=${(data.qualifications || []).length}`
+      : '');
+  } catch (err) {
+    log('TC-701', 'FAIL', err instanceof Error ? err.message : 'GP 701 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-702: GP player participant submission ───────── */
+async function runTc702(adminPage) {
+  let tournamentId = null;
+  const playerIds = [];
+  let playerBrowser = null;
+  try {
+    const stamp = Date.now();
+    const p1 = await apiCreatePlayer(adminPage, 'E2E GP 702 P1', `e2e_gp702_p1_${stamp}`);
+    const p2 = await apiCreatePlayer(adminPage, 'E2E GP 702 P2', `e2e_gp702_p2_${stamp}`);
+    playerIds.push(p1.id, p2.id);
+
+    tournamentId = await apiCreateTournament(adminPage, `E2E GP 702 ${stamp}`, { dualReportEnabled: false });
+    const setup = await apiSetupGpGroup(adminPage, tournamentId, [
+      { playerId: p1.id, group: 'A' },
+      { playerId: p2.id, group: 'A' },
+    ]);
+    if (setup.s !== 201) throw new Error(`GP setup failed (${setup.s})`);
+
+    const data = await apiFetchGp(adminPage, tournamentId);
+    const match = (data.matches || []).find((m) => !m.isBye);
+    if (!match) throw new Error('No non-BYE match');
+    if (!match.cup) throw new Error('Match cup not assigned');
+
+    const ctx = await loginPlayerBrowser(p1.nickname, p1.password);
+    playerBrowser = ctx.browser;
+    /* Submit 5 race positions via API from the player browser session. */
+    const reportRes = await ctx.page.evaluate(async ([u, body]) => {
+      const r = await fetch(u, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [
+      `/api/tournaments/${tournamentId}/gp/match/${match.id}/report`,
+      { reportingPlayer: 1, races: makeRacesP1Wins() },
+    ]);
+
+    /* dualReportEnabled=false → autoConfirmed on first report. */
+    const confirmed = reportRes.s === 200 &&
+      (reportRes.b?.data?.autoConfirmed === true || reportRes.b?.autoConfirmed === true);
+
+    const after = await apiFetchGp(adminPage, tournamentId);
+    const updated = (after.matches || []).find((m) => m.id === match.id);
+    /* P1 wins all 5 races at 1st = 45 points, P2 at 5th = 0 points. */
+    const persisted = updated?.completed === true && updated.points1 === 45 && updated.points2 === 0;
+
+    log('TC-702', confirmed && persisted ? 'PASS' : 'FAIL',
+      !confirmed ? `report not confirmed: status=${reportRes.s}`
+      : !persisted ? `points: ${updated?.points1}-${updated?.points2} completed=${updated?.completed}`
+      : '');
+  } catch (err) {
+    log('TC-702', 'FAIL', err instanceof Error ? err.message : 'GP 702 failed');
+  } finally {
+    if (playerBrowser) await playerBrowser.close().catch(() => {});
+    await apiDeleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await apiDeletePlayer(adminPage, id);
+  }
+}
+
+/* ───────── TC-703: 28-player full + finals bracket gen + 1 score ───────── */
+async function runTc703(adminPage) {
+  let setup = null;
+  try {
+    setup = await setupGp28PlayerFinals(adminPage, '703');
+
+    const gen = await apiGenerateGpFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    const matches = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const m1 = matches.find((m) => m.matchNumber === 1);
+    if (!m1) throw new Error('Match 1 missing');
+
+    /* GP finals validation: targetWins=3 default. score1=9 (P1 1st in 1 race) >= 3, score2=0 < 3. */
+    const valid = await apiSetGpFinalsScore(adminPage, setup.tournamentId, m1.id, 9, 0);
+    if (valid.s !== 200) throw new Error(`Score put failed (${valid.s})`);
+
+    const after = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const updated = after.find((m) => m.id === m1.id);
+    const winnerTarget = after.find((m) => m.matchNumber === 5);
+    const loserTarget = after.find((m) => m.matchNumber === 8);
+    const bracketCount = after.length === 17;
+    const scoreSaved = updated?.completed === true && updated.points1 === 9 && updated.points2 === 0;
+    const winnerRouted = [winnerTarget?.player1Id, winnerTarget?.player2Id].includes(m1.player1Id);
+    const loserRouted = [loserTarget?.player1Id, loserTarget?.player2Id].includes(m1.player2Id);
+
+    const ok = bracketCount && scoreSaved && winnerRouted && loserRouted;
+    log('TC-703', ok ? 'PASS' : 'FAIL',
+      !bracketCount ? `bracket size=${after.length}`
+      : !scoreSaved ? `score: ${updated?.points1}-${updated?.points2}`
+      : !winnerRouted || !loserRouted ? 'routing mismatch'
+      : '');
+  } catch (err) {
+    log('TC-703', 'FAIL', err instanceof Error ? err.message : 'GP 703 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-704: GP finals bracket reset ───────── */
+async function runTc704(adminPage) {
+  let setup = null;
+  try {
+    setup = await setupGp28PlayerFinals(adminPage, '704');
+
+    const gen = await apiGenerateGpFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    const before = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const m1 = before.find((m) => m.matchNumber === 1);
+    if (!m1) throw new Error('Match 1 missing');
+    const score = await apiSetGpFinalsScore(adminPage, setup.tournamentId, m1.id, 9, 0);
+    if (score.s !== 200) throw new Error(`Score put failed (${score.s})`);
+
+    const completedBefore = (await apiFetchGpFinalsMatches(adminPage, setup.tournamentId))
+      .filter((m) => m.completed).length;
+    if (completedBefore < 1) throw new Error('Pre-reset score not persisted');
+
+    const reset = await apiGenerateGpFinals(adminPage, setup.tournamentId, 8);
+    if (reset.s !== 200 && reset.s !== 201) throw new Error(`Bracket reset failed (${reset.s})`);
+
+    const after = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const completedAfter = after.filter((m) => m.completed).length;
+    const ok = completedBefore >= 1 && completedAfter === 0 && after.length === 17;
+    log('TC-704', ok ? 'PASS' : 'FAIL',
+      ok ? '' : `before=${completedBefore} after=${completedAfter} total=${after.length}`);
+  } catch (err) {
+    log('TC-704', 'FAIL', err instanceof Error ? err.message : 'GP 704 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-705: GP Grand Final → champion ───────── */
+async function runTc705(adminPage) {
+  let setup = null;
+  try {
+    setup = await setupGp28PlayerFinals(adminPage, '705');
+    const { tournamentId, playerIds, nicknames } = setup;
+
+    const gen = await apiGenerateGpFinals(adminPage, tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    /* Drive M1..M16 with P1 always winning 9-0. */
+    for (let mn = 1; mn <= 16; mn++) {
+      const matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+      const match = matches.find((m) => m.matchNumber === mn);
+      if (!match || !match.player1Id || !match.player2Id) {
+        throw new Error(`Match ${mn} not ready`);
+      }
+      const res = await apiSetGpFinalsScore(adminPage, tournamentId, match.id, 9, 0);
+      if (res.s !== 200) throw new Error(`Match ${mn} put failed (${res.s})`);
+    }
+
+    const matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+    const m16 = matches.find((m) => m.matchNumber === 16);
+    const expectedChampionId = m16?.player1Id;
+    if (!expectedChampionId) throw new Error('GF M16 missing player1');
+    const championNickname = nicknames[playerIds.indexOf(expectedChampionId)];
+
+    await nav(adminPage, `/tournaments/${tournamentId}/gp/finals`);
+    const pageText = await adminPage.locator('body').innerText();
+    const championShown = pageText.includes(championNickname) &&
+      (pageText.includes('Champion') || pageText.includes('チャンピオン') || pageText.includes('優勝'));
+    const m16Ok = m16.completed === true && m16.points1 === 9 && m16.points2 === 0;
+
+    log('TC-705', m16Ok && championShown ? 'PASS' : 'FAIL',
+      !m16Ok ? 'M16 not completed'
+      : !championShown ? `Champion banner missing nickname ${championNickname}`
+      : '');
+  } catch (err) {
+    log('TC-705', 'FAIL', err instanceof Error ? err.message : 'GP 705 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-706: GP Grand Final Reset Match (M17) ───────── */
+async function runTc706(adminPage) {
+  let setup = null;
+  try {
+    setup = await setupGp28PlayerFinals(adminPage, '706');
+    const { tournamentId } = setup;
+
+    const gen = await apiGenerateGpFinals(adminPage, tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    /* M1..M15: P1 wins 9-0 each */
+    for (let mn = 1; mn <= 15; mn++) {
+      const matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+      const match = matches.find((m) => m.matchNumber === mn);
+      if (!match || !match.player1Id || !match.player2Id) throw new Error(`Match ${mn} not ready`);
+      const res = await apiSetGpFinalsScore(adminPage, tournamentId, match.id, 9, 0);
+      if (res.s !== 200) throw new Error(`Match ${mn} put failed (${res.s})`);
+    }
+
+    /* M16: P2 wins 0-9 → triggers Reset Match (M17) */
+    let matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+    const m16 = matches.find((m) => m.matchNumber === 16);
+    if (!m16 || !m16.player1Id || !m16.player2Id) throw new Error('M16 not ready');
+    const expectedResetChampionId = m16.player2Id;
+    const m16Res = await apiSetGpFinalsScore(adminPage, tournamentId, m16.id, 0, 9);
+    if (m16Res.s !== 200) throw new Error(`M16 put failed (${m16Res.s})`);
+
+    matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+    const m17 = matches.find((m) => m.matchNumber === 17);
+    if (!m17) throw new Error('M17 not generated');
+    const m17Populated = !!m17.player1Id && !!m17.player2Id;
+
+    const m17ScoreP1Wins = m17.player1Id === expectedResetChampionId;
+    const m17Res = await apiSetGpFinalsScore(adminPage, tournamentId, m17.id,
+      m17ScoreP1Wins ? 9 : 0,
+      m17ScoreP1Wins ? 0 : 9);
+    if (m17Res.s !== 200) throw new Error(`M17 put failed (${m17Res.s})`);
+
+    const finalMatches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+    const finalM17 = finalMatches.find((m) => m.matchNumber === 17);
+    const m17Completed = finalM17?.completed === true;
+
+    log('TC-706', m17Populated && m17Completed ? 'PASS' : 'FAIL',
+      !m17Populated ? `M17 not populated p1=${m17.player1Id} p2=${m17.player2Id}`
+      : !m17Completed ? 'M17 not completed'
+      : '');
+  } catch (err) {
+    log('TC-706', 'FAIL', err instanceof Error ? err.message : 'GP 706 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-707: GP dual report agreement → autoConfirmed ───────── */
+async function runTc707(adminPage) {
+  let tournamentId = null;
+  const playerIds = [];
+  const browsers = [];
+  try {
+    const stamp = Date.now();
+    const p1 = await apiCreatePlayer(adminPage, 'E2E GP 707 P1', `e2e_gp707_p1_${stamp}`);
+    const p2 = await apiCreatePlayer(adminPage, 'E2E GP 707 P2', `e2e_gp707_p2_${stamp}`);
+    playerIds.push(p1.id, p2.id);
+
+    tournamentId = await apiCreateTournament(adminPage, `E2E GP 707 ${stamp}`, { dualReportEnabled: true });
+    const setup = await apiSetupGpGroup(adminPage, tournamentId, [
+      { playerId: p1.id, group: 'A' },
+      { playerId: p2.id, group: 'A' },
+    ]);
+    if (setup.s !== 201) throw new Error(`GP setup failed (${setup.s})`);
+
+    const data = await apiFetchGp(adminPage, tournamentId);
+    const match = (data.matches || []).find((m) => !m.isBye);
+    if (!match) throw new Error('No non-BYE match');
+
+    const races = makeRacesP1Wins();
+    const ctx1 = await loginPlayerBrowser(p1.nickname, p1.password);
+    browsers.push(ctx1.browser);
+    const r1 = await ctx1.page.evaluate(async ([u, body]) => {
+      const r = await fetch(u, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [`/api/tournaments/${tournamentId}/gp/match/${match.id}/report`,
+        { reportingPlayer: 1, races }]);
+    const r1WaitingForP2 = r1.s === 200 &&
+      (r1.b?.data?.waitingFor === 'player2' || r1.b?.waitingFor === 'player2');
+
+    const ctx2 = await loginPlayerBrowser(p2.nickname, p2.password);
+    browsers.push(ctx2.browser);
+    const r2 = await ctx2.page.evaluate(async ([u, body]) => {
+      const r = await fetch(u, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [`/api/tournaments/${tournamentId}/gp/match/${match.id}/report`,
+        { reportingPlayer: 2, races }]);
+    const autoConfirmed = r2.s === 200 &&
+      (r2.b?.data?.autoConfirmed === true || r2.b?.autoConfirmed === true);
+
+    const finalData = await apiFetchGp(adminPage, tournamentId);
+    const finalMatch = (finalData.matches || []).find((m) => m.id === match.id);
+    const persisted = finalMatch?.completed === true &&
+      finalMatch.points1 === 45 && finalMatch.points2 === 0;
+
+    const ok = r1WaitingForP2 && autoConfirmed && persisted;
+    log('TC-707', ok ? 'PASS' : 'FAIL',
+      !r1WaitingForP2 ? `P1 missing waitingFor (status=${r1.s})`
+      : !autoConfirmed ? `P2 missing autoConfirmed (status=${r2.s})`
+      : !persisted ? `final not persisted: ${finalMatch?.points1}-${finalMatch?.points2}`
+      : '');
+  } catch (err) {
+    log('TC-707', 'FAIL', err instanceof Error ? err.message : 'GP 707 failed');
+  } finally {
+    for (const b of browsers) await b.close().catch(() => {});
+    await apiDeleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await apiDeletePlayer(adminPage, id);
+  }
+}
+
+/* ───────── TC-708: GP dual report mismatch ───────── */
+async function runTc708(adminPage) {
+  let tournamentId = null;
+  const playerIds = [];
+  const browsers = [];
+  try {
+    const stamp = Date.now();
+    const p1 = await apiCreatePlayer(adminPage, 'E2E GP 708 P1', `e2e_gp708_p1_${stamp}`);
+    const p2 = await apiCreatePlayer(adminPage, 'E2E GP 708 P2', `e2e_gp708_p2_${stamp}`);
+    playerIds.push(p1.id, p2.id);
+
+    tournamentId = await apiCreateTournament(adminPage, `E2E GP 708 ${stamp}`, { dualReportEnabled: true });
+    const setup = await apiSetupGpGroup(adminPage, tournamentId, [
+      { playerId: p1.id, group: 'A' },
+      { playerId: p2.id, group: 'A' },
+    ]);
+    if (setup.s !== 201) throw new Error(`GP setup failed (${setup.s})`);
+
+    const data = await apiFetchGp(adminPage, tournamentId);
+    const match = (data.matches || []).find((m) => !m.isBye);
+    if (!match) throw new Error('No non-BYE match');
+
+    const ctx1 = await loginPlayerBrowser(p1.nickname, p1.password);
+    browsers.push(ctx1.browser);
+    await ctx1.page.evaluate(async ([u, body]) => {
+      await fetch(u, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }, [`/api/tournaments/${tournamentId}/gp/match/${match.id}/report`,
+        { reportingPlayer: 1, races: makeRacesP1Wins() }]);
+
+    const ctx2 = await loginPlayerBrowser(p2.nickname, p2.password);
+    browsers.push(ctx2.browser);
+    /* P2 reports flipped (P2 wins) → mismatch */
+    const r2 = await ctx2.page.evaluate(async ([u, body]) => {
+      const r = await fetch(u, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [`/api/tournaments/${tournamentId}/gp/match/${match.id}/report`,
+        { reportingPlayer: 2, races: makeRacesP2Wins() }]);
+    const mismatchFlag = r2.s === 200 &&
+      (r2.b?.data?.mismatch === true || r2.b?.mismatch === true);
+
+    const midData = await apiFetchGp(adminPage, tournamentId);
+    const midMatch = (midData.matches || []).find((m) => m.id === match.id);
+    const stillIncomplete = midMatch?.completed === false;
+
+    /* Admin resolves with PUT (qualification PUT requires cup + races) */
+    const adminPut = await apiPutGpQualScore(adminPage, tournamentId, match.id, match.cup, makeRacesP1Wins());
+    const finalData = await apiFetchGp(adminPage, tournamentId);
+    const finalMatch = (finalData.matches || []).find((m) => m.id === match.id);
+    const adminConfirmed = adminPut.s === 200 && finalMatch?.completed === true;
+
+    const ok = mismatchFlag && stillIncomplete && adminConfirmed;
+    log('TC-708', ok ? 'PASS' : 'FAIL',
+      !mismatchFlag ? `mismatch flag missing (status=${r2.s})`
+      : !stillIncomplete ? 'match auto-completed despite mismatch'
+      : !adminConfirmed ? `admin PUT failed (${adminPut.s})`
+      : '');
+  } catch (err) {
+    log('TC-708', 'FAIL', err instanceof Error ? err.message : 'GP 708 failed');
+  } finally {
+    for (const b of browsers) await b.close().catch(() => {});
+    await apiDeleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await apiDeletePlayer(adminPage, id);
+  }
+}
+
+/* ───────── TC-709: GP finals admin-only enforcement (403) ───────── */
+async function runTc709(adminPage) {
+  let setup = null;
+  let extraChallengerId = null;
+  let playerBrowser = null;
+  try {
+    setup = await setupGp28PlayerFinals(adminPage, '709');
+
+    const gen = await apiGenerateGpFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    const matches = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const m1 = matches.find((m) => m.matchNumber === 1);
+    if (!m1) throw new Error('Match 1 missing');
+
+    /* Extra credentials-equipped player. The 28 setup players are admin-created
+     * but their passwords are returned at creation; we just need ONE we can
+     * actually log in as for the 403 test, so spawn an extra. */
+    const stamp = Date.now();
+    const challenger = await apiCreatePlayer(adminPage, 'E2E GP 709 Challenger', `e2e_gp709_ch_${stamp}`);
+    extraChallengerId = challenger.id;
+
+    const ctx = await loginPlayerBrowser(challenger.nickname, challenger.password);
+    playerBrowser = ctx.browser;
+
+    /* Player tries to PUT to GP finals — expect 403. */
+    const playerPut = await ctx.page.evaluate(async ([u, body]) => {
+      const r = await fetch(u, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status };
+    }, [`/api/tournaments/${setup.tournamentId}/gp/finals`, { matchId: m1.id, score1: 9, score2: 0 }]);
+
+    const ok = playerPut.s === 403;
+    log('TC-709', ok ? 'PASS' : 'FAIL', ok ? '' : `expected 403 got ${playerPut.s}`);
+  } catch (err) {
+    log('TC-709', 'FAIL', err instanceof Error ? err.message : 'GP 709 failed');
+  } finally {
+    if (playerBrowser) await playerBrowser.close().catch(() => {});
+    if (setup) await setup.cleanup();
+    await apiDeletePlayer(adminPage, extraChallengerId);
+  }
+}
+
+module.exports = {
+  runTc701, runTc702, runTc703, runTc704, runTc705, runTc706,
+  runTc707, runTc708, runTc709,
+};
+
+if (require.main === module) {
+  (async () => {
+    const browser = await chromium.launchPersistentContext(
+      '/tmp/playwright-smkc-profile',
+      { headless: false, viewport: { width: 1280, height: 720 } },
+    );
+    const page = browser.pages()[0] || await browser.newPage();
+
+    await nav(page, '/');
+
+    /* Light tests first; heavy 28-player full-workflow tests last */
+    await runTc702(page);
+    await runTc707(page);
+    await runTc708(page);
+    await runTc701(page);
+    await runTc703(page);
+    await runTc704(page);
+    await runTc705(page);
+    await runTc706(page);
+    await runTc709(page);
+
+    console.log('\n========== GP TEST SUMMARY ==========');
+    const p = results.filter((r) => r.status === 'PASS').length;
+    const f = results.filter((r) => r.status === 'FAIL').length;
+    const sk = results.filter((r) => r.status === 'SKIP').length;
+    console.log(`PASS: ${p} | FAIL: ${f} | SKIP: ${sk} | Total: ${results.length}`);
+    if (f > 0) results.filter((r) => r.status === 'FAIL')
+      .forEach((r) => console.log(`  ❌ [${r.tc}] ${r.detail}`));
+
+    await browser.close();
+    process.exit(f > 0 ? 1 : 0);
+  })();
+}

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -1,14 +1,22 @@
 /**
  * E2E MR (Match Race) focused tests.
  *
- * Mirrors tc-bm.js structure but covers MR-specific flows:
- * - TC-601: Full qualification with 12 players, seeding, snake-draft group assignment
- * - TC-602: Player login + MR participant score entry
- * - TC-603: MR draw (2-2) score submission
- * - TC-604: MR finals bracket generation + race-format score entry
- * - TC-608: MR dual report — agreement auto-confirm
- * - TC-609: MR dual report — mismatch detection
- * - TC-610: Finals admin-only enforcement (403 for non-admin)
+ * Mirrors tc-bm.js structure but covers MR-specific flows.
+ * Full-workflow tests use 28 players (4 groups × 7, snake-draft).
+ * Single-match tests use 2 players for speed.
+ *
+ *  TC-601  28-player qualification full flow + standings + course assignment
+ *  TC-602  MR participant score entry (UI, 2 players)
+ *  TC-603  MR draw 2-2 score (admin PUT, 2 players)
+ *  TC-604  28-player full + finals bracket gen + race-format UI score entry
+ *  TC-605  28-player full + finals bracket reset
+ *  TC-606  28-player full + Grand Final → champion
+ *  TC-607  28-player full + Grand Final Reset Match (M17)
+ *  TC-608  MR dual report — agreement → autoConfirmed
+ *  TC-609  MR dual report — mismatch detection
+ *  TC-610  MR finals admin-only enforcement (403 for non-admin)
+ *  TC-611  BM/MR/GP qualification confirmed → score-input lock
+ *  TC-612  GP race position validation (no-tie + double-game-over)
  *
  * Uses Playwright persistent profile at /tmp/playwright-smkc-profile.
  * Admin session must already exist in the profile (Discord OAuth).
@@ -17,88 +25,51 @@
  */
 const { chromium } = require('playwright');
 
-const BASE = process.env.E2E_BASE_URL || 'https://smkc.bluemoon.works';
-const WAIT = 8000;
-const results = [];
+/* Shared helpers (logging, API CRUD, snake-draft, 28-player setup) live in
+ * e2e/lib/common.js. We import-and-alias to keep call-sites in this file
+ * unchanged from the pre-common-extraction version. */
+const {
+  makeResults, makeLog, nav,
+  apiCreatePlayer: createPlayer,
+  apiCreateTournament: createTournament,
+  apiDeletePlayer: deletePlayer,
+  apiDeleteTournament: deleteTournament,
+  apiPutMrQualScore,
+  apiGenerateMrFinals: generateMrFinalsBracket,
+  apiSetMrFinalsScore: setMrFinalsScore,
+  apiFetchMrFinalsMatches: fetchMrFinalsMatches,
+  setupMr28PlayerFinals,
+  snakeDraft28: snakeDraftMr28,
+} = require('./lib/common');
 
-function log(tc, s, d = '') {
-  console.log(`${s === 'PASS' ? '✅' : s === 'SKIP' ? '⏭️' : '❌'} [${tc}] ${s}${d ? ' — ' + d : ''}`);
-  results.push({ tc, s, d });
-}
+const results = makeResults();
+const log = makeLog(results);
 
-async function nav(page, path) {
-  let lastError;
-  for (let attempt = 1; attempt <= 2; attempt++) {
-    try {
-      await page.goto(BASE + path, { waitUntil: 'domcontentloaded', timeout: 30000 });
-      await page.waitForTimeout(WAIT);
-      return;
-    } catch (err) {
-      lastError = err;
-      if (attempt === 2) throw err;
-      await page.waitForTimeout(3000);
+/** Complete every non-BYE MR qualification match via admin PUT (3-1 by default).
+ *  Used by TC-604/605/606/607 setup paths that call setupMr28PlayerFinals
+ *  internally; kept here for any tests that need to score additional matches
+ *  after the helper-driven setup. */
+async function completeAllMrQualMatches(adminPage, tournamentId, score1 = 3, score2 = 1) {
+  const data = await adminPage.evaluate(async (url) => {
+    const r = await fetch(url);
+    return r.json().catch(() => ({}));
+  }, `/api/tournaments/${tournamentId}/mr`);
+  const matches = (data.data?.matches || data.matches || []).filter((m) => !m.isBye && !m.completed);
+  for (const m of matches) {
+    const res = await apiPutMrQualScore(adminPage, tournamentId, m.id, score1, score2);
+    if (res.s !== 200) {
+      throw new Error(`MR qual put failed (${res.s}) match=${m.id}`);
     }
   }
-  throw lastError;
-}
-
-/** Helper: create a player via API and return { id, nickname, password } */
-async function createPlayer(page, name, nickname) {
-  const res = await page.evaluate(async (d) => {
-    const r = await fetch('/api/players', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(d),
-    });
-    return { s: r.status, b: await r.json().catch(() => ({})) };
-  }, { name, nickname, country: 'JP' });
-  const id = res.b?.data?.player?.id ?? null;
-  const password = res.b?.data?.temporaryPassword ?? null;
-  if (res.s !== 201 || !id) throw new Error(`Failed to create player ${nickname} (${res.s})`);
-  return { id, nickname, password };
-}
-
-/** Helper: delete a player via API */
-async function deletePlayer(page, id) {
-  await page.evaluate(async (url) => { await fetch(url, { method: 'DELETE' }); }, `/api/players/${id}`).catch(() => {});
-}
-
-/** Helper: delete a tournament via API.
- *  DELETE /api/tournaments/:id only accepts status='draft', so we demote first. */
-async function deleteTournament(page, id) {
-  if (!id) return;
-  await page.evaluate(async (url) => {
-    await fetch(url, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status: 'draft' }),
-    });
-  }, `/api/tournaments/${id}`).catch(() => {});
-  await page.evaluate(async (url) => { await fetch(url, { method: 'DELETE' }); }, `/api/tournaments/${id}`).catch(() => {});
-}
-
-/** Helper: create a tournament via API */
-async function createTournament(page, name, opts = {}) {
-  const res = await page.evaluate(async (d) => {
-    const r = await fetch('/api/tournaments', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(d),
-    });
-    return { s: r.status, b: await r.json().catch(() => ({})) };
-  }, { name, date: new Date().toISOString(), ...opts });
-  const id = res.b?.data?.id ?? null;
-  if (res.s !== 201 || !id) throw new Error(`Failed to create tournament ${name} (${res.s})`);
-  return id;
 }
 
 /**
- * TC-601: MR qualification full flow with 12 players, seeding, snake-draft groups
+ * TC-601: MR qualification full flow with 28 players, seeding, snake-draft 4 groups
  *
  * Verifies:
- * - 12 players with seeding 1-12 distributed across 3 groups (A/B/C × 4)
- * - Snake-draft: A=[1,6,7,12], B=[2,5,8,11], C=[3,4,9,10]
- * - All 18 matches (6 per group × 3 groups) scored with valid MR scores (sum=4)
+ * - 28 players with seeding 1-28 distributed across 4 groups (A/B/C/D × 7)
+ * - Snake-draft (boustrophedon: row r=floor(i/4), col=i%4 normally / 3-i%4 odd row)
+ * - All 84 non-BYE matches (7-player RR = 21 × 4 groups) scored sum=4 (BYE allowed for odd group size)
  * - Standings sorted by score desc → points desc per group
  * - Course assignment exists in match data (assignCoursesRandomly)
  */
@@ -109,8 +80,8 @@ async function runTc601(adminPage) {
   try {
     const stamp = Date.now();
 
-    // Step 1: Create 12 players
-    for (let i = 1; i <= 12; i++) {
+    // Step 1: Create 28 players
+    for (let i = 1; i <= 28; i++) {
       const p = await createPlayer(adminPage, `E2E MR P${i}`, `e2e_mr601_${stamp}_${i}`);
       playerIds.push(p.id);
     }
@@ -118,20 +89,15 @@ async function runTc601(adminPage) {
     // Step 2: Create tournament
     tournamentId = await createTournament(adminPage, `E2E MR Full ${stamp}`);
 
-    // Step 3: Setup MR qualification with seeding and 3 groups (snake draft)
-    // Snake distribution for 3 groups:
-    // Round 1 (asc):  A=seed1, B=seed2, C=seed3
-    // Round 2 (desc): C=seed4, B=seed5, A=seed6
-    // Round 3 (asc):  A=seed7, B=seed8, C=seed9
-    // Round 4 (desc): C=seed10, B=seed11, A=seed12
-    // So: A=[1,6,7,12], B=[2,5,8,11], C=[3,4,9,10]
-    const snakeGroups = { A: [0, 5, 6, 11], B: [1, 4, 7, 10], C: [2, 3, 8, 9] };
-    const players = [];
-    for (const [group, indices] of Object.entries(snakeGroups)) {
-      for (const idx of indices) {
-        players.push({ playerId: playerIds[idx], group, seeding: idx + 1 });
-      }
-    }
+    // Step 3: Setup MR qualification with seeding across 4 groups (snake draft).
+    // Boustrophedon: row r = floor(i/4); column c = i%4 on even rows, 3-(i%4) on odd rows.
+    // 7 rows × 4 cols = 28 entries. Each column maps to a group A/B/C/D.
+    const groupNames = ['A', 'B', 'C', 'D'];
+    const players = playerIds.map((playerId, i) => {
+      const row = Math.floor(i / 4);
+      const col = row % 2 === 0 ? (i % 4) : (3 - (i % 4));
+      return { playerId, group: groupNames[col], seeding: i + 1 };
+    });
 
     const setup = await adminPage.evaluate(async ([url, data]) => {
       const r = await fetch(url, {
@@ -153,8 +119,8 @@ async function runTc601(adminPage) {
     const matches = mrData.data?.matches || mrData.matches || [];
     const nonByeMatches = matches.filter((m) => !m.isBye);
 
-    // 4 players per group = 6 matches per group, 3 groups = 18 matches (no byes with even count)
-    const hasExpectedMatches = nonByeMatches.length === 18;
+    // 7-player RR per group = 21 matches × 4 groups = 84 non-BYE matches
+    const hasExpectedMatches = nonByeMatches.length === 84;
 
     // Step 5: Input scores for all matches (valid MR: score1+score2=4)
     // Use varied scores: 3-1, 2-2, 4-0, 1-3 to test all valid combinations
@@ -220,7 +186,7 @@ async function runTc601(adminPage) {
 
     const allPassed = hasExpectedMatches && allScoresOk && hasStandings && standingsSorted;
     log('TC-601', allPassed ? 'PASS' : 'FAIL',
-      !hasExpectedMatches ? `Expected 18 non-bye matches, got ${nonByeMatches.length}`
+      !hasExpectedMatches ? `Expected 84 non-bye matches, got ${nonByeMatches.length}`
       : !allScoresOk ? 'Some score inputs failed'
       : !hasStandings ? 'Standings page did not render properly'
       : !standingsSorted ? 'Standings not sorted correctly'
@@ -407,60 +373,21 @@ async function runTc603(adminPage) {
 }
 
 /**
- * TC-604: MR finals bracket generation and race-format score entry
+ * TC-604: MR predicated 28-player full + finals bracket gen + race-format UI score entry
  *
- * Creates 8 players, completes qualification, generates finals bracket,
- * verifies first-to-3 race entry (not first-to-5 like BM), and checks
- * winner/loser routing. Also validates that first-to-5 (BM style) is rejected.
+ * Creates 28 players in 4 groups (snake-draft), completes 84 qualification matches,
+ * then generates the finals bracket via the UI (top 8) and uses the race entry dialog
+ * to score the first match (first-to-3). Also validates that first-to-5 (BM style)
+ * is rejected via API. Verifies winner/loser routing into M5 and M8.
  */
 async function runTc604(adminPage) {
   let tournamentId = null;
-  const playerIds = [];
+  let playerIds = [];
 
   try {
-    const stamp = Date.now();
-
-    // Create 8 players
-    for (let i = 1; i <= 8; i++) {
-      const p = await createPlayer(adminPage, `E2E MR Final P${i}`, `e2e_mrf_${stamp}_${i}`);
-      playerIds.push(p.id);
-    }
-
-    tournamentId = await createTournament(adminPage, `E2E MR Finals ${stamp}`);
-
-    // Setup MR qualification with seeding
-    const setup = await adminPage.evaluate(async ([url, ids]) => {
-      const r = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          players: ids.map((playerId, index) => ({
-            playerId,
-            group: 'A',
-            seeding: index + 1,
-          })),
-        }),
-      });
-      return { s: r.status };
-    }, [`/api/tournaments/${tournamentId}/mr`, playerIds]);
-    if (setup.s !== 201) throw new Error(`MR setup failed (${setup.s})`);
-
-    // Complete all qualification matches via API
-    const mrData = await adminPage.evaluate(async (url) => {
-      const r = await fetch(url);
-      return r.json().catch(() => ({}));
-    }, `/api/tournaments/${tournamentId}/mr`);
-
-    const qualMatches = (mrData.data?.matches || mrData.matches || []).filter((m) => !m.isBye);
-    for (const m of qualMatches) {
-      await adminPage.evaluate(async ([url, body]) => {
-        await fetch(url, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
-        });
-      }, [`/api/tournaments/${tournamentId}/mr`, { matchId: m.id, score1: 3, score2: 1 }]);
-    }
+    const setup = await setupMr28PlayerFinals(adminPage, '604');
+    tournamentId = setup.tournamentId;
+    playerIds = setup.playerIds;
 
     // Navigate to finals page and generate bracket
     await nav(adminPage, `/tournaments/${tournamentId}/mr/finals`);
@@ -573,6 +500,160 @@ async function runTc604(adminPage) {
       : '');
   } catch (err) {
     log('TC-604', 'FAIL', err instanceof Error ? err.message : 'MR finals flow failed');
+  } finally {
+    if (tournamentId) await deleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await deletePlayer(adminPage, id);
+  }
+}
+
+/* setupMr28PlayerFinals / generateMrFinalsBracket / setMrFinalsScore /
+ * fetchMrFinalsMatches / snakeDraftMr28 are imported from ./lib/common above. */
+
+/* ───────── TC-605: MR finals bracket reset (28-player full) ─────────
+ * Re-POST to /finals (same endpoint the UI's Reset button calls) regenerates
+ * the bracket with all 17 matches pending. */
+async function runTc605(adminPage) {
+  let tournamentId = null;
+  let playerIds = [];
+  try {
+    const setup = await setupMr28PlayerFinals(adminPage, '605');
+    tournamentId = setup.tournamentId;
+    playerIds = setup.playerIds;
+
+    const gen = await generateMrFinalsBracket(adminPage, tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    const before = await fetchMrFinalsMatches(adminPage, tournamentId);
+    const m1 = before.find((m) => m.matchNumber === 1);
+    if (!m1) throw new Error('Bracket missing match 1');
+
+    const score = await setMrFinalsScore(adminPage, tournamentId, m1.id, 3, 0);
+    if (score.s !== 200) throw new Error(`Score put failed (${score.s})`);
+
+    const completedBefore = (await fetchMrFinalsMatches(adminPage, tournamentId))
+      .filter((m) => m.completed).length;
+    if (completedBefore < 1) throw new Error('Pre-reset score not persisted');
+
+    const reset = await generateMrFinalsBracket(adminPage, tournamentId, 8);
+    if (reset.s !== 200 && reset.s !== 201) throw new Error(`Bracket reset failed (${reset.s})`);
+
+    const after = await fetchMrFinalsMatches(adminPage, tournamentId);
+    const completedAfter = after.filter((m) => m.completed).length;
+    const ok = completedBefore >= 1 && completedAfter === 0 && after.length === 17;
+    log('TC-605', ok ? 'PASS' : 'FAIL',
+      ok ? '' : `before=${completedBefore} after=${completedAfter} total=${after.length}`);
+  } catch (err) {
+    log('TC-605', 'FAIL', err instanceof Error ? err.message : 'MR 605 failed');
+  } finally {
+    if (tournamentId) await deleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await deletePlayer(adminPage, id);
+  }
+}
+
+/* ───────── TC-606: MR Grand Final → champion (28-player full) ─────────
+ * Drive M1..M16 with player1 sweeping 3-0 each. The Winners-side champion
+ * takes M16 and the champion banner on /mr/finals must show the expected nick. */
+async function runTc606(adminPage) {
+  let tournamentId = null;
+  let playerIds = [];
+  let nicknames = [];
+  try {
+    const setup = await setupMr28PlayerFinals(adminPage, '606');
+    tournamentId = setup.tournamentId;
+    playerIds = setup.playerIds;
+    nicknames = setup.nicknames;
+
+    const gen = await generateMrFinalsBracket(adminPage, tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    /* Drive M1..M16 sequentially. P1 wins 3-0 so seeds propagate deterministically. */
+    for (let mn = 1; mn <= 16; mn++) {
+      const matches = await fetchMrFinalsMatches(adminPage, tournamentId);
+      const match = matches.find((m) => m.matchNumber === mn);
+      if (!match || !match.player1Id || !match.player2Id) {
+        throw new Error(`Match ${mn} not ready (p1=${match?.player1Id} p2=${match?.player2Id})`);
+      }
+      const res = await setMrFinalsScore(adminPage, tournamentId, match.id, 3, 0);
+      if (res.s !== 200) throw new Error(`Match ${mn} put failed (${res.s})`);
+    }
+
+    const finalMatches = await fetchMrFinalsMatches(adminPage, tournamentId);
+    const m16 = finalMatches.find((m) => m.matchNumber === 16);
+    const expectedChampionId = m16?.player1Id;
+    if (!expectedChampionId) throw new Error('GF (M16) missing player1');
+    const championNickname = nicknames[playerIds.indexOf(expectedChampionId)];
+
+    await nav(adminPage, `/tournaments/${tournamentId}/mr/finals`);
+    const pageText = await adminPage.locator('body').innerText();
+    const m16Completed = m16?.completed === true && m16.score1 === 3 && m16.score2 === 0;
+    const championShown = pageText.includes(championNickname) &&
+      (pageText.includes('Champion') || pageText.includes('チャンピオン') || pageText.includes('優勝'));
+
+    log('TC-606', m16Completed && championShown ? 'PASS' : 'FAIL',
+      !m16Completed ? `M16 not completed: ${m16?.score1}-${m16?.score2} completed=${m16?.completed}`
+      : !championShown ? `Champion banner missing nickname ${championNickname}`
+      : '');
+  } catch (err) {
+    log('TC-606', 'FAIL', err instanceof Error ? err.message : 'MR 606 failed');
+  } finally {
+    if (tournamentId) await deleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await deletePlayer(adminPage, id);
+  }
+}
+
+/* ───────── TC-607: MR Grand Final Reset Match (M17) ─────────
+ * If the L-side champion takes the GF, M17 is generated. We force this by
+ * scoring M16 0-3 (the L-side champion is in the P2 slot per bracket routing). */
+async function runTc607(adminPage) {
+  let tournamentId = null;
+  let playerIds = [];
+  try {
+    const setup = await setupMr28PlayerFinals(adminPage, '607');
+    tournamentId = setup.tournamentId;
+    playerIds = setup.playerIds;
+
+    const gen = await generateMrFinalsBracket(adminPage, tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    /* M1..M15: P1 wins 3-0 each */
+    for (let mn = 1; mn <= 15; mn++) {
+      const matches = await fetchMrFinalsMatches(adminPage, tournamentId);
+      const match = matches.find((m) => m.matchNumber === mn);
+      if (!match || !match.player1Id || !match.player2Id) throw new Error(`Match ${mn} not ready`);
+      const res = await setMrFinalsScore(adminPage, tournamentId, match.id, 3, 0);
+      if (res.s !== 200) throw new Error(`Match ${mn} put failed (${res.s})`);
+    }
+
+    /* M16: L-side champion (P2) wins 0-3 → triggers M17 */
+    let matches = await fetchMrFinalsMatches(adminPage, tournamentId);
+    const m16 = matches.find((m) => m.matchNumber === 16);
+    if (!m16 || !m16.player1Id || !m16.player2Id) throw new Error('M16 not ready');
+    const expectedResetChampionId = m16.player2Id;
+    const m16Res = await setMrFinalsScore(adminPage, tournamentId, m16.id, 0, 3);
+    if (m16Res.s !== 200) throw new Error(`M16 put failed (${m16Res.s})`);
+
+    matches = await fetchMrFinalsMatches(adminPage, tournamentId);
+    const m17 = matches.find((m) => m.matchNumber === 17);
+    if (!m17) throw new Error('M17 not generated');
+    const m17Populated = !!m17.player1Id && !!m17.player2Id;
+
+    /* Play M17. The L-side champion's slot may be P1 or P2 depending on routing. */
+    const m17ScoreP1Wins = m17.player1Id === expectedResetChampionId;
+    const m17Res = await setMrFinalsScore(adminPage, tournamentId, m17.id,
+      m17ScoreP1Wins ? 3 : 0,
+      m17ScoreP1Wins ? 0 : 3);
+    if (m17Res.s !== 200) throw new Error(`M17 put failed (${m17Res.s})`);
+
+    const finalMatches = await fetchMrFinalsMatches(adminPage, tournamentId);
+    const finalM17 = finalMatches.find((m) => m.matchNumber === 17);
+    const m17Completed = finalM17?.completed === true;
+
+    log('TC-607', m17Populated && m17Completed ? 'PASS' : 'FAIL',
+      !m17Populated ? `M17 not populated p1=${m17.player1Id} p2=${m17.player2Id}`
+      : !m17Completed ? 'M17 not completed'
+      : '');
+  } catch (err) {
+    log('TC-607', 'FAIL', err instanceof Error ? err.message : 'MR 607 failed');
   } finally {
     if (tournamentId) await deleteTournament(adminPage, tournamentId);
     for (const id of playerIds) await deletePlayer(adminPage, id);
@@ -1176,7 +1257,7 @@ async function runTc612(adminPage) {
 }
 
 // Export individual test functions for integration into tc-all.js
-module.exports = { runTc601, runTc602, runTc603, runTc604, runTc608, runTc609, runTc610, runTc611, runTc612 };
+module.exports = { runTc601, runTc602, runTc603, runTc604, runTc605, runTc606, runTc607, runTc608, runTc609, runTc610, runTc611, runTc612 };
 
 // Standalone execution
 if (require.main === module) {
@@ -1193,6 +1274,9 @@ if (require.main === module) {
     await runTc602(page);
     await runTc603(page);
     await runTc604(page);
+    await runTc605(page);
+    await runTc606(page);
+    await runTc607(page);
     await runTc608(page);
     await runTc609(page);
     await runTc610(page);
@@ -1200,11 +1284,11 @@ if (require.main === module) {
     await runTc612(page);
 
     console.log('\n========== MR TEST SUMMARY ==========');
-    const p = results.filter((r) => r.s === 'PASS').length;
-    const f = results.filter((r) => r.s === 'FAIL').length;
-    const sk = results.filter((r) => r.s === 'SKIP').length;
+    const p = results.filter((r) => r.status === 'PASS').length;
+    const f = results.filter((r) => r.status === 'FAIL').length;
+    const sk = results.filter((r) => r.status === 'SKIP').length;
     console.log(`PASS: ${p} | FAIL: ${f} | SKIP: ${sk} | Total: ${results.length}`);
-    if (f > 0) results.filter((r) => r.s === 'FAIL').forEach((r) => console.log(`  ❌ [${r.tc}] ${r.d}`));
+    if (f > 0) results.filter((r) => r.status === 'FAIL').forEach((r) => console.log(`  ❌ [${r.tc}] ${r.detail}`));
 
     await browser.close();
     process.exit(f > 0 ? 1 : 0);

--- a/smkc-score-app/package.json
+++ b/smkc-score-app/package.json
@@ -13,6 +13,7 @@
     "e2e:all": "node e2e/tc-all.js",
     "e2e:bm": "node e2e/tc-bm.js",
     "e2e:mr": "node e2e/tc-mr.js",
+    "e2e:gp": "node e2e/tc-gp.js",
     "build:cf": "npx @opennextjs/cloudflare build",
     "preview": "npx @opennextjs/cloudflare dev",
     "deploy": "npm run build:cf && npx wrangler deploy"


### PR DESCRIPTION
## Summary
- BM/MR の **フルワークフローテストを 28人プレイヤー (4グループ × 7名 snake-draft, 84予選試合) 前提に書き直し**、新規 GP テストスイート (`tc-gp.js`, TC-701..709) を追加。TT(TA) のフルワークフローシナリオ (TC-8xx) もドキュメント上で定義。
- 共通ヘルパーを `e2e/lib/common.js` に集約し、3ファイル間の重複を解消。リトライ・自動クリーンアップを内蔵。
- TC-108 (Players API ページネーション) を新規追加。TC-401/402 (旧軽量フルワークフロー) と TC-403/404 (GP ダイアログ UI チェック) はフル版に集約して廃止。
- TC ID 衝突を解消 (旧 TC-323 ×2 → TC-503 と TC-324 にリネーム)、重複 (TC-322 inline) を削除。
- `tc-all.js` の child process 起動を `execSync` → `spawnSync` + `stdio: inherit` に変更（1MB バッファ切り捨ての回避と運用中のリアルタイム可視性のため）。

## What's covered

### `e2e/lib/common.js` (新規)
- CRUD ヘルパー (apiCreatePlayer/Tournament, apiDeletePlayer/Tournament with demote-to-draft)
- snake-draft 28-player 配分 (boustrophedon)
- BM/MR/GP それぞれの setup28PlayerFinals: 28人作成 → 4グループ snake-draft → 全 84 試合スコア入力 → cleanup closure を返す。**部分失敗時は内部で cleanup 後に throw** するので本番にデータが残らない。
- `withRetry`: 5xx / 429 を指数バックオフで 2回リトライ (1s, 3s)。4xx は即時 fail で deterministic に。
- 別ブラウザコンテキストでの credentials login

### `e2e/tc-bm.js` (rewrite)
- TC-501/502: BM participant 単発 + 引き分け 2-2 (UI, 2名)
- TC-322: BM participant 訂正 (UI, 2名) — 旧版維持
- TC-503: 28人予選 + finals bracket gen + first-to-5 routing
- TC-504: 28人予選 + bracket reset
- TC-505: 28人予選 + Grand Final → champion
- TC-506: 28人予選 + Grand Final Reset Match (M17)
- TC-507/508/509: BM dual report (一致/不一致/previousReports)

### `e2e/tc-mr.js` (update)
- TC-601: 12→28 名に拡張 (4グループ snake-draft)
- TC-604: 28-player setup helper 経由に。UI race entry はそのまま
- TC-605/606/607 新規: bracket reset / GF / GF Reset
- TC-602/603/608/609/610/611/612 はそのまま維持

### `e2e/tc-gp.js` (新規)
- TC-701: 28人 GP 予選 + 84試合 driver points 換算
- TC-702: GP participant 5レース送信
- TC-703/704/705/706: bracket gen / reset / GF / GF Reset
- TC-707/708: dual report (一致/不一致)
- TC-709: 決勝 admin-only enforcement (403)

### `E2E_TEST_CASES.md`
- TC-108 (Players API ページネーション) を TC-1xx に追加
- TC-401〜TC-404 を削除（フル版に集約）
- TC-5xx / TC-6xx の 28名前提への書き換え
- TC-7xx (GP) と TC-8xx (TT scenario only) を新規定義
- TC ID 命名ルールと欠番/リネーム履歴を追記

## Test plan
- [ ] `npm run e2e:bm` を本番で実走し、TC-501..509 + TC-322 + TC-503..506 が全 PASS
- [ ] `npm run e2e:mr` を本番で実走し、TC-601..612 が全 PASS（TC-601 は 28人で実行されるか確認）
- [ ] `npm run e2e:gp` を本番で実走し、TC-701..709 が全 PASS
- [ ] `npm run e2e:all` で tc-all.js + 3つの child process が連動実行され、`spawnSync stdio: inherit` でリアルタイム出力が見える
- [ ] テスト中断/失敗時に本番側に「`E2E BM 5xx`」等のテストデータが残らない（`apiDeleteTournament` の demote-to-draft → DELETE 二段階＋ helper 内部の partial-failure cleanup）

## Notes
- 28人フルワークフローは 1テストあたり 84 PUT のシリアル投入で約 1〜2 分かかる。`tc-all.js` の child process timeout を 30 分に拡張済み。
- TC-8xx (TA) は scenario only。実装は別 PR で扱う。
- 独立したコードレビュー (general-purpose subagent) で挙がった「helper 重複」「setup leak」「execSync バッファ問題」「retry 不在」は本 PR 内で全て対応済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)