### PR TITLE
fix: add tournamentId verification to tt/entries GET route (#342)

### DIFF
--- a/smkc-score-app/src/app/api/tournaments/[id]/tt/entries/[entryId]/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/tt/entries/[entryId]/route.ts
@@ -28,6 +28,7 @@ import { createLogger } from "@/lib/logger";
 import { checkStageFrozen } from "@/lib/ta/freeze-check";
 import { timeToMs } from "@/lib/ta/time-utils";
 import { sanitizeInput } from "@/lib/sanitize";
+import { resolveTournamentId } from "@/lib/tournament-identifier";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -58,12 +59,14 @@ export async function GET(
 ) {
   // Logger created inside function for proper test mocking
   const logger = createLogger('tt-entry-api');
-  const { entryId } = await params;
+  const { id, entryId } = await params;
+  const tournamentId = await resolveTournamentId(id);
   try {
 
     // Fetch entry with related player and tournament data
+    // Verify entry belongs to the specified tournament (IDOR prevention)
     const entry = await prisma.tTEntry.findUnique({
-      where: { id: entryId },
+      where: { id: entryId, tournamentId },
       include: {
         player: true,
         tournament: true,
@@ -77,7 +80,7 @@ export async function GET(
     return createSuccessResponse(entry);
   } catch (error) {
     // Use structured logging for error tracking and debugging
-    logger.error("Failed to fetch entry", { error, entryId });
+    logger.error("Failed to fetch entry", { error, entryId, tournamentId });
     return handleDatabaseError(error, "fetch time trial entry");
   }
 }


### PR DESCRIPTION
## Summary

The GET handler in `tt/entries/[entryId]/route.ts` was ignoring the `tournamentId` parameter from the route URL, allowing any authenticated user to access Time Trial entries from any tournament by guessing entry IDs.

## Changes

- Import `resolveTournamentId` from `@/lib/tournament-identifier`
- Extract `id` from params and resolve to canonical `tournamentId`
- Add `tournamentId` to Prisma `where` clause to verify the entry belongs to the specified tournament
- Log with `tournamentId` context for audit trail

## Security Impact

**Before**: Any authenticated user could access any TT entry by guessing its ID, regardless of tournament membership.

**After**: The entry lookup verifies `tournamentId` matches, returning 404 if the entry doesn't belong to the specified tournament.

Fixes #342

## Test plan

- [ ] Verify GET returns 404 when entryId belongs to a different tournament
- [ ] Verify GET returns the entry when tournamentId matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)