### PR TITLE
fix(matches-polling-route): use createSuccessResponse for GET endpoint (#305)

### DIFF
--- a/smkc-score-app/src/lib/api-factories/matches-polling-route.ts
+++ b/smkc-score-app/src/lib/api-factories/matches-polling-route.ts
@@ -14,7 +14,7 @@ import prisma from '@/lib/prisma';
 import { paginate } from '@/lib/pagination';
 import { createLogger } from '@/lib/logger';
 import { auth } from '@/lib/auth';
-import { createErrorResponse, handleAuthError } from '@/lib/error-handling';
+import { createErrorResponse, createSuccessResponse, handleAuthError } from '@/lib/error-handling';
 import { resolveTournamentId } from '@/lib/tournament-identifier';
 
 export interface MatchesPollingConfig {
@@ -68,7 +68,7 @@ export function createMatchesPollingHandlers(config: MatchesPollingConfig) {
         { page, limit }
       );
 
-      return NextResponse.json(result);
+      return createSuccessResponse(result);
     } catch (error) {
       logger.error(config.errorMessage, { error, tournamentId });
       return createErrorResponse(config.errorMessage, 500, 'INTERNAL_ERROR');


### PR DESCRIPTION
## Summary

The GET handler in `matches-polling-route.ts` was returning `NextResponse.json(result)` directly, inconsistent with the project standard of using `createSuccessResponse()`.

## Changes

- Import `createSuccessResponse` from `@/lib/error-handling`
- Replace `NextResponse.json(result)` with `createSuccessResponse(result)`

All responses now follow `{ success: true, data: {...} }` format consistently.

## Test plan

- [ ] Verify polling endpoint returns `{ success: true, data: {...} }`
- [ ] Existing polling functionality remains unchanged

Fixes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)