### PR TITLE
fix(finals-route): use createSuccessResponse for GET/POST responses (#311)

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-bracket-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-bracket-route.test.ts
@@ -97,11 +97,11 @@ describe('Finals Bracket Route Factory', () => {
 
       expect(response.status).toBe(200);
       const json = await response.json();
-      expect(json.matches).toEqual(mockMatches);
+      expect(json.data.matches).toEqual(mockMatches);
       // Players should be mapped with qualifyingRank based on position
-      expect(json.players[0].qualifyingRank).toBe(1);
-      expect(json.players[1].qualifyingRank).toBe(2);
-      expect(json.players[3].qualifyingRank).toBe(4);
+      expect(json.data.players[0].qualifyingRank).toBe(1);
+      expect(json.data.players[1].qualifyingRank).toBe(2);
+      expect(json.data.players[3].qualifyingRank).toBe(4);
     });
 
     // Success: Returns totalPlayers count
@@ -115,7 +115,7 @@ describe('Finals Bracket Route Factory', () => {
       const response = await GET(request, { params });
 
       const json = await response.json();
-      expect(json.totalPlayers).toBe(8);
+      expect(json.data.totalPlayers).toBe(8);
     });
 
     // Query: Matches queried with stage='finals', ordered by matchNumber asc
@@ -145,7 +145,7 @@ describe('Finals Bracket Route Factory', () => {
       const response = await GET(request, { params });
 
       const json = await response.json();
-      expect(json.players[0]).toEqual({
+      expect(json.data.players[0]).toEqual({
         playerId: 'player-0',
         playerName: 'Player 1',
         playerNickname: 'P1',
@@ -216,10 +216,10 @@ describe('Finals Bracket Route Factory', () => {
 
       expect(response.status).toBe(200);
       const json = await response.json();
-      expect(json.winnerBracket).toEqual(mockBracketResult.winnerBracket);
-      expect(json.loserBracket).toEqual(mockBracketResult.loserBracket);
-      expect(json.grandFinal).toEqual(mockBracketResult.grandFinal);
-      expect(json.totalPlayers).toBe(8);
+      expect(json.data.winnerBracket).toEqual(mockBracketResult.winnerBracket);
+      expect(json.data.loserBracket).toEqual(mockBracketResult.loserBracket);
+      expect(json.data.grandFinal).toEqual(mockBracketResult.grandFinal);
+      expect(json.data.totalPlayers).toBe(8);
     });
 
     // Validation: Returns 400 when no qualifications exist
@@ -278,7 +278,7 @@ describe('Finals Bracket Route Factory', () => {
       // Should still return 200 despite audit log failure
       expect(response.status).toBe(200);
       const json = await response.json();
-      expect(json.totalPlayers).toBe(4);
+      expect(json.data.totalPlayers).toBe(4);
     });
 
     // Error: Returns 500 on database failure

--- a/smkc-score-app/__tests__/lib/api-factories/finals-matches-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-matches-route.test.ts
@@ -263,7 +263,7 @@ describe('Finals Matches Route Factory', () => {
     expect(response.status).toBe(201);
     const json = await response.json();
     expect(json.message).toBe('Match created successfully');
-    expect(json.match).toEqual(mockCreatedMatch);
+    expect(json.data.match).toEqual(mockCreatedMatch);
   });
 
   // Include: Player1 and player2 relations are included in create query
@@ -347,7 +347,7 @@ describe('Finals Matches Route Factory', () => {
     /* Should still return 201 despite audit log failure */
     expect(response.status).toBe(201);
     const json = await response.json();
-    expect(json.match).toEqual(mockCreatedMatch);
+    expect(json.data.match).toEqual(mockCreatedMatch);
   });
 
   // === ERROR HANDLING ===

--- a/smkc-score-app/__tests__/lib/error-handling.test.ts
+++ b/smkc-score-app/__tests__/lib/error-handling.test.ts
@@ -232,6 +232,20 @@ describe('Error Handling Module', () => {
       );
     });
 
+    it('should pass a custom status when provided', () => {
+      const data = { id: '1' };
+      createSuccessResponse(data, 'Created', { status: 201 });
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        {
+          success: true,
+          data,
+          message: 'Created',
+        },
+        { status: 201 }
+      );
+    });
+
     it('should not include message when not provided', () => {
       const data = { id: '1' };
       createSuccessResponse(data);

--- a/smkc-score-app/src/lib/api-factories/finals-bracket-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-bracket-route.ts
@@ -90,7 +90,7 @@ export function createFinalsBracketHandlers(config: FinalsBracketConfig) {
         points: q.points,
       }));
 
-      return NextResponse.json({
+      return createSuccessResponse({
         matches,
         players,
         totalPlayers: players.length,

--- a/smkc-score-app/src/lib/api-factories/finals-bracket-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-bracket-route.ts
@@ -12,7 +12,7 @@
  * POST: Generate a new double-elimination bracket from qualification results
  */
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
 import { generateDoubleEliminationBracket, BracketPlayer } from '@/lib/tournament/double-elimination';

--- a/smkc-score-app/src/lib/api-factories/finals-matches-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-matches-route.ts
@@ -18,7 +18,7 @@ import { createAuditLog } from '@/lib/audit-log';
 import { sanitizeInput } from '@/lib/sanitize';
 import { z } from 'zod';
 import { createLogger } from '@/lib/logger';
-import { createErrorResponse, handleValidationError, handleRateLimitError } from '@/lib/error-handling';
+import { createErrorResponse, createSuccessResponse, handleValidationError, handleRateLimitError } from '@/lib/error-handling';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { getClientIdentifier } from '@/lib/request-utils';
 import { resolveTournamentId } from '@/lib/tournament-identifier';
@@ -175,10 +175,7 @@ export function createFinalsMatchesHandlers(config: FinalsMatchesConfig) {
         logger.warn('Failed to create audit log', { error: logError, tournamentId, action: config.auditAction });
       }
 
-      return NextResponse.json(
-        { message: 'Match created successfully', match },
-        { status: 201 },
-      );
+      return createSuccessResponse({ match }, 'Match created successfully');
     } catch (error) {
       logger.error('Failed to create match', { error, tournamentId });
       return createErrorResponse('Failed to create match', 500, 'INTERNAL_ERROR');

--- a/smkc-score-app/src/lib/api-factories/finals-matches-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-matches-route.ts
@@ -11,7 +11,7 @@
  * POST: Create a new finals match with bracket metadata and player assignments
  */
 
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
 import { createAuditLog } from '@/lib/audit-log';
@@ -175,7 +175,7 @@ export function createFinalsMatchesHandlers(config: FinalsMatchesConfig) {
         logger.warn('Failed to create audit log', { error: logError, tournamentId, action: config.auditAction });
       }
 
-      return createSuccessResponse({ match }, 'Match created successfully');
+      return createSuccessResponse({ match }, 'Match created successfully', { status: 201 });
     } catch (error) {
       logger.error('Failed to create match', { error, tournamentId });
       return createErrorResponse('Failed to create match', 500, 'INTERNAL_ERROR');

--- a/smkc-score-app/src/lib/error-handling.ts
+++ b/smkc-score-app/src/lib/error-handling.ts
@@ -65,6 +65,12 @@ export interface SuccessResponse<T> {
   message?: string;
 }
 
+/** Options for success response creation. */
+export interface SuccessResponseOptions {
+  /** HTTP status code for the response. Defaults to NextResponse.json's 200. */
+  status?: number;
+}
+
 // ============================================================
 // Response Factory Functions
 // ============================================================
@@ -106,13 +112,13 @@ export function createErrorResponse(
 /**
  * Creates a standardized success response as a NextResponse object.
  *
- * Always returns HTTP 200 with the data payload wrapped in the
- * standard success response format.
+ * Returns the data payload wrapped in the standard success response format.
  *
  * @template T - The type of the data payload
  * @param data - The response data payload
  * @param message - Optional human-readable success message
- * @returns NextResponse with the success body and 200 status
+ * @param options - Optional response settings such as HTTP status
+ * @returns NextResponse with the success body and configured status
  *
  * @example
  *   const players = await prisma.player.findMany();
@@ -120,7 +126,8 @@ export function createErrorResponse(
  */
 export function createSuccessResponse<T>(
   data: T,
-  message?: string
+  message?: string,
+  options: SuccessResponseOptions = {}
 ): NextResponse {
   // Construct success response body following project standard format
   const body: SuccessResponse<T> = {
@@ -130,7 +137,9 @@ export function createSuccessResponse<T>(
     ...(message && { message }),
   };
 
-  return NextResponse.json(body);
+  return options.status !== undefined
+    ? NextResponse.json(body, { status: options.status })
+    : NextResponse.json(body);
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

The finals-bracket-route GET and finals-matches-route POST were using `NextResponse.json()` directly, inconsistent with the project standard of using `createSuccessResponse()`.

## Changes

- `finals-bracket-route.ts` GET: use `createSuccessResponse()` wrapper
- `finals-matches-route.ts` POST: use `createSuccessResponse()` wrapper

All responses now follow `{ success: true, data: {...} }` format consistently.

## Test plan

- [ ] Verify GET /finals-bracket returns `{ success: true, data: {...} }`
- [ ] Verify POST /finals-matches returns `{ success: true, data: { match }, message: '...' }`

Fixes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)