### PR TITLE
[codex] add e2e timeout runner

### DIFF
--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -467,8 +467,10 @@ async function apiGenerateGpFinals(page, tournamentId, topN = 8) {
   { label: `GP finals POST` });
 }
 
-/** GP finals uses 'paginated' GET style: { data, meta, totalPages }.
- *  Aggregate up to 5 pages of 50 entries (17 finals matches always fit in 1 page). */
+/** GP finals uses 'paginated' GET style: { success: true, data: { data: [...], meta: {...} } }.
+ *  Aggregate up to 5 pages of 50 entries (17 finals matches always fit in 1 page).
+ *  Note: createSuccessResponse wraps the paginated result, so json.data = { data, meta }.
+ *  TC-701/702/707/708 PASS because they use apiFetchGp (qualification), not finals. */
 async function apiFetchGpFinalsMatches(page, tournamentId) {
   const all = [];
   for (let p = 1; p <= 5; p++) {
@@ -476,13 +478,242 @@ async function apiFetchGpFinalsMatches(page, tournamentId) {
       const r = await fetch(`${u}?page=${pp}&limit=50&ts=${Date.now()}`, { cache: 'no-store' });
       return r.json().catch(() => ({}));
     }, [`/api/tournaments/${tournamentId}/gp/finals`, p]);
-    const data = json.data || [];
-    if (data.length === 0) break;
-    all.push(...data);
-    const totalPages = json.totalPages || 1;
+    /* Unwrap createSuccessResponse: json.data = { data: [...matches], meta: { total, page, limit, totalPages } } */
+    const wrapped = json.data;
+    const raw = (wrapped && typeof wrapped === 'object' && !Array.isArray(wrapped))
+      ? (wrapped.data || [])
+      : (Array.isArray(wrapped) ? wrapped : []);
+    if (raw.length === 0) break;
+    all.push(...raw);
+    const totalPages = wrapped?.meta?.totalPages || 1;
     if (p >= totalPages) break;
   }
   return all.slice().sort((a, b) => (a.matchNumber || 0) - (b.matchNumber || 0));
+}
+
+/* ───────── TA helpers ─────────
+ * TA (Time Attack / Time Trial) has two distinct PUT contracts:
+ *   1. Admin:       PUT /api/tournaments/:id/tt/entries/:entryId
+ *                   Body: { version, times: {MC1: "1:00.00", ...}, totalTime, rank }
+ *                   — sets the full qualification time record (optimistic-locked).
+ *   2. Participant: PUT /api/tournaments/:id/ta
+ *                   Body: { entryId, course, time }
+ *                   — updates a single course cell; allowed for self or partner.
+ * and several action flavours via PUT /ta: set_partner, update_seeding,
+ *   update_lives, reset_lives, eliminate. */
+
+const TA_COURSES = [
+  'MC1', 'DP1', 'GV1', 'BC1', 'MC2',
+  'CI1', 'GV2', 'DP2', 'BC2', 'MC3',
+  'KB1', 'CI2', 'VL1', 'BC3', 'MC4',
+  'DP3', 'KB2', 'GV3', 'VL2', 'RR',
+];
+
+/** PUT /api/tournaments/:id with arbitrary patch body. Used to activate (status)
+ *  or toggle feature flags (taPlayerSelfEdit, dualReportEnabled, etc.). */
+async function apiUpdateTournament(page, tournamentId, body) {
+  return page.evaluate(async ([u, d]) => {
+    const r = await fetch(u, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(d),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}`, body]);
+}
+
+/** Convenience wrapper — throws so callers can early-exit on activation failure. */
+async function apiActivateTournament(page, tournamentId) {
+  const res = await apiUpdateTournament(page, tournamentId, { status: 'active' });
+  if (res.s !== 200) {
+    throw new Error(`Failed to activate tournament ${tournamentId} (${res.s})`);
+  }
+  return res;
+}
+
+/** Add TA qualification entries. Supports both legacy single-player shape
+ *  (`{ playerId }`) and the preferred seeded form (`{ playerEntries: [...] }`). */
+async function apiAddTaEntries(page, tournamentId, payload) {
+  return page.evaluate(async ([u, d]) => {
+    const r = await fetch(u, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(d),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/ta`, payload]);
+}
+
+async function apiGetTtEntry(page, tournamentId, entryId) {
+  return page.evaluate(async (u) => {
+    const r = await fetch(u);
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, `/api/tournaments/${tournamentId}/tt/entries/${entryId}`);
+}
+
+/** Admin PUT: overwrite qualification times + totalTime + rank. Optimistic-locked
+ *  via `version`. Retried on 5xx since D1 occasionally 503s under load. */
+async function apiUpdateTtEntry(page, tournamentId, entryId, payload) {
+  return withRetry(() => page.evaluate(async ([u, d]) => {
+    const r = await fetch(u, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(d),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/tt/entries/${entryId}`, payload]),
+  { label: `TT entry PUT ${entryId}` });
+}
+
+/** Fetch current version, then PUT full times + totalTime + rank in one call.
+ *  Callers pass already-formatted `times` (e.g. { MC1: '1:00.00' }) + totalTimeMs + rank. */
+async function apiSeedTtEntry(page, tournamentId, entryId, times, totalTimeMs, rank) {
+  const ge = await apiGetTtEntry(page, tournamentId, entryId);
+  const version = ge.b?.data?.version;
+  if (ge.s !== 200 || typeof version !== 'number') {
+    throw new Error(`Failed to fetch TT entry version for ${entryId} (${ge.s})`);
+  }
+  const res = await apiUpdateTtEntry(page, tournamentId, entryId, {
+    version,
+    times,
+    totalTime: totalTimeMs,
+    rank,
+  });
+  if (res.s !== 200) {
+    throw new Error(`Failed to seed TT entry ${entryId} (${res.s}): ${JSON.stringify(res.b).slice(0, 200)}`);
+  }
+  return res;
+}
+
+async function apiPromoteTaPhase(page, tournamentId, action) {
+  return page.evaluate(async ([u, d]) => {
+    const r = await fetch(u, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(d),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/ta/phases`, { action }]);
+}
+
+async function apiSetTaPartner(page, tournamentId, entryId, partnerId) {
+  return page.evaluate(async ([u, d]) => {
+    const r = await fetch(u, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(d),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/ta`, { entryId, action: 'set_partner', partnerId }]);
+}
+
+async function apiUpdateTaSeeding(page, tournamentId, entryId, seeding) {
+  return page.evaluate(async ([u, d]) => {
+    const r = await fetch(u, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(d),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/ta`, { entryId, action: 'update_seeding', seeding }]);
+}
+
+/** Participant PUT: single-course time update. Works for self or partner per
+ *  taPlayerSelfEdit / partnerId rules. Admin can bypass. */
+async function apiTaParticipantEditTime(page, tournamentId, entryId, course, time) {
+  return page.evaluate(async ([u, d]) => {
+    const r = await fetch(u, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(d),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/ta`, { entryId, course, time }]);
+}
+
+async function apiFetchTa(page, tournamentId, stage = 'qualification') {
+  return page.evaluate(async (u) => {
+    const r = await fetch(u);
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, `/api/tournaments/${tournamentId}/ta?stage=${stage}`);
+}
+
+/** Format a ms duration as the "M:SS.mm" string the TT API accepts. */
+function formatTtTime(ms) {
+  const minutes = Math.floor(ms / 60000);
+  const seconds = Math.floor((ms % 60000) / 1000);
+  const hundredths = Math.floor((ms % 1000) / 10);
+  return `${minutes}:${seconds.toString().padStart(2, '0')}.${hundredths.toString().padStart(2, '0')}`;
+}
+
+/** Build a 20-course `times` object for a player at `rank`. Spacing is
+ *  rank×200 ms per course ⇒ ~4 sec total differential between players,
+ *  enough for the scoring engine to sort deterministically. */
+function makeTaTimesForRank(rank) {
+  const times = {};
+  let totalMs = 0;
+  for (const course of TA_COURSES) {
+    const courseMs = 60000 + rank * 200;
+    times[course] = formatTtTime(courseMs);
+    totalMs += courseMs;
+  }
+  return { times, totalMs };
+}
+
+/** 28-player TA qualification setup: creates players + tournament, activates,
+ *  adds all 28 via playerEntries, then seeds each entry with 20-course times.
+ *  Returns { tournamentId, playerIds, nicknames, entryIds, cleanup }. */
+async function setupTa28PlayerQual(adminPage, label, opts = {}) {
+  const stamp = Date.now();
+  const playerIds = [];
+  const nicknames = [];
+  const entryIds = [];
+  let tournamentId = null;
+
+  const cleanup = async () => {
+    await apiDeleteTournament(adminPage, tournamentId);
+    for (const id of playerIds) await apiDeletePlayer(adminPage, id);
+  };
+
+  try {
+    for (let i = 1; i <= 28; i++) {
+      const p = await apiCreatePlayer(
+        adminPage,
+        `E2E TA ${label} P${i}`,
+        `e2e_ta${label}_${stamp}_${i}`,
+      );
+      playerIds.push(p.id);
+      nicknames.push(p.nickname);
+    }
+    tournamentId = await apiCreateTournament(
+      adminPage,
+      `E2E TA ${label} ${stamp}`,
+      { dualReportEnabled: false, ...opts },
+    );
+    await apiActivateTournament(adminPage, tournamentId);
+
+    const add = await apiAddTaEntries(adminPage, tournamentId, {
+      playerEntries: playerIds.map((playerId, i) => ({ playerId, seeding: i + 1 })),
+    });
+    if (add.s !== 201) {
+      throw new Error(`TA 28-player add failed (${add.s}): ${JSON.stringify(add.b).slice(0, 200)}`);
+    }
+
+    /* Seed per-entry qualification times. Assign rank = seeding so the best
+     * seed produces the fastest time; real ranks are recomputed server-side. */
+    const entries = add.b?.data?.entries ?? [];
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      const rank = i + 1;
+      const { times, totalMs } = makeTaTimesForRank(rank);
+      await apiSeedTtEntry(adminPage, tournamentId, entry.id, times, totalMs, rank);
+      entryIds.push(entry.id);
+    }
+    return { tournamentId, playerIds, nicknames, entryIds, cleanup };
+  } catch (err) {
+    await cleanup();
+    throw err;
+  }
 }
 
 async function setupGp28PlayerFinals(adminPage, label, opts = {}) {
@@ -578,4 +809,20 @@ module.exports = {
   apiGenerateGpFinals,
   apiFetchGpFinalsMatches,
   setupGp28PlayerFinals,
+  /* TA */
+  TA_COURSES,
+  apiUpdateTournament,
+  apiActivateTournament,
+  apiAddTaEntries,
+  apiGetTtEntry,
+  apiUpdateTtEntry,
+  apiSeedTtEntry,
+  apiPromoteTaPhase,
+  apiSetTaPartner,
+  apiUpdateTaSeeding,
+  apiTaParticipantEditTime,
+  apiFetchTa,
+  formatTtTime,
+  makeTaTimesForRank,
+  setupTa28PlayerQual,
 };

--- a/smkc-score-app/e2e/lib/runner.js
+++ b/smkc-score-app/e2e/lib/runner.js
@@ -1,0 +1,187 @@
+const { chromium } = require('playwright');
+const { nav } = require('./common');
+
+const DEFAULT_PROFILE_DIR = '/tmp/playwright-smkc-profile';
+const DEFAULT_TEST_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_SUITE_TIMEOUT_MS = 35 * 60 * 1000;
+const DEFAULT_PROGRESS_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_BROWSER_CLOSE_TIMEOUT_MS = 15 * 1000;
+const DEFAULT_FORCE_EXIT_TIMEOUT_MS = 20 * 1000;
+
+function envMs(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function formatDuration(ms) {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds % 60;
+  return rest === 0 ? `${minutes}m` : `${minutes}m ${rest}s`;
+}
+
+function withTimeout(promise, timeoutMs, label) {
+  let timer = null;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      const err = new Error(`${label} timed out after ${formatDuration(timeoutMs)}`);
+      err.code = 'E2E_TIMEOUT';
+      reject(err);
+    }, timeoutMs);
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+function exitAfterCleanup(code, cleanup) {
+  const hardExitMs = envMs('E2E_FORCE_EXIT_TIMEOUT_MS', DEFAULT_FORCE_EXIT_TIMEOUT_MS);
+  const hardExit = setTimeout(() => process.exit(code), hardExitMs);
+  if (hardExit.unref) hardExit.unref();
+
+  Promise.resolve()
+    .then(() => (cleanup ? cleanup() : undefined))
+    .catch((err) => {
+      console.error('[E2E] cleanup before exit failed:', err instanceof Error ? err.message : err);
+    })
+    .finally(() => {
+      clearTimeout(hardExit);
+      process.exit(code);
+    });
+}
+
+function createProgressWatchdog(
+  label,
+  timeoutMs = envMs('E2E_PROGRESS_TIMEOUT_MS', DEFAULT_PROGRESS_TIMEOUT_MS),
+  onTimeout = null,
+) {
+  let timer = null;
+  let lastScope = 'startup';
+
+  const reset = (scope = lastScope) => {
+    lastScope = scope;
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      console.error(`[${label}] no progress for ${formatDuration(timeoutMs)} after ${lastScope}`);
+      exitAfterCleanup(124, onTimeout);
+    }, timeoutMs);
+    if (timer.unref) timer.unref();
+  };
+
+  const stop = () => {
+    if (timer) clearTimeout(timer);
+    timer = null;
+  };
+
+  reset();
+  return { reset, stop };
+}
+
+async function closeBrowser(browser) {
+  if (!browser) return;
+  const timeoutMs = envMs('E2E_BROWSER_CLOSE_TIMEOUT_MS', DEFAULT_BROWSER_CLOSE_TIMEOUT_MS);
+  try {
+    await withTimeout(browser.close(), timeoutMs, 'browser.close()');
+  } catch (err) {
+    console.error(`[E2E] failed to close browser cleanly: ${err.message}`);
+  }
+}
+
+function summarizeResults(suiteName, results) {
+  console.log(`\n========== ${suiteName} TEST SUMMARY ==========`);
+  const passed = results.filter((r) => r.status === 'PASS').length;
+  const failed = results.filter((r) => r.status === 'FAIL').length;
+  const skipped = results.filter((r) => r.status === 'SKIP').length;
+  console.log(`PASS: ${passed} | FAIL: ${failed} | SKIP: ${skipped} | Total: ${results.length}`);
+  if (failed > 0) {
+    results
+      .filter((r) => r.status === 'FAIL')
+      .forEach((r) => console.log(`  ❌ [${r.tc}] ${r.detail}`));
+  }
+  return { passed, failed, skipped };
+}
+
+function recordFailure(results, log, tc, detail) {
+  for (let i = results.length - 1; i >= 0; i--) {
+    if (results[i].tc === tc) {
+      results[i].status = 'FAIL';
+      results[i].detail = results[i].detail ? `${results[i].detail}; ${detail}` : detail;
+      console.log(`❌ [${tc}] FAIL — ${detail}`);
+      return;
+    }
+  }
+  log(tc, 'FAIL', detail);
+}
+
+async function runSuite({ suiteName, results, log, tests }) {
+  const suiteTimeoutMs = envMs('E2E_SUITE_TIMEOUT_MS', DEFAULT_SUITE_TIMEOUT_MS);
+  const testTimeoutMs = envMs('E2E_TEST_TIMEOUT_MS', DEFAULT_TEST_TIMEOUT_MS);
+  let browser = null;
+  const progress = createProgressWatchdog(suiteName, undefined, () => closeBrowser(browser));
+  let forcedFailure = false;
+
+  const suiteTimer = setTimeout(() => {
+    console.error(`[${suiteName}] suite timed out after ${formatDuration(suiteTimeoutMs)}`);
+    exitAfterCleanup(124, () => closeBrowser(browser));
+  }, suiteTimeoutMs);
+
+  try {
+    const profileDir = process.env.E2E_PROFILE_DIR || DEFAULT_PROFILE_DIR;
+    const headless = process.env.E2E_HEADLESS === '1';
+    browser = await chromium.launchPersistentContext(profileDir, {
+      headless,
+      viewport: { width: 1280, height: 720 },
+    });
+    const page = browser.pages()[0] || await browser.newPage();
+    page.setDefaultTimeout(envMs('E2E_ACTION_TIMEOUT_MS', 30 * 1000));
+    page.setDefaultNavigationTimeout(envMs('E2E_NAV_TIMEOUT_MS', 30 * 1000));
+
+    progress.reset('initial navigation');
+    await nav(page, '/');
+
+    for (const test of tests) {
+      const timeoutMs = test.timeoutMs || testTimeoutMs;
+      const started = Date.now();
+      progress.reset(test.name);
+      console.log(`\n[${suiteName}] Starting ${test.name}`);
+      try {
+        await withTimeout(test.fn(page), timeoutMs, `${suiteName} ${test.name}`);
+        console.log(`[${suiteName}] Finished ${test.name} in ${formatDuration(Date.now() - started)}`);
+      } catch (err) {
+        forcedFailure = true;
+        const detail = err instanceof Error ? err.message : `${test.name} failed`;
+        recordFailure(results, log, test.name, detail);
+        console.error(`[${suiteName}] Aborting after ${test.name}: ${detail}`);
+        break;
+      }
+    }
+  } catch (err) {
+    forcedFailure = true;
+    console.error(`[${suiteName}] fatal error:`, err instanceof Error ? err.stack || err.message : err);
+  } finally {
+    clearTimeout(suiteTimer);
+    progress.stop();
+    await closeBrowser(browser);
+    const summary = summarizeResults(suiteName, results);
+    process.exit(forcedFailure || summary.failed > 0 ? 1 : 0);
+  }
+}
+
+module.exports = {
+  DEFAULT_PROGRESS_TIMEOUT_MS,
+  DEFAULT_TEST_TIMEOUT_MS,
+  DEFAULT_SUITE_TIMEOUT_MS,
+  closeBrowser,
+  createProgressWatchdog,
+  envMs,
+  exitAfterCleanup,
+  formatDuration,
+  runSuite,
+  summarizeResults,
+  withTimeout,
+};

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -21,15 +21,24 @@ const {
   apiFetchTa,
   apiTaParticipantEditTime,
 } = require('./lib/common');
+const {
+  closeBrowser,
+  createProgressWatchdog,
+  envMs,
+  exitAfterCleanup,
+  formatDuration,
+} = require('./lib/runner');
 
 const BASE = process.env.E2E_BASE_URL || 'https://smkc.bluemoon.works';
 const TID = process.env.E2E_TOURNAMENT_ID || 'cmmvbmrr00000o01slo9jy3o8';
 const WAIT = 8000;
 const results = [];
+let progressWatchdog = null;
 
 function log(tc, s, d = '') {
   console.log(`${s === 'PASS' ? '✅' : s === 'SKIP' ? '⏭️' : '❌'} [${tc}] ${s}${d ? ' — ' + d : ''}`);
   results.push({ tc, s, d });
+  if (progressWatchdog) progressWatchdog.reset(tc);
 }
 async function vis(p) {
   const m = p.locator('main');
@@ -70,12 +79,68 @@ async function deletePlayer(p, id) {
   }, `/api/players/${id}`).catch(() => {});
 }
 
-(async () => {
-  const browser = await chromium.launchPersistentContext(
-    '/tmp/playwright-smkc-profile',
-    { headless: false, viewport: { width: 1280, height: 720 } }
-  );
-  const page = browser.pages()[0] || await browser.newPage();
+function httpsRequest(url, read, fallback) {
+  const timeoutMs = envMs('E2E_HTTP_TIMEOUT_MS', 15000);
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (value) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+
+    const req = https.get(url, (res) => read(res, done));
+    req.setTimeout(timeoutMs, () => {
+      req.destroy();
+      done(fallback);
+    });
+    req.on('error', () => done(fallback));
+  });
+}
+
+function getHeaders(url) {
+  return httpsRequest(url, (res, done) => {
+    done(res.headers);
+    res.resume();
+  }, {});
+}
+
+function getStatus(url) {
+  return httpsRequest(url, (res, done) => {
+    done(res.statusCode);
+    res.resume();
+  }, 0);
+}
+
+function getBody(url) {
+  return httpsRequest(url, (res, done) => {
+    let data = '';
+    res.setEncoding('utf8');
+    res.on('data', (chunk) => { data += chunk; });
+    res.on('end', () => done(data));
+  }, '');
+}
+
+async function main() {
+  let browser = null;
+  const suiteTimeoutMs = envMs('E2E_ALL_SUITE_TIMEOUT_MS', envMs('E2E_SUITE_TIMEOUT_MS', 60 * 60 * 1000));
+  const suiteTimer = setTimeout(() => {
+    console.error(`[tc-all] suite timed out after ${formatDuration(suiteTimeoutMs)}`);
+    exitAfterCleanup(124, () => closeBrowser(browser));
+  }, suiteTimeoutMs);
+  progressWatchdog = createProgressWatchdog('tc-all', undefined, () => closeBrowser(browser));
+
+  try {
+    browser = await chromium.launchPersistentContext(
+      process.env.E2E_PROFILE_DIR || '/tmp/playwright-smkc-profile',
+      {
+        headless: process.env.E2E_HEADLESS === '1',
+        viewport: { width: 1280, height: 720 },
+      },
+    );
+    const page = browser.pages()[0] || await browser.newPage();
+    page.setDefaultTimeout(envMs('E2E_ACTION_TIMEOUT_MS', 30 * 1000));
+    page.setDefaultNavigationTimeout(envMs('E2E_NAV_TIMEOUT_MS', 30 * 1000));
 
   // ===== Public page tests (work regardless of login state) =====
 
@@ -157,9 +222,7 @@ async function deletePlayer(p, id) {
   // ===== Security tests (no browser session needed — use https/curl) =====
 
   // TC-105
-  const hdrs = await new Promise(r => {
-    https.get(BASE + '/', res => { r(res.headers); res.resume(); }).on('error', () => r({}));
-  });
+  const hdrs = await getHeaders(BASE + '/');
   const miss = ['content-security-policy', 'x-frame-options', 'x-content-type-options', 'referrer-policy']
     .filter(h => !hdrs[h]);
   log('TC-105', miss.length === 0 ? 'PASS' : 'FAIL', miss.length > 0 ? 'Missing: ' + miss.join(',') : '');
@@ -171,10 +234,7 @@ async function deletePlayer(p, id) {
   // TC-107: Forbidden consistency (unauthenticated curl — not browser session)
   let tc107 = true;
   for (const ep of ['bm/standings', 'mr/standings', 'gp/standings', 'ta/standings']) {
-    const status = await new Promise(r => {
-      https.get(`${BASE}/api/tournaments/${TID}/${ep}`, res => { r(res.statusCode); res.resume(); })
-        .on('error', () => r(0));
-    });
+    const status = await getStatus(`${BASE}/api/tournaments/${TID}/${ep}`);
     if (status !== 403) tc107 = false;
   }
   log('TC-107', tc107 ? 'PASS' : 'FAIL');
@@ -969,13 +1029,7 @@ async function deletePlayer(p, id) {
   } else { log('TC-104', 'SKIP'); }
 
   // TC-304: Viewer empty group message (check via unauthenticated curl)
-  const mrBody = await new Promise(r => {
-    let data = '';
-    https.get(`${BASE}/tournaments/${TID}/mr`, res => {
-      res.on('data', d => data += d);
-      res.on('end', () => r(data));
-    }).on('error', () => r(''));
-  });
+  const mrBody = await getBody(`${BASE}/tournaments/${TID}/mr`);
   log('TC-304', (mrBody.includes('Please wait') || mrBody.includes('セットアップが完了するまで')) ? 'PASS' : 'FAIL');
 
   // TC-305: BM group dialog
@@ -1504,18 +1558,21 @@ async function deletePlayer(p, id) {
   // tracking, since the buffered "FAIL:" string parser can't see inherited output.
   const { spawnSync } = require('child_process');
   const projectRoot = __dirname.replace(/\/e2e$/, '');
-  await browser.close();
+  await closeBrowser(browser);
+  browser = null;
 
   function runChildScript(label, script) {
+    const timeoutMs = envMs('E2E_CHILD_TIMEOUT_MS', 40 * 60 * 1000);
     console.log(`\n========== Running ${label} (${script}) ==========`);
     const result = spawnSync('node', [script], {
       cwd: projectRoot,
       env: { ...process.env, E2E_BASE_URL: BASE },
-      timeout: 1800000, // 30 min: 28-player full workflows take several minutes each
+      timeout: timeoutMs,
+      killSignal: 'SIGTERM',
       stdio: 'inherit',
     });
     if (result.error) {
-      console.error(`[${label}] spawn error:`, result.error.message);
+      console.error(`[${label}] spawn error after ${formatDuration(timeoutMs)}:`, result.error.message);
       return true;
     }
     return result.status !== 0;
@@ -1538,5 +1595,20 @@ async function deletePlayer(p, id) {
   if (gpFailed) console.log('  ⚠️  GP tests (tc-gp.js) had failures — see output above');
   if (taFailed) console.log('  ⚠️  TA tests (tc-ta.js) had failures — see output above');
 
-  process.exit((f > 0 || bmFailed || mrFailed || gpFailed || taFailed) ? 1 : 0);
-})();
+    return (f > 0 || bmFailed || mrFailed || gpFailed || taFailed) ? 1 : 0;
+  } finally {
+    clearTimeout(suiteTimer);
+    if (progressWatchdog) {
+      progressWatchdog.stop();
+      progressWatchdog = null;
+    }
+    await closeBrowser(browser);
+  }
+}
+
+main()
+  .then((exitCode) => process.exit(exitCode))
+  .catch((err) => {
+    console.error('[tc-all] fatal error:', err instanceof Error ? err.stack || err.message : err);
+    process.exit(1);
+  });

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -10,6 +10,17 @@
  */
 const { chromium } = require('playwright');
 const https = require('https');
+const {
+  apiActivateTournament,
+  apiUpdateTournament,
+  apiAddTaEntries,
+  apiSeedTtEntry,
+  apiPromoteTaPhase,
+  apiSetTaPartner,
+  apiUpdateTaSeeding,
+  apiFetchTa,
+  apiTaParticipantEditTime,
+} = require('./lib/common');
 
 const BASE = process.env.E2E_BASE_URL || 'https://smkc.bluemoon.works';
 const TID = process.env.E2E_TOURNAMENT_ID || 'cmmvbmrr00000o01slo9jy3o8';
@@ -479,69 +490,21 @@ async function deletePlayer(p, id) {
       if (taTournament.s !== 201 || !taTournamentId) {
         throw new Error('Failed to create TA tournament');
       }
+      await apiActivateTournament(page, taTournamentId);
 
-      const activateTournament = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { ok: r.ok, s: r.status };
-      }, [`/api/tournaments/${taTournamentId}`, { status: 'active' }]);
-      if (!activateTournament.ok) {
-        throw new Error(`Failed to activate TA tournament (${activateTournament.s})`);
-      }
-
-      const addTaEntry = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [`/api/tournaments/${taTournamentId}/ta`, { playerId: pid }]);
+      const addTaEntry = await apiAddTaEntries(page, taTournamentId, { playerId: pid });
       const taEntryId = addTaEntry.b?.data?.entries?.[0]?.id ?? null;
       if (addTaEntry.s !== 201 || !taEntryId) {
         throw new Error(`Failed to create TA qualification entry (${addTaEntry.s})`);
       }
 
-      const getEntry = await page.evaluate(async (u) => {
-        const r = await fetch(u);
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, `/api/tournaments/${taTournamentId}/tt/entries/${taEntryId}`);
-      const version = getEntry.b?.data?.version;
-      if (getEntry.s !== 200 || typeof version !== 'number') {
-        throw new Error(`Failed to fetch TT entry version (${getEntry.s})`);
-      }
+      /* Seed rank 17 so promote_phase1 (ranks 17–24) picks this entry up. */
+      await apiSeedTtEntry(
+        page, taTournamentId, taEntryId,
+        { MC1: '1:00.00' }, 60000, 17
+      );
 
-      const seedQualification = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [
-        `/api/tournaments/${taTournamentId}/tt/entries/${taEntryId}`,
-        {
-          version,
-          times: { MC1: '1:00.00' },
-          totalTime: 60000,
-          rank: 17,
-        },
-      ]);
-      if (seedQualification.s !== 200) {
-        throw new Error(`Failed to seed qualification entry (${seedQualification.s})`);
-      }
-
-      const promotePhase1 = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [`/api/tournaments/${taTournamentId}/ta/phases`, { action: 'promote_phase1' }]);
+      const promotePhase1 = await apiPromoteTaPhase(page, taTournamentId, 'promote_phase1');
       if (promotePhase1.s !== 200) {
         throw new Error(`Failed to promote Phase 1 (${promotePhase1.s})`);
       }
@@ -601,69 +564,20 @@ async function deletePlayer(p, id) {
       if (taTournament.s !== 201 || !taTournamentId) {
         throw new Error('Failed to create TA tournament');
       }
+      await apiActivateTournament(page, taTournamentId);
 
-      const activateTournament = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { ok: r.ok, s: r.status };
-      }, [`/api/tournaments/${taTournamentId}`, { status: 'active' }]);
-      if (!activateTournament.ok) {
-        throw new Error(`Failed to activate TA tournament (${activateTournament.s})`);
-      }
-
-      const addTaEntry = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [`/api/tournaments/${taTournamentId}/ta`, { playerId: pid }]);
+      const addTaEntry = await apiAddTaEntries(page, taTournamentId, { playerId: pid });
       const taEntryId = addTaEntry.b?.data?.entries?.[0]?.id ?? null;
       if (addTaEntry.s !== 201 || !taEntryId) {
         throw new Error(`Failed to create TA qualification entry (${addTaEntry.s})`);
       }
 
-      const getEntry = await page.evaluate(async (u) => {
-        const r = await fetch(u);
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, `/api/tournaments/${taTournamentId}/tt/entries/${taEntryId}`);
-      const version = getEntry.b?.data?.version;
-      if (getEntry.s !== 200 || typeof version !== 'number') {
-        throw new Error(`Failed to fetch TT entry version (${getEntry.s})`);
-      }
+      await apiSeedTtEntry(
+        page, taTournamentId, taEntryId,
+        { MC1: '1:00.00' }, 60000, 17
+      );
 
-      const seedQualification = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [
-        `/api/tournaments/${taTournamentId}/tt/entries/${taEntryId}`,
-        {
-          version,
-          times: { MC1: '1:00.00' },
-          totalTime: 60000,
-          rank: 17,
-        },
-      ]);
-      if (seedQualification.s !== 200) {
-        throw new Error(`Failed to seed qualification entry (${seedQualification.s})`);
-      }
-
-      const promotePhase1 = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [`/api/tournaments/${taTournamentId}/ta/phases`, { action: 'promote_phase1' }]);
+      const promotePhase1 = await apiPromoteTaPhase(page, taTournamentId, 'promote_phase1');
       if (promotePhase1.s !== 200) {
         throw new Error(`Failed to promote Phase 1 (${promotePhase1.s})`);
       }
@@ -735,29 +649,11 @@ async function deletePlayer(p, id) {
       if (taTournament.s !== 201 || !taTournamentId) {
         throw new Error('Failed to create TA tournament');
       }
-
-      const activateTournament = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { ok: r.ok, s: r.status };
-      }, [`/api/tournaments/${taTournamentId}`, { status: 'active' }]);
-      if (!activateTournament.ok) {
-        throw new Error(`Failed to activate TA tournament (${activateTournament.s})`);
-      }
+      await apiActivateTournament(page, taTournamentId);
 
       const entryIds = [];
       for (const playerId of [pid, secondPlayerId]) {
-        const addTaEntry = await page.evaluate(async ([u, d]) => {
-          const r = await fetch(u, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(d),
-          });
-          return { s: r.status, b: await r.json().catch(() => ({})) };
-        }, [`/api/tournaments/${taTournamentId}/ta`, { playerId }]);
+        const addTaEntry = await apiAddTaEntries(page, taTournamentId, { playerId });
         const entryId = addTaEntry.b?.data?.entries?.[0]?.id ?? null;
         if (addTaEntry.s !== 201 || !entryId) {
           throw new Error(`Failed to create TA qualification entry (${addTaEntry.s})`);
@@ -766,44 +662,15 @@ async function deletePlayer(p, id) {
       }
 
       for (const [index, entryId] of entryIds.entries()) {
-        const getEntry = await page.evaluate(async (u) => {
-          const r = await fetch(u);
-          return { s: r.status, b: await r.json().catch(() => ({})) };
-        }, `/api/tournaments/${taTournamentId}/tt/entries/${entryId}`);
-        const version = getEntry.b?.data?.version;
-        if (getEntry.s !== 200 || typeof version !== 'number') {
-          throw new Error(`Failed to fetch TT entry version (${getEntry.s})`);
-        }
-
-        const updateEntry = await page.evaluate(async ([u, d]) => {
-          const r = await fetch(u, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(d),
-          });
-          return { s: r.status, b: await r.json().catch(() => ({})) };
-        }, [
-          `/api/tournaments/${taTournamentId}/tt/entries/${entryId}`,
-          {
-            version,
-            times: { MC1: index === 0 ? '1:00.00' : '1:01.00' },
-            totalTime: index === 0 ? 60000 : 61000,
-            rank: index + 1,
-          },
-        ]);
-        if (updateEntry.s !== 200) {
-          throw new Error(`Failed to seed qualification entry (${updateEntry.s})`);
-        }
+        await apiSeedTtEntry(
+          page, taTournamentId, entryId,
+          { MC1: index === 0 ? '1:00.00' : '1:01.00' },
+          index === 0 ? 60000 : 61000,
+          index + 1,
+        );
       }
 
-      const promotePhase3 = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [`/api/tournaments/${taTournamentId}/ta/phases`, { action: 'promote_phase3' }]);
+      const promotePhase3 = await apiPromoteTaPhase(page, taTournamentId, 'promote_phase3');
       if (promotePhase3.s !== 200) {
         throw new Error(`Failed to promote Phase 3 (${promotePhase3.s})`);
       }
@@ -875,75 +742,36 @@ async function deletePlayer(p, id) {
   if (pid) {
     let taTournamentId = null;
     try {
-      // Create temp tournament
-      const taTournament = await page.evaluate(async d => {
+      const created = await page.evaluate(async d => {
         const r = await fetch('/api/tournaments', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(d),
         });
         return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, {
-        name: `E2E TA Seeding ${Date.now()}`,
-        date: new Date().toISOString(),
-        dualReportEnabled: false,
+      }, { name: `E2E TA Seeding ${Date.now()}`, date: new Date().toISOString(), dualReportEnabled: false });
+      taTournamentId = created.b?.data?.id ?? null;
+      if (created.s !== 201 || !taTournamentId) throw new Error('Failed to create TA tournament');
+      await apiActivateTournament(page, taTournamentId);
+
+      const addResult = await apiAddTaEntries(page, taTournamentId, {
+        playerEntries: [{ playerId: pid, seeding: 3 }],
       });
-      taTournamentId = taTournament.b?.data?.id ?? null;
-      if (taTournament.s !== 201 || !taTournamentId) {
-        throw new Error('Failed to create TA tournament');
-      }
-
-      // Activate
-      await page.evaluate(async ([u, d]) => {
-        await fetch(u, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(d) });
-      }, [`/api/tournaments/${taTournamentId}`, { status: 'active' }]);
-
-      // Add entry via playerEntries (new format with seeding)
-      const addResult = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [`/api/tournaments/${taTournamentId}/ta`, { playerEntries: [{ playerId: pid, seeding: 3 }] }]);
       const entryId = addResult.b?.data?.entries?.[0]?.id ?? null;
       const initialSeeding = addResult.b?.data?.entries?.[0]?.seeding;
       if (addResult.s !== 201 || !entryId) {
         throw new Error(`Failed to create TA entry with seeding (${addResult.s})`);
       }
-
-      // Verify seeding was set on creation
       const step1 = initialSeeding === 3;
 
-      // Update seeding via PUT update_seeding
-      const updateResult = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [`/api/tournaments/${taTournamentId}/ta`, { entryId, action: 'update_seeding', seeding: 7 }]);
+      const updateResult = await apiUpdateTaSeeding(page, taTournamentId, entryId, 7);
       const step2 = updateResult.s === 200;
 
-      // Verify seeding persisted via GET
-      const getResult = await page.evaluate(async (u) => {
-        const r = await fetch(u);
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, `/api/tournaments/${taTournamentId}/ta?stage=qualification`);
+      const getResult = await apiFetchTa(page, taTournamentId);
       const entry = getResult.b?.data?.entries?.find(e => e.id === entryId);
       const step3 = entry?.seeding === 7;
 
-      // Clear seeding (set to null)
-      const clearResult = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [`/api/tournaments/${taTournamentId}/ta`, { entryId, action: 'update_seeding', seeding: null }]);
+      const clearResult = await apiUpdateTaSeeding(page, taTournamentId, entryId, null);
       const step4 = clearResult.s === 200 && clearResult.b?.data?.entry?.seeding === null;
 
       log('TC-317', step1 && step2 && step3 && step4 ? 'PASS' : 'FAIL',
@@ -966,7 +794,6 @@ async function deletePlayer(p, id) {
     let taTournamentId = null;
     let partnerPlayerId = null;
     try {
-      // Create a second player to be the partner
       const partnerNick = `e2e_pair_${Date.now()}`;
       const partnerResult = await page.evaluate(async (d) => {
         const r = await fetch('/api/players', {
@@ -982,83 +809,46 @@ async function deletePlayer(p, id) {
         throw new Error(`Failed to create partner player (${partnerResult.s})`);
       }
 
-      // Create tournament
-      const taTournament = await page.evaluate(async d => {
+      const created = await page.evaluate(async d => {
         const r = await fetch('/api/tournaments', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(d),
         });
         return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, {
-        name: `E2E TA Pair ${Date.now()}`,
-        date: new Date().toISOString(),
-        dualReportEnabled: false,
-      });
-      taTournamentId = taTournament.b?.data?.id ?? null;
-      if (taTournament.s !== 201 || !taTournamentId) {
-        throw new Error('Failed to create TA tournament');
-      }
+      }, { name: `E2E TA Pair ${Date.now()}`, date: new Date().toISOString(), dualReportEnabled: false });
+      taTournamentId = created.b?.data?.id ?? null;
+      if (created.s !== 201 || !taTournamentId) throw new Error('Failed to create TA tournament');
+      await apiActivateTournament(page, taTournamentId);
 
-      // Activate
-      await page.evaluate(async ([u, d]) => {
-        await fetch(u, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(d) });
-      }, [`/api/tournaments/${taTournamentId}`, { status: 'active' }]);
-
-      // Add both players with seeding via playerEntries
-      const addBoth = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [`/api/tournaments/${taTournamentId}/ta`, {
+      const addBoth = await apiAddTaEntries(page, taTournamentId, {
         playerEntries: [
           { playerId: pid, seeding: 1 },
           { playerId: partnerPlayerId, seeding: 2 },
         ],
-      }]);
-      if (addBoth.s !== 201) {
-        throw new Error(`Failed to add players to TA (${addBoth.s})`);
-      }
+      });
+      if (addBoth.s !== 201) throw new Error(`Failed to add players to TA (${addBoth.s})`);
       const entry1 = addBoth.b?.data?.entries?.find(e => e.playerId === pid);
       const entry2 = addBoth.b?.data?.entries?.find(e => e.playerId === partnerPlayerId);
       if (!entry1 || !entry2) throw new Error('Missing entries after add');
 
-      // Step 1: Set partner via admin API (pid ↔ partnerPlayerId)
-      const setPairResult = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [`/api/tournaments/${taTournamentId}/ta`, {
-        entryId: entry1.id,
-        action: 'set_partner',
-        partnerId: partnerPlayerId,
-      }]);
+      const setPairResult = await apiSetTaPartner(page, taTournamentId, entry1.id, partnerPlayerId);
       const step1 = setPairResult.s === 200;
 
-      // Step 2: Verify both entries have partner set (bidirectional)
-      const getEntries = await page.evaluate(async (u) => {
-        const r = await fetch(u);
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, `/api/tournaments/${taTournamentId}/ta?stage=qualification`);
+      const getEntries = await apiFetchTa(page, taTournamentId);
       const e1 = getEntries.b?.data?.entries?.find(e => e.playerId === pid);
       const e2 = getEntries.b?.data?.entries?.find(e => e.playerId === partnerPlayerId);
       const step2 = e1?.partnerId === partnerPlayerId && e2?.partnerId === pid;
 
-      // Step 3: Partner player logs in and edits pid's entry time
+      /* Partner session: separate ephemeral browser so the admin persistent
+       * profile stays untouched. The partner PUT /ta exercises the partnerId
+       * rule in src/app/api/tournaments/[id]/ta/route.ts. */
       let partnerBrowser = null;
       let step3 = false;
       try {
         partnerBrowser = await chromium.launch({ headless: false });
         const partnerCtx = await partnerBrowser.newContext({ viewport: { width: 1280, height: 720 } });
         const partnerPage = await partnerCtx.newPage();
-
-        // Login as partner player
         await nav(partnerPage, '/auth/signin');
         await partnerPage.locator('#nickname').fill(partnerNick);
         await partnerPage.locator('#password').fill(partnerPassword);
@@ -1066,29 +856,15 @@ async function deletePlayer(p, id) {
         await partnerPage.waitForURL((url) => url.pathname === '/tournaments', { timeout: 15000 });
         await partnerPage.waitForTimeout(2000);
 
-        // Partner edits pid's entry time (allowed because they are partners)
-        const partnerEditResult = await partnerPage.evaluate(async ([u, d]) => {
-          const r = await fetch(u, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(d),
-          });
-          return { s: r.status, b: await r.json().catch(() => ({})) };
-        }, [`/api/tournaments/${taTournamentId}/ta`, {
-          entryId: entry1.id,
-          course: 'MC1',
-          time: '1:23.45',
-        }]);
+        const partnerEditResult = await apiTaParticipantEditTime(
+          partnerPage, taTournamentId, entry1.id, 'MC1', '1:23.45'
+        );
         step3 = partnerEditResult.s === 200;
       } finally {
         if (partnerBrowser) await partnerBrowser.close().catch(() => {});
       }
 
-      // Step 4: Verify the time was saved
-      const verifyEntries = await page.evaluate(async (u) => {
-        const r = await fetch(u);
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, `/api/tournaments/${taTournamentId}/ta?stage=qualification`);
+      const verifyEntries = await apiFetchTa(page, taTournamentId);
       const updatedEntry = verifyEntries.b?.data?.entries?.find(e => e.playerId === pid);
       const step4 = updatedEntry?.times?.MC1 === '1:23.45';
 
@@ -1101,21 +877,18 @@ async function deletePlayer(p, id) {
     } catch (err) {
       log('TC-318', 'FAIL', err instanceof Error ? err.message : 'TA pair flow failed');
     } finally {
-      if (taTournamentId) {
-        await deleteTournament(page, taTournamentId);
-      }
-      if (partnerPlayerId) {
-        await deletePlayer(page, partnerPlayerId);
-      }
+      if (taTournamentId) await deleteTournament(page, taTournamentId);
+      if (partnerPlayerId) await deletePlayer(page, partnerPlayerId);
     }
   } else { log('TC-318', 'SKIP'); }
 
   // TC-319: taPlayerSelfEdit=false blocks self-edit, allows partner edit
+  // Verified indirectly: admin bypasses the self-edit gate, so we probe the
+  // flag via GET /ta.data.taPlayerSelfEdit and via a round-trip PUT toggle.
   if (pid) {
     let taTournamentId = null;
     let partnerPlayerId2 = null;
     try {
-      // Create partner player
       const pNick = `e2e_selfed_${Date.now()}`;
       const pResult = await page.evaluate(async (d) => {
         const r = await fetch('/api/players', {
@@ -1128,8 +901,7 @@ async function deletePlayer(p, id) {
       partnerPlayerId2 = pResult.b?.data?.player?.id ?? null;
       if (!partnerPlayerId2) throw new Error('Failed to create partner');
 
-      // Create tournament with taPlayerSelfEdit=false
-      const t = await page.evaluate(async d => {
+      const created = await page.evaluate(async d => {
         const r = await fetch('/api/tournaments', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -1142,84 +914,35 @@ async function deletePlayer(p, id) {
         dualReportEnabled: false,
         taPlayerSelfEdit: false,
       });
-      taTournamentId = t.b?.data?.id ?? null;
+      taTournamentId = created.b?.data?.id ?? null;
       if (!taTournamentId) throw new Error('Failed to create tournament');
+      await apiActivateTournament(page, taTournamentId);
 
-      // Activate
-      await page.evaluate(async ([u, d]) => {
-        await fetch(u, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(d) });
-      }, [`/api/tournaments/${taTournamentId}`, { status: 'active' }]);
-
-      // Add both players
-      const addResult = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, [`/api/tournaments/${taTournamentId}/ta`, {
+      const addResult = await apiAddTaEntries(page, taTournamentId, {
         playerEntries: [
           { playerId: pid, seeding: 1 },
           { playerId: partnerPlayerId2, seeding: 2 },
         ],
-      }]);
+      });
       const entry1 = addResult.b?.data?.entries?.find(e => e.playerId === pid);
       const entry2 = addResult.b?.data?.entries?.find(e => e.playerId === partnerPlayerId2);
       if (!entry1 || !entry2) throw new Error('Missing entries');
 
-      // Set partner
-      await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status };
-      }, [`/api/tournaments/${taTournamentId}/ta`, {
-        entryId: entry1.id, action: 'set_partner', partnerId: partnerPlayerId2,
-      }]);
+      await apiSetTaPartner(page, taTournamentId, entry1.id, partnerPlayerId2);
 
-      // Step 1: Self-edit should be blocked (player edits own entry)
-      // Login as pid player and try to edit own entry via API
-      const selfEditResult = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status };
-      }, [`/api/tournaments/${taTournamentId}/ta`, {
-        entryId: entry1.id, course: 'MC1', time: '1:00.00',
-      }]);
-      // Admin is doing the call, so it should succeed (admin bypass)
-      // We need to test as a player — but the admin session is active.
-      // Instead, verify the API returns taPlayerSelfEdit=false in GET
-      const getResult = await page.evaluate(async (u) => {
-        const r = await fetch(u);
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, `/api/tournaments/${taTournamentId}/ta?stage=qualification`);
+      /* Admin session → PUT /ta is allowed (admin bypass); this proves
+       * the endpoint is reachable and the toggle below is the only gate. */
+      const selfEditResult = await apiTaParticipantEditTime(
+        page, taTournamentId, entry1.id, 'MC1', '1:00.00'
+      );
+      const getResult = await apiFetchTa(page, taTournamentId);
       const step1 = getResult.b?.data?.taPlayerSelfEdit === false;
-
-      // Step 2: Admin can still edit (bypass)
       const step2 = selfEditResult.s === 200;
 
-      // Step 3: Verify setting can be toggled via PUT
-      const toggleResult = await page.evaluate(async ([u, d]) => {
-        const r = await fetch(u, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(d),
-        });
-        return { s: r.status };
-      }, [`/api/tournaments/${taTournamentId}`, { taPlayerSelfEdit: true }]);
+      const toggleResult = await apiUpdateTournament(page, taTournamentId, { taPlayerSelfEdit: true });
       const step3 = toggleResult.s === 200;
 
-      // Step 4: After toggle, taPlayerSelfEdit should be true
-      const getResult2 = await page.evaluate(async (u) => {
-        const r = await fetch(u);
-        return { s: r.status, b: await r.json().catch(() => ({})) };
-      }, `/api/tournaments/${taTournamentId}/ta?stage=qualification`);
+      const getResult2 = await apiFetchTa(page, taTournamentId);
       const step4 = getResult2.b?.data?.taPlayerSelfEdit === true;
 
       log('TC-319', step1 && step2 && step3 && step4 ? 'PASS' : 'FAIL',
@@ -1231,12 +954,8 @@ async function deletePlayer(p, id) {
     } catch (err) {
       log('TC-319', 'FAIL', err instanceof Error ? err.message : 'Self-edit toggle test failed');
     } finally {
-      if (taTournamentId) {
-        await deleteTournament(page, taTournamentId);
-      }
-      if (partnerPlayerId2) {
-        await deletePlayer(page, partnerPlayerId2);
-      }
+      if (taTournamentId) await deleteTournament(page, taTournamentId);
+      if (partnerPlayerId2) await deletePlayer(page, partnerPlayerId2);
     }
   } else { log('TC-319', 'SKIP'); }
 
@@ -1805,6 +1524,7 @@ async function deletePlayer(p, id) {
   const bmFailed = runChildScript('BM Tests', 'e2e/tc-bm.js');
   const mrFailed = runChildScript('MR Tests', 'e2e/tc-mr.js');
   const gpFailed = runChildScript('GP Tests', 'e2e/tc-gp.js');
+  const taFailed = runChildScript('TA Tests', 'e2e/tc-ta.js');
 
   // ===== Summary =====
   console.log('\n========== SUMMARY (tc-all.js inline tests) ==========');
@@ -1816,6 +1536,7 @@ async function deletePlayer(p, id) {
   if (bmFailed) console.log('  ⚠️  BM tests (tc-bm.js) had failures — see output above');
   if (mrFailed) console.log('  ⚠️  MR tests (tc-mr.js) had failures — see output above');
   if (gpFailed) console.log('  ⚠️  GP tests (tc-gp.js) had failures — see output above');
+  if (taFailed) console.log('  ⚠️  TA tests (tc-ta.js) had failures — see output above');
 
-  process.exit((f > 0 || bmFailed || mrFailed || gpFailed) ? 1 : 0);
+  process.exit((f > 0 || bmFailed || mrFailed || gpFailed || taFailed) ? 1 : 0);
 })();

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -26,7 +26,6 @@
  *
  * Run: node e2e/tc-bm.js  (from smkc-score-app/)  or:  npm run e2e:bm
  */
-const { chromium } = require('playwright');
 const {
   makeResults, makeLog, nav, escapeRegex,
   apiCreatePlayer, apiCreateTournament, apiDeletePlayer, apiDeleteTournament,
@@ -34,6 +33,7 @@ const {
   apiSetBmFinalsScore, apiGenerateBmFinals, apiFetchBmFinalsMatches,
   setupBm28PlayerFinals, loginPlayerBrowser,
 } = require('./lib/common');
+const { runSuite } = require('./lib/runner');
 
 const results = makeResults();
 const log = makeLog(results);
@@ -644,38 +644,21 @@ module.exports = {
 };
 
 if (require.main === module) {
-  (async () => {
-    const browser = await chromium.launchPersistentContext(
-      '/tmp/playwright-smkc-profile',
-      { headless: false, viewport: { width: 1280, height: 720 } },
-    );
-    const page = browser.pages()[0] || await browser.newPage();
-
-    await nav(page, '/');
-
-    /* Light single-match tests first (fast feedback) */
-    await runTc501(page);
-    await runTc502(page);
-    await runTc507(page);
-    await runTc508(page);
-    await runTc509(page);
-    await runTc322(page);
-
-    /* Heavy 28-player full-workflow tests last */
-    await runTc503(page);
-    await runTc504(page);
-    await runTc505(page);
-    await runTc506(page);
-
-    console.log('\n========== BM TEST SUMMARY ==========');
-    const p = results.filter((r) => r.status === 'PASS').length;
-    const f = results.filter((r) => r.status === 'FAIL').length;
-    const sk = results.filter((r) => r.status === 'SKIP').length;
-    console.log(`PASS: ${p} | FAIL: ${f} | SKIP: ${sk} | Total: ${results.length}`);
-    if (f > 0) results.filter((r) => r.status === 'FAIL')
-      .forEach((r) => console.log(`  ❌ [${r.tc}] ${r.detail}`));
-
-    await browser.close();
-    process.exit(f > 0 ? 1 : 0);
-  })();
+  runSuite({
+    suiteName: 'BM',
+    results,
+    log,
+    tests: [
+      { name: 'TC-501', fn: runTc501 },
+      { name: 'TC-502', fn: runTc502 },
+      { name: 'TC-507', fn: runTc507 },
+      { name: 'TC-508', fn: runTc508 },
+      { name: 'TC-509', fn: runTc509 },
+      { name: 'TC-322', fn: runTc322 },
+      { name: 'TC-503', fn: runTc503 },
+      { name: 'TC-504', fn: runTc504 },
+      { name: 'TC-505', fn: runTc505 },
+      { name: 'TC-506', fn: runTc506 },
+    ],
+  });
 }

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -18,7 +18,6 @@
  *
  * Run: node e2e/tc-gp.js  (from smkc-score-app/)  or:  npm run e2e:gp
  */
-const { chromium } = require('playwright');
 const {
   makeResults, makeLog, nav,
   apiCreatePlayer, apiCreateTournament, apiDeletePlayer, apiDeleteTournament,
@@ -27,6 +26,7 @@ const {
   setupGp28PlayerFinals, makeRacesP1Wins, makeRacesP2Wins,
   loginPlayerBrowser,
 } = require('./lib/common');
+const { runSuite } = require('./lib/runner');
 
 const results = makeResults();
 const log = makeLog(results);
@@ -488,35 +488,20 @@ module.exports = {
 };
 
 if (require.main === module) {
-  (async () => {
-    const browser = await chromium.launchPersistentContext(
-      '/tmp/playwright-smkc-profile',
-      { headless: false, viewport: { width: 1280, height: 720 } },
-    );
-    const page = browser.pages()[0] || await browser.newPage();
-
-    await nav(page, '/');
-
-    /* Light tests first; heavy 28-player full-workflow tests last */
-    await runTc702(page);
-    await runTc707(page);
-    await runTc708(page);
-    await runTc701(page);
-    await runTc703(page);
-    await runTc704(page);
-    await runTc705(page);
-    await runTc706(page);
-    await runTc709(page);
-
-    console.log('\n========== GP TEST SUMMARY ==========');
-    const p = results.filter((r) => r.status === 'PASS').length;
-    const f = results.filter((r) => r.status === 'FAIL').length;
-    const sk = results.filter((r) => r.status === 'SKIP').length;
-    console.log(`PASS: ${p} | FAIL: ${f} | SKIP: ${sk} | Total: ${results.length}`);
-    if (f > 0) results.filter((r) => r.status === 'FAIL')
-      .forEach((r) => console.log(`  ❌ [${r.tc}] ${r.detail}`));
-
-    await browser.close();
-    process.exit(f > 0 ? 1 : 0);
-  })();
+  runSuite({
+    suiteName: 'GP',
+    results,
+    log,
+    tests: [
+      { name: 'TC-702', fn: runTc702 },
+      { name: 'TC-707', fn: runTc707 },
+      { name: 'TC-708', fn: runTc708 },
+      { name: 'TC-701', fn: runTc701 },
+      { name: 'TC-703', fn: runTc703 },
+      { name: 'TC-704', fn: runTc704 },
+      { name: 'TC-705', fn: runTc705 },
+      { name: 'TC-706', fn: runTc706 },
+      { name: 'TC-709', fn: runTc709 },
+    ],
+  });
 }

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -41,6 +41,7 @@ const {
   setupMr28PlayerFinals,
   snakeDraft28: snakeDraftMr28,
 } = require('./lib/common');
+const { runSuite } = require('./lib/runner');
 
 const results = makeResults();
 const log = makeLog(results);
@@ -1261,36 +1262,23 @@ module.exports = { runTc601, runTc602, runTc603, runTc604, runTc605, runTc606, r
 
 // Standalone execution
 if (require.main === module) {
-  (async () => {
-    const browser = await chromium.launchPersistentContext(
-      '/tmp/playwright-smkc-profile',
-      { headless: false, viewport: { width: 1280, height: 720 } }
-    );
-    const page = browser.pages()[0] || await browser.newPage();
-
-    await nav(page, '/');
-
-    await runTc601(page);
-    await runTc602(page);
-    await runTc603(page);
-    await runTc604(page);
-    await runTc605(page);
-    await runTc606(page);
-    await runTc607(page);
-    await runTc608(page);
-    await runTc609(page);
-    await runTc610(page);
-    await runTc611(page);
-    await runTc612(page);
-
-    console.log('\n========== MR TEST SUMMARY ==========');
-    const p = results.filter((r) => r.status === 'PASS').length;
-    const f = results.filter((r) => r.status === 'FAIL').length;
-    const sk = results.filter((r) => r.status === 'SKIP').length;
-    console.log(`PASS: ${p} | FAIL: ${f} | SKIP: ${sk} | Total: ${results.length}`);
-    if (f > 0) results.filter((r) => r.status === 'FAIL').forEach((r) => console.log(`  ❌ [${r.tc}] ${r.detail}`));
-
-    await browser.close();
-    process.exit(f > 0 ? 1 : 0);
-  })();
+  runSuite({
+    suiteName: 'MR',
+    results,
+    log,
+    tests: [
+      { name: 'TC-601', fn: runTc601 },
+      { name: 'TC-602', fn: runTc602 },
+      { name: 'TC-603', fn: runTc603 },
+      { name: 'TC-604', fn: runTc604 },
+      { name: 'TC-605', fn: runTc605 },
+      { name: 'TC-606', fn: runTc606 },
+      { name: 'TC-607', fn: runTc607 },
+      { name: 'TC-608', fn: runTc608 },
+      { name: 'TC-609', fn: runTc609 },
+      { name: 'TC-610', fn: runTc610 },
+      { name: 'TC-611', fn: runTc611 },
+      { name: 'TC-612', fn: runTc612 },
+    ],
+  });
 }

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -1,0 +1,123 @@
+/**
+ * E2E TA (Time Attack / Time Trial) tests.
+ *
+ * Coverage (scenario: E2E_TEST_CASES.md § TT):
+ *   TC-801  28-player qualification fill — all 20 courses per player, server-
+ *           computed ranks are 1..28 and scoring output is present.
+ *   TC-804  Promote to Phase 1 — ranks 17-24 (8 players) move to phase1 stage.
+ *
+ * Setup:
+ *   - Uses the shared Playwright persistent profile (/tmp/playwright-smkc-profile).
+ *   - Admin Discord OAuth session must already be established in that profile.
+ *
+ * Not implemented yet (follow-up):
+ *   TC-802 (player participant UI), TC-803 (duplicates TC-318),
+ *   TC-805 (Phase 2 rounds), TC-806 (Phase 3 + champion) — all require
+ *   round-by-round UI automation that is out-of-scope for this pass.
+ *
+ * Run: node e2e/tc-ta.js  (from smkc-score-app/)
+ */
+const { chromium } = require('playwright');
+const {
+  makeResults, makeLog, nav,
+  apiFetchTa, apiPromoteTaPhase,
+  setupTa28PlayerQual,
+} = require('./lib/common');
+
+const results = makeResults();
+const log = makeLog(results);
+
+/* ───────── TC-801: 28-player full qualification ─────────
+ * The setup helper seeds 20-course times + totalTime + rank for all 28
+ * players via the admin /tt/entries PUT. We verify the persisted state:
+ * 28 entries, all with totalTime and a rank, ranks cover 1..28. Scoring
+ * (qualificationPoints) is computed by a separate finalize flow and is
+ * intentionally not asserted here. */
+async function runTc801(adminPage) {
+  let setup = null;
+  try {
+    setup = await setupTa28PlayerQual(adminPage, '801');
+    const data = await apiFetchTa(adminPage, setup.tournamentId);
+    const entries = data.b?.data?.entries ?? [];
+
+    const countOk = entries.length === 28;
+    const allHaveTimes = entries.every((e) => e.totalTime != null && e.totalTime > 0);
+    const ranks = entries.map((e) => e.rank).filter((r) => r != null).sort((a, b) => a - b);
+    /* Ranks must cover 1..28. Our seeded times are strictly increasing by
+     * seeding so no ties are expected. */
+    const ranksOk = ranks.length === 28 && ranks[0] === 1 && ranks[27] === 28;
+
+    const ok = countOk && allHaveTimes && ranksOk;
+    log('TC-801', ok ? 'PASS' : 'FAIL',
+      !countOk ? `entries=${entries.length} expected=28`
+      : !allHaveTimes ? `some entries missing totalTime`
+      : !ranksOk ? `ranks first=${ranks[0]} last=${ranks[ranks.length - 1]} count=${ranks.length}`
+      : '');
+  } catch (err) {
+    log('TC-801', 'FAIL', err instanceof Error ? err.message : 'TA 801 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-804: Promote to Phase 1 ─────────
+ * After promote_phase1, ranks 17-24 should move to stage='phase1'.
+ * The qualification stage still contains 28 entries (promotion clones, it
+ * doesn't remove), so we check phase1 count = 8 via the ?stage=phase1 GET. */
+async function runTc804(adminPage) {
+  let setup = null;
+  try {
+    setup = await setupTa28PlayerQual(adminPage, '804');
+
+    const promote = await apiPromoteTaPhase(adminPage, setup.tournamentId, 'promote_phase1');
+    if (promote.s !== 200) {
+      throw new Error(`promote_phase1 returned ${promote.s}: ${JSON.stringify(promote.b).slice(0, 200)}`);
+    }
+
+    const phase1 = await apiFetchTa(adminPage, setup.tournamentId, 'phase1');
+    const entries = phase1.b?.data?.entries ?? [];
+    const countOk = entries.length === 8;
+    /* The 8 phase1 entries must correspond to qual ranks 17-24. */
+    const sourceRanks = entries
+      .map((e) => e.rank)
+      .filter((r) => r != null)
+      .sort((a, b) => a - b);
+    const ranksOk = countOk && sourceRanks[0] === 17 && sourceRanks[7] === 24;
+
+    const ok = countOk && ranksOk;
+    log('TC-804', ok ? 'PASS' : 'FAIL',
+      !countOk ? `phase1 entries=${entries.length} expected=8`
+      : !ranksOk ? `source ranks=${sourceRanks.join(',')} expected 17..24`
+      : '');
+  } catch (err) {
+    log('TC-804', 'FAIL', err instanceof Error ? err.message : 'TA 804 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+if (require.main === module) {
+  (async () => {
+    const browser = await chromium.launchPersistentContext(
+      '/tmp/playwright-smkc-profile',
+      { headless: false, viewport: { width: 1280, height: 720 } },
+    );
+    const page = browser.pages()[0] || await browser.newPage();
+
+    await nav(page, '/');
+
+    await runTc801(page);
+    await runTc804(page);
+
+    console.log('\n========== TA TEST SUMMARY ==========');
+    const p = results.filter((r) => r.status === 'PASS').length;
+    const f = results.filter((r) => r.status === 'FAIL').length;
+    const sk = results.filter((r) => r.status === 'SKIP').length;
+    console.log(`PASS: ${p} | FAIL: ${f} | SKIP: ${sk} | Total: ${results.length}`);
+    if (f > 0) results.filter((r) => r.status === 'FAIL')
+      .forEach((r) => console.log(`  ❌ [${r.tc}] ${r.detail}`));
+
+    await browser.close();
+    process.exit(f > 0 ? 1 : 0);
+  })();
+}

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -17,12 +17,12 @@
  *
  * Run: node e2e/tc-ta.js  (from smkc-score-app/)
  */
-const { chromium } = require('playwright');
 const {
   makeResults, makeLog, nav,
   apiFetchTa, apiPromoteTaPhase,
   setupTa28PlayerQual,
 } = require('./lib/common');
+const { runSuite } = require('./lib/runner');
 
 const results = makeResults();
 const log = makeLog(results);
@@ -97,27 +97,13 @@ async function runTc804(adminPage) {
 }
 
 if (require.main === module) {
-  (async () => {
-    const browser = await chromium.launchPersistentContext(
-      '/tmp/playwright-smkc-profile',
-      { headless: false, viewport: { width: 1280, height: 720 } },
-    );
-    const page = browser.pages()[0] || await browser.newPage();
-
-    await nav(page, '/');
-
-    await runTc801(page);
-    await runTc804(page);
-
-    console.log('\n========== TA TEST SUMMARY ==========');
-    const p = results.filter((r) => r.status === 'PASS').length;
-    const f = results.filter((r) => r.status === 'FAIL').length;
-    const sk = results.filter((r) => r.status === 'SKIP').length;
-    console.log(`PASS: ${p} | FAIL: ${f} | SKIP: ${sk} | Total: ${results.length}`);
-    if (f > 0) results.filter((r) => r.status === 'FAIL')
-      .forEach((r) => console.log(`  ❌ [${r.tc}] ${r.detail}`));
-
-    await browser.close();
-    process.exit(f > 0 ? 1 : 0);
-  })();
+  runSuite({
+    suiteName: 'TA',
+    results,
+    log,
+    tests: [
+      { name: 'TC-801', fn: runTc801 },
+      { name: 'TC-804', fn: runTc804 },
+    ],
+  });
 }


### PR DESCRIPTION
## What Changed

Adds a shared E2E runner for the standalone BM/MR/GP/TA suites and moves those scripts onto it. The runner adds per-test timeouts, suite timeouts, no-progress watchdogs, safer browser cleanup, and configurable E2E environment knobs.

`tc-all.js` now also has watchdog protection, bounded HTTPS helper requests, child-suite timeouts, and cleanup-aware forced exits.

## Why

The E2E scripts could run for a very long time or appear hung when a Playwright action, browser close, child process, or raw HTTPS request stopped making progress. Failures were also hard to diagnose because the scripts did not consistently print the currently running test before getting stuck.

## Impact

When an E2E suite stalls, it now exits with a clear timeout message instead of waiting indefinitely. The output also shows test start and finish markers so the stuck test is easier to identify.

## Validation

Ran syntax checks for all touched E2E scripts:

```sh
node --check e2e/lib/runner.js
node --check e2e/tc-all.js
node --check e2e/tc-bm.js
node --check e2e/tc-gp.js
node --check e2e/tc-mr.js
node --check e2e/tc-ta.js
```

Full E2E execution was not run because it depends on the persistent admin Playwright profile and remote app state.
