### PR TITLE
fix(ta): expand pair management modal width

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
@@ -766,12 +766,12 @@ export default function TimeAttackPage({
                   {t('managePairs')}
                 </Button>
               </DialogTrigger>
-              <DialogContent className="max-w-2xl">
+              <DialogContent className="max-w-5xl max-h-[85vh] overflow-hidden flex flex-col">
                 <DialogHeader>
                   <DialogTitle>{t('managePairsTitle')}</DialogTitle>
                   <DialogDescription>{t('managePairsDesc')}</DialogDescription>
                 </DialogHeader>
-                <div className="space-y-4 py-2">
+                <div className="space-y-4 py-2 overflow-y-auto flex-1">
                   <Button variant="outline" size="sm" onClick={handleAutoPair}>
                     {t('autoPair')}
                   </Button>


### PR DESCRIPTION
## Summary
- TT pair management dialog was too narrow (max-w-2xl), causing UI elements to overflow
- Changed to max-w-5xl with max-h-[85vh] and flex layout for proper overflow handling

## Changes
- `src/app/tournaments/[id]/ta/page.tsx`:
  - DialogContent: max-w-2xl → max-w-5xl max-h-[85vh] overflow-hidden flex flex-col
  - Content wrapper: space-y-4 py-2 → space-y-4 py-2 overflow-y-auto flex-1

## Test plan
- [ ] Open TT pair management modal on a tournament with many players
- [ ] Verify table is visible and horizontally scrollable if needed
- [ ] Verify modal height is capped at 85vh with internal scrolling

Closes #360 (implied - UI overflow fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)