### PR TITLE
fix: treat seeding=0 as valid (not Infinity) (#299)

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
@@ -788,7 +788,7 @@ export default function TimeAttackPage({
                         // Compute once outside map to avoid O(N²) repeated filter calls
                         const qualEntries = entries.filter(e => e.stage === "qualification");
                         return qualEntries
-                        .sort((a, b) => (a.seeding ?? Infinity) - (b.seeding ?? Infinity))
+                        .sort((a, b) => (a.seeding == null ? Infinity : a.seeding) - (b.seeding == null ? Infinity : b.seeding))
                         .map(entry => {
                           const effectivePartnerId = entry.id in pairOverrides
                             ? pairOverrides[entry.id]

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -243,8 +243,8 @@ export function createQualificationHandlers(config: EventTypeConfig) {
         const groupPlayers = players
           .filter((p: { group: string }) => p.group === group)
           .sort((a: { seeding?: number }, b: { seeding?: number }) => {
-            const sa = a.seeding ?? Infinity;
-            const sb = b.seeding ?? Infinity;
+            const sa = a.seeding == null ? Infinity : a.seeding;
+            const sb = b.seeding == null ? Infinity : b.seeding;
             return sa - sb;
           });
         const playerIds = groupPlayers.map((p: { playerId: string }) => p.playerId);

--- a/smkc-score-app/src/lib/group-utils.ts
+++ b/smkc-score-app/src/lib/group-utils.ts
@@ -69,7 +69,7 @@ export function assignGroupsBySeeding(
   const groups = GROUPS.slice(0, safeCount);
   /* Sort by seeding ascending; players without seeding go to end */
   const sorted = [...players].sort(
-    (a, b) => (a.seeding ?? Infinity) - (b.seeding ?? Infinity),
+    (a, b) => (a.seeding == null ? Infinity : a.seeding) - (b.seeding == null ? Infinity : b.seeding),
   );
   return sorted.map((p, idx) => ({
     ...p,

--- a/smkc-score-app/src/lib/ta/pair-utils.ts
+++ b/smkc-score-app/src/lib/ta/pair-utils.ts
@@ -31,8 +31,8 @@ export interface PairPlayer {
  */
 export function computeAutoPairs<T extends PairPlayer>(players: T[]): Array<[T, T]> {
   const sorted = [...players].sort((a, b) => {
-    const sa = a.seeding ?? Infinity;
-    const sb = b.seeding ?? Infinity;
+    const sa = a.seeding == null ? Infinity : a.seeding;
+    const sb = b.seeding == null ? Infinity : b.seeding;
     // Secondary sort by playerId ensures deterministic output when seeding is equal
     return sa - sb || a.playerId.localeCompare(b.playerId);
   });


### PR DESCRIPTION
## Summary
- Fix: `seeding ?? Infinity` → `seeding == null ? Infinity : seeding` in 4 locations
- `seeding=0` is a valid top seed, but `??` treats 0 as falsy → incorrectly sorted last
- Fixes: #299

## Files changed
- `src/lib/group-utils.ts`
- `src/lib/ta/pair-utils.ts`
- `src/lib/api-factories/qualification-route.ts`
- `src/app/tournaments/[id]/ta/page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)