### PR TITLE
fix(qualification-route): PUT returns createSuccessResponse wrapper (#360)

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -786,8 +786,8 @@ describe('Qualification Route Factory', () => {
 
       expect(config.calculateMatchResult).toHaveBeenCalledWith(3, 1);
       const json = await response.json();
-      expect(json.result1).toBe('WIN');
-      expect(json.result2).toBe('LOSS');
+      expect(json.data.result1).toBe('WIN');
+      expect(json.data.result2).toBe('LOSS');
     });
 
     it('should aggregate player stats via config.aggregatePlayerStats', async () => {

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -469,7 +469,7 @@ export function createQualificationHandlers(config: EventTypeConfig) {
         });
       }
 
-      return NextResponse.json({ match, result1, result2 });
+      return createSuccessResponse({ match, result1, result2 });
     } catch (error) {
       // Surface cup validation errors (§7.1/§7.4) as 400 rather than 500
       if (error instanceof CupMismatchError) {


### PR DESCRIPTION
## Summary
- qualification-route PUT response formatを `NextResponse.json({ match, result1, result2 })` から `createSuccessResponse({ match, result1, result2 })` に変更
- GET/POST/PUT全methodでAPI response形式が統一された

## Test plan
- [x] PUT Handler test updated: `json.result1` → `json.data.result1`

## Closes
#360