### PR TITLE
feat(group-setup): allow 1 group for 2P modes (BM/MR/GP) (#284)

### DIFF
--- a/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
+++ b/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
@@ -116,6 +116,9 @@ export function GroupSetupDialog({
   /* Available groups based on current group count selection */
   const availableGroups = GROUPS.slice(0, groupCount);
 
+  /* 2P modes (BM/MR/GP) allow 1 group; TA requires at least 2 */
+  const minGroups = mode === "ta" ? 2 : 1;
+
   /**
    * Handle dialog open/close with automatic state management.
    * On open: pre-populates with existing assignments if in edit mode.
@@ -132,7 +135,7 @@ export function GroupSetupDialog({
       const maxIdx = Math.max(
         ...existingAssignments.map((a) => (GROUPS as readonly string[]).indexOf(a.group)),
       );
-      setGroupCount(Math.max(maxIdx + 1, 2));
+      setGroupCount(Math.max(maxIdx + 1, minGroups));
     } else if (!open) {
       /* Close: reset all form state */
       setSetupPlayers([]);
@@ -156,7 +159,7 @@ export function GroupSetupDialog({
   /** Handle random group assignment for all selected players */
   const handleRandomAssign = () => {
     if (setupPlayers.length === 0) return;
-    setSetupPlayers(randomlyAssignGroups(setupPlayers, groupCount));
+    setSetupPlayers(randomlyAssignGroups(setupPlayers, groupCount, minGroups));
   };
 
   /**
@@ -165,7 +168,7 @@ export function GroupSetupDialog({
    */
   const handleAutoDistribute = () => {
     if (setupPlayers.length === 0 || !allHaveSeeding) return;
-    setSetupPlayers(assignGroupsBySeeding(setupPlayers, groupCount));
+    setSetupPlayers(assignGroupsBySeeding(setupPlayers, groupCount, minGroups));
   };
 
   /**
@@ -329,7 +332,7 @@ export function GroupSetupDialog({
                 {/* Group count selector with auto-recommendation per §4.1 */}
                 <div className="flex items-center gap-1">
                   <span className="text-xs text-muted-foreground">{tc("groupCount")}:</span>
-                  {[2, 3, 4].map((n) => (
+                  {[...new Set([minGroups, 2, 3, 4])].map((n) => (
                     <Button
                       key={n}
                       variant={groupCount === n ? "default" : "outline"}

--- a/smkc-score-app/src/lib/group-utils.ts
+++ b/smkc-score-app/src/lib/group-utils.ts
@@ -9,7 +9,7 @@
 export const GROUPS = ["A", "B", "C", "D"] as const;
 
 /** Valid range for group count */
-const MIN_GROUPS = 2;
+const DEFAULT_MIN_GROUPS = 2;
 const MAX_GROUPS = GROUPS.length;
 
 /** Minimum player count to show a group-count recommendation in the UI */
@@ -23,11 +23,13 @@ export interface SetupPlayer {
 }
 
 /**
- * Clamp groupCount to valid range [2, GROUPS.length].
+ * Clamp groupCount to valid range [min, GROUPS.length].
  * Prevents division-by-zero and out-of-bounds access.
+ * @param groupCount - Raw group count from UI
+ * @param minGroups - Minimum allowed groups (default: 2, or 1 for BM/MR/GP)
  */
-function clampGroupCount(groupCount: number): number {
-  return Math.max(MIN_GROUPS, Math.min(MAX_GROUPS, Math.floor(groupCount)));
+function clampGroupCount(groupCount: number, minGroups: number = DEFAULT_MIN_GROUPS): number {
+  return Math.max(minGroups, Math.min(MAX_GROUPS, Math.floor(groupCount)));
 }
 
 /**
@@ -64,8 +66,9 @@ export function recommendGroupCount(playerCount: number): number {
 export function assignGroupsBySeeding(
   players: SetupPlayer[],
   groupCount: number,
+  minGroups: number = DEFAULT_MIN_GROUPS,
 ): SetupPlayer[] {
-  const safeCount = clampGroupCount(groupCount);
+  const safeCount = clampGroupCount(groupCount, minGroups);
   const groups = GROUPS.slice(0, safeCount);
   /* Sort by seeding ascending; players without seeding go to end */
   const sorted = [...players].sort(
@@ -89,8 +92,9 @@ export function assignGroupsBySeeding(
 export function randomlyAssignGroups(
   players: SetupPlayer[],
   groupCount: number = 3,
+  minGroups: number = DEFAULT_MIN_GROUPS,
 ): SetupPlayer[] {
-  const safeCount = clampGroupCount(groupCount);
+  const safeCount = clampGroupCount(groupCount, minGroups);
   const groups = GROUPS.slice(0, safeCount);
   /* Fisher-Yates shuffle for unbiased random ordering */
   const shuffled = [...players];


### PR DESCRIPTION
## Summary
- BM/MR/GP qualification setup now allows 1 group
- TA still requires minimum 2 groups
- `clampGroupCount`, `assignGroupsBySeeding`, `randomlyAssignGroups` accept configurable `minGroups`

## Changes
- `group-setup-dialog.tsx`: mode-specific `minGroups` (1 for 2P, 2 for TA)
- `group-utils.ts`: `clampGroupCount` takes optional `minGroups` param

## Closes
#284