### PR TITLE
fix(standings): exclude BYE matches from H2H calculation (#308)

### DIFF
--- a/smkc-score-app/src/lib/api-factories/standings-route.ts
+++ b/smkc-score-app/src/lib/api-factories/standings-route.ts
@@ -220,6 +220,7 @@ export function createStandingsHandlers(config: StandingsConfig) {
                 tournamentId,
                 stage: 'qualification',
                 completed: true,
+                isBye: false, // Exclude BYE matches from H2H calculation
                 player1Id: { in: tiedPlayerIds },
                 player2Id: { in: tiedPlayerIds },
               },


### PR DESCRIPTION
## Summary
- Add `isBye: false` filter to H2H query in standings-route.ts
- BYE matches have `completed: true` but should not count as actual matches in H2H calculation

## Fixes
- #308

## Test plan
- [x] Code change verified
- [ ] Need to test with a tournament that has BYE matches and tied players

🤖 Generated with [Claude Code](https://claude.ai/claude-code)