### PR TITLE
fix(tournament-identifier): validate identifier on DB error before returning (#378)

### DIFF
--- a/smkc-score-app/src/lib/tournament-identifier.ts
+++ b/smkc-score-app/src/lib/tournament-identifier.ts
@@ -26,6 +26,11 @@ export async function resolveTournamentId(identifier: string): Promise<string> {
 
     return tournament?.id ?? identifier;
   } catch {
+    // On DB error, validate identifier format before returning it.
+    // Invalid identifiers could indicate injection attempts or malformed input.
+    if (!isValidTournamentSlug(identifier)) {
+      throw new Error(`Invalid tournament identifier: ${identifier}`);
+    }
     return identifier;
   }
 }


### PR DESCRIPTION
## Summary
- Add validation check in `resolveTournamentId` to throw error if DB fails and identifier is invalid
- Prevents invalid identifiers from propagating through the API

## Fixes
- #378

🤖 Generated with [Claude Code](https://claude.ai/claude-code)