### PR TITLE
fix(auth): check Discord admin whitelist before email-based promotion (#376)

### DIFF
--- a/smkc-score-app/src/lib/auth.ts
+++ b/smkc-score-app/src/lib/auth.ts
@@ -50,6 +50,9 @@ async function handleDiscordAdminSignIn(user: any, account: any): Promise<void> 
   const providerAccountId = String(account.providerAccountId);
   const fallbackEmail = `discord-${providerAccountId}@discord.local`;
 
+  // Note: Discord admin whitelist check is already performed in the outer signIn
+  // callback before this function is called. Only whitelisted users reach here.
+
   const existingAccount = await prisma.account.findUnique({
     where: {
       provider_providerAccountId: {
@@ -83,6 +86,7 @@ async function handleDiscordAdminSignIn(user: any, account: any): Promise<void> 
       providerAccountId,
     });
   } else if (dbUser.role !== 'admin') {
+    // Only promote to admin if already verified as Discord admin via whitelist
     dbUser = await prisma.user.update({
       where: { id: dbUser.id },
       data: { role: 'admin' },

--- a/smkc-score-app/src/lib/auth.ts
+++ b/smkc-score-app/src/lib/auth.ts
@@ -45,13 +45,17 @@ function isAllowedDiscordAdmin(profile: { id?: string } | undefined): boolean {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function handleDiscordAdminSignIn(user: any, account: any): Promise<void> {
+async function handleDiscordAdminSignIn(user: any, account: any, profile: any): Promise<void> {
+  // Defense-in-depth: verify whitelist even if outer callback already checked.
+  // This prevents privilege escalation if the function is ever called directly
+  // without the outer guard.
+  if (!isAllowedDiscordAdmin(profile)) {
+    throw new Error('Discord admin sign-in attempted by non-whitelisted user');
+  }
+
   const prisma = await getPrisma();
   const providerAccountId = String(account.providerAccountId);
   const fallbackEmail = `discord-${providerAccountId}@discord.local`;
-
-  // Note: Discord admin whitelist check is already performed in the outer signIn
-  // callback before this function is called. Only whitelisted users reach here.
 
   const existingAccount = await prisma.account.findUnique({
     where: {
@@ -226,7 +230,7 @@ export const authConfig = {
         }
 
         try {
-          await handleDiscordAdminSignIn(user, account);
+          await handleDiscordAdminSignIn(user, account, profile);
           return true;
         } catch (error) {
           logger.error('Discord admin sign-in failed', {


### PR DESCRIPTION
## Summary
- Add `isAllowedDiscordAdmin` check at start of `handleDiscordAdminSignIn`
- Prevents email-based admin promotion for Discord users not in whitelist

## Fixes
- #376

🤖 Generated with [Claude Code](https://claude.ai/claude-code)