### PR TITLE
fix(finals): guard against undefined data in unwrapApiData

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -108,7 +108,8 @@ interface SeededPlayer {
 
 function unwrapApiData<T>(json: T | { success?: boolean; data?: T }): T {
   if (json && typeof json === "object" && "success" in json && "data" in json) {
-    return (json as { data: T }).data;
+    const data = (json as { data: T }).data;
+    if (data !== undefined) return data;
   }
   return json as T;
 }

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -97,7 +97,8 @@ interface SeededPlayer {
 
 function unwrapApiData<T>(json: T | { success?: boolean; data?: T }): T {
   if (json && typeof json === "object" && "success" in json && "data" in json) {
-    return (json as { data: T }).data;
+    const data = (json as { data: T }).data;
+    if (data !== undefined) return data;
   }
   return json as T;
 }

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -109,7 +109,8 @@ interface SeededPlayer {
 
 function unwrapApiData<T>(json: T | { success?: boolean; data?: T }): T {
   if (json && typeof json === "object" && "success" in json && "data" in json) {
-    return (json as { data: T }).data;
+    const data = (json as { data: T }).data;
+    if (data !== undefined) return data;
   }
   return json as T;
 }


### PR DESCRIPTION
## Summary
- Fix `unwrapApiData` to check `data !== undefined` before returning, preventing `undefined` return when API returns `{ success: true, data: undefined }`
- Applied to BM/GP/MR finals pages

## Root Cause
The `in` operator returns `true` even when `data` key exists with value `undefined`. If an API returns `{ success: true, data: undefined }`, the original code would return `undefined` instead of the raw JSON.

## Test plan
- [x] Build passed
- [x] Deployed to production (smkc.bluemoon.works)