### PR TITLE
fix(finals): guard unwrapApiData + drop noisy review trigger

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -7,15 +7,12 @@ on:
     types: [created]
   issues:
     types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   claude:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -108,7 +108,8 @@ interface SeededPlayer {
 
 function unwrapApiData<T>(json: T | { success?: boolean; data?: T }): T {
   if (json && typeof json === "object" && "success" in json && "data" in json) {
-    return (json as { data: T }).data;
+    const data = (json as { data: T }).data;
+    if (data !== undefined) return data;
   }
   return json as T;
 }

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -97,7 +97,8 @@ interface SeededPlayer {
 
 function unwrapApiData<T>(json: T | { success?: boolean; data?: T }): T {
   if (json && typeof json === "object" && "success" in json && "data" in json) {
-    return (json as { data: T }).data;
+    const data = (json as { data: T }).data;
+    if (data !== undefined) return data;
   }
   return json as T;
 }

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -109,7 +109,8 @@ interface SeededPlayer {
 
 function unwrapApiData<T>(json: T | { success?: boolean; data?: T }): T {
   if (json && typeof json === "object" && "success" in json && "data" in json) {
-    return (json as { data: T }).data;
+    const data = (json as { data: T }).data;
+    if (data !== undefined) return data;
   }
   return json as T;
 }


### PR DESCRIPTION
## Summary
- `unwrapApiData` が undefined を受け取ってもクラッシュしないようガード（BM/MR/GP finals page）
- `claude.yml` の `pull_request_review` トリガーを削除（自動レビューは `claude-code-review.yml` 側に集約、Skippedノイズを解消）

## Test plan
- [ ] BM/MR/GP finals ページで data 未取得時にエラーにならないこと
- [ ] PRレビュー投稿時に Claude Code workflow の Skipped run が出ないこと
- [ ] `@claude` メンション応答（issue/PRコメント）は引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)