### PR TITLE
feat(e2e): add TC-820/821/822 for MR/GP match page view-only tests

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -787,7 +787,7 @@
 
 ---
 
-## TT (Time Trial / TA) フルワークフローテスト  *(scenario only — 実装は別タスク)*
+## TT (Time Trial / TA) フルワークフローテスト  *(TC-801/804/805/806/807/808 実装済み)*
 
 ### 設計方針
 - **エントリー数**: 28名（TA はグループ分けなし、全員が同一プールでタイムを競う）
@@ -908,3 +908,37 @@ E2Eテストでは以下を必ず確認すること：
 3. **ローディング完了**: `読み込み中` が消えていること
 
 HTTPステータスコード200だけでは不十分。ページの`innerText`を取得して上記を検証すること（`textContent`はi18n JSONを含むため使用不可）。
+
+## 未カバー領域のテストケース（調査後追加）
+
+### TC-820: MR match/[matchId] ページ view-only確認
+- **URL**: /tournaments/[temp-id]/mr/match/[matchId]
+- **authRequired**: false
+- **背景**: TC-321はBM matchページのみテスト済み。MR/GP matchページもview-onlyであることを確認
+- **手順**:
+  1. MRPreparaciónをセットアップし、非BYEマッチを生成
+  2. `/mr/match/[matchId]` ページにアクセス
+  3. プレイヤー名とマッチ情報が表示されることを確認（view-only）
+  4. スコア入力フォーム要素が存在しないことを確認（参加者ページで入力）
+- **期待結果**: MR matchページはview-onlyでスコア入力フォームがない
+
+### TC-821: GP match/[matchId] ページ view-only確認
+- **URL**: /tournaments/[temp-id]/gp/match/[matchId]
+- **authRequired**: false
+- **手順**:
+  1. GPPreparaciónをセットアップし、非BYEマッチを生成
+  2. `/gp/match/[matchId]` ページにアクセス
+  3. プレイヤー名とマッチ情報が表示されることを確認（view-only）
+  4. スコア入力フォーム要素が存在しないことを確認
+- **期待結果**: GP matchページはview-onlyでスコア入力フォームがない
+
+### TC-822: MR二重報告 — 管理者確定後のスコア変更不可
+- **URL**: /api/tournaments/[temp-id]/mr/matches/[matchId]
+- **authRequired**: true (admin)
+- **背景**: 不一致報告後に管理者が確定したマッチは、scoresConfirmedフラグでロックされる
+- **手順**:
+  1. dualReportEnabled=trueのトーナメントでMRマッチを生成
+  2. P1が3-1で、P2が1-3で報告（不一致）
+  3. 管理者が不一致を確認後、PUTでスコアを確定
+  4. 同じマッチに再度PUTを送信 → 400で拒否されることを確認
+- **期待結果**: scoresConfirmed後のPUTは400で拒否される

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -579,8 +579,9 @@ async function runTc821(adminPage) {
     const matchText = await adminPage.locator('body').innerText();
 
     const showsPlayers = matchText.includes(player1.nickname) && matchText.includes(player2.nickname);
-    // GP match page shows driver points, not race entry form
-    const noRaceEntry = !matchText.includes('Submit') && !matchText.includes('1st') && !matchText.includes('送信');
+    // GP match page is view-only; score entry uses /gp/participant page
+    // Check for absence of form submission buttons
+    const noRaceEntry = !matchText.includes('Submit') && !matchText.includes('送信');
 
     log('TC-821', showsPlayers && noRaceEntry ? 'PASS' : 'FAIL',
       !showsPlayers ? 'Match page missing player names' : !noRaceEntry ? 'Match page has race entry form' : '');

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -524,7 +524,7 @@ async function runTc709(adminPage) {
 
 module.exports = {
   runTc701, runTc702, runTc703, runTc704, runTc705, runTc706,
-  runTc707, runTc708, runTc709,
+  runTc707, runTc708, runTc709, runTc821,
 };
 
 if (require.main === module) {
@@ -542,6 +542,53 @@ if (require.main === module) {
       { name: 'TC-705', fn: runTc705 },
       { name: 'TC-706', fn: runTc706 },
       { name: 'TC-709', fn: runTc709 },
+      { name: 'TC-821', fn: runTc821 },
     ],
   });
+}
+
+/* ───────── TC-821: GP match/[matchId] page view-only ─────────
+ * Similar to TC-320/TC-821 for MR, GP match pages are also view-only.
+ * Score entry is via /gp/participant or API report endpoint. */
+async function runTc821(adminPage) {
+  let tournamentId = null;
+  let player1 = null;
+  let player2 = null;
+  try {
+    const stamp = Date.now();
+    player1 = await apiCreatePlayer(adminPage, 'E2E GP 821 P1', `e2e_gp821_p1_${stamp}`);
+    player2 = await apiCreatePlayer(adminPage, 'E2E GP 821 P2', `e2e_gp821_p2_${stamp}`);
+    tournamentId = await apiCreateTournament(adminPage, `E2E GP 821 ${stamp}`);
+
+    const setup = await adminPage.evaluate(async ([url, data]) => {
+      const r = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+      return { s: r.status };
+    }, [`/api/tournaments/${tournamentId}/gp`, {
+      players: [{ playerId: player1.id, group: 'A' }, { playerId: player2.id, group: 'A' }],
+    }]);
+    if (setup.s !== 201) throw new Error(`GP setup failed (${setup.s})`);
+
+    const gpData = await adminPage.evaluate(async (url) => {
+      const r = await fetch(url);
+      return r.json().catch(() => ({}));
+    }, `/api/tournaments/${tournamentId}/gp`);
+    const match = (gpData.data?.matches || gpData.matches || []).find((m) => !m.isBye);
+    if (!match) throw new Error('No non-BYE match');
+
+    await nav(adminPage, `/tournaments/${tournamentId}/gp/match/${match.id}`);
+    const matchText = await adminPage.locator('body').innerText();
+
+    const showsPlayers = matchText.includes(player1.nickname) && matchText.includes(player2.nickname);
+    // GP match page shows driver points, not race entry form
+    const noRaceEntry = !matchText.includes('Submit') && !matchText.includes('1st') && !matchText.includes('送信');
+
+    log('TC-821', showsPlayers && noRaceEntry ? 'PASS' : 'FAIL',
+      !showsPlayers ? 'Match page missing player names' : !noRaceEntry ? 'Match page has race entry form' : '');
+  } catch (err) {
+    log('TC-821', 'FAIL', err instanceof Error ? err.message : 'GP match view test failed');
+  } finally {
+    if (tournamentId) await apiDeleteTournament(adminPage, tournamentId);
+    if (player1) await apiDeletePlayer(adminPage, player1.id);
+    if (player2) await apiDeletePlayer(adminPage, player2.id);
+  }
 }

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -1365,21 +1365,47 @@ async function runTc822(adminPage) {
     const match = (mrData.data?.matches || mrData.matches || []).find((m) => !m.isBye);
     if (!match) throw new Error('No non-BYE match');
 
-    // First PUT to confirm mismatched report (admin resolves)
+    // Step 1: P1 reports 3-1
+    await adminPage.evaluate(async ([url, body]) => {
+      await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }, [`/api/tournaments/${tournamentId}/mr/match/${match.id}/report`, {
+      reportingPlayer: 1, score1: 3, score2: 1,
+    }]);
+
+    // Step 2: P2 reports 1-3 (disagreement — mismatch detected)
+    const p2Report = await adminPage.evaluate(async ([url, body]) => {
+      const r = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [`/api/tournaments/${tournamentId}/mr/match/${match.id}/report`, {
+      reportingPlayer: 2, score1: 1, score2: 3,
+    }]);
+
+    const hasMismatch = p2Report.b?.data?.mismatch === true || p2Report.b?.mismatch === true;
+
+    // Step 3: Admin resolves mismatch via PUT (this sets scoresConfirmed)
     const confirm = await adminPage.evaluate(async ([url, data]) => {
       const r = await fetch(url, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
       return { s: r.status };
     }, [`/api/tournaments/${tournamentId}/mr`, { matchId: match.id, score1: 3, score2: 1 }]);
-    if (confirm.s !== 200) throw new Error(`Confirm failed (${confirm.s})`);
+    if (confirm.s !== 200) throw new Error(`Admin resolve failed (${confirm.s})`);
 
-    // Second PUT should be blocked
+    // Step 4: Second PUT should be blocked (scoresConfirmed is set)
     const secondPut = await adminPage.evaluate(async ([url, data]) => {
       const r = await fetch(url, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
       return { s: r.status };
     }, [`/api/tournaments/${tournamentId}/mr`, { matchId: match.id, score1: 2, score2: 2 }]);
 
-    log('TC-822', secondPut.s === 400 ? 'PASS' : 'FAIL',
-      secondPut.s !== 400 ? `Expected 400, got ${secondPut.s}` : '');
+    log('TC-822', hasMismatch && secondPut.s === 400 ? 'PASS' : 'FAIL',
+      !hasMismatch ? 'Mismatch not detected after dual report'
+        : secondPut.s !== 400 ? `Expected 400, got ${secondPut.s}` : '');
   } catch (err) {
     log('TC-822', 'FAIL', err instanceof Error ? err.message : 'MR scoresConfirmed test failed');
   } finally {

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -1397,14 +1397,24 @@ async function runTc822(adminPage) {
     }, [`/api/tournaments/${tournamentId}/mr`, { matchId: match.id, score1: 3, score2: 1 }]);
     if (confirm.s !== 200) throw new Error(`Admin resolve failed (${confirm.s})`);
 
+    // Verify match is completed after admin resolve
+    const finalCheck = await adminPage.evaluate(async (url) => {
+      const r = await fetch(url);
+      return r.json().catch(() => ({}));
+    }, `/api/tournaments/${tournamentId}/mr`);
+    const finalMatch = (finalCheck.data?.matches || finalCheck.matches || []).find((m) => m.id === match.id);
+    const isComplete = finalMatch?.completed === true;
+
     // Step 4: Second PUT should be blocked (scoresConfirmed is set)
     const secondPut = await adminPage.evaluate(async ([url, data]) => {
       const r = await fetch(url, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
       return { s: r.status };
     }, [`/api/tournaments/${tournamentId}/mr`, { matchId: match.id, score1: 2, score2: 2 }]);
 
-    log('TC-822', hasMismatch && secondPut.s === 400 ? 'PASS' : 'FAIL',
+    log('TC-822', hasMismatch && isComplete && secondPut.s === 400 ? 'PASS' : 'FAIL',
       !hasMismatch ? 'Mismatch not detected after dual report'
+        : !isComplete ? `Match not completed after resolve: completed=${finalMatch?.completed}`
+        : secondPut.s !== 400 ? `Expected 400, got ${secondPut.s}` : '');
         : secondPut.s !== 400 ? `Expected 400, got ${secondPut.s}` : '');
   } catch (err) {
     log('TC-822', 'FAIL', err instanceof Error ? err.message : 'MR scoresConfirmed test failed');

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -1415,7 +1415,6 @@ async function runTc822(adminPage) {
       !hasMismatch ? 'Mismatch not detected after dual report'
         : !isComplete ? `Match not completed after resolve: completed=${finalMatch?.completed}`
         : secondPut.s !== 400 ? `Expected 400, got ${secondPut.s}` : '');
-        : secondPut.s !== 400 ? `Expected 400, got ${secondPut.s}` : '');
   } catch (err) {
     log('TC-822', 'FAIL', err instanceof Error ? err.message : 'MR scoresConfirmed test failed');
   } finally {

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -1258,7 +1258,7 @@ async function runTc612(adminPage) {
 }
 
 // Export individual test functions for integration into tc-all.js
-module.exports = { runTc601, runTc602, runTc603, runTc604, runTc605, runTc606, runTc607, runTc608, runTc609, runTc610, runTc611, runTc612 };
+module.exports = { runTc601, runTc602, runTc603, runTc604, runTc605, runTc606, runTc607, runTc608, runTc609, runTc610, runTc611, runTc612, runTc820, runTc822 };
 
 // Standalone execution
 if (require.main === module) {
@@ -1279,6 +1279,112 @@ if (require.main === module) {
       { name: 'TC-610', fn: runTc610 },
       { name: 'TC-611', fn: runTc611 },
       { name: 'TC-612', fn: runTc612 },
+      { name: 'TC-820', fn: runTc820 },
+      { name: 'TC-822', fn: runTc822 },
     ],
   });
+}
+
+/* ───────── TC-820: MR match/[matchId] page view-only ─────────
+ * Similar to TC-321 (BM match page), MR match pages are also view-only.
+ * Score entry is consolidated to the /mr/participant page. */
+async function runTc820(adminPage) {
+  let tournamentId = null;
+  let player1 = null;
+  let player2 = null;
+  try {
+    const stamp = Date.now();
+    player1 = await createPlayer(adminPage, 'E2E MR 820 P1', `e2e_mr820_p1_${stamp}`);
+    player2 = await createPlayer(adminPage, 'E2E MR 820 P2', `e2e_mr820_p2_${stamp}`);
+    tournamentId = await createTournament(adminPage, `E2E MR 820 ${stamp}`);
+
+    // Setup MR qualification
+    const setup = await adminPage.evaluate(async ([url, data]) => {
+      const r = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+      return { s: r.status };
+    }, [`/api/tournaments/${tournamentId}/mr`, {
+      players: [{ playerId: player1.id, group: 'A' }, { playerId: player2.id, group: 'A' }],
+    }]);
+    if (setup.s !== 201) throw new Error(`MR setup failed (${setup.s})`);
+
+    // Get a non-BYE match
+    const mrData = await adminPage.evaluate(async (url) => {
+      const r = await fetch(url);
+      return r.json().catch(() => ({}));
+    }, `/api/tournaments/${tournamentId}/mr`);
+    const match = (mrData.data?.matches || mrData.matches || []).find((m) => !m.isBye);
+    if (!match) throw new Error('No non-BYE match');
+
+    // Visit match page
+    await nav(adminPage, `/tournaments/${tournamentId}/mr/match/${match.id}`);
+    const matchText = await adminPage.locator('body').innerText();
+
+    // Should show player names
+    const showsPlayers = matchText.includes(player1.nickname) && matchText.includes(player2.nickname);
+    // Should NOT have score entry form (winner buttons, course selectors)
+    const noScoreForm = !matchText.includes('wins race') && !matchText.includes('I am') && !matchText.includes('私は');
+
+    log('TC-820', showsPlayers && noScoreForm ? 'PASS' : 'FAIL',
+      !showsPlayers ? 'Match page missing player names' : !noScoreForm ? 'Match page has score entry form' : '');
+  } catch (err) {
+    log('TC-820', 'FAIL', err instanceof Error ? err.message : 'MR match view test failed');
+  } finally {
+    if (tournamentId) await deleteTournament(adminPage, tournamentId);
+    if (player1) await deletePlayer(adminPage, player1.id);
+    if (player2) await deletePlayer(adminPage, player2.id);
+  }
+}
+
+/* ───────── TC-822: MR scoresConfirmed → subsequent PUT blocked ─────────
+ * After admin confirms a mismatched dual-report, scoresConfirmed flag is set.
+ * A second PUT should return 400. */
+async function runTc822(adminPage) {
+  let tournamentId = null;
+  let player1 = null;
+  let player2 = null;
+  try {
+    const stamp = Date.now();
+    player1 = await createPlayer(adminPage, 'E2E MR 822 P1', `e2e_mr822_p1_${stamp}`);
+    player2 = await createPlayer(adminPage, 'E2E MR 822 P2', `e2e_mr822_p2_${stamp}`);
+    tournamentId = await createTournament(adminPage, `E2E MR 822 ${stamp}`, { dualReportEnabled: true });
+
+    // Setup MR with dualReport
+    const setup = await adminPage.evaluate(async ([url, data]) => {
+      const r = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+      return { s: r.status };
+    }, [`/api/tournaments/${tournamentId}/mr`, {
+      players: [{ playerId: player1.id, group: 'A' }, { playerId: player2.id, group: 'A' }],
+    }]);
+    if (setup.s !== 201) throw new Error(`MR setup failed (${setup.s})`);
+
+    // Get match
+    const mrData = await adminPage.evaluate(async (url) => {
+      const r = await fetch(url);
+      return r.json().catch(() => ({}));
+    }, `/api/tournaments/${tournamentId}/mr`);
+    const match = (mrData.data?.matches || mrData.matches || []).find((m) => !m.isBye);
+    if (!match) throw new Error('No non-BYE match');
+
+    // First PUT to confirm mismatched report (admin resolves)
+    const confirm = await adminPage.evaluate(async ([url, data]) => {
+      const r = await fetch(url, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+      return { s: r.status };
+    }, [`/api/tournaments/${tournamentId}/mr`, { matchId: match.id, score1: 3, score2: 1 }]);
+    if (confirm.s !== 200) throw new Error(`Confirm failed (${confirm.s})`);
+
+    // Second PUT should be blocked
+    const secondPut = await adminPage.evaluate(async ([url, data]) => {
+      const r = await fetch(url, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+      return { s: r.status };
+    }, [`/api/tournaments/${tournamentId}/mr`, { matchId: match.id, score1: 2, score2: 2 }]);
+
+    log('TC-822', secondPut.s === 400 ? 'PASS' : 'FAIL',
+      secondPut.s !== 400 ? `Expected 400, got ${secondPut.s}` : '');
+  } catch (err) {
+    log('TC-822', 'FAIL', err instanceof Error ? err.message : 'MR scoresConfirmed test failed');
+  } finally {
+    if (tournamentId) await deleteTournament(adminPage, tournamentId);
+    if (player1) await deletePlayer(adminPage, player1.id);
+    if (player2) await deletePlayer(adminPage, player2.id);
+  }
 }


### PR DESCRIPTION
## Summary
- TC-820: MR match/[matchId] page is view-only (no score entry form)
- TC-821: GP match/[matchId] page is view-only (no race entry form)
- TC-822: MR scoresConfirmed blocks subsequent PUT after admin confirms mismatch
- Updated E2E_TEST_CASES.md TT section header to reflect TC-806/807/808 are implemented
- Added TC-820/821/822 in new "未カバー領域" section

## Test plan
- [x] TC-820 added to tc-mr.js
- [x] TC-821 added to tc-gp.js
- [x] TC-822 added to tc-mr.js
- [ ] Run E2E tests in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)