### PR TITLE
fix(gp-finals): include player1/player2 in paginated query (#388)

### DIFF
--- a/smkc-score-app/__mocks__/lib/pagination.ts
+++ b/smkc-score-app/__mocks__/lib/pagination.ts
@@ -1,13 +1,14 @@
 // Create mock functions for pagination module
-export function getPaginationParams(options: { page?: number | string; limit?: number | string } = {}) {
+export function getPaginationParams(options: { page?: number | string; limit?: number | string; include?: Record<string, unknown> } = {}) {
   const page = Math.max(1, Number(options.page) || 1);
   const limit = Number(options.limit);
   const finalLimit = limit && limit > 0 ? Math.min(100, limit) : 50;
-  
+
   return {
     page,
     limit: finalLimit,
     skip: (page - 1) * finalLimit,
+    include: options?.include,
   };
 }
 

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -106,7 +106,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
           },
           { tournamentId, stage: 'finals' },
           { matchNumber: 'asc' },
-          { page, limit },
+          { page, limit, include: { player1: true, player2: true } },
         );
 
         const bracketStructure = result.data.length > 0

--- a/smkc-score-app/src/lib/pagination.ts
+++ b/smkc-score-app/src/lib/pagination.ts
@@ -73,6 +73,8 @@ export interface PaginationOptions {
   page?: number;
   /** Requested records per page. Defaults to 50, max 100. */
   limit?: number;
+  /** Optional Prisma include for eager-loading relations (e.g., player1/player2). */
+  include?: Record<string, unknown>;
 }
 
 // ============================================================
@@ -106,7 +108,7 @@ export interface PaginationOptions {
  */
 export function getPaginationParams(
   options?: PaginationOptions
-): { page: number; limit: number; skip: number } {
+): { page: number; limit: number; skip: number; include?: Record<string, unknown> } {
   // Apply defaults for missing values.
   // Page defaults to 1 (first page) and limit defaults to 50 records.
   const rawPage = options?.page ?? 1;
@@ -126,7 +128,7 @@ export function getPaginationParams(
   // Page 1 skips 0, page 2 skips `limit`, page 3 skips `2 * limit`, etc.
   const skip = (page - 1) * limit;
 
-  return { page, limit, skip };
+  return { page, limit, skip, include: options?.include };
 }
 
 // ============================================================
@@ -149,6 +151,7 @@ interface PrismaModelDelegate {
     orderBy: Record<string, unknown>;
     skip: number;
     take: number;
+    include?: Record<string, unknown>;
   }) => Promise<unknown[]>;
 }
 
@@ -185,7 +188,7 @@ export async function paginate<T>(
   options?: PaginationOptions
 ): Promise<PaginatedResponse<T>> {
   // Process and validate pagination parameters
-  const { page, limit, skip } = getPaginationParams(options);
+  const { page, limit, skip, include } = getPaginationParams(options);
 
   // Execute count and findMany in parallel for efficiency.
   // Both use the same where clause to ensure consistency.
@@ -198,6 +201,7 @@ export async function paginate<T>(
       orderBy,
       skip,
       take: limit,
+      ...(include ? { include } : {}),
     }),
   ]);
 


### PR DESCRIPTION
## Summary
- **Bug**: TC-705 FAIL: "Champion banner missing nickname" after M16 completes
- **Root cause**: GP finals API uses 'paginated' GET style which was missing player relations in the query. `getCompletedChampion()` accessed `player1.nickname` which was undefined.

## Fix
1. **pagination.ts**: Add `include` option to `PaginationOptions` and `PrismaModelDelegate.findMany` interface
2. **finals-route.ts**: Pass `include: { player1: true, player2: true }` in the paginated query

## Test plan
- [ ] Run `node e2e/tc-gp.js` — TC-705 should PASS
- [ ] Run `node e2e/tc-all.js` — confirm GP section still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)