### PR TITLE
fix(audit): replace XSS sanitization with log-injection prevention (#380)

### DIFF
--- a/smkc-score-app/__tests__/lib/audit-log.test.ts
+++ b/smkc-score-app/__tests__/lib/audit-log.test.ts
@@ -73,7 +73,7 @@ describe('Audit Log', () => {
 
       await createAuditLog(params);
 
-      const call = (prismaMock.auditLog.create as any).mock.calls[0];
+      const call = (prismaMock.auditLog.create as any).mock.calls[0][0];
       expect(call.data.ipAddress).toBe('192.168.1.1[FAKE_LOG_ENTRY]');
     });
 
@@ -86,7 +86,7 @@ describe('Audit Log', () => {
 
       await createAuditLog(params);
 
-      const call = (prismaMock.auditLog.create as any).mock.calls[0];
+      const call = (prismaMock.auditLog.create as any).mock.calls[0][0];
       expect(call.data.userAgent).toBe('Mozilla/5.0[INJECTED]');
     });
 
@@ -100,7 +100,7 @@ describe('Audit Log', () => {
 
       await createAuditLog(params);
 
-      const call = (prismaMock.auditLog.create as any).mock.calls[0];
+      const call = (prismaMock.auditLog.create as any).mock.calls[0][0];
       expect(call.data.details.userAgent).toBe('Red Text');
     });
 
@@ -118,7 +118,7 @@ describe('Audit Log', () => {
 
       await createAuditLog(params);
 
-      const call = (prismaMock.auditLog.create as any).mock.calls[0];
+      const call = (prismaMock.auditLog.create as any).mock.calls[0][0];
       expect(call.data.details.player).toBe('John[FAKE_LOG]');
       expect(call.data.details.score).toBe(100);
       expect(call.data.details.nested.message).toBe('TestInjection');
@@ -134,7 +134,7 @@ describe('Audit Log', () => {
 
       await createAuditLog(params);
 
-      const call = (prismaMock.auditLog.create as any).mock.calls[0];
+      const call = (prismaMock.auditLog.create as any).mock.calls[0][0];
       expect(call.data.ipAddress.length).toBe(500);
     });
 
@@ -195,7 +195,7 @@ describe('Audit Log', () => {
 
       await createAuditLog(params);
 
-      const call = (prismaMock.auditLog.create as any).mock.calls[0];
+      const call = (prismaMock.auditLog.create as any).mock.calls[0][0];
       expect(call.data.userId).toBeNull();
     });
 

--- a/smkc-score-app/__tests__/lib/audit-log.test.ts
+++ b/smkc-score-app/__tests__/lib/audit-log.test.ts
@@ -6,33 +6,20 @@
  * @module __tests__/lib/audit-log.test.ts
  * @description Test suite for the audit logging utility from `@/lib/audit-log`.
  *
- * This suite validates the `createAuditLog` function which records administrative
- * actions (tournament creation, unauthorized access attempts, etc.) to the database
- * via Prisma. Tests cover:
- *
- * - Successful audit log creation with all fields (userId, ipAddress, userAgent,
- *   action, targetId, targetType, details).
- * - Input sanitization of the `details` field via `sanitizeInput` to prevent XSS
- *   or injection attacks being persisted in audit records.
- * - Creation of audit logs without optional fields (userId, targetId, targetType,
- *   details).
- * - Graceful error handling: returns undefined (instead of throwing) when the
- *   database write fails, ensuring audit log failures never crash the main flow.
- * - Verification that `sanitizeInput` is not called when `details` is not provided.
- * - Anonymous user identification when userId is absent in error scenarios.
+ * Tests cover:
+ * - Successful audit log creation with all fields
+ * - Log injection prevention (removing LF, CR, control chars, ANSI escapes)
+ * - Recursive sanitization of object values in details
+ * - Maximum field length enforcement
+ * - Graceful error handling (fire-and-forget pattern)
+ * - Anonymous user handling when userId is absent
  */
 import { createAuditLog, AUDIT_ACTIONS } from '@/lib/audit-log';
-import { sanitizeInput } from '@/lib/sanitize';
-
-jest.mock('@/lib/sanitize');
-
-
 import { prisma as prismaMock } from '@/lib/prisma';
 
 describe('Audit Log', () => {
-  let mockSanitizeInput: jest.MockedFunction<typeof sanitizeInput>;
-
   beforeEach(() => {
+    jest.clearAllMocks();
     (prismaMock.auditLog.create as any).mockResolvedValue({
       id: 'audit-1',
       userId: 'user-123',
@@ -43,153 +30,185 @@ describe('Audit Log', () => {
       targetType: 'Tournament',
       details: { test: 'data' },
     });
-    mockSanitizeInput = sanitizeInput as jest.MockedFunction<typeof sanitizeInput>;
-    mockSanitizeInput.mockImplementation((input) => input);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should create audit log successfully', async () => {
-    const params = {
-      userId: 'user-123',
-      ipAddress: '192.168.1.1',
-      userAgent: 'Mozilla/5.0',
-      action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
-      targetId: 'tournament-456',
-      targetType: 'Tournament',
-      details: { test: 'data' },
-    };
+  describe('createAuditLog', () => {
+    it('should create audit log successfully', async () => {
+      const params = {
+        userId: 'user-123',
+        ipAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+        action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
+        targetId: 'tournament-456',
+        targetType: 'Tournament',
+        details: { test: 'data' },
+      };
 
-    const result = await createAuditLog(params);
+      const result = await createAuditLog(params);
 
-    expect(prismaMock.auditLog.create).toHaveBeenCalledWith({
-      data: {
-        userId: params.userId,
-        ipAddress: params.ipAddress,
-        userAgent: params.userAgent,
-        action: params.action,
-        targetId: params.targetId,
-        targetType: params.targetType,
-        details: JSON.parse(JSON.stringify(mockSanitizeInput(params.details))),
-      },
+      expect(prismaMock.auditLog.create).toHaveBeenCalledWith({
+        data: {
+          userId: params.userId,
+          ipAddress: params.ipAddress,
+          userAgent: params.userAgent,
+          action: params.action,
+          targetId: params.targetId,
+          targetType: params.targetType,
+          details: JSON.parse(JSON.stringify(params.details)),
+        },
+      });
+      expect(result).toBeUndefined();
     });
-    // createAuditLog returns Promise<void> (fire-and-forget pattern),
-    // so result is undefined on success. We verify success by checking
-    // that prisma.auditLog.create was called above.
-    expect(result).toBeUndefined();
-  });
 
-  it('should sanitize details before creating log', async () => {
-    const params = {
-      userId: 'user-123',
-      ipAddress: '192.168.1.1',
-      userAgent: 'Mozilla/5.0',
-      action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
-      details: { '<script>alert("xss")</script>': 'malicious' },
-    };
+    it('should remove newlines and control characters from ipAddress', async () => {
+      const params = {
+        ipAddress: '192.168.1.1\n[FAKE_LOG_ENTRY]',
+        userAgent: 'Mozilla/5.0',
+        action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
+      };
 
-    mockSanitizeInput.mockImplementation((input) => ({ sanitized: input }));
+      await createAuditLog(params);
 
-    await createAuditLog(params);
-
-    expect(mockSanitizeInput).toHaveBeenCalledWith(params.details);
-  });
-
-  it('should create log without optional fields', async () => {
-    const params = {
-      ipAddress: '192.168.1.1',
-      userAgent: 'Mozilla/5.0',
-      action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
-    };
-
-    const result = await createAuditLog(params);
-
-    // Source uses `params.userId || null` so missing userId becomes null
-    expect(prismaMock.auditLog.create).toHaveBeenCalledWith({
-      data: {
-        userId: null,
-        ipAddress: params.ipAddress,
-        userAgent: params.userAgent,
-        action: params.action,
-        targetId: undefined,
-        targetType: undefined,
-        details: undefined,
-      },
+      const call = (prismaMock.auditLog.create as any).mock.calls[0];
+      expect(call.data.ipAddress).toBe('192.168.1.1[FAKE_LOG_ENTRY]');
     });
-    // createAuditLog returns Promise<void>, so result is always undefined
-    expect(result).toBeUndefined();
-  });
 
-  it('should handle errors gracefully and return undefined', async () => {
-    const params = {
-      ipAddress: '192.168.1.1',
-      userAgent: 'Mozilla/5.0',
-      action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
-    };
+    it('should remove carriage return from userAgent', async () => {
+      const params = {
+        ipAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0\r\n[INJECTED]',
+        action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
+      };
 
-    (prismaMock.auditLog.create as any).mockRejectedValue(new Error('Database connection failed'));
+      await createAuditLog(params);
 
+      const call = (prismaMock.auditLog.create as any).mock.calls[0];
+      expect(call.data.userAgent).toBe('Mozilla/5.0[INJECTED]');
+    });
 
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-    const result = await createAuditLog(params);
+    it('should remove ANSI escape sequences', async () => {
+      const params = {
+        ipAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+        action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
+        details: { userAgent: '\x1B[31mRed Text\x1B[0m' },
+      };
 
-    expect(result).toBeUndefined();
-    // In test mode, logger is silent - console.error should not be called
-    // expect(consoleSpy).toHaveBeenCalledWith(
-    //   'Audit log creation failed - Action: %s, User: %s, Target: %s/%s, IP: %s, Error: %s',
-    //   AUDIT_ACTIONS.CREATE_TOURNAMENT,
-    //   'anonymous',
-    //   'N/A',
-    //   'N/A',
-    //   '192.168.1.1',
-    //   'Database connection failed'
-    // );
-    consoleSpy.mockRestore();
-  });
+      await createAuditLog(params);
 
-  // sanitizeInput is called on ipAddress, userAgent, action (always)
-  // but NOT on details when details is not provided
-  it('should not call sanitizeInput on details when details is not provided', async () => {
-    const params = {
-      ipAddress: '192.168.1.1',
-      userAgent: 'Mozilla/5.0',
-      action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
-    };
+      const call = (prismaMock.auditLog.create as any).mock.calls[0];
+      expect(call.data.details.userAgent).toBe('Red Text');
+    });
 
-    await createAuditLog(params);
+    it('should recursively sanitize details object', async () => {
+      const params = {
+        ipAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+        action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
+        details: {
+          player: 'John\n[FAKE_LOG]',
+          score: 100,
+          nested: { message: 'Test\r\nInjection' },
+        },
+      };
 
-    // sanitizeInput is called for ipAddress, userAgent, and action (3 times)
-    // but NOT for details since it's undefined
-    expect(mockSanitizeInput).toHaveBeenCalledTimes(3);
-    expect(mockSanitizeInput).toHaveBeenCalledWith('192.168.1.1');
-    expect(mockSanitizeInput).toHaveBeenCalledWith('Mozilla/5.0');
-    expect(mockSanitizeInput).toHaveBeenCalledWith(AUDIT_ACTIONS.CREATE_TOURNAMENT);
-  });
+      await createAuditLog(params);
 
-  it('should log user as anonymous when userId not provided', async () => {
-    const params = {
-      ipAddress: '192.168.1.1',
-      userAgent: 'Mozilla/5.0',
-      action: AUDIT_ACTIONS.UNAUTHORIZED_ACCESS,
-    };
+      const call = (prismaMock.auditLog.create as any).mock.calls[0];
+      expect(call.data.details.player).toBe('John[FAKE_LOG]');
+      expect(call.data.details.score).toBe(100);
+      expect(call.data.details.nested.message).toBe('TestInjection');
+    });
 
-    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-    (prismaMock.auditLog.create as any).mockRejectedValue(new Error('DB error'));
+    it('should trim and limit field length to 500 chars', async () => {
+      const longString = 'A'.repeat(600);
+      const params = {
+        ipAddress: longString,
+        userAgent: 'Mozilla/5.0',
+        action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
+      };
 
-    await createAuditLog(params);
+      await createAuditLog(params);
 
-    // In test mode, logger is silent - console.error should not be called
-    // expect(consoleSpy).toHaveBeenCalledWith(
-    //   'Audit log creation failed - Action: %s, User: %s, Target: %s/%s, IP: %s, Error: %s',
-    //   AUDIT_ACTIONS.UNAUTHORIZED_ACCESS,
-    //   'anonymous',
-    //   'N/A',
-    //   'N/A',
-    //   '192.168.1.1',
-    //   'DB error'
-    // );
-    consoleSpy.mockRestore();
+      const call = (prismaMock.auditLog.create as any).mock.calls[0];
+      expect(call.data.ipAddress.length).toBe(500);
+    });
+
+    it('should handle empty strings', async () => {
+      const params = {
+        ipAddress: '',
+        userAgent: '',
+        action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
+      };
+
+      const result = await createAuditLog(params);
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle errors gracefully and return undefined', async () => {
+      const params = {
+        ipAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+        action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
+      };
+
+      (prismaMock.auditLog.create as any).mockRejectedValue(new Error('Database connection failed'));
+
+      const result = await createAuditLog(params);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should create log without optional fields', async () => {
+      const params = {
+        ipAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+        action: AUDIT_ACTIONS.LOGIN_FAILURE,
+      };
+
+      const result = await createAuditLog(params);
+
+      expect(prismaMock.auditLog.create).toHaveBeenCalledWith({
+        data: {
+          userId: null,
+          ipAddress: params.ipAddress,
+          userAgent: params.userAgent,
+          action: params.action,
+          targetId: undefined,
+          targetType: undefined,
+          details: undefined,
+        },
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('should use null for missing userId', async () => {
+      const params = {
+        ipAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+        action: AUDIT_ACTIONS.UNAUTHORIZED_ACCESS,
+      };
+
+      await createAuditLog(params);
+
+      const call = (prismaMock.auditLog.create as any).mock.calls[0];
+      expect(call.data.userId).toBeNull();
+    });
+
+    it('should handle null details', async () => {
+      const params = {
+        ipAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+        action: AUDIT_ACTIONS.CREATE_TOURNAMENT,
+        details: null,
+      };
+
+      const result = await createAuditLog(params);
+      expect(result).toBeUndefined();
+    });
   });
 });

--- a/smkc-score-app/src/lib/audit-log.ts
+++ b/smkc-score-app/src/lib/audit-log.ts
@@ -32,11 +32,78 @@
  */
 
 import prisma from '@/lib/prisma';
-import { sanitizeInput } from '@/lib/sanitize';
 import { createLogger } from '@/lib/logger';
 
-/** Logger scoped to audit logging operations */
+/**
+ * Logger scoped to audit logging operations
+ */
 const logger = createLogger('audit-log');
+
+/**
+ * Maximum length for audit log string fields.
+ * Prevents excessive storage usage and long-field issues in logs.
+ */
+const MAX_AUDIT_LOG_FIELD_LENGTH = 500;
+
+/**
+ * Sanitizes a string for safe inclusion in audit logs.
+ *
+ * Unlike sanitizeInput (XSS prevention), this function targets log injection
+ * attacks which use:
+ * - Newlines and line breaks to fake structured log entries
+ * - Control characters to corrupt log parsers
+ * - ANSI escape sequences to colorize fake log entries
+ *
+ * This function does NOT perform HTML encoding because audit logs are
+ * stored in database tables, not rendered in HTML contexts.
+ *
+ * @param str - Raw string to sanitize for audit logging
+ * @param maxLength - Maximum allowed length (default 500)
+ * @returns Sanitized string safe for audit logs
+ */
+function sanitizeForAuditLog(str: string, maxLength = MAX_AUDIT_LOG_FIELD_LENGTH): string {
+  if (!str) return '';
+
+  return str
+    // Remove control characters except tab (0x09) which is valid in many contexts
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
+    // Remove ANSI escape sequences that could colorize fake entries
+    .replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '')
+    // Trim whitespace and limit length
+    .trim()
+    .slice(0, maxLength);
+}
+
+/**
+ * Sanitizes an object for safe inclusion in audit logs.
+ * Recursively processes all string values within the object.
+ *
+ * @param obj - Object to sanitize for audit logging
+ * @param maxLength - Maximum allowed length per field (default 500)
+ * @returns Sanitized object with all string values sanitized
+ */
+function sanitizeObjectForAuditLog(
+  obj: Record<string, unknown>,
+  maxLength = MAX_AUDIT_LOG_FIELD_LENGTH
+): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === 'string') {
+      sanitized[key] = sanitizeForAuditLog(value, maxLength);
+    } else if (Array.isArray(value)) {
+      sanitized[key] = value.map((item) =>
+        typeof item === 'string' ? sanitizeForAuditLog(item, maxLength) : item
+      );
+    } else if (value !== null && typeof value === 'object') {
+      sanitized[key] = sanitizeObjectForAuditLog(value as Record<string, unknown>, maxLength);
+    } else {
+      sanitized[key] = value;
+    }
+  }
+
+  return sanitized;
+}
 
 // ============================================================
 // Types
@@ -109,25 +176,24 @@ export interface AuditLogParams {
 export async function createAuditLog(params: AuditLogParams): Promise<void> {
   try {
     // Sanitize all string inputs to prevent log injection attacks.
-    // Log injection occurs when attackers include newlines, control
-    // characters, or HTML in logged values to corrupt log files
-    // or exploit log viewing dashboards.
-    const sanitizedIpAddress = sanitizeInput(params.ipAddress);
-    const sanitizedUserAgent = sanitizeInput(params.userAgent);
-    const sanitizedAction = sanitizeInput(params.action);
+    // Unlike sanitizeInput (XSS prevention), this targets log injection
+    // which uses newlines, control characters, and ANSI escapes.
+    const sanitizedIpAddress = sanitizeForAuditLog(params.ipAddress);
+    const sanitizedUserAgent = sanitizeForAuditLog(params.userAgent);
+    const sanitizedAction = sanitizeForAuditLog(params.action);
 
     // Sanitize optional fields only when present
     const sanitizedTargetId = params.targetId
-      ? sanitizeInput(params.targetId)
+      ? sanitizeForAuditLog(params.targetId)
       : undefined;
     const sanitizedTargetType = params.targetType
-      ? sanitizeInput(params.targetType)
+      ? sanitizeForAuditLog(params.targetType)
       : undefined;
 
     // Sanitize the details object if provided.
     // This recursively sanitizes all string values within the JSON.
     const sanitizedDetails = params.details
-      ? sanitizeInput(params.details)
+      ? sanitizeObjectForAuditLog(params.details)
       : undefined;
 
     // Create the audit log entry in the database.

--- a/smkc-score-app/src/lib/audit-log.ts
+++ b/smkc-score-app/src/lib/audit-log.ts
@@ -65,8 +65,9 @@ function sanitizeForAuditLog(str: string, maxLength = MAX_AUDIT_LOG_FIELD_LENGTH
   if (!str) return '';
 
   return str
-    // Remove control characters except tab (0x09) which is valid in many contexts
-    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
+    // Remove control characters including LF (0x0A) and CR (0x0D)
+    // which are the primary vectors for log injection attacks
+    .replace(/[\x00-\x08\x0A-\x0D\x0E-\x1F\x7F]/g, '')
     // Remove ANSI escape sequences that could colorize fake entries
     .replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '')
     // Trim whitespace and limit length


### PR DESCRIPTION
## Summary
- Replace `sanitizeInput` (XSS prevention) with `sanitizeForAuditLog` in audit-log.ts
- The previous approach incorrectly used HTML sanitization for audit logs

## Problem
`sanitizeInput` uses the `xss` library designed for HTML context, but audit logs are:
- Stored in database tables, not rendered as HTML
- Vulnerable to log injection attacks that use newlines/control characters, not HTML tags
- Could incorrectly strip valid characters like `<` and `>` from IP addresses

## Fix
Created `sanitizeForAuditLog` function that:
- Removes control characters (except tab) to prevent log injection
- Removes ANSI escape sequences to prevent colorization attacks  
- Limits field length to 500 chars
- Does NOT do HTML encoding since logs aren't HTML

## Test plan
- [ ] Existing audit log functionality still works
- [ ] No regression in logging behavior

🤖 Generated with [Claude Code](https://claude.ai/claude-code)