### PR TITLE
fix(optimistic-lock): require P2025 code AND message for lock detection (#379)

### DIFF
--- a/smkc-score-app/__tests__/lib/optimistic-locking.test.ts
+++ b/smkc-score-app/__tests__/lib/optimistic-locking.test.ts
@@ -123,8 +123,9 @@ describe('updateWithRetry', () => {
 
   it('should retry on optimistic lock error (version in message)', async () => {
     const { Prisma } = jest.requireMock('@prisma/client');
+    // P2025 with version message = optimistic lock error (not a genuine "not found")
     const versionError = new Prisma.PrismaClientKnownRequestError('version mismatch detected', {
-      code: 'P2003',
+      code: 'P2025',
       clientVersion: '5.0.0',
     });
 
@@ -141,8 +142,9 @@ describe('updateWithRetry', () => {
 
   it('should retry on optimistic lock error (Record to update not found)', async () => {
     const { Prisma } = jest.requireMock('@prisma/client');
+    // P2025 with "Record to update not found" = optimistic lock error (version mismatch in D1)
     const notFoundError = new Prisma.PrismaClientKnownRequestError('Record to update not found', {
-      code: 'P2001',
+      code: 'P2025',
       clientVersion: '5.0.0',
     });
 

--- a/smkc-score-app/src/lib/optimistic-locking.ts
+++ b/smkc-score-app/src/lib/optimistic-locking.ts
@@ -209,12 +209,10 @@ function isOptimisticLockError(error: Prisma.PrismaClientKnownRequestError): boo
   // 2. The record exists but the version doesn't match (optimistic lock failure)
   // We require BOTH the P2025 code AND a version-related message to avoid
   // treating generic "not found" errors as lock conflicts.
-  if (error.code === 'P2025') {
-    return error.message.includes('version') ||
-           error.message.includes('Record to update not found');
-  }
-  return error.message.includes('version') ||
-         error.message.includes('Record to update not found');
+  return error.code === 'P2025' && (
+    error.message.includes('version') ||
+    error.message.includes('Record to update not found')
+  );
 }
 
 /**

--- a/smkc-score-app/src/lib/optimistic-locking.ts
+++ b/smkc-score-app/src/lib/optimistic-locking.ts
@@ -204,9 +204,17 @@ export async function updateWithRetry<T>(
  * @returns True if the error indicates an optimistic lock conflict
  */
 function isOptimisticLockError(error: Prisma.PrismaClientKnownRequestError): boolean {
-  return error.message.includes('Record to update not found') ||
-         error.message.includes('version') ||
-         error.code === 'P2025';
+  // P2025 is a generic "record not found" error that can mean either:
+  // 1. The record genuinely doesn't exist
+  // 2. The record exists but the version doesn't match (optimistic lock failure)
+  // We require BOTH the P2025 code AND a version-related message to avoid
+  // treating generic "not found" errors as lock conflicts.
+  if (error.code === 'P2025') {
+    return error.message.includes('version') ||
+           error.message.includes('Record to update not found');
+  }
+  return error.message.includes('version') ||
+         error.message.includes('Record to update not found');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix `isOptimisticLockError` to require BOTH P2025 code AND version-related message
- Previously, any P2025 error was treated as an optimistic lock failure

## Problem
P2025 is a generic "record not found" error that can mean:
1. The record genuinely doesn't exist
2. The record exists but the version doesn't match (lock conflict)

The old code treated ALL P2025 errors as lock conflicts, which is incorrect.

## Fix
Now we require BOTH:
- `error.code === 'P2025'`
- AND a version-related message (`'version'` or `'Record to update not found'`)

## Fixes
- #379

🤖 Generated with [Claude Code](https://claude.ai/claude-code)