### PR TITLE
fix(report): add score correction path for completed MR/GP matches (#377)

### DIFF
--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -105,10 +105,6 @@ export async function POST(
       return handleValidationError("Match not found", "matchId");
     }
 
-    if (match.completed) {
-      return handleValidationError("Match already completed", "matchStatus");
-    }
-
     /* Validate reportingPlayer before auth check to prevent invalid values propagating */
     if (reportingPlayer !== 1 && reportingPlayer !== 2) {
       return handleValidationError("reportingPlayer must be 1 or 2", "reportingPlayer");
@@ -118,6 +114,77 @@ export async function POST(
     const isAuthorized = await checkScoreReportAuth(request, tournamentId, reportingPlayer, match);
     if (!isAuthorized) {
       return handleAuthError('Unauthorized: Not authorized for this match');
+    }
+
+    /*
+     * Correction path: let a participant fix a GP score after the match has
+     * already been confirmed. Keep the match completed, update the final score
+     * and the reporting player's stored report, then recalculate standings.
+     */
+    if (match.completed) {
+      /* Process races: convert finishing positions to driver points (same as normal flow) */
+      let totalPoints1 = 0;
+      let totalPoints2 = 0;
+
+      const processedRaces = races.map((race: { position1: number; position2: number; course: string }) => {
+        const pts1 = getDriverPoints(race.position1);
+        const pts2 = getDriverPoints(race.position2);
+        totalPoints1 += pts1;
+        totalPoints2 += pts2;
+        return {
+          course: race.course,
+          position1: race.position1,
+          position2: race.position2,
+          points1: pts1,
+          points2: pts2,
+        };
+      });
+
+      try {
+        const correctedMatch = await updateWithRetry(prisma, async (tx) => {
+          const currentMatch = await tx.gPMatch.findUnique({
+            where: { id: matchId },
+            select: { version: true },
+          });
+
+          if (!currentMatch) {
+            throw new Error("Match not found");
+          }
+
+          const reportData =
+            reportingPlayer === 1
+              ? { player1ReportedPoints1: totalPoints1, player1ReportedPoints2: totalPoints2, player1ReportedRaces: processedRaces }
+              : { player2ReportedPoints1: totalPoints1, player2ReportedPoints2: totalPoints2, player2ReportedRaces: processedRaces };
+
+          return tx.gPMatch.update({
+            where: { id: matchId, version: currentMatch.version },
+            data: {
+              points1: totalPoints1,
+              points2: totalPoints2,
+              completed: true,
+              ...reportData,
+              version: { increment: 1 },
+            },
+            include: { player1: true, player2: true },
+          });
+        });
+
+        await recalculatePlayerStats(GP_RECALC_CONFIG, tournamentId, correctedMatch.player1Id);
+        await recalculatePlayerStats(GP_RECALC_CONFIG, tournamentId, correctedMatch.player2Id);
+
+        return createSuccessResponse({
+          match: correctedMatch,
+          corrected: true,
+        }, "Score correction saved");
+      } catch (error) {
+        if (error instanceof OptimisticLockError) {
+          return createErrorResponse(
+            "This match was updated by someone else. Please refresh and try again.",
+            409, "OPTIMISTIC_LOCK_ERROR", { requiresRefresh: true }
+          );
+        }
+        return handleDatabaseError(error, "score correction");
+      }
     }
 
     /* Validate character selection */

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -122,6 +122,25 @@ export async function POST(
      * and the reporting player's stored report, then recalculate standings.
      */
     if (match.completed) {
+      /* Validate GP race positions are in legal range (0-8) before processing */
+      if (!Array.isArray(races) || races.length !== TOTAL_GP_RACES) {
+        return handleValidationError(`races must be an array of ${TOTAL_GP_RACES} entries`, "races");
+      }
+      for (let i = 0; i < races.length; i++) {
+        const race = races[i] as { position1: number; position2: number; course: string };
+        const pos1Result = validateGPRacePosition(race.position1);
+        if (!pos1Result.isValid) return handleValidationError(pos1Result.error!, "position1");
+        const pos2Result = validateGPRacePosition(race.position2);
+        if (!pos2Result.isValid) return handleValidationError(pos2Result.error!, "position2");
+        /* Two players cannot finish in the same position (except both game-over at 0 per §7.2) */
+        if (race.position1 === race.position2 && race.position1 !== 0) {
+          return handleValidationError(
+            `Race ${i + 1}: both players cannot finish in the same position (${race.position1})`,
+            "position",
+          );
+        }
+      }
+
       /* Process races: convert finishing positions to driver points (same as normal flow) */
       let totalPoints1 = 0;
       let totalPoints2 = 0;

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
@@ -128,6 +128,12 @@ export async function POST(
      * and the reporting player's stored report, then recalculate standings.
      */
     if (match.completed) {
+      /* Validate MR scores are in legal range (sum must equal TOTAL_MR_RACES=4) */
+      const scoreValidation = validateMatchRaceScores(score1, score2);
+      if (!scoreValidation.isValid) {
+        return handleValidationError(scoreValidation.error!, "scores");
+      }
+
       try {
         const correctedMatch = await updateWithRetry(prisma, async (tx) => {
           const currentMatch = await tx.mRMatch.findUnique({

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
@@ -107,11 +107,6 @@ export async function POST(
       return handleValidationError("Match not found", "matchId");
     }
 
-    /* Prevent reports on completed matches (checked before auth) */
-    if (match.completed) {
-      return handleValidationError("Match already completed", "matchStatus");
-    }
-
     /* Validate required fields before auth to fail fast on malformed requests */
     if (reportingPlayer !== 1 && reportingPlayer !== 2) {
       return handleValidationError("reportingPlayer must be 1 or 2", "reportingPlayer");
@@ -125,6 +120,59 @@ export async function POST(
     const isAuthorized = await checkScoreReportAuth(request, tournamentId, reportingPlayer, match);
     if (!isAuthorized) {
       return handleAuthError('Unauthorized: Not authorized for this match');
+    }
+
+    /*
+     * Correction path: let a participant fix a MR score after the match has
+     * already been confirmed. Keep the match completed, update the final score
+     * and the reporting player's stored report, then recalculate standings.
+     */
+    if (match.completed) {
+      try {
+        const correctedMatch = await updateWithRetry(prisma, async (tx) => {
+          const currentMatch = await tx.mRMatch.findUnique({
+            where: { id: matchId },
+            select: { version: true },
+          });
+
+          if (!currentMatch) {
+            throw new Error("Match not found");
+          }
+
+          const reportData =
+            reportingPlayer === 1
+              ? { player1ReportedPoints1: score1, player1ReportedPoints2: score2, player1ReportedRaces: rounds }
+              : { player2ReportedPoints1: score1, player2ReportedPoints2: score2, player2ReportedRaces: rounds };
+
+          return tx.mRMatch.update({
+            where: { id: matchId, version: currentMatch.version },
+            data: {
+              score1,
+              score2,
+              completed: true,
+              ...reportData,
+              version: { increment: 1 },
+            },
+            include: { player1: true, player2: true },
+          });
+        });
+
+        await recalculatePlayerStats(MR_RECALC_CONFIG, tournamentId, correctedMatch.player1Id);
+        await recalculatePlayerStats(MR_RECALC_CONFIG, tournamentId, correctedMatch.player2Id);
+
+        return createSuccessResponse({
+          match: correctedMatch,
+          corrected: true,
+        }, "Score correction saved");
+      } catch (error) {
+        if (error instanceof OptimisticLockError) {
+          return createErrorResponse(
+            "This match was updated by someone else. Please refresh and try again.",
+            409, "OPTIMISTIC_LOCK_ERROR", { requiresRefresh: true }
+          );
+        }
+        return handleDatabaseError(error, "score correction");
+      }
     }
 
     /* Validate MR scores are in legal range (sum must equal TOTAL_MR_RACES=4) */


### PR DESCRIPTION
## Summary
- Add score correction path for completed matches in MR and GP routes
- Previously, MR and GP routes blocked score reports on completed matches with "Match already completed" error
- Now they allow corrections like BM does

## Changes
- **MR route**: Replace error with correction path that uses optimistic locking
- **GP route**: Replace error with correction path that processes races and uses optimistic locking
- Both correction paths recalculate player stats after update

## Technical Details
- Uses `updateWithRetry` for safe concurrent updates
- Returns `{ corrected: true }` in response to distinguish from normal reports
- Handles `OptimisticLockError` with 409 response

## Fixes
- #377

🤖 Generated with [Claude Code](https://claude.ai/claude-code)