### PR TITLE
fix(finals): create new matches before deleting old ones (#313)

### DIFF
--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -216,10 +216,6 @@ export function createFinalsHandlers(config: FinalsConfig) {
         );
       }
 
-      await model(prisma).deleteMany({
-        where: { tournamentId, stage: 'finals' },
-      });
-
       const bracketStructure = generateBracketStructure(topN);
 
       const seededPlayers = qualifications.map(
@@ -230,6 +226,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
         }),
       );
 
+      /*
+       * Create all matches BEFORE deleting old ones.
+       * This ensures that if creation fails, the old matches are still intact.
+       * Only delete old matches after all new matches are successfully created.
+       * This prevents leaving the tournament in an incomplete state (no finals matches).
+       */
       const createdMatches = [];
       for (const bracketMatch of bracketStructure) {
         const player1 = bracketMatch.player1Seed
@@ -260,6 +262,11 @@ export function createFinalsHandlers(config: FinalsConfig) {
           player2Seed: bracketMatch.player2Seed,
         });
       }
+
+      /* Delete old matches only after all new matches are successfully created */
+      await model(prisma).deleteMany({
+        where: { tournamentId, stage: 'finals', id: { notIn: createdMatches.map(m => m.id) } },
+      });
 
       return NextResponse.json(
         {


### PR DESCRIPTION
## Summary
- Change bracket creation order: create new matches BEFORE deleting old ones
- Delete old matches only after all new matches are successfully created

## Problem
Previously:
1. Delete all existing finals matches
2. Create new matches in a loop
3. If step 2 fails partway through, tournament has NO finals matches

Now:
1. Create all new matches
2. If all succeed, delete old matches using `notIn` filter
3. If any create fails, old matches remain intact

## Fixes
- #313

🤖 Generated with [Claude Code](https://claude.ai/claude-code)