### PR TITLE
fix(e2e): increase wait time for TC-305 dialog close to 8s (#374)

### DIFF
--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -1042,7 +1042,7 @@ async function main() {
     if (await saveBtn305.count() > 0) {
       // Click save and verify dialog closes
       await saveBtn305.click();
-      await page.waitForTimeout(5000); // Wait for save + dialog close
+      await page.waitForTimeout(8000); // Wait for save + dialog close (increased from 5s per issue #374)
       const dialogCount = await page.locator('[role="dialog"]').count();
       const dialogClosed = dialogCount === 0;
       log('TC-305', dialogClosed ? 'PASS' : 'FAIL', dialogClosed ? '' : `Dialog still open after save (count=${dialogCount})`);


### PR DESCRIPTION
## Summary

- Increase the wait time in TC-305 from 5s to 8s to account for API latency
- The save operation correctly calls `setIsSetupDialogOpen(false)` on success

## Problem

TC-305 (BM group dialog close test) was failing because the 5-second wait time was insufficient for the API save operation to complete in the Cloudflare Workers environment.

## Fix

Changed `page.waitForTimeout(5000)` to `page.waitForTimeout(8000)` in TC-305.

## Test plan

- [ ] Run E2E tests against production and confirm TC-305 passes consistently

## Fixes

- #374

🤖 Generated with [Claude Code](https://claude.ai/claude-code)