### PR TITLE
fix: hide MR/GP score entry from admins on match detail pages (TC-820/821)

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
@@ -22,7 +22,6 @@ import { fetchWithRetry } from "@/lib/fetch-with-retry";
 
 import { useState, useEffect, useCallback, use } from "react";
 import { useLocale, useTranslations } from "next-intl";
-import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import {
@@ -104,10 +103,8 @@ export default function GPMatchPage({
   const [loading, setLoading] = useState(true);
 
   /* Authorization: determines if current user can report scores */
-  const { data: session } = useSession();
-  const { canReport, isSessionLoading, selectedPlayer, setSelectedPlayer } =
+  const { canReport, isAdmin, isSessionLoading, selectedPlayer, setSelectedPlayer } =
     useMatchReportAuth(match);
-  const isAdmin = session?.user?.role === "admin";
 
   const [submitting, setSubmitting] = useState(false);
   /* GP cup has 5 races (§7.2), each with course and position selections */

--- a/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
@@ -22,6 +22,7 @@ import { fetchWithRetry } from "@/lib/fetch-with-retry";
 
 import { useState, useEffect, useCallback, use } from "react";
 import { useLocale, useTranslations } from "next-intl";
+import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import {
@@ -103,8 +104,10 @@ export default function GPMatchPage({
   const [loading, setLoading] = useState(true);
 
   /* Authorization: determines if current user can report scores */
+  const { data: session } = useSession();
   const { canReport, isSessionLoading, selectedPlayer, setSelectedPlayer } =
     useMatchReportAuth(match);
+  const isAdmin = session?.user?.role === "admin";
 
   const [submitting, setSubmitting] = useState(false);
   /* GP cup has 5 races (§7.2), each with course and position selections */
@@ -333,8 +336,9 @@ export default function GPMatchPage({
           </Card>
         )}
 
-        {/* Result entry form (shown when match is not complete and user is authorized) */}
-        {!match.completed && !submitted && canReport && (
+        {/* Result entry form (shown when match is not complete and user is authorized)
+            Admins should not see the score entry form here — they use the /gp/participant page. */}
+        {!match.completed && !submitted && canReport && !isAdmin && (
           <Card>
             <CardHeader>
               <CardTitle>{tMatch('enterResult')}</CardTitle>

--- a/smkc-score-app/src/app/tournaments/[id]/mr/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/match/[matchId]/page.tsx
@@ -21,6 +21,7 @@ import { fetchWithRetry } from "@/lib/fetch-with-retry";
 
 import { useState, useEffect, useCallback, use } from "react";
 import { useTranslations } from "next-intl";
+import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import {
@@ -107,8 +108,10 @@ export default function MatchDetailPage({
   const [loading, setLoading] = useState(true);
 
   /* Authorization: determines if current user can report scores */
+  const { data: session } = useSession();
   const { canReport, isSessionLoading, selectedPlayer, setSelectedPlayer } =
     useMatchReportAuth(match);
+  const isAdmin = session?.user?.role === "admin";
 
   const [submitting, setSubmitting] = useState(false);
   /*
@@ -329,8 +332,9 @@ export default function MatchDetailPage({
           </Card>
         )}
 
-        {/* Score entry form (shown when match is not completed and user is authorized) */}
-        {!match.completed && !submitted && canReport && (
+        {/* Score entry form (shown when match is not completed and user is authorized)
+            Admins should not see the score entry form here — they use the /mr/participant page. */}
+        {!match.completed && !submitted && canReport && !isAdmin && (
           <Card>
             <CardHeader>
               {/* i18n: Score entry form header */}

--- a/smkc-score-app/src/app/tournaments/[id]/mr/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/match/[matchId]/page.tsx
@@ -21,7 +21,6 @@ import { fetchWithRetry } from "@/lib/fetch-with-retry";
 
 import { useState, useEffect, useCallback, use } from "react";
 import { useTranslations } from "next-intl";
-import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import {
@@ -108,10 +107,8 @@ export default function MatchDetailPage({
   const [loading, setLoading] = useState(true);
 
   /* Authorization: determines if current user can report scores */
-  const { data: session } = useSession();
-  const { canReport, isSessionLoading, selectedPlayer, setSelectedPlayer } =
+  const { canReport, isAdmin, isSessionLoading, selectedPlayer, setSelectedPlayer } =
     useMatchReportAuth(match);
-  const isAdmin = session?.user?.role === "admin";
 
   const [submitting, setSubmitting] = useState(false);
   /*

--- a/smkc-score-app/src/lib/hooks/useMatchReportAuth.ts
+++ b/smkc-score-app/src/lib/hooks/useMatchReportAuth.ts
@@ -26,6 +26,8 @@ interface MatchForAuth {
 interface UseMatchReportAuthResult {
   /** Whether the current user can report scores (admin or match participant) */
   canReport: boolean;
+  /** Whether the current user is an admin */
+  isAdmin: boolean;
   /** Whether the session is still loading (avoid showing "not authorized" flash) */
   isSessionLoading: boolean;
   /** Auto-selected player identity (1 or 2), or null if not auto-selectable */
@@ -49,6 +51,7 @@ export function useMatchReportAuth(
 
   return {
     canReport,
+    isAdmin,
     isSessionLoading: status === "loading",
     selectedPlayer: selectedPlayer ?? autoSelectedPlayer,
     setSelectedPlayer,


### PR DESCRIPTION
## Summary
- Fix TC-820/821: Admins were incorrectly shown the score entry form on MR and GP match detail pages
- MR and GP match detail pages now correctly hide the score entry form for admins (BM already did this)
- Admins should use the `/mr/participant` and `/gp/participant` pages for score entry

## Changes
- `src/app/tournaments/[id]/mr/match/[matchId]/page.tsx`: Added `isAdmin` check to hide score entry form
- `src/app/tournaments/[id]/gp/match/[matchId]/page.tsx`: Added `isAdmin` check to hide score entry form

## Test Plan
- [ ] TC-820: Admin accessing MR match page sees view-only (no score entry form)
- [ ] TC-821: Admin accessing GP match page sees view-only (no score entry form)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)