### PR TITLE
fix(finals-route): infer bracket size from match count in GET (#413)

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -193,6 +193,46 @@ describe('Finals Route Factory', () => {
       expect(mockGenerateBracketStructure).toHaveBeenCalledWith(8);
     });
 
+    it('should infer 16-player bracket when total matches > 20 (paginated)', async () => {
+      mockPaginate.mockResolvedValue({
+        data: [createMockMatch()],
+        meta: { total: 31, page: 1, limit: 50, totalPages: 1 },
+      });
+
+      const config = createMockConfig({ getStyle: 'paginated' });
+      const { GET } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000');
+      const response = await GET(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockGenerateBracketStructure).toHaveBeenCalledWith(16);
+      const json = await response.json();
+      expect(json.bracketSize).toBe(16);
+    });
+
+    it('should default to 8-player bracket when total is 0 (paginated)', async () => {
+      mockPaginate.mockResolvedValue({
+        data: [],
+        meta: { total: 0, page: 1, limit: 50, totalPages: 0 },
+      });
+
+      const config = createMockConfig({ getStyle: 'paginated' });
+      const { GET } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000');
+      const response = await GET(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockGenerateBracketStructure).toHaveBeenCalledWith(8);
+      const json = await response.json();
+      expect(json.bracketSize).toBe(8);
+    });
+
     it('should return grouped response when getStyle is grouped', async () => {
       const mockMatches = [
         createMockMatch({ round: 'winners_qf' }),
@@ -222,6 +262,28 @@ describe('Finals Route Factory', () => {
       expect(json.grandFinalMatches).toHaveLength(1); // grand_final
       expect(json.bracketStructure).toBeDefined();
       expect(json.roundNames).toEqual(roundNames);
+      expect(json.bracketSize).toBe(8);
+    });
+
+    it('should infer 16-player bracket when matches > 20 (grouped)', async () => {
+      // 16-player bracket has 31 matches
+      const mockMatches = Array.from({ length: 31 }, (_, i) =>
+        createMockMatch({ matchNumber: i + 1 })
+      );
+      (prisma.bMMatch as any).findMany.mockResolvedValue(mockMatches);
+
+      const config = createMockConfig({ getStyle: 'grouped' });
+      const { GET } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000');
+      const response = await GET(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockGenerateBracketStructure).toHaveBeenCalledWith(16);
+      const json = await response.json();
+      expect(json.bracketSize).toBe(16);
     });
 
     it('should return simple response when getStyle is simple', async () => {
@@ -244,6 +306,7 @@ describe('Finals Route Factory', () => {
       expect(json.winnersMatches).toBeUndefined();
       expect(json.losersMatches).toBeUndefined();
       expect(json.grandFinalMatches).toBeUndefined();
+      expect(json.bracketSize).toBe(8);
     });
 
     it('should return empty bracketStructure when matches array is empty', async () => {
@@ -261,6 +324,7 @@ describe('Finals Route Factory', () => {
       const json = await response.json();
       expect(json.matches).toEqual([]);
       expect(json.bracketStructure).toEqual([]);
+      expect(json.bracketSize).toBe(8);
     });
 
     it('should return 500 on database error', async () => {

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -28,6 +28,13 @@ import { getClientIdentifier } from '@/lib/request-utils';
 import { resolveTournamentId } from '@/lib/tournament-identifier';
 
 /**
+ * Bracket size inference thresholds.
+ * 8-player bracket = 17 matches, 16-player bracket = 31 matches.
+ * Threshold of 20 distinguishes between the two (>20 means 16-player).
+ */
+const BRACKET_SIZE_THRESHOLD = 20;
+
+/**
  * Configuration for a finals route handler set.
  *
  * Each event type (BM, MR, GP) supplies its own config to produce
@@ -111,11 +118,9 @@ export function createFinalsHandlers(config: FinalsConfig) {
 
         /* Infer bracket size from total match count:
          * 8-player bracket = 17 matches, 16-player bracket = 31 matches.
-         * Use count > 20 as threshold to distinguish. */
-        const totalCount = await model(prisma).count({
-          where: { tournamentId, stage: 'finals' },
-        });
-        const bracketSize = totalCount > 20 ? 16 : 8;
+         * Use count > 20 as threshold to distinguish.
+         * Use result.total from paginate() to avoid an extra count query. */
+        const bracketSize = (result.total ?? 0) > BRACKET_SIZE_THRESHOLD ? 16 : 8;
 
         const bracketStructure = result.data.length > 0
           ? generateBracketStructure(bracketSize)
@@ -139,7 +144,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
       /* Infer bracket size from match count:
        * 8-player bracket = 17 matches, 16-player bracket = 31 matches.
        * Use count > 20 as threshold to distinguish. */
-      const bracketSize = matches.length > 20 ? 16 : 8;
+      const bracketSize = matches.length > BRACKET_SIZE_THRESHOLD ? 16 : 8;
 
       const bracketStructure = matches.length > 0
         ? generateBracketStructure(bracketSize)

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -109,13 +109,22 @@ export function createFinalsHandlers(config: FinalsConfig) {
           { page, limit, include: { player1: true, player2: true } },
         );
 
+        /* Infer bracket size from total match count:
+         * 8-player bracket = 17 matches, 16-player bracket = 31 matches.
+         * Use count > 20 as threshold to distinguish. */
+        const totalCount = await model(prisma).count({
+          where: { tournamentId, stage: 'finals' },
+        });
+        const bracketSize = totalCount > 20 ? 16 : 8;
+
         const bracketStructure = result.data.length > 0
-          ? generateBracketStructure(8)
+          ? generateBracketStructure(bracketSize)
           : [];
 
         return createSuccessResponse({
           ...result,
           bracketStructure,
+          bracketSize,
           roundNames,
         });
       }
@@ -127,8 +136,13 @@ export function createFinalsHandlers(config: FinalsConfig) {
         orderBy: { matchNumber: 'asc' },
       });
 
+      /* Infer bracket size from match count:
+       * 8-player bracket = 17 matches, 16-player bracket = 31 matches.
+       * Use count > 20 as threshold to distinguish. */
+      const bracketSize = matches.length > 20 ? 16 : 8;
+
       const bracketStructure = matches.length > 0
-        ? generateBracketStructure(8)
+        ? generateBracketStructure(bracketSize)
         : [];
 
       if (config.getStyle === 'grouped') {
@@ -148,6 +162,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
           losersMatches,
           grandFinalMatches,
           bracketStructure,
+          bracketSize,
           roundNames,
         });
       }
@@ -156,6 +171,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
       return createSuccessResponse({
         matches,
         bracketStructure,
+        bracketSize,
         roundNames,
       });
     } catch (error) {


### PR DESCRIPTION
## Summary
- GET が常に8-player bracketStructure を返していた問題を修正
- match 数からbracket sizeを推定: 17 matches → 8-player, 31 matches → 16-player
- 全GET応答(grouped/simple/paginated)に `bracketSize` フィールドを追加

## Changes
- GET (paginated): countクエリで全match数を取得しbracketSizeを推定
- GET (grouped/simple): `matches.length` からbracketSizeを推定
- 応答に `bracketSize` フィールドを追加

## Test plan
- [ ] 8-player bracket作成→GETでbracketSize=8を確認
- [ ] 16-player bracket作成→GETでbracketSize=16を確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)