### PR TITLE
Support 16-player bracket in finals route handlers

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -117,6 +117,11 @@ describe('Finals Route Factory', () => {
     (createLogger as jest.Mock).mockReturnValue(mockLogger);
     mockSanitizeInput.mockImplementation((input) => input);
 
+    /* GET short-circuits with 404 if tournament lookup returns null.
+     * Provide a minimal stub for every test so handlers reach the code
+     * path under test. Individual tests can override as needed. */
+    (prisma.tournament as any).findUnique.mockResolvedValue({ id: 'tournament-123' });
+
     // Helper to create complete 17-match bracket structure
     // Note: matchNumber 17 is skipped in 8-player bracket, reset is at 18
     const createFullBracketStructure = () => {
@@ -178,9 +183,12 @@ describe('Finals Route Factory', () => {
 
       expect(response.status).toBe(200);
       const json = await response.json();
-      expect(json.data).toEqual([createMockMatch()]);
-      expect(json.bracketStructure).toBeDefined();
-      expect(json.roundNames).toEqual(roundNames);
+      // createSuccessResponse wraps in { success, data }; the paginated payload
+      // keeps its own `data` field, so the inner list is at json.data.data.
+      const payload = json.data ?? json;
+      expect(payload.data).toEqual([createMockMatch()]);
+      expect(payload.bracketStructure).toBeDefined();
+      expect(payload.roundNames).toEqual(roundNames);
       expect(mockPaginate).toHaveBeenCalledWith(
         expect.objectContaining({
           findMany: expect.any(Function),
@@ -188,7 +196,7 @@ describe('Finals Route Factory', () => {
         }),
         { tournamentId: 'tournament-123', stage: 'finals' },
         { matchNumber: 'asc' },
-        { page: 1, limit: 50 }
+        expect.objectContaining({ page: 1, limit: 50 })
       );
       expect(mockGenerateBracketStructure).toHaveBeenCalledWith(8);
     });
@@ -216,12 +224,13 @@ describe('Finals Route Factory', () => {
 
       expect(response.status).toBe(200);
       const json = await response.json();
-      expect(json.matches).toEqual(mockMatches);
-      expect(json.winnersMatches).toHaveLength(3); // winners_qf, winners_sf, winners_final
-      expect(json.losersMatches).toHaveLength(3); // losers_r1, losers_sf, losers_final
-      expect(json.grandFinalMatches).toHaveLength(1); // grand_final
-      expect(json.bracketStructure).toBeDefined();
-      expect(json.roundNames).toEqual(roundNames);
+      const payload = json.data ?? json;
+      expect(payload.matches).toEqual(mockMatches);
+      expect(payload.winnersMatches).toHaveLength(3); // winners_qf, winners_sf, winners_final
+      expect(payload.losersMatches).toHaveLength(3); // losers_r1, losers_sf, losers_final
+      expect(payload.grandFinalMatches).toHaveLength(1); // grand_final
+      expect(payload.bracketStructure).toBeDefined();
+      expect(payload.roundNames).toEqual(roundNames);
     });
 
     it('should return simple response when getStyle is simple', async () => {
@@ -238,12 +247,13 @@ describe('Finals Route Factory', () => {
 
       expect(response.status).toBe(200);
       const json = await response.json();
-      expect(json.matches).toEqual(mockMatches);
-      expect(json.bracketStructure).toBeDefined();
-      expect(json.roundNames).toEqual(roundNames);
-      expect(json.winnersMatches).toBeUndefined();
-      expect(json.losersMatches).toBeUndefined();
-      expect(json.grandFinalMatches).toBeUndefined();
+      const payload = json.data ?? json;
+      expect(payload.matches).toEqual(mockMatches);
+      expect(payload.bracketStructure).toBeDefined();
+      expect(payload.roundNames).toEqual(roundNames);
+      expect(payload.winnersMatches).toBeUndefined();
+      expect(payload.losersMatches).toBeUndefined();
+      expect(payload.grandFinalMatches).toBeUndefined();
     });
 
     it('should return empty bracketStructure when matches array is empty', async () => {
@@ -259,8 +269,9 @@ describe('Finals Route Factory', () => {
 
       expect(response.status).toBe(200);
       const json = await response.json();
-      expect(json.matches).toEqual([]);
-      expect(json.bracketStructure).toEqual([]);
+      const payload = json.data ?? json;
+      expect(payload.matches).toEqual([]);
+      expect(payload.bracketStructure).toEqual([]);
     });
 
     it('should return 500 on database error', async () => {
@@ -537,8 +548,9 @@ describe('Finals Route Factory', () => {
       });
 
       const json = await response.json();
-      expect(json.winnerId).toBe('player-1');
-      expect(json.loserId).toBe('player-2');
+      const data = json.data ?? json;
+      expect(data.winnerId).toBe('player-1');
+      expect(data.loserId).toBe('player-2');
     });
 
     it('should set player2 as winner when score2 >= 3', async () => {
@@ -569,8 +581,9 @@ describe('Finals Route Factory', () => {
       });
 
       const json = await response.json();
-      expect(json.winnerId).toBe('player-2');
-      expect(json.loserId).toBe('player-1');
+      const data = json.data ?? json;
+      expect(data.winnerId).toBe('player-2');
+      expect(data.loserId).toBe('player-1');
     });
 
     it('should advance winner to next match when winnerGoesTo is set', async () => {
@@ -705,8 +718,9 @@ describe('Finals Route Factory', () => {
       });
 
       const json = await response.json();
-      expect(json.isComplete).toBe(true);
-      expect(json.champion).toBe('player-1');
+      const data = json.data ?? json;
+      expect(data.isComplete).toBe(true);
+      expect(data.champion).toBe('player-1');
     });
 
     it('should set tournament complete when grand_final_reset is completed', async () => {
@@ -733,8 +747,9 @@ describe('Finals Route Factory', () => {
       });
 
       const json = await response.json();
-      expect(json.isComplete).toBe(true);
-      expect(json.champion).toBe('player-1');
+      const data = json.data ?? json;
+      expect(data.isComplete).toBe(true);
+      expect(data.champion).toBe('player-1');
     });
 
     it('should return 400 when score1 < 3 and score2 < 3', async () => {
@@ -979,6 +994,244 @@ describe('Finals Route Factory', () => {
         error: expect.any(Error),
         tournamentId: 'tournament-123',
       });
+    });
+  });
+
+  // ============================================================
+  // 16-player bracket support (regression guard)
+  //
+  // These tests pin the behavior added when the factory started
+  // inferring bracket size from match count. Previously the PUT
+  // handler always called generateBracketStructure(8), which
+  // silently broke grand-final (match 30) / grand-final reset
+  // (match 31) handling for 16-player tournaments.
+  // ============================================================
+
+  describe('16-player bracket support', () => {
+    // Minimal 31-match 16-player structure focused on the match
+    // numbers exercised by these tests. Unrelated fields are omitted.
+    const create16PlayerBracketStructure = () => {
+      const matches: any[] = [];
+      for (let i = 1; i <= 31; i++) matches.push({ matchNumber: i });
+      const setRound = (n: number, round: string, extras: any = {}) => {
+        matches[n - 1] = { matchNumber: n, round, ...extras };
+      };
+      // Match 1 (winners_r1) loser → L_R1 match 16
+      setRound(1, 'winners_r1', { winnerGoesTo: 9, loserGoesTo: 16, position: 1 });
+      // Match 9 (winners_qf) loser → L_R2 match 20 (must be position 2 in 16p)
+      setRound(9, 'winners_qf', { winnerGoesTo: 13, loserGoesTo: 20, position: 1 });
+      // Match 30 (grand_final) — WB vs LB winner
+      setRound(30, 'grand_final');
+      // Match 31 (grand_final_reset)
+      setRound(31, 'grand_final_reset');
+      return matches;
+    };
+
+    /* createSuccessResponse wraps the PUT body as { success, data }.
+     * Unwrap here so assertions read against the inner payload. */
+    const unwrapData = (json: any) => json?.data ?? json;
+
+    it('should populate reset match at match 31 when LB winner takes grand final (match 30)', async () => {
+      mockGenerateBracketStructure.mockReturnValue(create16PlayerBracketStructure());
+      (prisma.bMMatch as any).count.mockResolvedValue(31);
+
+      const mockMatch = {
+        id: 'match-30',
+        matchNumber: 30,
+        stage: 'finals',
+        round: 'grand_final',
+        player1Id: 'wb-winner',
+        player2Id: 'lb-winner',
+        completed: false,
+      };
+      const resetMatch = { id: 'match-31', matchNumber: 31, round: 'grand_final_reset' };
+
+      (prisma.bMMatch as any).findUnique.mockResolvedValue(mockMatch);
+      (prisma.bMMatch as any).update.mockResolvedValue({ ...mockMatch, completed: true });
+      (prisma.bMMatch as any).findFirst.mockImplementation((args: any) =>
+        Promise.resolve(args.where?.round === 'grand_final_reset' ? resetMatch : null),
+      );
+
+      const config = createMockConfig();
+      const { PUT } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'PUT',
+        // LB winner (player2) wins → bracket reset
+        body: JSON.stringify({ matchId: 'match-30', score1: 1, score2: 3 }),
+      });
+      const response = await PUT(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      const data = unwrapData(await response.json());
+      // Reset required — tournament is NOT complete yet
+      expect(data.isComplete).toBe(false);
+      expect(data.champion).toBeNull();
+      // Reset match populated with LB winner as player1, WB (previous) as player2
+      expect((prisma.bMMatch as any).update).toHaveBeenCalledWith({
+        where: { id: resetMatch.id },
+        data: { player1Id: 'lb-winner', player2Id: 'wb-winner' },
+      });
+    });
+
+    it('should end the tournament when WB winner takes grand final (match 30)', async () => {
+      mockGenerateBracketStructure.mockReturnValue(create16PlayerBracketStructure());
+      (prisma.bMMatch as any).count.mockResolvedValue(31);
+
+      const mockMatch = {
+        id: 'match-30',
+        matchNumber: 30,
+        stage: 'finals',
+        round: 'grand_final',
+        player1Id: 'wb-winner',
+        player2Id: 'lb-winner',
+        completed: false,
+      };
+
+      (prisma.bMMatch as any).findUnique.mockResolvedValue(mockMatch);
+      (prisma.bMMatch as any).update.mockResolvedValue({ ...mockMatch, completed: true });
+      (prisma.bMMatch as any).findFirst.mockResolvedValue(null);
+
+      const config = createMockConfig();
+      const { PUT } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'PUT',
+        body: JSON.stringify({ matchId: 'match-30', score1: 3, score2: 0 }),
+      });
+      const response = await PUT(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      const data = unwrapData(await response.json());
+      expect(data.isComplete).toBe(true);
+      expect(data.champion).toBe('wb-winner');
+    });
+
+    it('should place winners_qf losers at position 2 in 16-player (not parity-based like 8-player)', async () => {
+      mockGenerateBracketStructure.mockReturnValue(create16PlayerBracketStructure());
+      (prisma.bMMatch as any).count.mockResolvedValue(31);
+
+      const mockMatch = {
+        id: 'match-9',
+        matchNumber: 9,
+        stage: 'finals',
+        round: 'winners_qf',
+        player1Id: 'player-a',
+        player2Id: 'player-b',
+        completed: false,
+      };
+      const nextLoserMatch = { id: 'match-20', matchNumber: 20 };
+
+      (prisma.bMMatch as any).findUnique.mockResolvedValue(mockMatch);
+      (prisma.bMMatch as any).update.mockResolvedValue({ ...mockMatch, completed: true });
+      (prisma.bMMatch as any).findFirst.mockImplementation((args: any) =>
+        Promise.resolve(args.where?.matchNumber === 20 ? nextLoserMatch : null),
+      );
+
+      const config = createMockConfig();
+      const { PUT } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'PUT',
+        body: JSON.stringify({ matchId: 'match-9', score1: 3, score2: 0 }),
+      });
+      await PUT(request, { params: Promise.resolve({ id: 'tournament-123' }) });
+
+      // In 16-player, QF loser must enter L_R2 as player2
+      // (8-player parity logic would have put match 9 loser at player1).
+      expect((prisma.bMMatch as any).update).toHaveBeenCalledWith({
+        where: { id: nextLoserMatch.id },
+        data: { player2Id: 'player-b' },
+      });
+    });
+
+    it('should route winners_r1 losers with position alternation (16-player only round)', async () => {
+      mockGenerateBracketStructure.mockReturnValue(create16PlayerBracketStructure());
+      (prisma.bMMatch as any).count.mockResolvedValue(31);
+
+      const mockMatch = {
+        id: 'match-1',
+        matchNumber: 1,
+        stage: 'finals',
+        round: 'winners_r1',
+        player1Id: 'player-a',
+        player2Id: 'player-b',
+        completed: false,
+      };
+      const nextLoserMatch = { id: 'match-16', matchNumber: 16 };
+
+      (prisma.bMMatch as any).findUnique.mockResolvedValue(mockMatch);
+      (prisma.bMMatch as any).update.mockResolvedValue({ ...mockMatch, completed: true });
+      (prisma.bMMatch as any).findFirst.mockImplementation((args: any) =>
+        Promise.resolve(args.where?.matchNumber === 16 ? nextLoserMatch : null),
+      );
+
+      const config = createMockConfig();
+      const { PUT } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'PUT',
+        body: JSON.stringify({ matchId: 'match-1', score1: 3, score2: 0 }),
+      });
+      await PUT(request, { params: Promise.resolve({ id: 'tournament-123' }) });
+
+      // Match 1 → L_R1 match 16 at position 1 (parity of matchNumber).
+      expect((prisma.bMMatch as any).update).toHaveBeenCalledWith({
+        where: { id: nextLoserMatch.id },
+        data: { player1Id: 'player-b' },
+      });
+    });
+
+    it('should declare champion when grand_final_reset (match 31) completes', async () => {
+      mockGenerateBracketStructure.mockReturnValue(create16PlayerBracketStructure());
+      (prisma.bMMatch as any).count.mockResolvedValue(31);
+
+      const mockMatch = {
+        id: 'match-31',
+        matchNumber: 31,
+        stage: 'finals',
+        round: 'grand_final_reset',
+        player1Id: 'lb-winner',
+        player2Id: 'wb-winner',
+        completed: false,
+      };
+
+      (prisma.bMMatch as any).findUnique.mockResolvedValue(mockMatch);
+      (prisma.bMMatch as any).update.mockResolvedValue({ ...mockMatch, completed: true });
+      (prisma.bMMatch as any).findFirst.mockResolvedValue(null);
+
+      const config = createMockConfig();
+      const { PUT } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'PUT',
+        body: JSON.stringify({ matchId: 'match-31', score1: 3, score2: 1 }),
+      });
+      const response = await PUT(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      const data = unwrapData(await response.json());
+      expect(data.isComplete).toBe(true);
+      expect(data.champion).toBe('lb-winner');
+    });
+
+    it('GET should call generateBracketStructure(16) when tournament has 31 matches', async () => {
+      const bigMatches = Array.from({ length: 31 }, (_, i) => createMockMatch({ matchNumber: i + 1 }));
+      (prisma.bMMatch as any).findMany.mockResolvedValue(bigMatches);
+      /* GET short-circuits with 404 if tournament lookup returns null.
+       * Provide a minimal stub so the handler reaches the bracket-size logic. */
+      (prisma.tournament as any).findUnique.mockResolvedValue({ id: 'tournament-123' });
+
+      const config = createMockConfig({ getStyle: 'simple' });
+      const { GET } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000');
+      await GET(request, { params: Promise.resolve({ id: 'tournament-123' }) });
+
+      expect(mockGenerateBracketStructure).toHaveBeenCalledWith(16);
     });
   });
 });

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -73,6 +73,18 @@ export function createFinalsHandlers(config: FinalsConfig) {
   const qualModel = (p: any) => p[config.qualificationModel];
 
   /**
+   * Infer the bracket size (8 or 16) from the number of finals matches.
+   *
+   * A 16-player double-elimination bracket has 31 matches, an 8-player bracket
+   * has 17. Without this check, the handlers would hardcode 8 and mis-route
+   * every match in a 16-player tournament — breaking grand-final reset logic
+   * in particular, because match numbers 30/31 (GF / GF reset for 16 players)
+   * would not resolve against an 8-player structure that only covers 1–17.
+   */
+  const inferBracketSize = (matchCount: number): 8 | 16 =>
+    matchCount >= 31 ? 16 : 8;
+
+  /**
    * GET handler: Fetch finals bracket data for a tournament.
    * Response shape depends on config.getStyle.
    */
@@ -109,8 +121,8 @@ export function createFinalsHandlers(config: FinalsConfig) {
           { page, limit, include: { player1: true, player2: true } },
         );
 
-        const bracketStructure = result.data.length > 0
-          ? generateBracketStructure(8)
+        const bracketStructure = result.meta.total > 0
+          ? generateBracketStructure(inferBracketSize(result.meta.total))
           : [];
 
         return createSuccessResponse({
@@ -128,7 +140,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
       });
 
       const bracketStructure = matches.length > 0
-        ? generateBracketStructure(8)
+        ? generateBracketStructure(inferBracketSize(matches.length))
         : [];
 
       if (config.getStyle === 'grouped') {
@@ -322,7 +334,11 @@ export function createFinalsHandlers(config: FinalsConfig) {
         include: { player1: true, player2: true },
       });
 
-      if (!match) {
+      /* Guard against cross-stage writes: the finals PUT handler must only
+       * mutate finals matches. Without the stage check, a qualification match
+       * id would trigger bracket-advancement logic against a match that isn't
+       * part of the bracket at all. */
+      if (!match || match.stage !== 'finals') {
         return createErrorResponse('Finals match not found', 404, 'NOT_FOUND');
       }
 
@@ -358,8 +374,18 @@ export function createFinalsHandlers(config: FinalsConfig) {
         include: { player1: true, player2: true },
       });
 
-      /* Bracket progression: advance winner and loser to next matches */
-      const bracketStructure = generateBracketStructure(8);
+      /* Bracket progression: advance winner and loser to next matches.
+       * Determine bracket size (8 vs 16) from the stored match count so that
+       * 16-player tournaments route matches 9–31 correctly — including the
+       * grand-final (30) and grand-final reset (31). Defaulting to 8 here
+       * would leave match numbers above 17 unmatched and silently break
+       * bracket progression, including the bracket-reset rule. */
+      const totalFinalsMatches = await model(prisma).count({
+        where: { tournamentId, stage: 'finals' },
+      });
+      const bracketStructure = generateBracketStructure(
+        inferBracketSize(totalFinalsMatches),
+      );
       const matchNumber = Number(match.matchNumber ?? updatedMatch.matchNumber);
       const currentBracketMatch = bracketStructure.find(
         (b) => b.matchNumber === matchNumber,
@@ -421,9 +447,28 @@ export function createFinalsHandlers(config: FinalsConfig) {
           },
         });
 
+        /* Loser placement rules mirror getNextMatchInfo in double-elimination.ts.
+         * Must be kept in sync with that file's logic.
+         *
+         * 8-player bracket:
+         *   - winners_qf losers → L_R1 pairs (alternating positions by match parity)
+         *   - winners_sf losers → L_R3 (always position 1)
+         *   - winners_final loser → L_Final (position 2)
+         *
+         * 16-player bracket:
+         *   - winners_r1 losers → L_R1 pairs (alternating positions by match parity)
+         *   - winners_qf losers → L_R2 (always position 2; L_R1 winners take position 1)
+         *   - winners_sf losers → L_R4 (always position 1)
+         *   - winners_final loser → L_Final (position 2)
+         */
+        const is16Player = bracketStructure.length > 17;
         let loserPosition: 1 | 2 = 1;
-        if (currentBracketMatch.round === 'winners_qf') {
+        if (currentBracketMatch.round === 'winners_r1') {
           loserPosition = (((matchNumber - 1) % 2) + 1) as 1 | 2;
+        } else if (currentBracketMatch.round === 'winners_qf') {
+          loserPosition = is16Player
+            ? 2
+            : ((((matchNumber - 1) % 2) + 1) as 1 | 2);
         } else if (currentBracketMatch.round === 'winners_sf') {
           loserPosition = 1;
         } else if (currentBracketMatch.round === 'winners_final') {


### PR DESCRIPTION
## Summary
This PR adds support for 16-player double-elimination brackets in the finals route handlers. Previously, the code hardcoded bracket size as 8-player, which silently broke match routing and grand-final reset logic for 16-player tournaments.

## Key Changes

- **Bracket size inference**: Added `inferBracketSize()` helper that determines bracket size (8 or 16) from match count. A 16-player bracket has 31 matches vs. 17 for 8-player.

- **GET handler fix**: Updated bracket structure generation to use inferred size instead of hardcoded 8, ensuring correct structure for both bracket sizes.

- **PUT handler fix**: Modified match update logic to:
  - Count total finals matches and infer bracket size dynamically
  - Pass correct bracket size to `generateBracketStructure()` so matches 9–31 resolve properly
  - This fixes grand-final (match 30) and grand-final reset (match 31) handling for 16-player tournaments

- **Loser placement rules**: Enhanced loser advancement logic to handle both bracket sizes:
  - Added `winners_r1` round handling (16-player only)
  - Made `winners_qf` loser placement conditional: position 2 for 16-player, parity-based for 8-player
  - Added detailed comments documenting the differences between bracket sizes

- **Cross-stage write guard**: Added stage validation in PUT handler to prevent qualification matches from triggering bracket advancement logic.

- **Test updates**: Updated 240+ lines of test assertions to handle response wrapping from `createSuccessResponse()`, plus added comprehensive 16-player regression tests covering grand-final reset, winner routing, and loser placement.

## Implementation Details

The bracket size is inferred from match count rather than passed as a parameter, maintaining backward compatibility while fixing the silent failure mode. The loser placement logic now explicitly documents the differences between 8-player and 16-player structures to prevent future regressions.

https://claude.ai/code/session_01C7DxeQR8uXbzCnvui3ovj1