### PR TITLE
fix(finals-route): correct PaginatedResponse access path (meta.total)

### DIFF
--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -119,8 +119,8 @@ export function createFinalsHandlers(config: FinalsConfig) {
         /* Infer bracket size from total match count:
          * 8-player bracket = 17 matches, 16-player bracket = 31 matches.
          * Use count > 20 as threshold to distinguish.
-         * Use result.total from paginate() to avoid an extra count query. */
-        const bracketSize = (result.total ?? 0) > BRACKET_SIZE_THRESHOLD ? 16 : 8;
+         * Use result.meta.total from paginate() to avoid an extra count query. */
+        const bracketSize = (result.meta.total ?? 0) > BRACKET_SIZE_THRESHOLD ? 16 : 8;
 
         const bracketStructure = result.data.length > 0
           ? generateBracketStructure(bracketSize)


### PR DESCRIPTION
The paginated GET path broke the Cloudflare Workers build with:

  ./src/lib/api-factories/finals-route.ts:123:37
  Type error: Property 'total' does not exist on type 'PaginatedResponse<unknown>'.

paginate() returns { data, meta: { total, page, limit, totalPages } }, so the total count lives at result.meta.total, not result.total. Tests mock the shape correctly ({ meta: { total: ... } }); only the source read the wrong path, which TypeScript caught during `next build`.