### PR TITLE
fix(qualification-route): delete before create to fix "Failed to setu…

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -714,6 +714,59 @@ describe('Qualification Route Factory', () => {
       const createCall = (prisma.bMMatch as any).create.mock.calls[0];
       expect(createCall[0].data.assignedCourses).toBeUndefined();
     });
+
+    it('should succeed on re-setup when qualifications already exist (group edit)', async () => {
+      /*
+       * Regression test for "Failed to setup match race" bug.
+       * When a user clicks グループ編集 to re-edit groups, the same playerIds
+       * are submitted again. MRQualification has @@unique([tournamentId, playerId])
+       * and MRMatch has @@unique([tournamentId, matchNumber, stage]), so a
+       * create-before-delete pattern hits a unique-constraint violation and
+       * returns 500. The fix: delete existing records first, then create new ones
+       * (matches the finals-route.ts pattern from commit 7c7e57d / TC-504).
+       */
+      const players = [
+        { playerId: 'player-1', group: 'A', seeding: 1 },
+        { playerId: 'player-2', group: 'A', seeding: 2 },
+      ];
+
+      (prisma.mRQualification as any).create.mockResolvedValue({ id: 'new-qual' });
+      (prisma.mRQualification as any).deleteMany.mockResolvedValue({ count: 2 });
+      (prisma.mRMatch as any).create.mockResolvedValue({ id: 'new-match' });
+      (prisma.mRMatch as any).deleteMany.mockResolvedValue({ count: 1 });
+
+      const config = createMockConfig({
+        eventTypeCode: 'mr',
+        matchModel: 'mRMatch',
+        qualificationModel: 'mRQualification',
+        eventDisplayName: 'match race',
+      });
+      const { POST } = createQualificationHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ players }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(201);
+      /* Both deletes scoped to tournament must run before any create */
+      expect((prisma.mRQualification as any).deleteMany).toHaveBeenCalledWith({
+        where: { tournamentId: 'tournament-123' },
+      });
+      expect((prisma.mRMatch as any).deleteMany).toHaveBeenCalledWith({
+        where: { tournamentId: 'tournament-123', stage: 'qualification' },
+      });
+      /* Verify delete-before-create order via mock invocation timing */
+      const qualDeleteOrder = (prisma.mRQualification as any).deleteMany.mock.invocationCallOrder[0];
+      const qualCreateOrder = (prisma.mRQualification as any).create.mock.invocationCallOrder[0];
+      const matchDeleteOrder = (prisma.mRMatch as any).deleteMany.mock.invocationCallOrder[0];
+      const matchCreateOrder = (prisma.mRMatch as any).create.mock.invocationCallOrder[0];
+      expect(qualDeleteOrder).toBeLessThan(qualCreateOrder);
+      expect(matchDeleteOrder).toBeLessThan(matchCreateOrder);
+    });
   });
 
   // ============================================================

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -176,17 +176,22 @@ export function createQualificationHandlers(config: EventTypeConfig) {
       }
 
       /*
-       * Collect existing record IDs before DELETE to enable safe delete-first-then-create pattern.
-       * D1 does not support prisma.$transaction, so we collect IDs first, then create new records,
-       * then delete old records by ID (not by tournamentId which would also delete new records).
+       * Delete existing qualification records and matches first to avoid
+       * unique-constraint violations on re-setup (e.g. グループ編集). Without
+       * this, the create calls below collide with existing rows on
+       * MR/BM/GP-Qualification @@unique([tournamentId, playerId]) and
+       * @@unique([tournamentId, matchNumber, stage]) and the request fails with
+       * "Failed to setup ${eventDisplayName}" (matches finals-route.ts pattern
+       * from commit 7c7e57d / TC-504). D1 has no interactive transactions, so
+       * if creation fails afterward the tournament is left without
+       * qualifications — but the alternative (always failing on re-setup)
+       * is worse.
        */
-      const existingQualificationIds = await qualModel(prisma).findMany({
-        where: { tournamentId },
-        select: { id: true },
-      });
-      const existingMatchIds = await matchModel(prisma).findMany({
+      await matchModel(prisma).deleteMany({
         where: { tournamentId, stage: 'qualification' },
-        select: { id: true },
+      });
+      await qualModel(prisma).deleteMany({
+        where: { tournamentId },
       });
 
       /* Create qualification records for each player */
@@ -354,21 +359,6 @@ export function createQualificationHandlers(config: EventTypeConfig) {
             action: config.auditAction,
           });
         }
-      }
-
-      /*
-       * Delete old records after all creates succeed — preserves new records.
-       * Uses ID-based deletion (not tournamentId) to avoid deleting newly created records.
-       */
-      if (existingQualificationIds.length > 0) {
-        await qualModel(prisma).deleteMany({
-          where: { id: { in: existingQualificationIds.map((q: { id: string }) => q.id) } },
-        });
-      }
-      if (existingMatchIds.length > 0) {
-        await matchModel(prisma).deleteMany({
-          where: { id: { in: existingMatchIds.map((m: { id: string }) => m.id) } },
-        });
       }
 
       return NextResponse.json(


### PR DESCRIPTION
…p match race" on re-setup

Re-editing groups (グループ編集) on the MR/BM/GP qualification page failed with "Failed to setup match race" because the POST handler used a create-first-then-delete pattern. The unique constraints @@unique([tournamentId, playerId]) on {BM,MR,GP}Qualification and @@unique([tournamentId, matchNumber, stage]) on {BM,MR,GP}Match caused the create calls to throw on every re-setup (the old rows still existed), which fell into the catch block and returned 500.

Switched to delete-before-create, matching the pattern commit 7c7e57d already applied to finals-route.ts for the same reason (TC-504 / #313). D1 has no interactive transactions, so partial failure after delete leaves the tournament without qualifications — but the alternative was always failing on re-setup.

Added a regression test that asserts deleteMany runs before create.

Also fixes several pre-existing POST-handler tests that were crashing on undefined existingQualificationIds.length.

https://claude.ai/code/session_01DE6434i8bbn1DHFEA87SZG