### PR TITLE
fix(ta-participant): enable Fill Random Times button in production (#421)

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
@@ -128,9 +128,6 @@ export default function TimeAttackParticipantPage({
   const [taPlayerSelfEdit, setTaPlayerSelfEdit] = useState(true);
   const [submitting, setSubmitting] = useState(false);
 
-  /* Dev-only features: use NODE_ENV per CLAUDE.md (not hostname checks) */
-  const isDevelopment = process.env.NODE_ENV === 'development';
-
   /**
    * Admin-only: Fill all course times with random values for testing.
    * Generates realistic TA times between 45s and 3:30 per course.
@@ -693,8 +690,8 @@ export default function TimeAttackParticipantPage({
                         <div className="text-2xl font-bold font-mono text-center">{msToDisplayTime(getTotalTime())}</div>
                       </div>
 
-                      {/* Admin-only: Fill random times button (development only) */}
-                      {isAdmin && isDevelopment && myEntry && (
+                      {/* Admin-only: Fill random times button */}
+                      {isAdmin && myEntry && (
                         <Button
                           onClick={handleFillRandomTimes}
                           variant="outline"
@@ -702,7 +699,7 @@ export default function TimeAttackParticipantPage({
                           className="w-full border-dashed border-orange-400 text-orange-600 hover:bg-orange-50"
                         >
                           <Dice5 className="h-4 w-4 mr-2" />
-                          Fill Random Times (Dev Only)
+                          Fill Random Times
                         </Button>
                       )}
 


### PR DESCRIPTION
## Summary
Admin-only random time fill button was gated behind `NODE_ENV=development`. Enable it for admin users in production.

## Changes
- Remove `isDevelopment` check (NODE_ENV === 'development')
- Update button text: "Fill Random Times (Dev Only)" → "Fill Random Times"
- Update comment to remove "development only" note

## Test plan
- [ ] Deploy to production
- [ ] Login as admin and verify "Fill Random Times" button appears in TA participant page

🤖 Generated with [Claude Code](https://claude.ai/claude-code)