### PR TITLE
Remove e2e-coverage worktree and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 hidden_docs/
 .DS_STORE
 node_modules/
+.claude/worktrees/
 
 STATE.md
 IMPL.md


### PR DESCRIPTION
## Summary
This PR removes the e2e-coverage worktree subproject reference and updates the gitignore to exclude the entire `.claude/worktrees/` directory from version control.

## Key Changes
- Removed the `.claude/worktrees/e2e-coverage` subproject commit reference
- Added `.claude/worktrees/` to `.gitignore` to prevent future worktree directories from being tracked

## Details
The e2e-coverage worktree is no longer needed and has been removed. Rather than managing individual worktree entries, the gitignore has been updated to broadly exclude all worktrees under `.claude/worktrees/`, providing better maintainability and preventing accidental commits of local development worktrees.

https://claude.ai/code/session_016JDPtPb7iihZZKyju8d9bY