### PR TITLE
fix(finals-route): 16-player bracket routing in PUT handler (#413)

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -117,6 +117,9 @@ describe('Finals Route Factory', () => {
     (createLogger as jest.Mock).mockReturnValue(mockLogger);
     mockSanitizeInput.mockImplementation((input) => input);
 
+    // Default 8-player bracket count (17 matches: 17 <= 20 → bracketSize=8)
+    (prisma.bMMatch as any).count.mockResolvedValue(17);
+
     // Helper to create complete 17-match bracket structure
     // Note: matchNumber 17 is skipped in 8-player bracket, reset is at 18
     const createFullBracketStructure = () => {
@@ -700,6 +703,63 @@ describe('Finals Route Factory', () => {
       expect((prisma.bMMatch as any).update).toHaveBeenCalledWith({
         where: { id: nextLoserMatch.id },
         data: { player1Id: 'player-2' },
+      });
+    });
+
+    it('should infer 16-player bracket from totalFinalsMatches count in PUT', async () => {
+      // 16-player bracket has 31 matches (31 > 20 threshold)
+      (prisma.bMMatch as any).count.mockResolvedValue(31);
+      (prisma.bMMatch as any).findUnique.mockResolvedValue(null);
+      (prisma.bMMatch as any).update.mockResolvedValue(null);
+
+      const config = createMockConfig();
+      const { PUT } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'PUT',
+        body: JSON.stringify({ matchId: 'match-1', score1: 3, score2: 1 }),
+      });
+      const response = await PUT(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect((prisma.bMMatch as any).count).toHaveBeenCalledWith({
+        where: { tournamentId: 'tournament-123', stage: 'finals' },
+      });
+      expect(mockGenerateBracketStructure).toHaveBeenCalledWith(16);
+    });
+
+    it('should route 16-player QF loser to player2Id (loserPosition=2)', async () => {
+      // In 16-player bracket, QF losers enter L_R2 at position 2
+      const requestBody = createMockRequestBody();
+      const mockMatch = createMockMatch({
+        matchNumber: 1, // winners_qf in 16-player bracket
+        player1Id: 'player-1',
+        player2Id: 'player-2',
+      });
+      const nextLoserMatch = createMockMatch({ matchNumber: 10 }); // L_R2 in 16-player
+
+      (prisma.bMMatch as any).count.mockResolvedValue(31); // 16-player bracket
+      (prisma.bMMatch as any).findUnique.mockResolvedValue(mockMatch);
+      (prisma.bMMatch as any).update.mockResolvedValue(createMockMatch({ completed: true }));
+      (prisma.bMMatch as any).findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce(nextLoserMatch);
+
+      const config = createMockConfig();
+      const { PUT } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+      });
+      const response = await PUT(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      // In 16-player QF, loserPosition=2 → player2Id set
+      expect((prisma.bMMatch as any).update).toHaveBeenCalledWith({
+        where: { id: nextLoserMatch.id },
+        data: { player2Id: 'player-2' },
       });
     });
 

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -347,6 +347,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
         return createErrorResponse('Finals match not found', 404, 'NOT_FOUND');
       }
 
+      /* Defensive: reject non-finals stage to prevent cross-stage bracket mutation.
+       * Qualification matches should never trigger bracket advancement logic. */
+      if (match.stage !== 'finals') {
+        return createErrorResponse('Finals match not found', 404, 'NOT_FOUND');
+      }
+
       const targetWins = config.targetWins ?? 3;
       const player1ReachedTarget = score1 >= targetWins;
       const player2ReachedTarget = score2 >= targetWins;
@@ -379,8 +385,17 @@ export function createFinalsHandlers(config: FinalsConfig) {
         include: { player1: true, player2: true },
       });
 
+      /* Infer bracket size from total finals match count:
+       * 8-player bracket = 17 matches, 16-player bracket = 31 matches.
+       * Threshold of 20 distinguishes between the two (>20 means 16-player).
+       * This ensures correct bracket routing for both sizes in PUT handler. */
+      const totalFinalsMatches = await model(prisma).count({
+        where: { tournamentId, stage: 'finals' },
+      });
+      const bracketSize = totalFinalsMatches > BRACKET_SIZE_THRESHOLD ? 16 : 8;
+
       /* Bracket progression: advance winner and loser to next matches */
-      const bracketStructure = generateBracketStructure(8);
+      const bracketStructure = generateBracketStructure(bracketSize);
       const matchNumber = Number(match.matchNumber ?? updatedMatch.matchNumber);
       const currentBracketMatch = bracketStructure.find(
         (b) => b.matchNumber === matchNumber,
@@ -444,7 +459,9 @@ export function createFinalsHandlers(config: FinalsConfig) {
 
         let loserPosition: 1 | 2 = 1;
         if (currentBracketMatch.round === 'winners_qf') {
-          loserPosition = (((matchNumber - 1) % 2) + 1) as 1 | 2;
+          /* 16-player: losers from QF enter L_R2 at position 2.
+           * 8-player: uses parity-based calculation ((matchNumber-1)%2 + 1). */
+          loserPosition = bracketSize === 16 ? 2 : (((matchNumber - 1) % 2) + 1) as 1 | 2;
         } else if (currentBracketMatch.round === 'winners_sf') {
           loserPosition = 1;
         } else if (currentBracketMatch.round === 'winners_final') {


### PR DESCRIPTION
## Summary
Fixes 16-player double-elimination bracket routing in the finals route PUT handler. The GET fix was merged in #426; this addresses the missing PUT fix.

## Changes

1. **Bracket size inference in PUT**: Count total finals matches and infer bracket size (8 or 16) using threshold of 20. Pass the correct size to `generateBracketStructure()` so matches 9–31 resolve properly for 16-player brackets.

2. **Loser placement for winners_qf**: For 16-player brackets, losers from QF enter L_R2 at position 2. For 8-player, the existing parity-based calculation is unchanged.

3. **Cross-stage write guard**: Added stage validation in PUT to reject non-finals matches, preventing qualification matches from triggering bracket advancement logic.

## Implementation

- `totalFinalsMatches = await model(prisma).count({ where: { tournamentId, stage: 'finals' } })`
- `bracketSize = totalFinalsMatches > BRACKET_SIZE_THRESHOLD ? 16 : 8`
- `generateBracketStructure(bracketSize)` for bracket structure lookup
- Winner/loser routing uses the correctly-sized structure

🤖 Generated with [Claude Code](https://claude.ai/claude-code)