### PR TITLE
Fix double-elimination bracket horizontal overflow on desktop

### DIFF
--- a/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Tests for the DoubleEliminationBracket layout wrapper.
+ *
+ * Covers issue #424: when the bracket gets wide horizontally (16-player
+ * bracket, 5+ round columns), the content used to overflow its containing
+ * pane on desktop because the row wrapper had `md:overflow-visible` applied,
+ * which disabled the horizontal scrollbar inherited from `overflow-x-auto`.
+ *
+ * These tests assert that every round-row wrapper inside each bracket
+ * section keeps `overflow-x-auto` active at all breakpoints so the bracket
+ * scrolls horizontally instead of breaking the surrounding layout.
+ */
+
+import { render } from "@testing-library/react";
+import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
+
+/**
+ * Build a minimal 8-player double-elimination bracket structure.
+ * The exact match data doesn't matter for the overflow test -- we only
+ * need each round-row wrapper to be rendered so we can inspect classes.
+ */
+function build8PlayerStructure() {
+  return [
+    { matchNumber: 1, round: "winners_qf", bracket: "winners" as const, player1Seed: 1, player2Seed: 8 },
+    { matchNumber: 2, round: "winners_qf", bracket: "winners" as const, player1Seed: 4, player2Seed: 5 },
+    { matchNumber: 3, round: "winners_qf", bracket: "winners" as const, player1Seed: 2, player2Seed: 7 },
+    { matchNumber: 4, round: "winners_qf", bracket: "winners" as const, player1Seed: 3, player2Seed: 6 },
+    { matchNumber: 5, round: "winners_sf", bracket: "winners" as const },
+    { matchNumber: 6, round: "winners_sf", bracket: "winners" as const },
+    { matchNumber: 7, round: "winners_final", bracket: "winners" as const },
+    { matchNumber: 8, round: "losers_r1", bracket: "losers" as const },
+    { matchNumber: 9, round: "losers_r1", bracket: "losers" as const },
+    { matchNumber: 10, round: "losers_r2", bracket: "losers" as const },
+    { matchNumber: 11, round: "losers_r2", bracket: "losers" as const },
+    { matchNumber: 12, round: "losers_r3", bracket: "losers" as const },
+    { matchNumber: 13, round: "losers_sf", bracket: "losers" as const },
+    { matchNumber: 14, round: "losers_final", bracket: "losers" as const },
+    { matchNumber: 15, round: "grand_final", bracket: "grand_final" as const },
+    { matchNumber: 16, round: "grand_final_reset", bracket: "grand_final" as const },
+  ];
+}
+
+describe("DoubleEliminationBracket horizontal overflow (issue #424)", () => {
+  it("allows horizontal scrolling in every bracket section at all breakpoints", () => {
+    const { container } = render(
+      <DoubleEliminationBracket
+        matches={[]}
+        bracketStructure={build8PlayerStructure()}
+        roundNames={{}}
+      />
+    );
+
+    /* Each section (Winners / Losers / Grand Final) wraps its round columns
+     * in a flex row. That row is the element that needs to scroll when the
+     * bracket is wider than its container. */
+    const roundRows = container.querySelectorAll<HTMLElement>("div.md\\:flex-row");
+
+    /* Winners, Losers, Grand Final => 3 round-row wrappers. */
+    expect(roundRows.length).toBe(3);
+
+    roundRows.forEach((row) => {
+      /* Scrolling must be active; the prior bug was that `md:overflow-visible`
+       * cancelled this on desktop and the bracket broke out of the pane. */
+      expect(row.className).toContain("overflow-x-auto");
+      expect(row.className).not.toContain("md:overflow-visible");
+    });
+  });
+});

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -305,7 +305,11 @@ export function DoubleEliminationBracket({
     <div className="space-y-6" role="region" aria-live="polite" aria-atomic="false">
       {/* Winners Bracket - Players with no losses */}
       <BracketSection title="Winners Bracket">
-        <div className="flex flex-col gap-6 md:flex-row md:items-start md:gap-8 overflow-x-auto pb-4 md:overflow-visible md:pb-0">
+        {/* overflow-x-auto stays on at every breakpoint: 16-player brackets have
+         * five round columns (R1 → QF → SF → Final + gaps) that routinely exceed
+         * the container width on desktop. Without horizontal scrolling here the
+         * rightmost matches were breaking out of the page pane (issue #424). */}
+        <div className="flex flex-col gap-6 md:flex-row md:items-start md:gap-8 overflow-x-auto pb-4">
           {/* Round 1 - Only in 16-player brackets */}
           {is16Player && (
             <div className="space-y-2">
@@ -402,7 +406,10 @@ export function DoubleEliminationBracket({
 
       {/* Losers Bracket - Players with one loss get a second chance */}
       <BracketSection title="Losers Bracket" variant="losers">
-        <div className="flex flex-col gap-6 md:flex-row md:items-start md:gap-8 overflow-x-auto pb-4 md:overflow-visible md:pb-0">
+        {/* See Winners Bracket above: horizontal scrolling must stay enabled on
+         * desktop so wide 16-player losers brackets (up to 6 round columns) can
+         * scroll instead of overflowing the containing pane (issue #424). */}
+        <div className="flex flex-col gap-6 md:flex-row md:items-start md:gap-8 overflow-x-auto pb-4">
           {/* Losers Round 1 - First matchups of eliminated players */}
           <div className="space-y-2">
             <h4 className="text-sm font-medium text-muted-foreground">
@@ -545,7 +552,9 @@ export function DoubleEliminationBracket({
 
       {/* Grand Final - Winners champion vs Losers champion */}
       <BracketSection title="Grand Final" variant="final">
-        <div className="flex flex-col gap-4 md:flex-row md:items-start md:gap-8 overflow-x-auto pb-4 md:overflow-visible md:pb-0">
+        {/* Kept consistent with Winners/Losers sections for predictable layout
+         * behaviour across all bracket sections (issue #424). */}
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:gap-8 overflow-x-auto pb-4">
           {/* Grand Final match */}
           <div className="space-y-2">
             <h4 className="text-sm font-medium text-muted-foreground">


### PR DESCRIPTION
## Summary
Fixes issue #424 where wide double-elimination brackets (16-player tournaments with 5+ round columns) would overflow their containing pane on desktop instead of scrolling horizontally.

## Changes
- **Removed `md:overflow-visible` and `md:pb-0`** from the round-row wrapper divs in all three bracket sections (Winners, Losers, and Grand Final)
- **Kept `overflow-x-auto` active at all breakpoints** so horizontal scrolling remains enabled on desktop when bracket width exceeds container width
- **Added explanatory comments** documenting why horizontal scrolling must be preserved across all breakpoints
- **Added test coverage** with a new test file (`double-elimination-bracket.test.tsx`) that verifies each bracket section maintains `overflow-x-auto` and does not apply `md:overflow-visible`

## Implementation Details
The root cause was that `md:overflow-visible` on desktop was canceling the inherited `overflow-x-auto` from mobile, causing wide brackets to break out of the page layout instead of scrolling. By removing the responsive overflow override, the horizontal scrollbar now works consistently across all screen sizes, allowing users to scroll through wide brackets rather than experiencing layout breakage.

The padding adjustment (`pb-4` → `pb-4` only, removing `md:pb-0`) is a minor side effect that maintains consistent spacing.

https://claude.ai/code/session_01XnPJcU6GHMgQ5QVKnwpJtB