### PR TITLE
Improve score entry dialog width on tablet and desktop

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -499,6 +499,7 @@ export default function BattleModeFinals({
       {/* Score Entry Dialog: admin-only */}
       {isAdmin && <Dialog open={isScoreDialogOpen} onOpenChange={setIsScoreDialogOpen}>
         <DialogContent
+          className="sm:max-w-2xl"
           onOpenAutoFocus={(e) => {
             /* Auto-focus the first score input for keyboard usability */
             e.preventDefault();


### PR DESCRIPTION
## Summary
Updated the score entry dialog in the Battle Mode Finals page to use a larger maximum width on medium screens and above, improving the layout and usability of the dialog on tablet and desktop devices.

## Key Changes
- Added `className="sm:max-w-2xl"` to the DialogContent component to set a maximum width of 42rem (672px) on small screens and larger

## Implementation Details
This change uses Tailwind CSS's responsive sizing utility to ensure the score entry dialog has adequate width for better readability and interaction on larger viewports, while maintaining appropriate sizing on mobile devices.

https://claude.ai/code/session_01JdY32w4ERfsZFgsK5PzhTC