### PR TITLE
fix(mr-report): add optimistic locking to MR auto-confirm path (#434)

### DIFF
--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
@@ -273,19 +273,28 @@ export async function POST(
       return handleDatabaseError(error, "score report update");
     }
 
-    /* If dual report is disabled (default), immediately confirm the match */
+    /* If dual report is disabled (default), immediately confirm the match.
+     * Use updateWithRetry to prevent concurrent auto-confirm from overwriting. */
     if (!(await isDualReportEnabled(tournamentId))) {
       try {
-        const finalMatch = await prisma.mRMatch.update({
-          where: { id: matchId },
-          data: { score1, score2, completed: true },
-          include: { player1: true, player2: true },
-        });
+        const finalMatch = await updateWithRetry(prisma, async (tx) =>
+          tx.mRMatch.update({
+            where: { id: matchId, version: result.version },
+            data: { score1, score2, completed: true, version: { increment: 1 } },
+            include: { player1: true, player2: true },
+          })
+        );
         await recalculatePlayerStats(MR_RECALC_CONFIG, tournamentId, finalMatch.player1Id);
         await recalculatePlayerStats(MR_RECALC_CONFIG, tournamentId, finalMatch.player2Id);
         return createSuccessResponse({ match: finalMatch, autoConfirmed: true },
           "Score confirmed (dual report disabled)");
       } catch (error) {
+        if (error instanceof OptimisticLockError) {
+          return createErrorResponse(
+            "This match was updated by someone else. Please refresh and try again.",
+            409, "OPTIMISTIC_LOCK_ERROR", { requiresRefresh: true }
+          );
+        }
         return handleDatabaseError(error, "match completion");
       }
     }


### PR DESCRIPTION
## Summary

MR match report auto-confirm path (when dual report is disabled) now uses `updateWithRetry` with version guard, preventing concurrent score updates from overwriting each other.

## Changes

`smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts`:

```typescript
// Before: direct prisma.mRMatch.update() with no version guard
const finalMatch = await prisma.mRMatch.update({
  where: { id: matchId },
  data: { score1, score2, completed: true },
});

// After: updateWithRetry with version guard
const finalMatch = await updateWithRetry(prisma, async (tx) =>
  tx.mRMatch.update({
    where: { id: matchId, version: result.version },
    data: { score1, score2, completed: true, version: { increment: 1 } },
    include: { player1: true, player2: true },
  })
);
```

Also handles `OptimisticLockError` with 409 response for consistency with other modes.

## Test plan

- [ ] Run MR qualification flow with dual report disabled
- [ ] Verify auto-confirm fires correctly for both single and concurrent submissions
- [ ] Run E2E tests for MR finals

🤖 Generated with [Claude Code](https://claude.ai/claude-code)