### PR TITLE
fix(tc-ta): scope player search to table row in TC-805 (#443)

### DIFF
--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -176,7 +176,9 @@ async function runTc805(adminPage) {
 
     await adminPage.getByRole('button', { name: /プレイヤー追加|Add Player/ }).click();
     await adminPage.getByPlaceholder(/プレイヤーを検索|Search players/).fill(p1.nickname);
-    await adminPage.getByText(new RegExp(p1.nickname)).waitFor({ timeout: 10000 });
+    // Use rowFor to scope to the table row, avoiding the toast notification
+    // which also contains the player nickname
+    await rowFor(p1.nickname).waitFor({ timeout: 10000 });
 
     const ok = removedFromApi && retainedOther;
     log('TC-805', ok ? 'PASS' : 'FAIL',


### PR DESCRIPTION
## Summary

Fix TC-805 strict mode violation where `getByText()` matched multiple DOM elements (table cell + toast notification) when searching for a removed player nickname.

## Changes

- Replace `getByText(new RegExp(p1.nickname))` with `rowFor(p1.nickname)` which scopes the search to the table row, avoiding the toast notification that also contains the player nickname

## Test plan

- [ ] Run TC-805 on staging: `node e2e/tc-ta.js` should pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)