### PR TITLE
refactor: remove redundant matchId destructuring (#461)

### DIFF
--- a/smkc-score-app/src/lib/api-factories/match-detail-route.ts
+++ b/smkc-score-app/src/lib/api-factories/match-detail-route.ts
@@ -93,7 +93,7 @@ export function createMatchDetailHandlers(config: MatchDetailConfig) {
     const { matchId } = await params;
 
     try {
-      const { id: tournamentId, matchId } = await params;
+      const { id: tournamentId } = await params;
       const match = await model(prisma).findUnique({
         where: { id: matchId, tournamentId },
         include: { player1: true, player2: true },


### PR DESCRIPTION
## Summary
- Remove redundant `matchId` destructuring in GET handler of match-detail-route.ts
- The duplicate declaration shadowed the outer scope declaration

## Test plan
- [x] Type check passes (simple refactor, no logic change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)