### PR TITLE
fix(group-setup-dialog): enable right column scroll on desktop (#450)

### DIFF
--- a/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
+++ b/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
@@ -242,7 +242,7 @@ export function GroupSetupDialog({
          * - Right: selected players with seeding + group assignments
          */}
         {/* On mobile: whole area scrolls; on desktop: each column scrolls independently */}
-        <div className="flex-1 overflow-y-auto md:overflow-hidden">
+        <div className="flex-1 overflow-y-auto md:overflow-y-auto">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4 md:h-full">
             {/* Left column: Player selection with search */}
             <div className="flex flex-col min-h-0">


### PR DESCRIPTION
## Summary
- Change `md:overflow-hidden` to `md:overflow-y-auto` in group-setup-dialog.tsx
- Allows the right column (selected players list) to scroll independently on desktop
- Fixes issue where only 11 of 24 selected players were visible

## Test plan
- [ ] Open group edit dialog with 24+ players
- [ ] Verify all players are visible and scrollable in the right column

🤖 Generated with [Claude Code](https://claude.com/claude-code)