### PR TITLE
fix(bm): handle 0-0 cleared matches as no_contest in standings (#453)

### DIFF
--- a/smkc-score-app/__tests__/lib/score-validation.test.ts
+++ b/smkc-score-app/__tests__/lib/score-validation.test.ts
@@ -132,30 +132,25 @@ describe('Score Validation Utilities', () => {
       expect(result.error).toBe(`Score must be between ${MIN_BATTLE_SCORE} and ${MAX_BATTLE_SCORE}`);
     });
 
-    // === Sum check: score1 + score2 must equal TOTAL_BM_ROUNDS ===
+    // === Sum check: score1 + score2 must be at most TOTAL_BM_ROUNDS (≤ 4) ===
+    // Allows sub-total scores for admin corrections (e.g., 0-0 clear)
 
-    it('should reject scores that do not sum to TOTAL_BM_ROUNDS (2+3=5)', () => {
+    it('should reject scores that exceed TOTAL_BM_ROUNDS (2+3=5)', () => {
       const result = validateBattleModeScores(2, 3);
       expect(result.isValid).toBe(false);
       expect(result.error).toBe(
-        `Scores must total exactly ${TOTAL_BM_ROUNDS} rounds (got 5)`
+        `Scores must total at most ${TOTAL_BM_ROUNDS} rounds (got 5)`
       );
     });
 
-    it('should reject scores that do not sum to TOTAL_BM_ROUNDS (1+1=2)', () => {
+    it('should accept sub-total scores for corrections (1+1=2)', () => {
       const result = validateBattleModeScores(1, 1);
-      expect(result.isValid).toBe(false);
-      expect(result.error).toBe(
-        `Scores must total exactly ${TOTAL_BM_ROUNDS} rounds (got 2)`
-      );
+      expect(result.isValid).toBe(true);
     });
 
-    it('should reject scores that do not sum to TOTAL_BM_ROUNDS (0+0=0)', () => {
+    it('should accept zero scores for clear/correction (0+0=0)', () => {
       const result = validateBattleModeScores(0, 0);
-      expect(result.isValid).toBe(false);
-      expect(result.error).toBe(
-        `Scores must total exactly ${TOTAL_BM_ROUNDS} rounds (got 0)`
-      );
+      expect(result.isValid).toBe(true);
     });
 
   });

--- a/smkc-score-app/__tests__/lib/score-validation.test.ts
+++ b/smkc-score-app/__tests__/lib/score-validation.test.ts
@@ -132,20 +132,20 @@ describe('Score Validation Utilities', () => {
       expect(result.error).toBe(`Score must be between ${MIN_BATTLE_SCORE} and ${MAX_BATTLE_SCORE}`);
     });
 
-    // === Sum check: score1 + score2 must be at most TOTAL_BM_ROUNDS (≤ 4) ===
-    // Allows sub-total scores for admin corrections (e.g., 0-0 clear)
+    // === Sum check: score1 + score2 must be TOTAL_BM_ROUNDS (4) or 0-0 to clear ===
+    // Allows 0-0 for admin corrections (disputed/no-show matches)
 
     it('should reject scores that exceed TOTAL_BM_ROUNDS (2+3=5)', () => {
       const result = validateBattleModeScores(2, 3);
       expect(result.isValid).toBe(false);
       expect(result.error).toBe(
-        `Scores must total at most ${TOTAL_BM_ROUNDS} rounds (got 5)`
+        `Scores must total ${TOTAL_BM_ROUNDS} for a normal match, or be 0-0 to clear a match`
       );
     });
 
-    it('should accept sub-total scores for corrections (1+1=2)', () => {
+    it('should reject sub-total scores (1+1=2) for corrections', () => {
       const result = validateBattleModeScores(1, 1);
-      expect(result.isValid).toBe(true);
+      expect(result.isValid).toBe(false);
     });
 
     it('should accept zero scores for clear/correction (0+0=0)', () => {

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -73,6 +73,8 @@
     "second": "2nd",
     "gameOver": "Game Over",
     "totalRoundsShouldEqual4": "Total rounds should equal 4",
+    "totalRoundsShouldBeAtMost4": "Total rounds should be at most 4",
+    "clearScores": "Clear",
     "select4UniqueCourses": "Please select 4 unique courses",
     "selectWinnerForAllRaces": "Please select a winner for all {count} races",
     "scorePreview": "Score Preview",

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -73,7 +73,7 @@
     "second": "2nd",
     "gameOver": "Game Over",
     "totalRoundsShouldEqual4": "Total rounds should equal 4",
-    "totalRoundsShouldBeAtMost4": "Total rounds should be at most 4",
+    "totalRoundsMustBe4Or0": "Scores must be 4 total (or 0-0 to clear)",
     "clearScores": "Clear",
     "select4UniqueCourses": "Please select 4 unique courses",
     "selectWinnerForAllRaces": "Please select a winner for all {count} races",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -73,7 +73,7 @@
     "second": "2位",
     "gameOver": "ゲームオーバー",
     "totalRoundsShouldEqual4": "ラウンド合計は4になる必要があります",
-    "totalRoundsShouldBeAtMost4": "ラウンド合計は最大4にしてください",
+    "totalRoundsMustBe4Or0": "合計4、または0-0でクリア",
     "clearScores": "クリア",
     "select4UniqueCourses": "4つの異なるコースを選択してください",
     "selectWinnerForAllRaces": "{count}レースすべての勝者を選択してください",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -73,6 +73,8 @@
     "second": "2位",
     "gameOver": "ゲームオーバー",
     "totalRoundsShouldEqual4": "ラウンド合計は4になる必要があります",
+    "totalRoundsShouldBeAtMost4": "ラウンド合計は最大4にしてください",
+    "clearScores": "クリア",
     "select4UniqueCourses": "4つの異なるコースを選択してください",
     "selectWinnerForAllRaces": "{count}レースすべての勝者を選択してください",
     "scorePreview": "スコア入力プレビュー",

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
@@ -273,10 +273,12 @@ export default function BattleModePage({
   const handleScoreSubmit = async () => {
     if (!selectedMatch) return;
 
-    /* Client-side validation: BM qualification requires at most 4 rounds total.
-     * Allow sub-total scores (e.g., 0-0 clear) for score corrections. */
-    if (scoreForm.score1 + scoreForm.score2 > 4) {
-      alert(tc('totalRoundsShouldBeAtMost4'));
+    /* Client-side validation: BM qualification requires sum === 4 for normal matches,
+     * or 0-0 for disputed/no-show match clearing. */
+    const isNormalMatch = scoreForm.score1 + scoreForm.score2 === 4;
+    const isClearedMatch = scoreForm.score1 === 0 && scoreForm.score2 === 0;
+    if (!isNormalMatch && !isClearedMatch) {
+      alert(tc('totalRoundsMustBe4Or0'));
       return;
     }
 
@@ -821,8 +823,8 @@ export default function BattleModePage({
             </div>
             {/* Validation warning when total rounds > 4.
                Always rendered to reserve vertical space and prevent layout shift. */}
-            <p className={`text-sm text-center ${scoreForm.score1 + scoreForm.score2 > 4 ? 'text-yellow-600' : 'invisible'}`}>
-              {tc('totalRoundsShouldBeAtMost4')}
+            <p className={`text-sm text-center ${(scoreForm.score1 + scoreForm.score2 !== 4 && !(scoreForm.score1 === 0 && scoreForm.score2 === 0)) ? 'text-yellow-600' : 'invisible'}`}>
+              {tc('totalRoundsMustBe4Or0')}
             </p>
           </div>
           <DialogFooter>

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
@@ -273,9 +273,10 @@ export default function BattleModePage({
   const handleScoreSubmit = async () => {
     if (!selectedMatch) return;
 
-    /* Client-side validation: BM qualification requires exactly 4 rounds */
-    if (scoreForm.score1 + scoreForm.score2 !== 4) {
-      alert(tc('totalRoundsShouldEqual4'));
+    /* Client-side validation: BM qualification requires at most 4 rounds total.
+     * Allow sub-total scores (e.g., 0-0 clear) for score corrections. */
+    if (scoreForm.score1 + scoreForm.score2 > 4) {
+      alert(tc('totalRoundsShouldBeAtMost4'));
       return;
     }
 
@@ -818,15 +819,22 @@ export default function BattleModePage({
                 />
               </div>
             </div>
-            {/* Validation warning when total rounds != 4.
-               Always rendered to reserve vertical space and prevent layout shift
-               when the warning appears/disappears during score input. */}
-            <p className={`text-sm text-center ${scoreForm.score1 + scoreForm.score2 !== 4 ? 'text-yellow-600' : 'invisible'}`}>
-              {tc('totalRoundsShouldEqual4')}
+            {/* Validation warning when total rounds > 4.
+               Always rendered to reserve vertical space and prevent layout shift. */}
+            <p className={`text-sm text-center ${scoreForm.score1 + scoreForm.score2 > 4 ? 'text-yellow-600' : 'invisible'}`}>
+              {tc('totalRoundsShouldBeAtMost4')}
             </p>
           </div>
           <DialogFooter>
-            <Button onClick={handleScoreSubmit}>{tc('saveScore')}</Button>
+            <div className="flex w-full justify-between">
+              <Button
+                variant="outline"
+                onClick={() => setScoreForm({ score1: 0, score2: 0 })}
+              >
+                {tc('clearScores')}
+              </Button>
+              <Button onClick={handleScoreSubmit}>{tc('saveScore')}</Button>
+            </div>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/smkc-score-app/src/lib/event-types/bm-config.ts
+++ b/smkc-score-app/src/lib/event-types/bm-config.ts
@@ -12,12 +12,19 @@ import { validateBattleModeScores } from '@/lib/score-validation';
 
 /**
  * Calculate BM match result from round scores.
- * Total rounds must equal 4 for a valid result; otherwise treated as tie.
+ * - 0-0 (cleared match): returns 'no_contest' - match does not count in standings
+ * - sum !== 4: returns 'no_contest' - invalid match (should not reach here if validation works)
+ * - sum === 4 with score >= 3: returns 'win' or 'loss'
+ * - sum === 4 with score < 3: returns 'tie' (2-2 is a valid draw per §4.1)
  */
 function calculateMatchResult(score1: number, score2: number): MatchResult {
+  // 0-0 indicates admin-cleared match (voided) - does not count
+  if (score1 === 0 && score2 === 0) {
+    return { winner: null, result1: 'no_contest', result2: 'no_contest' };
+  }
   const totalRounds = score1 + score2;
   if (totalRounds !== 4) {
-    return { winner: null, result1: 'tie', result2: 'tie' };
+    return { winner: null, result1: 'no_contest', result2: 'no_contest' };
   }
   if (score1 >= 3) {
     return { winner: 1, result1: 'win', result2: 'loss' };
@@ -84,6 +91,11 @@ export const bmConfig: EventTypeConfig = {
   aggregatePlayerStats: (matches, playerId, calcResult) => {
     const stats = { mp: 0, wins: 0, ties: 0, losses: 0, winRounds: 0, lossRounds: 0 };
     for (const m of matches) {
+      // Skip 0-0 matches: these are admin-cleared matches (not actual ties).
+      // A 0-0 score indicates the match was voided and should not affect standings.
+      const isClearedMatch = m.score1 === 0 && m.score2 === 0;
+      if (isClearedMatch) continue;
+
       stats.mp++;
       const isPlayer1 = m.player1Id === playerId;
       stats.winRounds += isPlayer1 ? m.score1 : m.score2;

--- a/smkc-score-app/src/lib/event-types/types.ts
+++ b/smkc-score-app/src/lib/event-types/types.ts
@@ -13,8 +13,8 @@
 /** Result of a single match calculation */
 export type MatchResult = {
   winner: number | null;
-  result1: 'win' | 'loss' | 'tie';
-  result2: 'win' | 'loss' | 'tie';
+  result1: 'win' | 'loss' | 'tie' | 'no_contest';
+  result2: 'win' | 'loss' | 'tie' | 'no_contest';
 };
 
 /** Parsed PUT request body for qualification match updates */

--- a/smkc-score-app/src/lib/score-validation.ts
+++ b/smkc-score-app/src/lib/score-validation.ts
@@ -83,13 +83,14 @@ export function validateBattleModeScores(score1: number, score2: number): ScoreV
   }
 
   // Sum check: BM matches require TOTAL_BM_ROUNDS rounds (sum = 4) for a valid
-  // qualification result. However, admin score corrections may need to set scores
-  // to 0-0 (disputed/no-show) or other sub-total values. Allow sum <= TOTAL_BM_ROUNDS
-  // to support both normal entry and correction scenarios.
-  if (score1 + score2 > TOTAL_BM_ROUNDS) {
+  // qualification result. Admin score corrections for disputed/no-show matches
+  // (0-0) are also allowed to support clearing invalid match entries.
+  const isNormalMatch = score1 + score2 === TOTAL_BM_ROUNDS;
+  const isClearedMatch = score1 === 0 && score2 === 0;
+  if (!isNormalMatch && !isClearedMatch) {
     return {
       isValid: false,
-      error: `Scores must total at most ${TOTAL_BM_ROUNDS} rounds (got ${score1 + score2})`,
+      error: `Scores must total ${TOTAL_BM_ROUNDS} for a normal match, or be 0-0 to clear a match`,
     };
   }
 

--- a/smkc-score-app/src/lib/score-validation.ts
+++ b/smkc-score-app/src/lib/score-validation.ts
@@ -82,13 +82,14 @@ export function validateBattleModeScores(score1: number, score2: number): ScoreV
     };
   }
 
-  // Sum check: BM matches are exactly TOTAL_BM_ROUNDS rounds. Without this check,
-  // a score like 1-2 (sum = 3) passes range validation but is silently treated
-  // as a tie by the match result calculation (which requires totalRounds === 4).
-  if (score1 + score2 !== TOTAL_BM_ROUNDS) {
+  // Sum check: BM matches require TOTAL_BM_ROUNDS rounds (sum = 4) for a valid
+  // qualification result. However, admin score corrections may need to set scores
+  // to 0-0 (disputed/no-show) or other sub-total values. Allow sum <= TOTAL_BM_ROUNDS
+  // to support both normal entry and correction scenarios.
+  if (score1 + score2 > TOTAL_BM_ROUNDS) {
     return {
       isValid: false,
-      error: `Scores must total exactly ${TOTAL_BM_ROUNDS} rounds (got ${score1 + score2})`,
+      error: `Scores must total at most ${TOTAL_BM_ROUNDS} rounds (got ${score1 + score2})`,
     };
   }
 


### PR DESCRIPTION
## Summary

Addresses reviewer concern about 0-0 cleared matches being treated as ties in standings.

When an admin clears a BM match to 0-0, the match should not affect standings (not be counted as a tie). This change:

1. Updates `MatchResult` type to include `'no_contest'` result
2. Modifies `calculateMatchResult` in `bm-config.ts` to return `'no_contest'` for 0-0 and invalid sum (< 4) matches
3. Modifies `aggregatePlayerStats` in `bm-config.ts` to skip 0-0 matches entirely from standings aggregation

## Changes

- `types.ts`: Added `'no_contest'` to `MatchResult.result1` and `result2` union types
- `bm-config.ts`: 
  - Updated `calculateMatchResult` comment and logic to return 'no_contest' for 0-0/invalid sum
  - Updated `aggregatePlayerStats` to skip 0-0 matches with explanation comment

## Test plan

- [x] All score-validation tests pass (64/64)
- [x] TypeScript build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)