### PR TITLE
fix(usePolling): add TTL-based cache expiration (#470)

### DIFF
--- a/smkc-score-app/__tests__/lib/hooks/usePolling.test.ts
+++ b/smkc-score-app/__tests__/lib/hooks/usePolling.test.ts
@@ -770,5 +770,101 @@ describe('usePolling', () => {
       );
       expect(retainedResult.current.data).toEqual({ id: 20 });
     });
+
+    it('should return undefined for expired cache entries', async () => {
+      /*
+       * Test that getCacheEntry returns undefined for entries that have
+       * exceeded the TTL (POLLING_CACHE_TTL_MS = 30 minutes).
+       */
+      const mockData = { id: 1, name: 'expired-test' };
+      const mockFetch = jest.fn().mockResolvedValue(mockData);
+      const cacheKey = 'test/ttl-expired';
+
+      /* First mount: cache the data */
+      const { unmount } = await act(async () => {
+        return renderHook(() => usePolling(mockFetch, { cacheKey }));
+      });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      unmount();
+
+      /* Advance timers by more than TTL (30 minutes) */
+      act(() => {
+        jest.advanceTimersByTime(31 * 60 * 1000); // 31 minutes
+      });
+
+      /* Remount: should get null data because entry expired */
+      const { result } = renderHook(() =>
+        usePolling(jest.fn().mockResolvedValue(null), {
+          immediate: false,
+          cacheKey,
+        })
+      );
+
+      /* Expired entries return undefined from getCacheEntry,
+       * so data should be null */
+      expect(result.current.data).toBeNull();
+    });
+
+    it('should evict expired entries when cache exceeds max size', async () => {
+      /*
+       * Test that when cache exceeds max size (20), expired entries
+       * are evicted first before non-expired entries.
+       */
+      const mockData = { id: 1 };
+      const cacheKeyPrefix = 'test/ttl-size-';
+
+      /* Create 15 entries that will expire soon */
+      for (let i = 0; i < 15; i++) {
+        const { unmount } = await act(async () => {
+          return renderHook(() =>
+            usePolling(jest.fn().mockResolvedValue({ id: i }), {
+              cacheKey: `${cacheKeyPrefix}${i}`,
+            })
+          );
+        });
+        unmount();
+      }
+
+      /* Advance time past TTL for the first 15 entries */
+      act(() => {
+        jest.advanceTimersByTime(31 * 60 * 1000); // 31 minutes
+      });
+
+      /* Now add 10 more fresh entries - this should trigger eviction
+       * of the expired entries before the non-expired ones */
+      for (let i = 15; i < 25; i++) {
+        const { unmount } = await act(async () => {
+          return renderHook(() =>
+            usePolling(jest.fn().mockResolvedValue({ id: i }), {
+              cacheKey: `${cacheKeyPrefix}${i}`,
+            })
+          );
+        });
+        unmount();
+      }
+
+      /* First 5 expired entries (0-4) should have been evicted
+       * to make room, even though they were inserted first */
+      const { result: evictedResult } = renderHook(() =>
+        usePolling(jest.fn().mockResolvedValue(null), {
+          immediate: false,
+          cacheKey: `${cacheKeyPrefix}0`,
+        })
+      );
+      expect(evictedResult.current.data).toBeNull();
+
+      /* Later entries (15-24) should still be cached */
+      const { result: retainedResult } = renderHook(() =>
+        usePolling(jest.fn().mockResolvedValue(null), {
+          immediate: false,
+          cacheKey: `${cacheKeyPrefix}24`,
+        })
+      );
+      expect(retainedResult.current.data).toEqual({ id: 24 });
+    });
   });
 });

--- a/smkc-score-app/src/lib/hooks/usePolling.ts
+++ b/smkc-score-app/src/lib/hooks/usePolling.ts
@@ -36,6 +36,18 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { POLLING_INTERVAL } from '@/lib/constants';
 
+/** TTL for cached polling entries: 30 minutes */
+const POLLING_CACHE_TTL_MS = 30 * 60 * 1000;
+
+/** Maximum number of entries in the polling cache */
+const POLLING_CACHE_MAX_SIZE = 20;
+
+/** Cache entry with timestamp for TTL tracking */
+interface CacheEntry {
+  data: unknown;
+  timestamp: number;
+}
+
 /**
  * Module-level LRU cache for persisting polling data across component
  * unmount/remount cycles. When a component using usePolling unmounts
@@ -50,6 +62,7 @@ import { POLLING_INTERVAL } from '@/lib/constants';
  * Max size is capped to prevent unbounded memory growth during long
  * sessions (e.g., admin browsing many tournaments). When the limit is
  * reached, the oldest entry is evicted (Map preserves insertion order).
+ * Entries also expire after POLLING_CACHE_TTL_MS (30 minutes).
  */
 const pollingCache = new Map<string, CacheEntry>();
 

--- a/smkc-score-app/src/lib/hooks/usePolling.ts
+++ b/smkc-score-app/src/lib/hooks/usePolling.ts
@@ -51,33 +51,52 @@ import { POLLING_INTERVAL } from '@/lib/constants';
  * sessions (e.g., admin browsing many tournaments). When the limit is
  * reached, the oldest entry is evicted (Map preserves insertion order).
  */
-const pollingCache = new Map<string, unknown>();
+const pollingCache = new Map<string, CacheEntry>();
 
 /**
- * Maximum number of entries in the polling cache.
- * 20 entries covers ~4 tournaments × 5 tabs each, which is a reasonable
- * working set for a single-user admin session.
+ * Evict expired entries and oldest entry if over capacity.
+ * Called on every setCacheEntry to keep cache bounded.
  */
-const POLLING_CACHE_MAX_SIZE = 20;
-
-/**
- * Set a value in the polling cache with LRU eviction.
- * If the key already exists, it is deleted and re-inserted to move it
- * to the end (most recently used). If the cache exceeds the max size,
- * the oldest entry (first in Map iteration order) is evicted.
- */
-function setCacheEntry(key: string, value: unknown): void {
-  // Delete first to re-insert at the end (LRU ordering)
-  pollingCache.delete(key);
-  pollingCache.set(key, value);
-
-  // Evict oldest entry if over capacity
-  if (pollingCache.size > POLLING_CACHE_MAX_SIZE) {
+function evictStaleEntries(): void {
+  const now = Date.now();
+  for (const [key, entry] of pollingCache.entries()) {
+    if (now - entry.timestamp > POLLING_CACHE_TTL_MS) {
+      pollingCache.delete(key);
+    }
+  }
+  while (pollingCache.size > POLLING_CACHE_MAX_SIZE) {
     const oldestKey = pollingCache.keys().next().value;
     if (oldestKey !== undefined) {
       pollingCache.delete(oldestKey);
     }
   }
+}
+
+/**
+ * Set a value in the polling cache with LRU eviction and TTL expiration.
+ * If the key already exists, it is deleted and re-inserted to move it
+ * to the end (most recently used). Expired entries are evicted on each call.
+ */
+function setCacheEntry(key: string, value: unknown): void {
+  evictStaleEntries();
+  pollingCache.set(key, { data: value, timestamp: Date.now() });
+}
+
+/**
+ * Get a cache entry if it exists and is not expired.
+ * Returns undefined if the entry is missing or expired.
+ */
+function getCacheEntry(key: string): unknown | undefined {
+  const entry = pollingCache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.timestamp > POLLING_CACHE_TTL_MS) {
+    pollingCache.delete(key);
+    return undefined;
+  }
+  // Move to end (most recently used) on access
+  pollingCache.delete(key);
+  pollingCache.set(key, entry);
+  return entry.data;
 }
 
 /**
@@ -136,9 +155,7 @@ export function usePolling<T>(
   // Uses a lazy initializer (function form) so the cache lookup runs only
   // on the initial mount, not on every render.
   const [data, setData] = useState<T | null>(() =>
-    cacheKey && pollingCache.has(cacheKey)
-      ? (pollingCache.get(cacheKey) as T)
-      : null
+    cacheKey ? (getCacheEntry(cacheKey) as T) : null
   );
   const [error, setError] = useState<Error | null>(null);
   const [lastETag, setLastETag] = useState<string | null>(null);

--- a/smkc-score-app/src/lib/hooks/usePolling.ts
+++ b/smkc-score-app/src/lib/hooks/usePolling.ts
@@ -92,6 +92,9 @@ function evictStaleEntries(): void {
  */
 function setCacheEntry(key: string, value: unknown): void {
   evictStaleEntries();
+  // Delete first to ensure the key is removed from its current position
+  // (Map preserves insertion order, so re-inserting moves key to end)
+  pollingCache.delete(key);
   pollingCache.set(key, { data: value, timestamp: Date.now() });
 }
 


### PR DESCRIPTION
## Summary
Add timestamp-based TTL eviction to the polling cache to prevent unbounded growth of stale entries.

## Changes
- Added `POLLING_CACHE_TTL_MS` (30 minutes) constant
- Added `CacheEntry` interface with `{ data, timestamp }`
- Added `evictStaleEntries()` to remove expired entries on every cache write
- Added `getCacheEntry()` to check TTL on access and return undefined for expired entries
- Cache entries older than 30 minutes are automatically evicted
- LRU eviction still applies when cache exceeds MAX_SIZE

## Test plan
- [x] Existing tests pass (useState lazy initializer compatible)
- [ ] Verify expired entries are evicted when cache size exceeds limit
- [ ] Verify getCacheEntry returns undefined for expired entries

Fixes #470