### PR TITLE
Optimize bulk database operations with createMany (issue #420)

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/route.test.ts
@@ -210,7 +210,9 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
 
       (prisma.bMQualification.findMany as jest.Mock).mockResolvedValue(mockQualifications);
       (prisma.bMMatch.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
-      (prisma.bMMatch.create as jest.Mock).mockResolvedValue(mockCreatedMatch);
+      // Issue #420: bracket inserted in one createMany then re-fetched.
+      (prisma.bMMatch.createMany as jest.Mock).mockResolvedValue({ count: 17 });
+      (prisma.bMMatch.findMany as jest.Mock).mockResolvedValue([mockCreatedMatch]);
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm/finals', { topN: 8 });
       const params = Promise.resolve({ id: 't1' });
@@ -242,7 +244,8 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
 
       (prisma.bMQualification.findMany as jest.Mock).mockResolvedValue(mockQualifications);
       (prisma.bMMatch.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
-      (prisma.bMMatch.create as jest.Mock).mockResolvedValue({ id: 'm1' });
+      (prisma.bMMatch.createMany as jest.Mock).mockResolvedValue({ count: 17 });
+      (prisma.bMMatch.findMany as jest.Mock).mockResolvedValue([]);
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm/finals', {});
       const params = Promise.resolve({ id: 't1' });
@@ -309,7 +312,8 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
 
       (prisma.bMQualification.findMany as jest.Mock).mockResolvedValue(mockQualifications);
       (prisma.bMMatch.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
-      (prisma.bMMatch.create as jest.Mock).mockResolvedValue({ id: 'm1', player1: { id: 'p1' }, player2: { id: 'p2' } });
+      (prisma.bMMatch.createMany as jest.Mock).mockResolvedValue({ count: 17 });
+      (prisma.bMMatch.findMany as jest.Mock).mockResolvedValue([]);
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm/finals', { topN: 8 });
       const params = Promise.resolve({ id: 't1' });

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
@@ -77,10 +77,12 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
     (prisma.bMQualification.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.bMQualification.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
     (prisma.bMQualification.create as jest.Mock).mockResolvedValue({});
+    (prisma.bMQualification.createMany as jest.Mock).mockResolvedValue({ count: 0 });
     (prisma.bMQualification.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
     (prisma.bMMatch.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.bMMatch.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
     (prisma.bMMatch.create as jest.Mock).mockResolvedValue({});
+    (prisma.bMMatch.createMany as jest.Mock).mockResolvedValue({ count: 0 });
     (prisma.bMMatch.update as jest.Mock).mockResolvedValue({});
   });
 
@@ -166,19 +168,24 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
         { playerId: 'p1', group: 'A', seeding: 1 },
         { playerId: 'p2', group: 'A', seeding: 2 },
       ];
-      (prisma.bMQualification.create as jest.Mock).mockResolvedValue({ id: 'q1' });
-      (prisma.bMMatch.create as jest.Mock).mockResolvedValue({ id: 'm1' });
+      // Issue #420: setup now uses createMany (1 call per model) plus a
+      // findMany re-fetch for the response payload.
+      (prisma.bMQualification.createMany as jest.Mock).mockResolvedValue({ count: 2 });
+      (prisma.bMQualification.findMany as jest.Mock).mockResolvedValue([{ id: 'q1' }, { id: 'q2' }]);
+      (prisma.bMMatch.createMany as jest.Mock).mockResolvedValue({ count: 1 });
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm', { players: mockPlayers });
       const params = Promise.resolve({ id: 't1' });
       const result = await POST(request, { params });
 
-      expect(result.data).toEqual({ message: 'Battle mode setup complete', qualifications: expect.any(Array) });
+      expect(result.data).toEqual({ success: true, data: { message: 'Battle mode setup complete', qualifications: expect.any(Array) } });
       expect(result.status).toBe(201);
       expect(prisma.bMQualification.deleteMany).toHaveBeenCalledWith({ where: { tournamentId: 't1' } });
       expect(prisma.bMMatch.deleteMany).toHaveBeenCalledWith({ where: { tournamentId: 't1', stage: 'qualification' } });
-      expect(prisma.bMQualification.create).toHaveBeenCalledTimes(2);
-      expect(prisma.bMMatch.create).toHaveBeenCalledTimes(1);
+      expect(prisma.bMQualification.createMany).toHaveBeenCalledTimes(1);
+      expect((prisma.bMQualification.createMany as jest.Mock).mock.calls[0][0].data).toHaveLength(2);
+      expect(prisma.bMMatch.createMany).toHaveBeenCalledTimes(1);
+      expect((prisma.bMMatch.createMany as jest.Mock).mock.calls[0][0].data).toHaveLength(1);
       expect(auditLogMock.createAuditLog).toHaveBeenCalledWith({
         userId: 'admin1',
         ipAddress: 'test-ip',
@@ -202,15 +209,19 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
         { playerId: 'p4', group: 'B' },
       ];
 
-      (prisma.bMQualification.create as jest.Mock).mockResolvedValue({ id: 'q1' });
-      (prisma.bMMatch.create as jest.Mock).mockResolvedValue({ id: 'm1' });
+      (prisma.bMQualification.createMany as jest.Mock).mockResolvedValue({ count: 4 });
+      (prisma.bMQualification.findMany as jest.Mock).mockResolvedValue([{ id: 'q1' }]);
+      (prisma.bMMatch.createMany as jest.Mock).mockResolvedValue({ count: 2 });
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm', { players: mockPlayers });
       const params = Promise.resolve({ id: 't1' });
       const result = await POST(request, { params });
 
       expect(result.status).toBe(201);
-      expect(prisma.bMMatch.create).toHaveBeenCalledTimes(2);
+      // Two groups → one createMany call carrying both group A's match
+      // and group B's match in a single 2-element data array.
+      expect(prisma.bMMatch.createMany).toHaveBeenCalledTimes(1);
+      expect((prisma.bMMatch.createMany as jest.Mock).mock.calls[0][0].data).toHaveLength(2);
       expect(auditLogMock.createAuditLog).toHaveBeenCalledWith(expect.objectContaining({
         details: { mode: 'qualification', playerCount: 4 }
       }));

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -235,12 +235,9 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       (prisma.gPQualification.findMany as jest.Mock).mockResolvedValue(mockQualifications);
       (prisma.gPMatch.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
       (generateBracketStructure as jest.Mock).mockReturnValue(mockBracket);
-      (prisma.gPMatch.create as jest.Mock).mockImplementation((data) => ({
-        id: `m${data.data.matchNumber}`,
-        ...data.data,
-        player1: mockQualifications[data.data.player1Id - 1]?.player || mockQualifications[0].player,
-        player2: mockQualifications[data.data.player2Id - 1]?.player || mockQualifications[1].player,
-      }));
+      // Issue #420: bracket inserted in one createMany then re-fetched.
+      (prisma.gPMatch.createMany as jest.Mock).mockResolvedValue({ count: mockBracket.length });
+      (prisma.gPMatch.findMany as jest.Mock).mockResolvedValue([]);
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/finals', { topN: 8 });
       const params = Promise.resolve({ id: 't1' });
@@ -255,7 +252,9 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         bracketStructure: mockBracket,
       });
       expect(prisma.gPMatch.deleteMany).toHaveBeenCalledWith({ where: { tournamentId: 't1', stage: 'finals' } });
-      expect(prisma.gPMatch.create).toHaveBeenCalledTimes(mockBracket.length);
+      // All bracket matches inserted in a single createMany call carrying all matchNumbers.
+      expect(prisma.gPMatch.createMany).toHaveBeenCalledTimes(1);
+      expect((prisma.gPMatch.createMany as jest.Mock).mock.calls[0][0].data).toHaveLength(mockBracket.length);
     });
 
     // Validation error case - Returns 400 when topN is not 8
@@ -313,7 +312,8 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       (prisma.gPQualification.findMany as jest.Mock).mockResolvedValue(mockQualifications);
       (prisma.gPMatch.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
       (generateBracketStructure as jest.Mock).mockReturnValue([]);
-      (prisma.gPMatch.create as jest.Mock).mockResolvedValue({ id: 'm1' });
+      (prisma.gPMatch.createMany as jest.Mock).mockResolvedValue({ count: 0 });
+      (prisma.gPMatch.findMany as jest.Mock).mockResolvedValue([]);
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/finals', {});
       const params = Promise.resolve({ id: 't1' });

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/route.test.ts
@@ -58,10 +58,12 @@ describe('GP API Route - /api/tournaments/[id]/gp', () => {
     /* Reset all prisma model mocks to ensure no queued mockResolvedValueOnce values leak between tests */
     (prisma.gPQualification.findMany as jest.Mock).mockReset();
     (prisma.gPQualification.create as jest.Mock).mockReset();
+    (prisma.gPQualification.createMany as jest.Mock).mockReset();
     (prisma.gPQualification.deleteMany as jest.Mock).mockReset();
     (prisma.gPQualification.updateMany as jest.Mock).mockReset();
     (prisma.gPMatch.findMany as jest.Mock).mockReset();
     (prisma.gPMatch.create as jest.Mock).mockReset();
+    (prisma.gPMatch.createMany as jest.Mock).mockReset();
     (prisma.gPMatch.deleteMany as jest.Mock).mockReset();
     (prisma.gPMatch.update as jest.Mock).mockReset();
     (createLogger as jest.Mock).mockReturnValue(loggerMock);
@@ -152,19 +154,23 @@ describe('GP API Route - /api/tournaments/[id]/gp', () => {
         { playerId: 'p2', group: 'A', seeding: 2 },
       ];
 
-      (prisma.gPQualification.create as jest.Mock).mockResolvedValue({ id: 'q1' });
-      (prisma.gPMatch.create as jest.Mock).mockResolvedValue({ id: 'm1' });
+      // Issue #420: setup uses createMany + a findMany re-fetch.
+      (prisma.gPQualification.createMany as jest.Mock).mockResolvedValue({ count: 2 });
+      (prisma.gPQualification.findMany as jest.Mock).mockResolvedValue([{ id: 'q1' }, { id: 'q2' }]);
+      (prisma.gPMatch.createMany as jest.Mock).mockResolvedValue({ count: 1 });
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp', { players: mockPlayers });
       const params = Promise.resolve({ id: 't1' });
       const result = await POST(request, { params });
 
-      expect(result.data).toEqual({ message: 'Grand prix setup complete', qualifications: expect.any(Array) });
+      expect(result.data).toEqual({ success: true, data: { message: 'Grand prix setup complete', qualifications: expect.any(Array) } });
       expect(result.status).toBe(201);
       expect(prisma.gPQualification.deleteMany).toHaveBeenCalledWith({ where: { tournamentId: 't1' } });
       expect(prisma.gPMatch.deleteMany).toHaveBeenCalledWith({ where: { tournamentId: 't1', stage: 'qualification' } });
-      expect(prisma.gPQualification.create).toHaveBeenCalledTimes(2);
-      expect(prisma.gPMatch.create).toHaveBeenCalledTimes(1);
+      expect(prisma.gPQualification.createMany).toHaveBeenCalledTimes(1);
+      expect((prisma.gPQualification.createMany as jest.Mock).mock.calls[0][0].data).toHaveLength(2);
+      expect(prisma.gPMatch.createMany).toHaveBeenCalledTimes(1);
+      expect((prisma.gPMatch.createMany as jest.Mock).mock.calls[0][0].data).toHaveLength(1);
     });
 
     // Success case - Handles multiple groups correctly
@@ -179,15 +185,18 @@ describe('GP API Route - /api/tournaments/[id]/gp', () => {
         { playerId: 'p4', group: 'B' },
       ];
 
-      (prisma.gPQualification.create as jest.Mock).mockResolvedValue({ id: 'q1' });
-      (prisma.gPMatch.create as jest.Mock).mockResolvedValue({ id: 'm1' });
+      (prisma.gPQualification.createMany as jest.Mock).mockResolvedValue({ count: 4 });
+      (prisma.gPQualification.findMany as jest.Mock).mockResolvedValue([{ id: 'q1' }]);
+      (prisma.gPMatch.createMany as jest.Mock).mockResolvedValue({ count: 2 });
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp', { players: mockPlayers });
       const params = Promise.resolve({ id: 't1' });
       const result = await POST(request, { params });
 
       expect(result.status).toBe(201);
-      expect(prisma.gPMatch.create).toHaveBeenCalledTimes(2);
+      // Two groups → one createMany call carrying both groups' matches.
+      expect(prisma.gPMatch.createMany).toHaveBeenCalledTimes(1);
+      expect((prisma.gPMatch.createMany as jest.Mock).mock.calls[0][0].data).toHaveLength(2);
     });
 
     // Authorization failure case - Returns 403 when user is not authenticated
@@ -298,8 +307,9 @@ describe('GP API Route - /api/tournaments/[id]/gp', () => {
         { playerId: 'p3', group: 'A' },
       ];
 
-      (prisma.gPQualification.create as jest.Mock).mockResolvedValue({ id: 'q1' });
-      (prisma.gPMatch.create as jest.Mock).mockResolvedValue({ id: 'm1' });
+      (prisma.gPQualification.createMany as jest.Mock).mockResolvedValue({ count: 3 });
+      (prisma.gPQualification.findMany as jest.Mock).mockResolvedValue([{ id: 'q1' }]);
+      (prisma.gPMatch.createMany as jest.Mock).mockResolvedValue({ count: 6 });
       // BYE stat recalculation: each BYE recipient's completed matches are fetched
       (prisma.gPMatch.findMany as jest.Mock).mockResolvedValue([]);
       (prisma.gPQualification.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
@@ -309,7 +319,9 @@ describe('GP API Route - /api/tournaments/[id]/gp', () => {
       const result = await POST(request, { params });
 
       expect(result.status).toBe(201);
-      expect(prisma.gPMatch.create).toHaveBeenCalledTimes(6);
+      // 3 players (odd) → BREAK added → 6 matches inserted in a single createMany call
+      expect(prisma.gPMatch.createMany).toHaveBeenCalledTimes(1);
+      expect((prisma.gPMatch.createMany as jest.Mock).mock.calls[0][0].data).toHaveLength(6);
     });
   });
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
@@ -168,7 +168,9 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
       ];
 
       (prisma.mRQualification.findMany as jest.Mock).mockResolvedValue(mockQualifications);
-      (prisma.mRMatch.create as jest.Mock).mockResolvedValue({ id: 'm1', player1: { id: 'p1' }, player2: { id: 'p8' } });
+      // Issue #420: bracket inserted in one createMany then re-fetched.
+      (prisma.mRMatch.createMany as jest.Mock).mockResolvedValue({ count: 17 });
+      (prisma.mRMatch.findMany as jest.Mock).mockResolvedValue([]);
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', { topN: 8 });
       const params = Promise.resolve({ id: 't1' });
@@ -182,7 +184,7 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
       });
       // Source returns 201 for successful resource creation (POST)
       expect(result.status).toBe(201);
-      expect(prisma.mRMatch.create).toHaveBeenCalled();
+      expect(prisma.mRMatch.createMany).toHaveBeenCalled();
     });
 
     // Success case - Uses default topN=8 when not provided
@@ -200,7 +202,8 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
       ];
 
       (prisma.mRQualification.findMany as jest.Mock).mockResolvedValue(mockQualifications);
-      (prisma.mRMatch.create as jest.Mock).mockResolvedValue({ id: 'm1', player1: { id: 'p1' }, player2: { id: 'p8' } });
+      (prisma.mRMatch.createMany as jest.Mock).mockResolvedValue({ count: 17 });
+      (prisma.mRMatch.findMany as jest.Mock).mockResolvedValue([]);
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', {});
       const params = Promise.resolve({ id: 't1' });

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
@@ -149,17 +149,21 @@ describe('MR API Route - /api/tournaments/[id]/mr', () => {
       ];
       const _mockQualifications = [{ id: 'q1', tournamentId: 't1', playerId: 'p1', group: 'A' }];
 
-      (prisma.mRQualification.create as jest.Mock).mockResolvedValue({ id: 'q1' });
-      (prisma.mRMatch.create as jest.Mock).mockResolvedValue({ id: 'm1' });
+      // Issue #420: setup now uses createMany + a findMany re-fetch.
+      (prisma.mRQualification.createMany as jest.Mock).mockResolvedValue({ count: 2 });
+      (prisma.mRQualification.findMany as jest.Mock).mockResolvedValue([{ id: 'q1' }, { id: 'q2' }]);
+      (prisma.mRMatch.createMany as jest.Mock).mockResolvedValue({ count: 1 });
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr', { players: mockPlayers });
       const params = Promise.resolve({ id: 't1' });
       const result = await POST(request, { params });
 
-      expect(result.data).toEqual({ message: 'Match race setup complete', qualifications: expect.any(Array) });
+      expect(result.data).toEqual({ success: true, data: { message: 'Match race setup complete', qualifications: expect.any(Array) } });
       expect(result.status).toBe(201);
-      expect(prisma.mRQualification.create).toHaveBeenCalledTimes(2);
-      expect(prisma.mRMatch.create).toHaveBeenCalledTimes(1);
+      expect(prisma.mRQualification.createMany).toHaveBeenCalledTimes(1);
+      expect((prisma.mRQualification.createMany as jest.Mock).mock.calls[0][0].data).toHaveLength(2);
+      expect(prisma.mRMatch.createMany).toHaveBeenCalledTimes(1);
+      expect((prisma.mRMatch.createMany as jest.Mock).mock.calls[0][0].data).toHaveLength(1);
     });
 
     // Success case - Handles multiple groups correctly
@@ -174,15 +178,18 @@ describe('MR API Route - /api/tournaments/[id]/mr', () => {
         { playerId: 'p4', group: 'B' },
       ];
 
-      (prisma.mRQualification.create as jest.Mock).mockResolvedValue({ id: 'q1' });
-      (prisma.mRMatch.create as jest.Mock).mockResolvedValue({ id: 'm1' });
+      (prisma.mRQualification.createMany as jest.Mock).mockResolvedValue({ count: 4 });
+      (prisma.mRQualification.findMany as jest.Mock).mockResolvedValue([{ id: 'q1' }]);
+      (prisma.mRMatch.createMany as jest.Mock).mockResolvedValue({ count: 2 });
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr', { players: mockPlayers });
       const params = Promise.resolve({ id: 't1' });
       const result = await POST(request, { params });
 
       expect(result.status).toBe(201);
-      expect(prisma.mRMatch.create).toHaveBeenCalledTimes(2);
+      // Two groups → one createMany call carrying both groups' matches.
+      expect(prisma.mRMatch.createMany).toHaveBeenCalledTimes(1);
+      expect((prisma.mRMatch.createMany as jest.Mock).mock.calls[0][0].data).toHaveLength(2);
     });
 
     // Authorization failure case - Returns 403 when user is not authenticated

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/route.test.ts
@@ -295,8 +295,18 @@ describe('/api/tournaments/[id]/ta', () => {
         player: { id: VALID_UUID2, nickname: 'TestPlayer' },
       };
 
-      (prisma.tTEntry.findUnique as jest.Mock).mockResolvedValue(null);
-      (prisma.tTEntry.create as jest.Mock).mockResolvedValue(mockEntry);
+      /*
+       * Issue #420: bulk insert path. POST now does:
+       *   1. findFirst (knockout-stage check)
+       *   2. findMany — duplicate-detection scan over playerIds
+       *   3. createMany — bulk insert of new entries
+       *   4. findMany — re-fetch with includes for response payload
+       * Mock the two findMany calls in order.
+       */
+      (prisma.tTEntry.findMany as jest.Mock)
+        .mockResolvedValueOnce([])           // duplicate-detection: nothing exists
+        .mockResolvedValueOnce([mockEntry]); // re-fetch with player include
+      (prisma.tTEntry.createMany as jest.Mock).mockResolvedValue({ count: 1 });
 
       await taRoute.POST(
         new NextRequest(`http://localhost:3000/api/tournaments/${VALID_UUID}/ta`, {
@@ -306,15 +316,14 @@ describe('/api/tournaments/[id]/ta', () => {
         { params: Promise.resolve({ id: VALID_UUID }) }
       );
 
-      expect(prisma.tTEntry.create).toHaveBeenCalledWith({
-        data: {
+      expect(prisma.tTEntry.createMany).toHaveBeenCalledWith({
+        data: [{
           tournamentId: VALID_UUID,
           playerId: VALID_UUID2,
           stage: 'qualification',
           times: {},
           seeding: null,
-        },
-        include: { player: true },
+        }],
       });
 
       expect(NextResponse.json).toHaveBeenCalledWith(
@@ -341,7 +350,7 @@ describe('/api/tournaments/[id]/ta', () => {
         { success: false, error: 'Cannot add players after knockout stage has started', code: 'CONFLICT' },
         { status: 409 }
       );
-      expect(prisma.tTEntry.create).not.toHaveBeenCalled();
+      expect(prisma.tTEntry.createMany).not.toHaveBeenCalled();
     });
 
     it('should return 409 when player tries to self-register after knockout has started', async () => {
@@ -362,7 +371,7 @@ describe('/api/tournaments/[id]/ta', () => {
         { success: false, error: 'Cannot add players after knockout stage has started', code: 'CONFLICT' },
         { status: 409 }
       );
-      expect(prisma.tTEntry.create).not.toHaveBeenCalled();
+      expect(prisma.tTEntry.createMany).not.toHaveBeenCalled();
     });
 
     it('should resolve tournament slug for POST', async () => {
@@ -370,14 +379,16 @@ describe('/api/tournaments/[id]/ta', () => {
       (auth as jest.Mock).mockResolvedValue({
         user: { id: 'admin-1', email: 'admin@example.com', role: 'admin' },
       });
-      (prisma.tTEntry.findUnique as jest.Mock).mockResolvedValue(null);
-      (prisma.tTEntry.create as jest.Mock).mockResolvedValue({
-        id: VALID_ENTRY_ID,
-        tournamentId: VALID_UUID,
-        playerId: VALID_UUID2,
-        stage: 'qualification',
-        player: { nickname: 'Player' },
-      });
+      (prisma.tTEntry.findMany as jest.Mock)
+        .mockResolvedValueOnce([])  // duplicate-detection
+        .mockResolvedValueOnce([{
+          id: VALID_ENTRY_ID,
+          tournamentId: VALID_UUID,
+          playerId: VALID_UUID2,
+          stage: 'qualification',
+          player: { nickname: 'Player' },
+        }]);
+      (prisma.tTEntry.createMany as jest.Mock).mockResolvedValue({ count: 1 });
 
       await taRoute.POST(
         new NextRequest('http://localhost:3000/api/tournaments/jsmkc2026/ta', {
@@ -387,11 +398,11 @@ describe('/api/tournaments/[id]/ta', () => {
         { params: Promise.resolve({ id: 'jsmkc2026' }) }
       );
 
-      expect(prisma.tTEntry.create).toHaveBeenCalledWith(
+      expect(prisma.tTEntry.createMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({
-            tournamentId: VALID_UUID,
-          }),
+          data: expect.arrayContaining([
+            expect.objectContaining({ tournamentId: VALID_UUID }),
+          ]),
         })
       );
     });
@@ -470,8 +481,10 @@ describe('/api/tournaments/[id]/ta', () => {
         player: { id: VALID_UUID2, nickname: 'TestPlayer' },
       };
 
-      (prisma.tTEntry.findUnique as jest.Mock).mockResolvedValue(null);
-      (prisma.tTEntry.create as jest.Mock).mockResolvedValue(mockEntry);
+      (prisma.tTEntry.findMany as jest.Mock)
+        .mockResolvedValueOnce([])           // duplicate-detection
+        .mockResolvedValueOnce([mockEntry]); // re-fetch with player include
+      (prisma.tTEntry.createMany as jest.Mock).mockResolvedValue({ count: 1 });
 
       await taRoute.POST(
         new NextRequest(`http://localhost:3000/api/tournaments/${VALID_UUID}/ta`, {

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -404,7 +404,10 @@ describe('Finals Route Factory', () => {
       });
       (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(8));
       (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });
-      (prisma.bMMatch as any).create.mockResolvedValue(createMockMatch());
+      // Issue #420: bracket inserted in a single createMany; the inserted rows
+      // are then re-fetched with includes via findMany for the response shape.
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 17 });
+      (prisma.bMMatch as any).findMany.mockResolvedValue([]);
 
       const config = createMockConfig({ postRequiresAuth: true });
       const { POST } = createFinalsHandlers(config);
@@ -427,7 +430,8 @@ describe('Finals Route Factory', () => {
       mockAuth.mockResolvedValue(null);
       (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(8));
       (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });
-      (prisma.bMMatch as any).create.mockResolvedValue(createMockMatch());
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 17 });
+      (prisma.bMMatch as any).findMany.mockResolvedValue([]);
 
       const config = createMockConfig({ postRequiresAuth: false });
       const { POST } = createFinalsHandlers(config);
@@ -446,7 +450,8 @@ describe('Finals Route Factory', () => {
     it('should create 8-player bracket when topN is 8', async () => {
       (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(8));
       (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });
-      (prisma.bMMatch as any).create.mockResolvedValue(createMockMatch());
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 17 });
+      (prisma.bMMatch as any).findMany.mockResolvedValue([]);
 
       const config = createMockConfig();
       const { POST } = createFinalsHandlers(config);
@@ -461,7 +466,10 @@ describe('Finals Route Factory', () => {
 
       expect(response.status).toBe(201);
       expect(mockGenerateBracketStructure).toHaveBeenCalledWith(8);
-      expect((prisma.bMMatch as any).create).toHaveBeenCalledTimes(17); // 17 matches in 8-player bracket
+      // Issue #420: all 17 bracket matches are inserted in one createMany call
+      expect((prisma.bMMatch as any).createMany).toHaveBeenCalledTimes(1);
+      const call = (prisma.bMMatch as any).createMany.mock.calls[0][0];
+      expect(call.data).toHaveLength(17);
     });
 
     it('should return 400 when topN is not 8', async () => {
@@ -545,7 +553,8 @@ describe('Finals Route Factory', () => {
     it('should sanitize body when sanitizePostBody is true', async () => {
       (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(8));
       (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });
-      (prisma.bMMatch as any).create.mockResolvedValue(createMockMatch());
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 17 });
+      (prisma.bMMatch as any).findMany.mockResolvedValue([]);
       mockSanitizeInput.mockReturnValue({ topN: 8 });
 
       const config = createMockConfig({ sanitizePostBody: true });

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -202,8 +202,14 @@ describe('Qualification Route Factory', () => {
     it('should create round-robin matches from players array', async () => {
       const players = createMockPlayers();
 
-      (prisma.bMQualification as any).create.mockResolvedValue({ id: 'qual-1' });
-      (prisma.bMMatch as any).create.mockResolvedValue({ id: 'match-1' });
+      /*
+       * Issue #420: qualification + match creation switched to createMany.
+       * Tests now assert one createMany call per model, with the data array
+       * matching the expected count and shape.
+       */
+      (prisma.bMQualification as any).createMany.mockResolvedValue({ count: 4 });
+      (prisma.bMQualification as any).findMany.mockResolvedValue([{ id: 'qual-1' }]);
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 2 });
 
       const config = createMockConfig();
       const { POST } = createQualificationHandlers(config);
@@ -220,22 +226,30 @@ describe('Qualification Route Factory', () => {
 
       // Group A: player-1 vs player-2 (1 match via circle method)
       // Group B: player-3 vs player-4 (1 match via circle method)
-      // Total: 4 qualification records + 2 matches
-      expect((prisma.bMQualification as any).create).toHaveBeenCalledTimes(4);
-      expect((prisma.bMMatch as any).create).toHaveBeenCalledTimes(2);
-
-      // Verify match generation includes round-robin fields (roundNumber, player1Side, etc.)
-      expect((prisma.bMMatch as any).create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          tournamentId: 'tournament-123',
-          matchNumber: 1,
-          stage: 'qualification',
-          roundNumber: 1,
-          isBye: false,
-          player1Side: 1,
-          player2Side: 2,
-        }),
+      // Total: 4 qualification records (1 createMany call) + 2 matches (1 createMany call)
+      expect((prisma.bMQualification as any).createMany).toHaveBeenCalledTimes(1);
+      expect((prisma.bMQualification as any).createMany).toHaveBeenCalledWith({
+        data: expect.arrayContaining([
+          expect.objectContaining({ tournamentId: 'tournament-123', playerId: 'player-1', group: 'A' }),
+          expect.objectContaining({ tournamentId: 'tournament-123', playerId: 'player-4', group: 'B' }),
+        ]),
       });
+      const qualCall = (prisma.bMQualification as any).createMany.mock.calls[0][0];
+      expect(qualCall.data).toHaveLength(4);
+
+      expect((prisma.bMMatch as any).createMany).toHaveBeenCalledTimes(1);
+      const matchCall = (prisma.bMMatch as any).createMany.mock.calls[0][0];
+      expect(matchCall.data).toHaveLength(2);
+      // Verify match generation includes round-robin fields (roundNumber, player1Side, etc.)
+      expect(matchCall.data[0]).toEqual(expect.objectContaining({
+        tournamentId: 'tournament-123',
+        matchNumber: 1,
+        stage: 'qualification',
+        roundNumber: 1,
+        isBye: false,
+        player1Side: 1,
+        player2Side: 2,
+      }));
     });
 
     it('should handle multiple groups and generate round-robin matches within each', async () => {
@@ -247,8 +261,9 @@ describe('Qualification Route Factory', () => {
         { playerId: 'player-5', group: 'B', seeding: 2 }, // Group B: 2 players, 1 match (4v5)
       ];
 
-      (prisma.bMQualification as any).create.mockResolvedValue({ id: 'qual-1' });
-      (prisma.bMMatch as any).create.mockResolvedValue({ id: 'match-1' });
+      (prisma.bMQualification as any).createMany.mockResolvedValue({ count: 5 });
+      (prisma.bMQualification as any).findMany.mockResolvedValue([]);
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 7 });
 
       const config = createMockConfig();
       const { POST } = createQualificationHandlers(config);
@@ -264,15 +279,17 @@ describe('Qualification Route Factory', () => {
       expect(response.status).toBe(201);
       // Group A: 3 players (odd) → BREAK added → 3 days × 2 matches = 6 (3 real + 3 bye)
       // Group B: 2 players → 1 day × 1 match = 1
-      // Total: 6 + 1 = 7
-      expect((prisma.bMMatch as any).create).toHaveBeenCalledTimes(7);
+      // Total: 6 + 1 = 7 matches inserted in a single createMany call
+      const matchCall = (prisma.bMMatch as any).createMany.mock.calls[0][0];
+      expect(matchCall.data).toHaveLength(7);
     });
 
     it('should create audit log when auditAction is configured', async () => {
       const players = createMockPlayers();
 
-      (prisma.bMQualification as any).create.mockResolvedValue({ id: 'qual-1' });
-      (prisma.bMMatch as any).create.mockResolvedValue({ id: 'match-1' });
+      (prisma.bMQualification as any).createMany.mockResolvedValue({ count: 4 });
+      (prisma.bMQualification as any).findMany.mockResolvedValue([]);
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 2 });
       mockAuth.mockResolvedValue({
         user: {
           id: 'user-1',
@@ -366,8 +383,9 @@ describe('Qualification Route Factory', () => {
     it('should log warning when audit log creation fails (non-critical)', async () => {
       const players = createMockPlayers();
 
-      (prisma.bMQualification as any).create.mockResolvedValue({ id: 'qual-1' });
-      (prisma.bMMatch as any).create.mockResolvedValue({ id: 'match-1' });
+      (prisma.bMQualification as any).createMany.mockResolvedValue({ count: 4 });
+      (prisma.bMQualification as any).findMany.mockResolvedValue([]);
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 2 });
       mockAuth.mockResolvedValue({
         user: {
           id: 'user-1',
@@ -400,8 +418,9 @@ describe('Qualification Route Factory', () => {
     it('should apply sanitizeInput to request body', async () => {
       const players = createMockPlayers();
 
-      (prisma.bMQualification as any).create.mockResolvedValue({ id: 'qual-1' });
-      (prisma.bMMatch as any).create.mockResolvedValue({ id: 'match-1' });
+      (prisma.bMQualification as any).createMany.mockResolvedValue({ count: 4 });
+      (prisma.bMQualification as any).findMany.mockResolvedValue([]);
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 2 });
       mockSanitizeInput.mockImplementation((input) => {
         if (typeof input === 'string') {
           return input.replace(/<script>/g, '');
@@ -437,8 +456,9 @@ describe('Qualification Route Factory', () => {
         { playerId: 'player-3', group: 'A' }, // Odd group → BREAK added → 3 BYE matches generated
       ];
 
-      (prisma.bMQualification as any).create.mockResolvedValue({ id: 'qual-1' });
-      (prisma.bMMatch as any).create.mockResolvedValue({ id: 'match-1' });
+      (prisma.bMQualification as any).createMany.mockResolvedValue({ count: 3 });
+      (prisma.bMQualification as any).findMany.mockResolvedValue([]);
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 6 });
       /*
        * findMany is called once per BYE recipient to fetch their completed matches.
        * Return a BYE match for each player (simplified - same data for all 3 calls).
@@ -484,8 +504,9 @@ describe('Qualification Route Factory', () => {
         { playerId: 'player-1', group: 'A', seeding: 1 }, // seeding 1 listed second
       ];
 
-      (prisma.bMQualification as any).create.mockResolvedValue({ id: 'qual-1' });
-      (prisma.bMMatch as any).create.mockResolvedValue({ id: 'match-1' });
+      (prisma.bMQualification as any).createMany.mockResolvedValue({ count: 2 });
+      (prisma.bMQualification as any).findMany.mockResolvedValue([]);
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 1 });
 
       const config = createMockConfig();
       const { POST } = createQualificationHandlers(config);
@@ -497,13 +518,12 @@ describe('Qualification Route Factory', () => {
       await POST(request, { params: Promise.resolve({ id: 'tournament-123' }) });
 
       // player-1 (seeding:1) must be player1 even though player-2 was listed first.
-      expect((prisma.bMMatch as any).create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          matchNumber: 1,
-          player1Id: 'player-1',
-          player2Id: 'player-2',
-        }),
-      });
+      const matchCall = (prisma.bMMatch as any).createMany.mock.calls[0][0];
+      expect(matchCall.data[0]).toEqual(expect.objectContaining({
+        matchNumber: 1,
+        player1Id: 'player-1',
+        player2Id: 'player-2',
+      }));
     });
 
     // Course assignment tests (§10.5)
@@ -520,13 +540,13 @@ describe('Qualification Route Factory', () => {
       ];
 
       (prisma.mRQualification as any) = {
-        create: jest.fn().mockResolvedValue({ id: 'qual-1' }),
+        createMany: jest.fn().mockResolvedValue({ count: 2 }),
         deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
         updateMany: jest.fn().mockResolvedValue({ count: 1 }),
         findMany: jest.fn().mockResolvedValue([]),
       };
       (prisma.mRMatch as any) = {
-        create: jest.fn().mockResolvedValue({ id: 'match-1' }),
+        createMany: jest.fn().mockResolvedValue({ count: 1 }),
         deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
         findMany: jest.fn().mockResolvedValue([]),
       };
@@ -546,13 +566,11 @@ describe('Qualification Route Factory', () => {
       await POST(request, { params: Promise.resolve({ id: 'tournament-123' }) });
 
       // Each match must have assignedCourses: array of 4 course abbreviations
-      expect((prisma.mRMatch as any).create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          assignedCourses: expect.arrayContaining([expect.any(String)]),
-        }),
-      });
-      const createCall = (prisma.mRMatch as any).create.mock.calls[0];
-      expect(createCall[0].data.assignedCourses).toHaveLength(4);
+      const createCall = (prisma.mRMatch as any).createMany.mock.calls[0];
+      expect(createCall[0].data[0]).toEqual(expect.objectContaining({
+        assignedCourses: expect.arrayContaining([expect.any(String)]),
+      }));
+      expect(createCall[0].data[0].assignedCourses).toHaveLength(4);
     });
 
     // Cup assignment tests (§7.4)
@@ -571,13 +589,13 @@ describe('Qualification Route Factory', () => {
       const cupList = ['Mushroom', 'Flower', 'Star', 'Special'] as const;
 
       (prisma.gPQualification as any) = {
-        create: jest.fn().mockResolvedValue({ id: 'qual-1' }),
+        createMany: jest.fn().mockResolvedValue({ count: 2 }),
         deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
         updateMany: jest.fn().mockResolvedValue({ count: 1 }),
         findMany: jest.fn().mockResolvedValue([]),
       };
       (prisma.gPMatch as any) = {
-        create: jest.fn().mockResolvedValue({ id: 'match-1' }),
+        createMany: jest.fn().mockResolvedValue({ count: 1 }),
         deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
         findMany: jest.fn().mockResolvedValue([]),
       };
@@ -598,9 +616,9 @@ describe('Qualification Route Factory', () => {
       await POST(request, { params: Promise.resolve({ id: 'tournament-123' }) });
 
       // Each match must have a cup field with a valid cup name
-      const createCall = (prisma.gPMatch as any).create.mock.calls[0];
-      expect(createCall[0].data.cup).toBeDefined();
-      expect(cupList).toContain(createCall[0].data.cup);
+      const createCall = (prisma.gPMatch as any).createMany.mock.calls[0];
+      expect(createCall[0].data[0].cup).toBeDefined();
+      expect(cupList).toContain(createCall[0].data[0].cup);
     });
 
     it('should cycle cups via modulo when there are more matches than cups', async () => {
@@ -617,13 +635,13 @@ describe('Qualification Route Factory', () => {
       const cupList = ['Mushroom', 'Flower', 'Star', 'Special'] as const;
 
       (prisma.gPQualification as any) = {
-        create: jest.fn().mockResolvedValue({ id: 'qual-1' }),
+        createMany: jest.fn().mockResolvedValue({ count: 3 }),
         deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
         updateMany: jest.fn().mockResolvedValue({ count: 1 }),
         findMany: jest.fn().mockResolvedValue([]),
       };
       (prisma.gPMatch as any) = {
-        create: jest.fn().mockResolvedValue({ id: 'match-1' }),
+        createMany: jest.fn().mockResolvedValue({ count: 6 }),
         deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
         findMany: jest.fn().mockResolvedValue([
           { id: 'bye-1', player1Id: 'player-1', player2Id: '__BREAK__', score1: 45, score2: 0, completed: true, isBye: true },
@@ -646,17 +664,20 @@ describe('Qualification Route Factory', () => {
       await POST(request, { params: Promise.resolve({ id: 'tournament-123' }) });
 
       // 3 players (odd) → BREAK added → 4 participants → 3 days × 2 matches = 6 matches
-      const createCalls = (prisma.gPMatch as any).create.mock.calls;
-      expect(createCalls.length).toBe(6);
+      const createCall = (prisma.gPMatch as any).createMany.mock.calls[0];
+      expect(createCall[0].data.length).toBe(6);
 
-      // All cups must be from cupList and all 4 cups must appear at least once
-      const assignedCups = createCalls.map((c: any) => c[0].data.cup);
-      assignedCups.forEach((cup: string) => {
+      // BYE matches are auto-completed and skip cup assignment, so only real
+      // matches carry a cup. Filter out the byes before asserting cup coverage.
+      const realMatchCups = createCall[0].data
+        .filter((m: any) => !m.isBye)
+        .map((m: any) => m.cup);
+      realMatchCups.forEach((cup: string) => {
         expect(cupList).toContain(cup);
       });
-      // With 6 matches and 4 cups, all 4 cups appear (4 unique + 2 wrapping)
-      const uniqueCups = new Set(assignedCups);
-      expect(uniqueCups.size).toBe(4);
+      // With 3 real matches drawn from 4 shuffled cups, all should be unique.
+      const uniqueCups = new Set(realMatchCups);
+      expect(uniqueCups.size).toBe(realMatchCups.length);
     });
 
     it('should NOT assign cup when assignCupRandomly is not set (BM/MR)', async () => {
@@ -669,8 +690,9 @@ describe('Qualification Route Factory', () => {
         { playerId: 'player-2', group: 'A', seeding: 2 },
       ];
 
-      (prisma.bMQualification as any).create.mockResolvedValue({ id: 'qual-1' });
-      (prisma.bMMatch as any).create.mockResolvedValue({ id: 'match-1' });
+      (prisma.bMQualification as any).createMany.mockResolvedValue({ count: 2 });
+      (prisma.bMQualification as any).findMany.mockResolvedValue([]);
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 1 });
 
       // Default BM config has no assignCupRandomly
       const config = createMockConfig();
@@ -683,8 +705,8 @@ describe('Qualification Route Factory', () => {
       await POST(request, { params: Promise.resolve({ id: 'tournament-123' }) });
 
       // No cup for BM matches
-      const createCall = (prisma.bMMatch as any).create.mock.calls[0];
-      expect(createCall[0].data.cup).toBeUndefined();
+      const createCall = (prisma.bMMatch as any).createMany.mock.calls[0];
+      expect(createCall[0].data[0].cup).toBeUndefined();
     });
 
     it('should NOT assign courses when assignCoursesRandomly is false (BM/GP)', async () => {
@@ -697,8 +719,9 @@ describe('Qualification Route Factory', () => {
         { playerId: 'player-2', group: 'A', seeding: 2 },
       ];
 
-      (prisma.bMQualification as any).create.mockResolvedValue({ id: 'qual-1' });
-      (prisma.bMMatch as any).create.mockResolvedValue({ id: 'match-1' });
+      (prisma.bMQualification as any).createMany.mockResolvedValue({ count: 2 });
+      (prisma.bMQualification as any).findMany.mockResolvedValue([]);
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 1 });
 
       // Default BM config has no assignCoursesRandomly
       const config = createMockConfig();
@@ -711,8 +734,8 @@ describe('Qualification Route Factory', () => {
       await POST(request, { params: Promise.resolve({ id: 'tournament-123' }) });
 
       // No assignedCourses for BM matches
-      const createCall = (prisma.bMMatch as any).create.mock.calls[0];
-      expect(createCall[0].data.assignedCourses).toBeUndefined();
+      const createCall = (prisma.bMMatch as any).createMany.mock.calls[0];
+      expect(createCall[0].data[0].assignedCourses).toBeUndefined();
     });
 
     it('should succeed on re-setup when qualifications already exist (group edit)', async () => {
@@ -730,9 +753,10 @@ describe('Qualification Route Factory', () => {
         { playerId: 'player-2', group: 'A', seeding: 2 },
       ];
 
-      (prisma.mRQualification as any).create.mockResolvedValue({ id: 'new-qual' });
+      (prisma.mRQualification as any).createMany.mockResolvedValue({ count: 2 });
+      (prisma.mRQualification as any).findMany.mockResolvedValue([]);
       (prisma.mRQualification as any).deleteMany.mockResolvedValue({ count: 2 });
-      (prisma.mRMatch as any).create.mockResolvedValue({ id: 'new-match' });
+      (prisma.mRMatch as any).createMany.mockResolvedValue({ count: 1 });
       (prisma.mRMatch as any).deleteMany.mockResolvedValue({ count: 1 });
 
       const config = createMockConfig({
@@ -761,9 +785,9 @@ describe('Qualification Route Factory', () => {
       });
       /* Verify delete-before-create order via mock invocation timing */
       const qualDeleteOrder = (prisma.mRQualification as any).deleteMany.mock.invocationCallOrder[0];
-      const qualCreateOrder = (prisma.mRQualification as any).create.mock.invocationCallOrder[0];
+      const qualCreateOrder = (prisma.mRQualification as any).createMany.mock.invocationCallOrder[0];
       const matchDeleteOrder = (prisma.mRMatch as any).deleteMany.mock.invocationCallOrder[0];
-      const matchCreateOrder = (prisma.mRMatch as any).create.mock.invocationCallOrder[0];
+      const matchCreateOrder = (prisma.mRMatch as any).createMany.mock.invocationCallOrder[0];
       expect(qualDeleteOrder).toBeLessThan(qualCreateOrder);
       expect(matchDeleteOrder).toBeLessThan(matchCreateOrder);
     });

--- a/smkc-score-app/jest.setup.js
+++ b/smkc-score-app/jest.setup.js
@@ -110,6 +110,7 @@ jest.mock('@/lib/prisma', () => {
     groupBy: jest.fn(),
     findUnique: jest.fn(),
     create: jest.fn(),
+    createMany: jest.fn(),
     update: jest.fn(),
     updateMany: jest.fn(),
     delete: jest.fn(),

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
@@ -20,6 +20,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import type { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { createAuditLog, AUDIT_ACTIONS } from "@/lib/audit-log";
 import { getClientIdentifier, getUserAgent } from "@/lib/request-utils";
@@ -282,7 +283,9 @@ export async function POST(
      * the per-row id; that's acceptable since the create itself is the
      * dominant cost the user perceives.
      */
-    let createdEntries: Awaited<ReturnType<typeof prisma.tTEntry.findMany>> = [];
+    // Explicit payload type so TypeScript knows `.player.nickname` is
+    // safe on each entry after the later findMany runs with the include.
+    let createdEntries: Prisma.TTEntryGetPayload<{ include: { player: true } }>[] = [];
 
     if (playerIds.length > 0) {
       const existingEntries = await prisma.tTEntry.findMany({
@@ -333,7 +336,7 @@ export async function POST(
                 details: {
                   tournamentId,
                   playerId: entry.playerId,
-                  playerNickname: (entry as typeof entry & { player: { nickname: string } }).player.nickname,
+                  playerNickname: entry.player.nickname,
                 },
               }),
             ),

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
@@ -272,52 +272,78 @@ export async function POST(
     const ipAddress = getClientIdentifier(request);
     const userAgent = getUserAgent(request);
 
-    const createdEntries = [];
+    /*
+     * Bulk player registration (issue #420). The previous implementation issued
+     * one findUnique + one create per player, so registering 16 players cost
+     * 32 sequential round-trips. Now we do a single findMany to detect
+     * existing entries, a single createMany to insert the new ones, and a
+     * single findMany to recover the inserted rows for the response payload.
+     * Audit logs are still written one-per-entry in parallel because they need
+     * the per-row id; that's acceptable since the create itself is the
+     * dominant cost the user perceives.
+     */
+    let createdEntries: Awaited<ReturnType<typeof prisma.tTEntry.findMany>> = [];
 
-    for (const pid of playerIds) {
-      // Check for existing entry to prevent duplicates (idempotency)
-      const existing = await prisma.tTEntry.findUnique({
+    if (playerIds.length > 0) {
+      const existingEntries = await prisma.tTEntry.findMany({
         where: {
-          tournamentId_playerId_stage: {
-            tournamentId,
-            playerId: pid,
-            stage: "qualification",
-          },
+          tournamentId,
+          stage: "qualification",
+          playerId: { in: playerIds },
         },
+        select: { playerId: true },
       });
+      const existingPlayerIds = new Set(existingEntries.map((e) => e.playerId));
+      const newPlayerIds = playerIds.filter((pid) => !existingPlayerIds.has(pid));
 
-      if (!existing) {
-        // Create qualification entry with empty times and optional seeding
-        const entry = await prisma.tTEntry.create({
-          data: {
+      if (newPlayerIds.length > 0) {
+        await prisma.tTEntry.createMany({
+          data: newPlayerIds.map((pid) => ({
             tournamentId,
             playerId: pid,
             stage: "qualification",
+            // Empty times object — typed as InputJsonValue at runtime via Prisma
             times: {},
             seeding: seedingMap.get(pid) ?? null,
+          })),
+        });
+
+        createdEntries = await prisma.tTEntry.findMany({
+          where: {
+            tournamentId,
+            stage: "qualification",
+            playerId: { in: newPlayerIds },
           },
           include: { player: true },
         });
-        createdEntries.push(entry);
 
-        // Audit log for accountability (non-critical, failure is logged)
+        // Audit logs in parallel. createAuditLog never throws (it catches
+        // and logs its own errors internally — see audit-log.ts), so wrap
+        // the whole batch in a defensive try/catch instead of per-promise.
         try {
-          await createAuditLog({
-            userId: authResult.session!.user.id!,
-            ipAddress,
-            userAgent,
-            action: AUDIT_ACTIONS.CREATE_TA_ENTRY,
-            targetId: entry.id,
-            targetType: "TTEntry",
-            details: {
-              tournamentId,
-              playerId: pid,
-              playerNickname: entry.player.nickname,
-            },
-          });
+          await Promise.all(
+            createdEntries.map((entry) =>
+              createAuditLog({
+                userId: authResult.session!.user.id!,
+                ipAddress,
+                userAgent,
+                action: AUDIT_ACTIONS.CREATE_TA_ENTRY,
+                targetId: entry.id,
+                targetType: "TTEntry",
+                details: {
+                  tournamentId,
+                  playerId: entry.playerId,
+                  playerNickname: (entry as typeof entry & { player: { nickname: string } }).player.nickname,
+                },
+              }),
+            ),
+          );
         } catch (logError) {
-          // Audit log failure is non-critical but should be logged for security tracking
-          logger.warn("Failed to create audit log", { error: logError, tournamentId, entryId: entry?.id, action: 'CREATE_TA_ENTRY' });
+          logger.warn("Failed to create audit log", {
+            error: logError,
+            tournamentId,
+            action: "CREATE_TA_ENTRY",
+          });
         }
       }
     }

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -255,16 +255,25 @@ export function createFinalsHandlers(config: FinalsConfig) {
         }),
       );
 
-      const createdMatches = [];
-      for (const bracketMatch of bracketStructure) {
+      /*
+       * Bulk-insert bracket matches (issue #420). Replaces a sequential
+       * for-loop of N create() calls with a single createMany() — for an
+       * 8-player bracket that's 17 round-trips collapsed into 1, and 31
+       * for a 16-player bracket. createMany on D1 doesn't return the
+       * inserted rows, so we re-fetch with includes after insertion to
+       * preserve the existing response shape (player1/player2 relations).
+       */
+      const matchPlans = bracketStructure.map((bracketMatch) => {
         const player1 = bracketMatch.player1Seed
           ? seededPlayers.find((p: { seed: number }) => p.seed === bracketMatch.player1Seed)
           : null;
         const player2 = bracketMatch.player2Seed
           ? seededPlayers.find((p: { seed: number }) => p.seed === bracketMatch.player2Seed)
           : null;
-
-        const match = await model(prisma).create({
+        return {
+          bracketMatch,
+          player1,
+          player2,
           data: {
             tournamentId,
             matchNumber: bracketMatch.matchNumber,
@@ -274,17 +283,35 @@ export function createFinalsHandlers(config: FinalsConfig) {
             player2Id: player2?.playerId || player1?.playerId || seededPlayers[0].playerId,
             completed: false,
           },
-          include: { player1: true, player2: true },
-        });
+        };
+      });
 
-        createdMatches.push({
-          ...match,
-          hasPlayer1: !!player1,
-          hasPlayer2: !!player2,
-          player1Seed: bracketMatch.player1Seed,
-          player2Seed: bracketMatch.player2Seed,
-        });
-      }
+      await model(prisma).createMany({ data: matchPlans.map((p) => p.data) });
+
+      const insertedMatches = await model(prisma).findMany({
+        where: { tournamentId, stage: 'finals' },
+        include: { player1: true, player2: true },
+        orderBy: { matchNumber: 'asc' },
+      });
+
+      // Map by matchNumber so we can attach the bracket metadata that's not
+      // stored in the DB (hasPlayer1/hasPlayer2/seed) to each fetched row.
+      const insertedByNumber = new Map<number, (typeof insertedMatches)[number]>(
+        insertedMatches.map((m: { matchNumber: number }) => [m.matchNumber, m]),
+      );
+      const createdMatches = matchPlans
+        .map((p) => {
+          const match = insertedByNumber.get(p.bracketMatch.matchNumber);
+          if (!match) return null;
+          return {
+            ...match,
+            hasPlayer1: !!p.player1,
+            hasPlayer2: !!p.player2,
+            player1Seed: p.bracketMatch.player1Seed,
+            player2Seed: p.bracketMatch.player2Seed,
+          };
+        })
+        .filter((m): m is NonNullable<typeof m> => m !== null);
 
       return NextResponse.json(
         {

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -194,14 +194,26 @@ export function createQualificationHandlers(config: EventTypeConfig) {
         where: { tournamentId },
       });
 
-      /* Create qualification records for each player */
-      const qualifications = await Promise.all(
-        players.map((p: { playerId: string; group: string; seeding?: number }) =>
-          qualModel(prisma).create({
-            data: { tournamentId, playerId: p.playerId, group: p.group, seeding: p.seeding },
-          }),
-        ),
+      /*
+       * Bulk-insert qualification records (issue #420).
+       * Single createMany call replaces N parallel create() calls — turning
+       * 32 round-trips (4 groups × 8 players) into 1 SQL statement on D1.
+       * createMany doesn't return inserted rows on SQLite/D1, so we follow
+       * up with one findMany() to recover IDs for the response payload.
+       */
+      const qualData = players.map(
+        (p: { playerId: string; group: string; seeding?: number }) => ({
+          tournamentId,
+          playerId: p.playerId,
+          group: p.group,
+          seeding: p.seeding,
+        }),
       );
+      await qualModel(prisma).createMany({ data: qualData });
+      const qualifications = await qualModel(prisma).findMany({
+        where: { tournamentId },
+        orderBy: config.qualificationOrderBy,
+      });
 
       /*
        * Generate round-robin matches using the circle method.
@@ -237,6 +249,13 @@ export function createQualificationHandlers(config: EventTypeConfig) {
        * first real match is submitted via PUT (which triggers a full recalculation).
        */
       const byeRecipientIds: Set<string> = new Set();
+
+      /*
+       * Collect all match payloads in memory, then bulk-insert with a single
+       * createMany call (issue #420). For an 8-player single-group BM tournament
+       * this turns 28 sequential round-trips into 1 SQL statement.
+       */
+      const matchData: Array<Record<string, unknown>> = [];
 
       for (const group of groups) {
         /*
@@ -281,24 +300,22 @@ export function createQualificationHandlers(config: EventTypeConfig) {
             ? shuffledCups[matchSequenceIndex % shuffledCups.length]
             : undefined;
 
-          await matchModel(prisma).create({
-            data: {
-              tournamentId,
-              matchNumber,
-              stage: 'qualification',
-              player1Id: p1Id,
-              player2Id: p2Id,
-              player1Side: 1,
-              player2Side: 2,
-              roundNumber: m.day,
-              isBye: m.isBye,
-              /* Pre-assigned courses for the match (undefined for BM/GP without course assignment) */
-              ...(assignedCourses ? { assignedCourses } : {}),
-              /* Pre-assigned cup for the match (undefined for BM/MR without cup assignment) */
-              ...(assignedCup ? { cup: assignedCup } : {}),
-              /* Auto-complete BYE matches with fixed scores (§10.2) */
-              ...(m.isBye ? { completed: true, ...byeData } : {}),
-            },
+          matchData.push({
+            tournamentId,
+            matchNumber,
+            stage: 'qualification',
+            player1Id: p1Id,
+            player2Id: p2Id,
+            player1Side: 1,
+            player2Side: 2,
+            roundNumber: m.day,
+            isBye: m.isBye,
+            /* Pre-assigned courses for the match (undefined for BM/GP without course assignment) */
+            ...(assignedCourses ? { assignedCourses } : {}),
+            /* Pre-assigned cup for the match (undefined for BM/MR without cup assignment) */
+            ...(assignedCup ? { cup: assignedCup } : {}),
+            /* Auto-complete BYE matches with fixed scores (§10.2) */
+            ...(m.isBye ? { completed: true, ...byeData } : {}),
           });
 
           if (m.isBye) {
@@ -309,6 +326,10 @@ export function createQualificationHandlers(config: EventTypeConfig) {
 
           matchNumber++;
         }
+      }
+
+      if (matchData.length > 0) {
+        await matchModel(prisma).createMany({ data: matchData });
       }
 
       /*

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -210,6 +210,12 @@ export function createQualificationHandlers(config: EventTypeConfig) {
         }),
       );
       await qualModel(prisma).createMany({ data: qualData });
+      /*
+       * Unqualified findMany is safe only because the deleteMany at the
+       * top of this handler cleared every qualification row for this
+       * tournament. If that delete is ever scoped down, this query must
+       * grow an additional filter or it will surface stale prior rows.
+       */
       const qualifications = await qualModel(prisma).findMany({
         where: { tournamentId },
         orderBy: config.qualificationOrderBy,


### PR DESCRIPTION
## Summary
This PR replaces sequential single-row database operations with bulk `createMany()` calls across qualification, match, and tournament entry creation endpoints. This significantly reduces database round-trips and improves performance for tournament setup operations.

## Key Changes

### Qualification & Match Creation (qualification-route.ts)
- Replaced N parallel `create()` calls with a single `createMany()` for qualification records
- Replaced sequential `create()` calls in match generation loop with a single `createMany()` for all matches
- Added `findMany()` re-fetch after bulk insert to recover IDs and maintain response shape (necessary because SQLite/D1 doesn't return inserted rows from `createMany()`)
- For an 8-player single-group tournament, this reduces ~28 round-trips to 2 SQL statements

### Tournament Entry Registration (ta/route.ts)
- Replaced per-player `findUnique()` + `create()` pattern with:
  - Single `findMany()` to detect existing entries
  - Single `createMany()` to insert new entries
  - Single `findMany()` to re-fetch with player relations for response
- Audit logs remain parallelized (acceptable since DB insert is the dominant cost)
- For 16-player registration, reduces from 32 sequential round-trips to 3 SQL statements

### Finals Bracket Creation (finals-route.ts)
- Replaced sequential bracket match creation loop with single `createMany()` call
- Added `findMany()` re-fetch with player relations to preserve response shape
- For 8-player bracket (17 matches), reduces from 17 round-trips to 2 SQL statements

### Test Updates
- Updated all test mocks to use `createMany()` instead of `create()`
- Added `findMany()` mock calls where needed for re-fetch operations
- Updated assertions to verify single `createMany()` call with correct data array length and shape
- Ensured test coverage for bulk operation behavior across BM, MR, and GP event types

## Implementation Details
- All bulk inserts maintain data integrity by collecting payloads in memory before insertion
- The `findMany()` re-fetch pattern is safe because prior `deleteMany()` calls clear tournament-scoped data
- Audit logging remains non-blocking and doesn't impact the critical path
- Response shapes are preserved by mapping re-fetched rows back to bracket/match metadata

https://claude.ai/code/session_01T3Vj7QPMFvnkJz8XXjPPW1