### PR TITLE
Add Top-24 pre-bracket playoff support (issue #454)

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -481,7 +481,9 @@ describe('Finals Route Factory', () => {
 
       expect(response.status).toBe(400);
       const json = await response.json();
-      expect(json.error).toBe('Only 8-player and 16-player brackets are supported');
+      expect(json.error).toBe(
+        'Only 8-player, 16-player, or 24-player (Top-16 + playoff) brackets are supported',
+      );
     });
 
     it('should return 400 when not enough players qualified', async () => {

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -43,7 +43,7 @@ jest.mock('@/lib/sanitize');
 jest.mock('@/lib/logger');
 
 import { auth } from '@/lib/auth';
-import { generateBracketStructure, roundNames } from '@/lib/double-elimination';
+import { generateBracketStructure, generatePlayoffStructure, roundNames } from '@/lib/double-elimination';
 import { paginate } from '@/lib/pagination';
 import { sanitizeInput } from '@/lib/sanitize';
 import { createLogger } from '@/lib/logger';
@@ -52,6 +52,7 @@ import prisma from '@/lib/prisma';
 describe('Finals Route Factory', () => {
   let mockAuth: jest.MockedFunction<typeof auth>;
   let mockGenerateBracketStructure: jest.MockedFunction<typeof generateBracketStructure>;
+  let mockGeneratePlayoffStructure: jest.MockedFunction<typeof generatePlayoffStructure>;
   let mockPaginate: jest.MockedFunction<typeof paginate>;
   let mockSanitizeInput: jest.MockedFunction<typeof sanitizeInput>;
   let mockLogger: ReturnType<typeof createLogger>;
@@ -105,6 +106,7 @@ describe('Finals Route Factory', () => {
     // Setup mocks
     mockAuth = auth as jest.MockedFunction<typeof auth>;
     mockGenerateBracketStructure = generateBracketStructure as jest.MockedFunction<typeof generateBracketStructure>;
+    mockGeneratePlayoffStructure = generatePlayoffStructure as jest.MockedFunction<typeof generatePlayoffStructure>;
     mockPaginate = paginate as jest.MockedFunction<typeof paginate>;
     mockSanitizeInput = sanitizeInput as jest.MockedFunction<typeof sanitizeInput>;
     mockLogger = {
@@ -157,6 +159,20 @@ describe('Finals Route Factory', () => {
 
     // Default bracket structure with 17 matches
     mockGenerateBracketStructure.mockReturnValue(createFullBracketStructure());
+
+    // Default playoff structure (issue #454) — 8 matches, 4 R1 + 4 R2.
+    // Mirrors real generatePlayoffStructure(12) so handleTop24Post tests
+    // exercise the real routing/mapping semantics end-to-end.
+    mockGeneratePlayoffStructure.mockReturnValue([
+      { matchNumber: 1, round: 'playoff_r1', bracket: 'winners', player1Seed: 8, player2Seed: 9, winnerGoesTo: 5, position: 2 },
+      { matchNumber: 2, round: 'playoff_r1', bracket: 'winners', player1Seed: 5, player2Seed: 12, winnerGoesTo: 6, position: 2 },
+      { matchNumber: 3, round: 'playoff_r1', bracket: 'winners', player1Seed: 6, player2Seed: 11, winnerGoesTo: 7, position: 2 },
+      { matchNumber: 4, round: 'playoff_r1', bracket: 'winners', player1Seed: 7, player2Seed: 10, winnerGoesTo: 8, position: 2 },
+      { matchNumber: 5, round: 'playoff_r2', bracket: 'winners', player1Seed: 1, advancesToUpperSeed: 16 },
+      { matchNumber: 6, round: 'playoff_r2', bracket: 'winners', player1Seed: 4, advancesToUpperSeed: 13 },
+      { matchNumber: 7, round: 'playoff_r2', bracket: 'winners', player1Seed: 3, advancesToUpperSeed: 14 },
+      { matchNumber: 8, round: 'playoff_r2', bracket: 'winners', player1Seed: 2, advancesToUpperSeed: 15 },
+    ]);
 
     // Default paginated result
     mockPaginate.mockResolvedValue({
@@ -566,6 +582,208 @@ describe('Finals Route Factory', () => {
 
       expect(mockSanitizeInput).toHaveBeenCalled();
       expect(response.status).toBe(201);
+    });
+  });
+
+  // ============================================================
+  // POST Handler — Top 24 Playoff Flow (issue #454)
+  // ============================================================
+
+  describe('POST Handler — Top 24 Playoff', () => {
+    /* Top-24 creates a pre-bracket playoff in Phase 1 (from qual 13-24) and
+     * then, on a second POST call, builds the 16-player Upper Bracket in
+     * Phase 2 (qual top-12 + 4 playoff winners). Each test exercises one
+     * of those transitions or their guard rails. */
+
+    const createMockQualifications = (count = 24) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: `qual-${i}`,
+        playerId: `player-${i}`,
+        group: 'A',
+        seeding: i + 1,
+        player: { id: `player-${i}`, name: `Player ${i + 1}` },
+      }));
+
+    it('Phase 1: creates 8 playoff matches when no playoff exists yet', async () => {
+      (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(24));
+      /* No existing playoff rows → triggers Phase 1 creation. */
+      (prisma.bMMatch as any).findMany.mockResolvedValue([]);
+      (prisma.bMMatch as any).create.mockImplementation(
+        ({ data }: { data: { matchNumber: number; round: string } }) => ({
+          id: `playoff-${data.matchNumber}`,
+          ...data,
+          player1: { id: data.matchNumber },
+          player2: { id: data.matchNumber },
+        }),
+      );
+
+      const config = createMockConfig();
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 24 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(201);
+      const json = await response.json();
+      expect(json.data.phase).toBe('playoff');
+      expect(json.data.matches).toHaveLength(8);
+      /* Verifies 8 matches were created with stage='playoff' — the key
+       * distinction from Top-8/Top-16 paths which write stage='finals'. */
+      expect((prisma.bMMatch as any).create).toHaveBeenCalledTimes(8);
+      const createdStages = (prisma.bMMatch as any).create.mock.calls.map(
+        (c: [{ data: { stage: string } }]) => c[0].data.stage,
+      );
+      expect(createdStages.every((s: string) => s === 'playoff')).toBe(true);
+      /* Playoff seeds 1-12 must map to qual positions 13-24 — i.e., the top
+       * 12 qualifiers are NOT in the playoff pool. */
+      const createdPlayerIds = (prisma.bMMatch as any).create.mock.calls.map(
+        (c: [{ data: { player1Id: string } }]) => c[0].data.player1Id,
+      );
+      expect(createdPlayerIds.some((id: string) => ['player-0', 'player-11'].includes(id))).toBe(false);
+    });
+
+    it('returns 400 when fewer than 24 qualifiers exist', async () => {
+      /* Top-24 is only viable when 24 players have completed qualification;
+       * otherwise we refuse to create a partial/ambiguous bracket. */
+      (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(20));
+
+      const config = createMockConfig();
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 24 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.error).toBe('Not enough players qualified. Need 24, found 20');
+      expect((prisma.bMMatch as any).create).not.toHaveBeenCalled();
+    });
+
+    it('Phase 2 blocked: returns 409 when playoff R2 matches are still incomplete', async () => {
+      /* Second POST after Phase 1 must wait until all 4 playoff_r2 matches
+       * are completed. If the admin tries to jump ahead, we return
+       * PLAYOFF_INCOMPLETE with a hint on how many matches remain. */
+      (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(24));
+      const incompletePlayoff = [
+        ...Array.from({ length: 4 }, (_, i) => ({
+          id: `p-r1-${i}`,
+          matchNumber: i + 1,
+          round: 'playoff_r1',
+          stage: 'playoff',
+          completed: true,
+          score1: 5,
+          score2: 0,
+          player1Id: `player-${12 + i}`,
+          player2Id: `player-${20 + i}`,
+        })),
+        /* Only 2 of 4 R2 matches completed → Phase 2 cannot start. */
+        { id: 'p-r2-5', matchNumber: 5, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'x', player2Id: 'y' },
+        { id: 'p-r2-6', matchNumber: 6, round: 'playoff_r2', stage: 'playoff', completed: false, score1: 0, score2: 0, player1Id: 'x', player2Id: 'y' },
+        { id: 'p-r2-7', matchNumber: 7, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'x', player2Id: 'y' },
+        { id: 'p-r2-8', matchNumber: 8, round: 'playoff_r2', stage: 'playoff', completed: false, score1: 0, score2: 0, player1Id: 'x', player2Id: 'y' },
+      ];
+      (prisma.bMMatch as any).findMany.mockResolvedValue(incompletePlayoff);
+
+      const config = createMockConfig();
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 24 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(409);
+      const json = await response.json();
+      expect(json.code).toBe('PLAYOFF_INCOMPLETE');
+      expect(json.error).toMatch(/2 R2 match\(es\) remaining/);
+      expect((prisma.bMMatch as any).create).not.toHaveBeenCalled();
+    });
+
+    it('Phase 2: builds 16-player finals bracket from qual top-12 + 4 playoff winners', async () => {
+      /* All 4 playoff_r2 matches completed with player1 winning each time.
+       * Expected Upper-seed mapping (R2 match → Upper seed):
+       *   match 5 → Upper seed 16 (winner = player-12)
+       *   match 6 → Upper seed 13 (winner = player-15)
+       *   match 7 → Upper seed 14 (winner = player-14)
+       *   match 8 → Upper seed 15 (winner = player-13)
+       * Together with qual top-12 (player-0 … player-11) these fill the 16 seeds. */
+      (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(24));
+      const playoffRows = [
+        /* R1 rows — completed but irrelevant to seat assignment (R2 winners
+         * are what we consume). */
+        ...Array.from({ length: 4 }, (_, i) => ({
+          id: `p-r1-${i}`,
+          matchNumber: i + 1,
+          round: 'playoff_r1',
+          stage: 'playoff',
+          completed: true,
+          score1: 5,
+          score2: 0,
+          player1Id: `player-${12 + i}`,
+          player2Id: `player-${20 + i}`,
+          player1: { id: `player-${12 + i}` },
+          player2: { id: `player-${20 + i}` },
+        })),
+        { id: 'p-r2-5', matchNumber: 5, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-12', player2Id: 'player-20', player1: { id: 'player-12' }, player2: { id: 'player-20' } },
+        { id: 'p-r2-6', matchNumber: 6, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-15', player2Id: 'player-21', player1: { id: 'player-15' }, player2: { id: 'player-21' } },
+        { id: 'p-r2-7', matchNumber: 7, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-14', player2Id: 'player-22', player1: { id: 'player-14' }, player2: { id: 'player-22' } },
+        { id: 'p-r2-8', matchNumber: 8, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-13', player2Id: 'player-23', player1: { id: 'player-13' }, player2: { id: 'player-23' } },
+      ];
+      (prisma.bMMatch as any).findMany.mockResolvedValue(playoffRows);
+      (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });
+      (prisma.bMMatch as any).create.mockImplementation(
+        ({ data }: { data: { matchNumber: number; round: string; stage: string } }) => ({
+          id: `finals-${data.matchNumber}`,
+          ...data,
+          player1: { id: data.matchNumber },
+          player2: { id: data.matchNumber },
+        }),
+      );
+
+      const config = createMockConfig();
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 24 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(201);
+      const json = await response.json();
+      expect(json.data.phase).toBe('finals');
+      /* 16-player bracket generator is invoked once we have 4 playoff winners. */
+      expect(mockGenerateBracketStructure).toHaveBeenCalledWith(16);
+      /* Existing finals (if any) must be cleared before Phase-2 creation —
+       * this supports reset scenarios where Phase-2 is retried. */
+      expect((prisma.bMMatch as any).deleteMany).toHaveBeenCalledWith({
+        where: { tournamentId: 'tournament-123', stage: 'finals' },
+      });
+      /* Verify seed 13-16 mapping: playoff R2 match → Upper-bracket seed. */
+      const seededPlayers: Array<{ seed: number; playerId: string }> = json.data.seededPlayers;
+      const seedMap = new Map(seededPlayers.map(p => [p.seed, p.playerId]));
+      expect(seedMap.get(16)).toBe('player-12'); /* From playoff R2 match 5 */
+      expect(seedMap.get(13)).toBe('player-15'); /* From playoff R2 match 6 */
+      expect(seedMap.get(14)).toBe('player-14'); /* From playoff R2 match 7 */
+      expect(seedMap.get(15)).toBe('player-13'); /* From playoff R2 match 8 */
+      /* Direct-advance qualifiers occupy seeds 1-12. */
+      expect(seedMap.get(1)).toBe('player-0');
+      expect(seedMap.get(12)).toBe('player-11');
     });
   });
 
@@ -1104,6 +1322,56 @@ describe('Finals Route Factory', () => {
       expect(mockLogger.error).toHaveBeenCalledWith('Failed to update finals match', {
         error: expect.any(Error),
         tournamentId: 'tournament-123',
+      });
+    });
+
+    it('playoff R1 winner advances to R2 at position 2 (issue #454)', async () => {
+      /* Completing playoff_r1 match 1 (seeds 8v9) with player1 winning should
+       * write player-8 into match 5 (playoff_r2) as player2 — the standard
+       * bracket routing for playoff. Finals stage must not be touched. */
+      const playoffMatch = createMockMatch({
+        id: 'playoff-1',
+        matchNumber: 1,
+        stage: 'playoff',
+        round: 'playoff_r1',
+        player1Id: 'player-8',
+        player2Id: 'player-9',
+      });
+      (prisma.bMMatch as any).findUnique.mockResolvedValue(playoffMatch);
+      (prisma.bMMatch as any).update.mockResolvedValue({
+        ...playoffMatch,
+        score1: 5,
+        score2: 0,
+        completed: true,
+      });
+      (prisma.bMMatch as any).updateMany.mockResolvedValue({ count: 1 });
+      (prisma.bMMatch as any).findMany.mockResolvedValue([]);
+
+      const config = createMockConfig();
+      const { PUT } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'PUT',
+        body: JSON.stringify({ matchId: 'playoff-1', score1: 5, score2: 0 }),
+      });
+      const response = await PUT(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(200);
+      const json = await response.json();
+      expect(json.data.stage).toBe('playoff');
+      expect(json.data.winnerId).toBe('player-8');
+      expect(json.data.loserId).toBe('player-9');
+      /* Confirm the cross-match advancement targeted playoff_r2 match 5
+       * as player2 — not a finals bracket row. */
+      expect((prisma.bMMatch as any).updateMany).toHaveBeenCalledWith({
+        where: {
+          tournamentId: 'tournament-123',
+          stage: 'playoff',
+          matchNumber: 5,
+        },
+        data: { player2Id: 'player-8' },
       });
     });
   });

--- a/smkc-score-app/__tests__/lib/double-elimination.test.ts
+++ b/smkc-score-app/__tests__/lib/double-elimination.test.ts
@@ -25,6 +25,7 @@
 import { describe, it, expect } from '@jest/globals';
 import {
   generateBracketStructure,
+  generatePlayoffStructure,
   getNextMatchInfo,
   roundNames
 } from '@/lib/double-elimination';
@@ -375,7 +376,143 @@ describe('Double Elimination Bracket Structure', () => {
     });
   });
 
+  /**
+   * Pre-Bracket Playoff (a.k.a. "barrage") — Top 24 → Top 16.
+   *
+   * Resolves issue #454. 12 entrants from qualification positions 13-24
+   * compete in a single-elimination tournament whose 4 winners fill
+   * Upper-Bracket seeds 13-16. Top 4 playoff seeds receive a Round 1 BYE.
+   */
+  describe('generatePlayoffStructure', () => {
+    it('should generate 8 matches for 12 entrants (4 R1 + 4 R2, top 4 BYE)', () => {
+      const matches = generatePlayoffStructure(12);
+      expect(matches).toHaveLength(8);
+    });
+
+    it('should throw for unsupported entrant counts', () => {
+      expect(() => generatePlayoffStructure(0)).toThrow();
+      expect(() => generatePlayoffStructure(8)).toThrow();
+      expect(() => generatePlayoffStructure(16)).toThrow();
+    });
+
+    it('should split matches into playoff_r1 (4) and playoff_r2 (4)', () => {
+      const matches = generatePlayoffStructure(12);
+      const r1 = matches.filter(m => m.round === 'playoff_r1');
+      const r2 = matches.filter(m => m.round === 'playoff_r2');
+      expect(r1).toHaveLength(4);
+      expect(r2).toHaveLength(4);
+    });
+
+    it('should pair seeds 5-12 in R1 using standard bracket order (8v9, 5v12, 6v11, 7v10)', () => {
+      /* Standard bracket pairing for the lower 8 seeds guarantees seeds that
+       * meet at the same round are maximally separated in the overall bracket. */
+      const matches = generatePlayoffStructure(12);
+      const r1 = matches.filter(m => m.round === 'playoff_r1');
+      /* Seeds are playoff-local (1-12). Seeds 1-4 BYE, 5-12 play R1. */
+      const pairings = r1.map(m => [m.player1Seed, m.player2Seed]);
+      expect(pairings).toEqual([
+        [8, 9],
+        [5, 12],
+        [6, 11],
+        [7, 10],
+      ]);
+    });
+
+    it('should set the BYE seeds (1-4) as player1 on R2 matches', () => {
+      const matches = generatePlayoffStructure(12);
+      const r2 = matches.filter(m => m.round === 'playoff_r2');
+      /* R2 match order mirrors R1 feeder order so R1→R2 routing stays trivial.
+       * R2 M5: seed 1 BYE vs R1 M1 (8v9) winner
+       * R2 M6: seed 4 BYE vs R1 M2 (5v12) winner
+       * R2 M7: seed 3 BYE vs R1 M3 (6v11) winner
+       * R2 M8: seed 2 BYE vs R1 M4 (7v10) winner */
+      expect(r2[0].player1Seed).toBe(1);
+      expect(r2[1].player1Seed).toBe(4);
+      expect(r2[2].player1Seed).toBe(3);
+      expect(r2[3].player1Seed).toBe(2);
+      /* player2 on each R2 match is filled by an R1 winner, not a direct seed. */
+      r2.forEach(m => expect(m.player2Seed).toBeUndefined());
+    });
+
+    it('should route R1 winners to their corresponding R2 match at position 2', () => {
+      const matches = generatePlayoffStructure(12);
+      const r1 = matches.filter(m => m.round === 'playoff_r1');
+      /* R1 matches 1-4 → R2 matches 5-8 respectively */
+      expect(r1[0].winnerGoesTo).toBe(5);
+      expect(r1[1].winnerGoesTo).toBe(6);
+      expect(r1[2].winnerGoesTo).toBe(7);
+      expect(r1[3].winnerGoesTo).toBe(8);
+      r1.forEach(m => expect(m.position).toBe(2));
+    });
+
+    it('should eliminate R1 losers (no loserGoesTo)', () => {
+      const matches = generatePlayoffStructure(12);
+      const r1 = matches.filter(m => m.round === 'playoff_r1');
+      /* Single-elimination: one loss eliminates. No drop-down destination. */
+      r1.forEach(m => expect(m.loserGoesTo).toBeUndefined());
+    });
+
+    it('should assign Upper-Bracket seeds 13-16 to R2 winners symmetrically', () => {
+      /* Each playoff-R2 winner fills a specific Upper-Bracket seed so the
+       * strongest playoff survivor (facing the lowest BYE seed) enters
+       * opposite #1 in the Upper Bracket — mirroring standard bracket balance.
+       *
+       * Upper R1 pairings are [1,16], [8,9], [5,12], [4,13], [3,14], [6,11], [7,10], [2,15].
+       * We assign upper seeds 13-16 to playoff R2 match winners so that:
+       *   - Playoff R2 M5 (featuring playoff seed 1) winner → Upper seed 16 (plays Upper #1)
+       *   - Playoff R2 M6 (featuring playoff seed 4) winner → Upper seed 13 (plays Upper #4)
+       *   - Playoff R2 M7 (featuring playoff seed 3) winner → Upper seed 14 (plays Upper #3)
+       *   - Playoff R2 M8 (featuring playoff seed 2) winner → Upper seed 15 (plays Upper #2)
+       */
+      const matches = generatePlayoffStructure(12);
+      const r2 = matches.filter(m => m.round === 'playoff_r2');
+      expect(r2[0].advancesToUpperSeed).toBe(16);
+      expect(r2[1].advancesToUpperSeed).toBe(13);
+      expect(r2[2].advancesToUpperSeed).toBe(14);
+      expect(r2[3].advancesToUpperSeed).toBe(15);
+    });
+
+    it('should not route R2 winners via winnerGoesTo (handled at upper-bracket level)', () => {
+      const matches = generatePlayoffStructure(12);
+      const r2 = matches.filter(m => m.round === 'playoff_r2');
+      /* R2 is the terminal round for the playoff stage. Cross-stage routing to
+       * the Upper Bracket uses advancesToUpperSeed, not winnerGoesTo. */
+      r2.forEach(m => {
+        expect(m.winnerGoesTo).toBeUndefined();
+        expect(m.loserGoesTo).toBeUndefined();
+      });
+    });
+
+    it('should number matches 1-8 sequentially', () => {
+      const matches = generatePlayoffStructure(12);
+      expect(matches.map(m => m.matchNumber)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    });
+  });
+
+  describe('getNextMatchInfo with playoff bracket', () => {
+    it('should route playoff R1 winner to R2 at position 2', () => {
+      const matches = generatePlayoffStructure(12);
+      const result = getNextMatchInfo(matches, 1, true);
+      expect(result).toEqual({ nextMatchNumber: 5, position: 2 });
+    });
+
+    it('should return null for playoff R1 loser (eliminated)', () => {
+      const matches = generatePlayoffStructure(12);
+      expect(getNextMatchInfo(matches, 1, false)).toBeNull();
+    });
+
+    it('should return null for playoff R2 winner (cross-stage advancement handled elsewhere)', () => {
+      const matches = generatePlayoffStructure(12);
+      expect(getNextMatchInfo(matches, 5, true)).toBeNull();
+    });
+  });
+
   describe('roundNames', () => {
+    it('should include playoff round names', () => {
+      expect(roundNames.playoff_r1).toBeDefined();
+      expect(roundNames.playoff_r2).toBeDefined();
+    });
+
     it('should export correct round display names', () => {
       expect(roundNames.winners_qf).toBe('Winners Quarter Final');
       expect(roundNames.winners_sf).toBe('Winners Semi Final');

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -18,7 +18,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
-import { generateBracketStructure, roundNames } from '@/lib/double-elimination';
+import { generateBracketStructure, generatePlayoffStructure, roundNames } from '@/lib/double-elimination';
 import { paginate } from '@/lib/pagination';
 import { sanitizeInput } from '@/lib/sanitize';
 import { createLogger } from '@/lib/logger';
@@ -33,6 +33,13 @@ import { resolveTournamentId } from '@/lib/tournament-identifier';
  * Threshold of 20 distinguishes between the two (>20 means 16-player).
  */
 const BRACKET_SIZE_THRESHOLD = 20;
+
+/**
+ * Pre-Bracket Playoff ("barrage") entrant count. Supports issue #454:
+ * Top 24 qualifiers → Top 16 Upper Bracket, with 12 entrants from qualification
+ * positions 13-24 competing for the 4 Upper-Bracket seats 13-16.
+ */
+const PLAYOFF_ENTRANT_COUNT = 12;
 
 /**
  * Configuration for a finals route handler set.
@@ -161,11 +168,21 @@ export function createFinalsHandlers(config: FinalsConfig) {
           (m: { round?: string }) => m.round?.startsWith('grand_final') || false,
         );
 
+        /* Pre-Bracket Playoff (issue #454) lives in a distinct `stage='playoff'`
+         * row and must be fetched separately. Empty array when the tournament
+         * uses the standard Top-8/Top-16 flow. */
+        const playoffMatches = await model(prisma).findMany({
+          where: { tournamentId, stage: 'playoff' },
+          include: { player1: true, player2: true },
+          orderBy: { matchNumber: 'asc' },
+        });
+
         return createSuccessResponse({
           matches,
           winnersMatches,
           losersMatches,
           grandFinalMatches,
+          playoffMatches,
           bracketStructure,
           bracketSize,
           roundNames,
@@ -218,9 +235,22 @@ export function createFinalsHandlers(config: FinalsConfig) {
       const body = sanitizeInput(await request.json());
       const { topN = 8 } = body;
 
-      /* Support 8-player and 16-player brackets (§4.2) */
-      if (topN !== 8 && topN !== 16) {
-        return handleValidationError('Only 8-player and 16-player brackets are supported', 'topN');
+      /* Supported bracket sizes:
+       *   8  → 8-player double elimination
+       *  16  → 16-player double elimination (§4.2)
+       *  24  → 16-player Upper Bracket + 12-player Pre-Bracket Playoff (§4.2, issue #454).
+       *        Two-phase: first POST call creates the playoff stage; a second
+       *        call (once all playoff_r2 matches are complete) builds the
+       *        Upper Bracket with the 4 playoff winners filling seeds 13-16. */
+      if (topN !== 8 && topN !== 16 && topN !== 24) {
+        return handleValidationError(
+          'Only 8-player, 16-player, or 24-player (Top-16 + playoff) brackets are supported',
+          'topN',
+        );
+      }
+
+      if (topN === 24) {
+        return handleTop24Post(model, qualModel, tournamentId, config);
       }
 
       const qualifications = await qualModel(prisma).findMany({
@@ -299,6 +329,224 @@ export function createFinalsHandlers(config: FinalsConfig) {
   }
 
   /**
+   * Check whether all 4 playoff_r2 matches for a tournament are complete —
+   * the readiness condition for Phase-2 POST that creates the Upper Bracket.
+   */
+  async function isPlayoffComplete(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    matchModel: (p: any) => any,
+    tournamentId: string,
+  ): Promise<boolean> {
+    const r2Matches = await matchModel(prisma).findMany({
+      where: { tournamentId, stage: 'playoff', round: 'playoff_r2' },
+      select: { completed: true },
+    });
+    return r2Matches.length === 4 && r2Matches.every((m: { completed: boolean }) => m.completed);
+  }
+
+  /**
+   * Handle POST with topN=24 — Top 16 bracket with Pre-Bracket Playoff (issue #454).
+   *
+   * Two-phase flow:
+   *   Phase 1: No playoff matches exist → create 8 playoff matches (stage='playoff')
+   *            from qualification positions 13-24. Return playoff structure.
+   *   Phase 2: All 4 playoff_r2 matches complete → build 16-player Upper Bracket
+   *            (stage='finals') using qual top 12 + 4 playoff winners for seeds 13-16.
+   *
+   * Intermediate state: Phase 2 call before playoff completes → 409 Conflict with
+   * a remaining-matches hint so the caller knows why the transition is blocked.
+   *
+   * @returns Response with created matches for the current phase
+   */
+  async function handleTop24Post(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    matchModel: (p: any) => any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    qualificationModel: (p: any) => any,
+    tournamentId: string,
+    finalsConfig: FinalsConfig,
+  ): Promise<NextResponse> {
+    const logger = createLogger(finalsConfig.loggerName);
+
+    try {
+      /* Fetch Top 24 qualifiers — needed for both phases (Phase 1 picks 13-24 as
+       * playoff seeds; Phase 2 picks 1-12 as direct Upper-Bracket seeds). */
+      const qualifications = await qualificationModel(prisma).findMany({
+        where: { tournamentId },
+        include: { player: true },
+        orderBy: finalsConfig.qualificationOrderBy,
+        take: 24,
+      });
+
+      if (qualifications.length < 24) {
+        return handleValidationError(
+          `Not enough players qualified. Need 24, found ${qualifications.length}`,
+          'qualifications',
+        );
+      }
+
+      const existingPlayoff = await matchModel(prisma).findMany({
+        where: { tournamentId, stage: 'playoff' },
+        orderBy: { matchNumber: 'asc' },
+      });
+
+      /* --- PHASE 1: Create playoff matches --- */
+      if (existingPlayoff.length === 0) {
+        const playoffStructure = generatePlayoffStructure(PLAYOFF_ENTRANT_COUNT);
+
+        /* Playoff-local seeds 1-12 map to qualification positions 13-24. */
+        const playoffSeededPlayers = qualifications
+          .slice(12, 24)
+          .map((q: { playerId: string; player: unknown }, index: number) => ({
+            seed: index + 1,
+            playerId: q.playerId,
+            player: q.player,
+          }));
+
+        const createdPlayoffMatches = [];
+        for (const bracketMatch of playoffStructure) {
+          const player1 = bracketMatch.player1Seed
+            ? playoffSeededPlayers.find((p: { seed: number }) => p.seed === bracketMatch.player1Seed)
+            : null;
+          const player2 = bracketMatch.player2Seed
+            ? playoffSeededPlayers.find((p: { seed: number }) => p.seed === bracketMatch.player2Seed)
+            : null;
+
+          /* Fallback player IDs satisfy the NOT NULL constraint on player1Id/player2Id
+           * for R2 matches whose player2 comes from an R1 winner (not known yet). */
+          const match = await matchModel(prisma).create({
+            data: {
+              tournamentId,
+              matchNumber: bracketMatch.matchNumber,
+              stage: 'playoff',
+              round: bracketMatch.round,
+              player1Id: player1?.playerId || playoffSeededPlayers[0].playerId,
+              player2Id: player2?.playerId || player1?.playerId || playoffSeededPlayers[0].playerId,
+              completed: false,
+            },
+            include: { player1: true, player2: true },
+          });
+
+          createdPlayoffMatches.push({
+            ...match,
+            hasPlayer1: !!player1,
+            hasPlayer2: !!player2,
+            player1Seed: bracketMatch.player1Seed,
+            player2Seed: bracketMatch.player2Seed,
+            advancesToUpperSeed: bracketMatch.advancesToUpperSeed,
+          });
+        }
+
+        return createSuccessResponse({
+          message: 'Playoff bracket created',
+          phase: 'playoff',
+          matches: createdPlayoffMatches,
+          playoffStructure,
+          /* Note: Upper Bracket seats 1-12 for qual top 12 are reserved; the
+           * finals bracket will be created in Phase 2 after playoff completes. */
+        }, 'Playoff bracket created', { status: 201 });
+      }
+
+      /* --- PHASE 2: Build Upper Bracket once playoff is complete --- */
+      const r2Matches = existingPlayoff.filter(
+        (m: { round?: string }) => m.round === 'playoff_r2',
+      );
+      const incompleteR2 = r2Matches.filter((m: { completed: boolean }) => !m.completed);
+
+      if (incompleteR2.length > 0) {
+        return createErrorResponse(
+          `Playoff not complete: ${incompleteR2.length} R2 match(es) remaining`,
+          409,
+          'PLAYOFF_INCOMPLETE',
+        );
+      }
+
+      /* Derive each playoff winner and map to its advancesToUpperSeed target. */
+      const playoffStructure = generatePlayoffStructure(PLAYOFF_ENTRANT_COUNT);
+      const upperSeedToPlayer = new Map<number, { playerId: string; player: unknown }>();
+
+      for (const r2BracketMatch of playoffStructure.filter(m => m.round === 'playoff_r2')) {
+        const dbMatch = r2Matches.find(
+          (m: { matchNumber: number }) => m.matchNumber === r2BracketMatch.matchNumber,
+        );
+        if (!dbMatch || !r2BracketMatch.advancesToUpperSeed) continue;
+        const winnerId = dbMatch.score1 >= dbMatch.score2 ? dbMatch.player1Id : dbMatch.player2Id;
+        const winnerPlayer = dbMatch.player1Id === winnerId ? dbMatch.player1 : dbMatch.player2;
+        upperSeedToPlayer.set(r2BracketMatch.advancesToUpperSeed, {
+          playerId: winnerId,
+          player: winnerPlayer,
+        });
+      }
+
+      /* Build the 16 seeded players: 1-12 from qualification, 13-16 from playoff winners. */
+      const directPlayers = qualifications.slice(0, 12).map(
+        (q: { playerId: string; player: unknown }, index: number) => ({
+          seed: index + 1,
+          playerId: q.playerId,
+          player: q.player,
+        }),
+      );
+      const playoffWinnerSeeds = [13, 14, 15, 16].map((upperSeed) => {
+        const winner = upperSeedToPlayer.get(upperSeed);
+        if (!winner) {
+          throw new Error(`Playoff winner for Upper seed ${upperSeed} not resolved`);
+        }
+        return { seed: upperSeed, playerId: winner.playerId, player: winner.player };
+      });
+      const seededPlayers = [...directPlayers, ...playoffWinnerSeeds];
+
+      const bracketStructure = generateBracketStructure(16);
+
+      /* Clean slate on any previous finals for reset scenarios. */
+      await matchModel(prisma).deleteMany({
+        where: { tournamentId, stage: 'finals' },
+      });
+
+      const createdMatches = [];
+      for (const bracketMatch of bracketStructure) {
+        const player1 = bracketMatch.player1Seed
+          ? seededPlayers.find(p => p.seed === bracketMatch.player1Seed)
+          : null;
+        const player2 = bracketMatch.player2Seed
+          ? seededPlayers.find(p => p.seed === bracketMatch.player2Seed)
+          : null;
+
+        const match = await matchModel(prisma).create({
+          data: {
+            tournamentId,
+            matchNumber: bracketMatch.matchNumber,
+            stage: 'finals',
+            round: bracketMatch.round,
+            player1Id: player1?.playerId || seededPlayers[0].playerId,
+            player2Id: player2?.playerId || player1?.playerId || seededPlayers[0].playerId,
+            completed: false,
+          },
+          include: { player1: true, player2: true },
+        });
+
+        createdMatches.push({
+          ...match,
+          hasPlayer1: !!player1,
+          hasPlayer2: !!player2,
+          player1Seed: bracketMatch.player1Seed,
+          player2Seed: bracketMatch.player2Seed,
+        });
+      }
+
+      return createSuccessResponse({
+        message: 'Finals bracket created from playoff results',
+        phase: 'finals',
+        matches: createdMatches,
+        seededPlayers,
+        bracketStructure,
+      }, 'Finals bracket created', { status: 201 });
+    } catch (error) {
+      logger.error('Failed to create Top-24 finals', { error, tournamentId });
+      return createErrorResponse(finalsConfig.postErrorMessage, 500, 'INTERNAL_ERROR');
+    }
+  }
+
+  /**
    * PUT handler: Update a finals match result and advance players through the bracket.
    * Handles winner/loser advancement, grand final reset logic, and tournament completion.
    */
@@ -344,9 +592,10 @@ export function createFinalsHandlers(config: FinalsConfig) {
         return createErrorResponse('Finals match not found', 404, 'NOT_FOUND');
       }
 
-      /* Defensive: reject non-finals stage to prevent cross-stage bracket mutation.
-       * Qualification matches should never trigger bracket advancement logic. */
-      if (match.stage !== 'finals') {
+      /* Defensive: reject non-finals/non-playoff stage to prevent cross-stage
+       * bracket mutation. Qualification matches should never trigger bracket
+       * advancement logic; playoff matches use their own advancement path below. */
+      if (match.stage !== 'finals' && match.stage !== 'playoff') {
         return createErrorResponse('Finals match not found', 404, 'NOT_FOUND');
       }
 
@@ -381,6 +630,39 @@ export function createFinalsHandlers(config: FinalsConfig) {
         data: updateData,
         include: { player1: true, player2: true },
       });
+
+      /* --- Playoff advancement path (issue #454) ---
+       * Playoff matches are a separate stage; only playoff_r1 winners advance
+       * within the playoff (to playoff_r2 as player 2). playoff_r2 winners
+       * stay in the playoff stage — the Upper Bracket is materialised later
+       * via a Phase-2 POST that reads completed playoff results. */
+      if (match.stage === 'playoff') {
+        const playoffStructure = generatePlayoffStructure(PLAYOFF_ENTRANT_COUNT);
+        const matchNumber = Number(match.matchNumber ?? updatedMatch.matchNumber);
+        const currentPlayoff = playoffStructure.find(b => b.matchNumber === matchNumber);
+
+        if (currentPlayoff?.winnerGoesTo) {
+          const position = currentPlayoff.position || 1;
+          await model(prisma).updateMany({
+            where: {
+              tournamentId,
+              stage: 'playoff',
+              matchNumber: currentPlayoff.winnerGoesTo,
+            },
+            data: position === 1 ? { player1Id: winnerId } : { player2Id: winnerId },
+          });
+        }
+
+        return createSuccessResponse({
+          match: updatedMatch,
+          winnerId,
+          loserId,
+          stage: 'playoff',
+          /* Signal whether all playoff_r2 matches are complete so clients can
+           * prompt the admin to trigger Phase-2 POST (finals bracket creation). */
+          playoffComplete: await isPlayoffComplete(model, tournamentId),
+        });
+      }
 
       /* Infer bracket size from total finals match count:
        * 8-player bracket = 17 matches, 16-player bracket = 31 matches.

--- a/smkc-score-app/src/lib/double-elimination.ts
+++ b/smkc-score-app/src/lib/double-elimination.ts
@@ -374,6 +374,94 @@ function generate16PlayerBracket(): BracketMatch[] {
 }
 
 /**
+ * Generate the Pre-Bracket Playoff ("barrage") structure for 12 entrants.
+ *
+ * Resolves issue #454: Top 24 → Top 16. Qualification positions 13-24 enter
+ * a single-elimination playoff whose 4 winners fill Upper-Bracket seeds 13-16.
+ * Top 4 playoff seeds (qualification 13-16) receive a Round 1 BYE.
+ *
+ * Structure (8 matches total):
+ *   R1 (playoff_r1, 4 matches): Seeds 8v9, 5v12, 6v11, 7v10 — standard bracket pairing
+ *                               for the non-BYE seeds, maximally separating stronger seeds.
+ *   R2 (playoff_r2, 4 matches): BYE seeds 1-4 each face one R1 winner. Winners advance.
+ *
+ * Upper-Bracket seed assignment mirrors 16-player bracket balance so the
+ * strongest playoff survivor (faced the lowest BYE seed in R2) enters the
+ * Upper Bracket opposite Upper-seed 1 — the toughest path — preserving the
+ * competitive advantage of direct-advance qualifiers:
+ *   R2 match 5 (playoff seed 1) winner → Upper seed 16
+ *   R2 match 6 (playoff seed 4) winner → Upper seed 13
+ *   R2 match 7 (playoff seed 3) winner → Upper seed 14
+ *   R2 match 8 (playoff seed 2) winner → Upper seed 15
+ *
+ * Cross-stage advancement (playoff_r2 winner → Upper Bracket slot) is handled
+ * by the finals-route PUT handler, not by the generic getNextMatchInfo mechanism,
+ * because the target match lives in a different `stage` row.
+ *
+ * @param entrantCount - Number of playoff entrants (currently only 12 supported)
+ * @returns Array of BracketMatch objects defining the full playoff
+ * @throws Error if entrantCount is not 12
+ */
+export function generatePlayoffStructure(entrantCount: number): BracketMatch[] {
+  if (entrantCount !== 12) {
+    throw new Error("Only 12-entrant playoff is supported");
+  }
+
+  const matches: BracketMatch[] = [];
+
+  /* --- PLAYOFF ROUND 1 (Matches 1-4): 8 lower seeds pair up ---
+   * Standard single-elimination pairing for seeds 5-12: 8v9, 5v12, 6v11, 7v10.
+   * This order ensures R1 winners flow naturally into the R2 bracket positions
+   * held by BYE seeds 1, 4, 3, 2 respectively. */
+  const r1Pairs = [
+    [8, 9],
+    [5, 12],
+    [6, 11],
+    [7, 10],
+  ];
+  for (let i = 0; i < 4; i++) {
+    matches.push({
+      matchNumber: i + 1,
+      round: "playoff_r1",
+      bracket: "winners",
+      player1Seed: r1Pairs[i][0],
+      player2Seed: r1Pairs[i][1],
+      /* R1 winners enter R2 as player 2 (the BYE seed holds player 1). */
+      winnerGoesTo: 5 + i,
+      position: 2,
+      /* No loserGoesTo — single-elimination, losers are out. */
+    });
+  }
+
+  /* --- PLAYOFF ROUND 2 (Matches 5-8): BYE seeds meet R1 winners ---
+   * Each R2 match is a "decider": winner advances to the Upper Bracket.
+   * advancesToUpperSeed specifies which of seeds 13-16 the winner claims.
+   *
+   * The assignment inverts the playoff seed → upper seed relationship so the
+   * strongest playoff survivor faces Upper #1: see function-level comment. */
+  const byeSeedToUpperSeed: Array<{ byeSeed: number; upperSeed: number }> = [
+    { byeSeed: 1, upperSeed: 16 },
+    { byeSeed: 4, upperSeed: 13 },
+    { byeSeed: 3, upperSeed: 14 },
+    { byeSeed: 2, upperSeed: 15 },
+  ];
+  for (let i = 0; i < 4; i++) {
+    matches.push({
+      matchNumber: 5 + i,
+      round: "playoff_r2",
+      bracket: "winners",
+      player1Seed: byeSeedToUpperSeed[i].byeSeed,
+      /* player2Seed intentionally omitted — filled at runtime by R1 winner. */
+      advancesToUpperSeed: byeSeedToUpperSeed[i].upperSeed,
+      /* No winnerGoesTo/loserGoesTo — cross-stage advancement is handled by
+       * the finals route, and losers are eliminated. */
+    });
+  }
+
+  return matches;
+}
+
+/**
  * Determine where a player goes after a match result.
  *
  * Given a completed match and whether the player won or lost, returns
@@ -447,6 +535,8 @@ export function getNextMatchInfo(
  * Used in the tournament UI to label match phases clearly.
  */
 export const roundNames: Record<string, string> = {
+  playoff_r1: "Playoff Round 1",
+  playoff_r2: "Playoff Round 2",
   winners_r1: "Winners Round 1",
   winners_qf: "Winners Quarter Final",
   winners_sf: "Winners Semi Final",

--- a/smkc-score-app/src/types/bracket.ts
+++ b/smkc-score-app/src/types/bracket.ts
@@ -19,6 +19,8 @@ export type BracketType = "winners" | "losers" | "grand_final";
 
 /** All possible round identifiers in a double elimination bracket */
 export type BracketRound =
+  | "playoff_r1"      // Pre-Bracket Playoff Round 1 — Top 24 → Top 16 barrage (4 matches)
+  | "playoff_r2"      // Pre-Bracket Playoff Round 2 — decider producing 4 Upper-Bracket entrants (4 matches)
   | "winners_qf"      // Winners Bracket Quarter-Finals (4 matches)
   | "winners_sf"      // Winners Bracket Semi-Finals (2 matches)
   | "winners_final"   // Winners Bracket Final (1 match)
@@ -47,4 +49,10 @@ export interface BracketMatch {
   loserGoesTo?: number;
   /** Display position within the receiving match (1 or 2) */
   position?: 1 | 2;
+  /**
+   * For playoff matches only: the Upper-Bracket seed (1-16) the winner receives
+   * when entering the 16-player double-elimination bracket. Only set on final
+   * playoff round matches (playoff_r2) whose winners advance to Upper Bracket.
+   */
+  advancesToUpperSeed?: number;
 }


### PR DESCRIPTION
## Summary
Implements a two-phase pre-bracket playoff ("barrage") system to support 24-player tournaments. The top 12 qualifiers advance directly to the Upper Bracket (seeds 1-12), while qualifiers 13-24 compete in a single-elimination playoff whose 4 winners fill Upper-Bracket seeds 13-16.

## Key Changes

- **New `generatePlayoffStructure()` function** in `double-elimination.ts`:
  - Generates 8 matches (4 R1 + 4 R2) for 12 playoff entrants
  - Top 4 seeds (1-4) receive Round 1 BYE
  - Seeds 5-12 pair using standard bracket order (8v9, 5v12, 6v11, 7v10)
  - R2 winners map to Upper-Bracket seeds 13-16 with symmetric seeding

- **Two-phase POST handler** (`handleTop24Post`) in `finals-route.ts`:
  - **Phase 1**: Creates playoff matches from qualification positions 13-24 when no playoff exists
  - **Phase 2**: Builds 16-player Upper Bracket once all playoff R2 matches complete
  - Returns 409 Conflict if Phase 2 is attempted before playoff completion, with remaining-match count

- **Playoff advancement in PUT handler**:
  - R1 winners advance to R2 as player 2 (position-based routing)
  - R2 winners stay in playoff stage; cross-stage advancement to Upper Bracket handled by Phase-2 POST
  - Added `playoffComplete` flag to response so clients can prompt Phase-2 trigger

- **GET handler enhancement**:
  - Fetches and returns `playoffMatches` separately from finals matches
  - Allows clients to display playoff bracket independently

- **Type updates** in `bracket.ts`:
  - Added `playoff_r1` and `playoff_r2` to `BracketRound` type
  - Added round display names to `roundNames` export

- **Validation**:
  - Extended POST validation to accept `topN=24` alongside existing 8 and 16
  - Validates 24 qualifiers exist before proceeding

## Implementation Details

- Playoff uses its own `stage='playoff'` database rows, separate from `stage='finals'`
- R1→R2 routing uses `winnerGoesTo` and `position` fields (standard bracket mechanism)
- R2→Upper-Bracket routing uses new `advancesToUpperSeed` field (cross-stage, handled explicitly)
- Single-elimination: losers are eliminated (no `loserGoesTo`)
- Supports reset scenarios by deleting previous finals matches before Phase-2 creation
- Comprehensive test coverage for playoff structure generation and routing logic

https://claude.ai/code/session_01FMQt2vruDrgzgqaaVZF25Y