### PR TITLE
docs(auth): clarify authentication requirements in JSDoc (#471)

### DIFF
--- a/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/report/route.ts
@@ -70,6 +70,8 @@ const BM_RECALC_CONFIG: RecalculateStatsConfig = {
  * Report score from a player's perspective. Supports:
  * 1. Admin session (full access)
  * 2. Player session (restricted to own matches)
+ *
+ * Authentication: admin or player (for their own reports).
  */
 export async function POST(
   request: NextRequest,

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -66,6 +66,8 @@ const GP_RECALC_CONFIG: RecalculateStatsConfig = {
  * Submit a GP match score report from a participant.
  * Processes race-by-race positions into driver points and
  * stores the report. Auto-confirms when both players agree.
+ *
+ * Authentication: admin or player (for their own reports).
  */
 export async function POST(
   request: NextRequest,

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
@@ -66,6 +66,8 @@ const MR_RECALC_CONFIG: RecalculateStatsConfig = {
  * Submit a participant's score report for an MR match.
  * Both players report independently; when reports match,
  * the match is automatically confirmed.
+ *
+ * Authentication: admin or player (for their own reports).
  */
 export async function POST(
   request: NextRequest,

--- a/smkc-score-app/src/lib/api-factories/match-detail-route.ts
+++ b/smkc-score-app/src/lib/api-factories/match-detail-route.ts
@@ -112,6 +112,9 @@ export function createMatchDetailHandlers(config: MatchDetailConfig) {
   /**
    * PUT handler: Update match score with optimistic locking.
    * Requires version number for conflict detection.
+   *
+   * Authentication: admin only. Players should use the score report endpoint
+   * to submit their own match results.
    */
   async function PUT(
     request: NextRequest,


### PR DESCRIPTION
## Summary
Clarify authentication requirements for match detail PUT and score report routes in JSDoc comments:
- `match-detail-route.ts` PUT: admin only (players use report endpoint)
- BM/MR/GP report routes: admin or player (for their own reports)

This clarifies the design intent: PUT is admin-only for direct score updates, while report endpoints allow players to submit their own match results.

## Changes
- `src/lib/api-factories/match-detail-route.ts`: Added auth note to PUT handler JSDoc
- `src/app/api/tournaments/[id]/bm/match/[matchId]/report/route.ts`: Added auth note
- `src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts`: Added auth note
- `src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts`: Added auth note

## Test plan
- [x] Build passes (JSDoc only changes)

Fixes #471