### PR TITLE
fix(auth): require authentication for GET match detail endpoints (#481)

### DIFF
--- a/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/route.ts
@@ -24,6 +24,7 @@ const { GET, PUT } = createMatchDetailHandlers({
   validateFinalsScores: validateBattleModeFinalScores,
   sanitizeBody: true,
   putRequiresAuth: true,
+  getRequiresAuth: true,
 });
 
 export { GET, PUT };

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/route.ts
@@ -18,6 +18,7 @@ const { GET, PUT } = createMatchDetailHandlers({
     updateGPMatchScore(prisma, matchId, version, val1, val2, completed, detail),
   sanitizeBody: true,
   putRequiresAuth: true,
+  getRequiresAuth: true,
 });
 
 export { GET, PUT };

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/route.ts
@@ -22,6 +22,7 @@ const { GET, PUT } = createMatchDetailHandlers({
   validateScores: validateMatchRaceScores,
   sanitizeBody: true,
   putRequiresAuth: true,
+  getRequiresAuth: true,
 });
 
 export { GET, PUT };

--- a/smkc-score-app/src/lib/api-factories/match-detail-route.ts
+++ b/smkc-score-app/src/lib/api-factories/match-detail-route.ts
@@ -57,6 +57,8 @@ export interface MatchDetailConfig {
   sanitizeBody?: boolean;
   /** Whether PUT endpoint requires admin authentication */
   putRequiresAuth?: boolean;
+  /** Whether GET endpoint requires authentication (player or admin). Defaults to false for backward compatibility. */
+  getRequiresAuth?: boolean;
   /**
    * Optional score validation function called before updateMatchScore.
    * Receives the two score values from the request body.
@@ -85,12 +87,23 @@ export function createMatchDetailHandlers(config: MatchDetailConfig) {
 
   /**
    * GET handler: Fetch a single match by matchId with player details.
+   *
+   * Authentication: if getRequiresAuth is set, requires session auth (admin or player).
+   * If not set, returns match data without authentication (backward-compatible default).
    */
   async function GET(
     request: NextRequest,
     { params }: { params: Promise<{ id: string; matchId: string }> },
   ) {
     const { matchId } = await params;
+
+    /* Optional auth check for GET endpoint */
+    if (config.getRequiresAuth) {
+      const session = await auth();
+      if (!session?.user) {
+        return createErrorResponse('Unauthorized', 401, 'UNAUTHORIZED');
+      }
+    }
 
     try {
       const { id: tournamentId } = await params;


### PR DESCRIPTION
## Summary
- Add `getRequiresAuth` config option to `match-detail-route.ts` factory
- GET handler now checks for valid session when option is enabled
- BM, MR, GP match detail routes all set `getRequiresAuth: true`

## Test plan
- [ ] Verify unauthenticated GET to `/api/tournaments/[id]/bm/match/[matchId]` returns 401
- [ ] Verify authenticated player/admin GET returns match data

🤖 Generated with [Claude Code](https://claude.com/claude-code)