### PR TITLE
fix(report): use result version to avoid race in dual-confirm (#482)

### DIFF
--- a/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/report/route.ts
@@ -280,24 +280,20 @@ export async function POST(
       p1s1 === p2s1 && p1s2 === p2s2
     ) {
       try {
+        /*
+         * Use result.version directly to avoid a race where concurrent
+         * auto-confirm from the other player increments the version between
+         * our findUnique and update, causing an unnecessary OptimisticLockError.
+         */
         const finalMatch = await updateWithRetry(prisma, async (tx) => {
-          const currentMatch = await tx.bMMatch.findUnique({
-            where: { id: matchId },
-            select: { version: true }
-          });
-
-          if (!currentMatch) {
-            throw new Error("Match not found");
-          }
-
           const finalResult = await tx.bMMatch.update({
-            where: { id: matchId, version: currentMatch.version },
+            where: { id: matchId, version: result.version },
             data: { score1: p1s1, score2: p1s2, completed: true, version: { increment: 1 } },
             include: { player1: true, player2: true },
           });
 
           if (!finalResult) {
-            throw new OptimisticLockError('Match was updated by another user', currentMatch.version);
+            throw new OptimisticLockError('Match was updated by another user', result.version);
           }
 
           return finalResult;

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -382,24 +382,20 @@ export async function POST(
       const racesToUse = p1Races || p2Races;
 
       try {
+        /*
+         * Use updatedMatch.version directly to avoid a race where concurrent
+         * auto-confirm from the other player increments the version between
+         * our findUnique and update, causing an unnecessary OptimisticLockError.
+         */
         const confirmedMatch = await updateWithRetry(prisma, async (tx) => {
-          const currentMatch = await tx.gPMatch.findUnique({
-            where: { id: matchId },
-            select: { version: true }
-          });
-
-          if (!currentMatch) {
-            throw new Error("Match not found");
-          }
-
           const finalResult = await tx.gPMatch.update({
-            where: { id: matchId, version: currentMatch.version },
+            where: { id: matchId, version: updatedMatch.version },
             data: { points1: p1p1, points2: p1p2, races: racesToUse || [], completed: true, version: { increment: 1 } },
             include: { player1: true, player2: true },
           });
 
           if (!finalResult) {
-            throw new OptimisticLockError('Match was updated by another user', currentMatch.version);
+            throw new OptimisticLockError('Match was updated by another user', updatedMatch.version);
           }
 
           return finalResult;

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
@@ -325,25 +325,20 @@ export async function POST(
            * Uses explicit field names (score1/score2) to ensure correct mapping
            * to the MRMatch schema. MR matches store final scores in score1/score2,
            * while GP matches use points1/points2 for driver points.
+           *
+           * Use result.version directly to avoid a race where concurrent
+           * auto-confirm from the other player increments the version between
+           * our findUnique and update, causing an unnecessary OptimisticLockError.
            */
           const completedMatch = await updateWithRetry(prisma, async (tx) => {
-            const currentMatch = await tx.mRMatch.findUnique({
-              where: { id: matchId },
-              select: { version: true }
-            });
-
-            if (!currentMatch) {
-              throw new Error("Match not found");
-            }
-
             const finalResult = await tx.mRMatch.update({
-              where: { id: matchId, version: currentMatch.version },
+              where: { id: matchId, version: result.version },
               data: { score1: p1Score1, score2: p1Score2, rounds: racesToUse || [], completed: true, version: { increment: 1 } },
               include: { player1: true, player2: true },
             });
 
             if (!finalResult) {
-              throw new OptimisticLockError('Match was updated by another user', currentMatch.version);
+              throw new OptimisticLockError('Match was updated by another user', result.version);
             }
 
             return finalResult;


### PR DESCRIPTION
## Summary
- Remove redundant findUnique in auto-confirm block of BM, MR, and GP report routes
- Use version from first update result instead of re-querying
- Prevents TOCTOU race where concurrent auto-confirm increments version between read and write

## Test plan
- [ ] Dual-report auto-confirm still works when both players submit simultaneously
- [ ] No unnecessary OptimisticLockError in concurrent scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)