### PR TITLE
fix(gp-report): move character validation before completed-match block (#487)

### DIFF
--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -118,6 +118,11 @@ export async function POST(
       return handleAuthError('Unauthorized: Not authorized for this match');
     }
 
+    /* Validate character selection before any processing (including completed-match corrections) */
+    if (!validateCharacter(character)) {
+      return handleValidationError("Invalid character", "character");
+    }
+
     /*
      * Correction path: let a participant fix a GP score after the match has
      * already been confirmed. Keep the match completed, update the final score
@@ -206,11 +211,6 @@ export async function POST(
         }
         return handleDatabaseError(error, "score correction");
       }
-    }
-
-    /* Validate character selection */
-    if (!validateCharacter(character)) {
-      return handleValidationError("Invalid character", "character");
     }
 
     const reportingPlayerId = reportingPlayer === 1 ? match.player1Id : match.player2Id;


### PR DESCRIPTION
## Summary
- Move `validateCharacter()` call before `match.completed` block in GP report route
- Now consistent with BM/MR which validate before the completed block

## Test plan
- [ ] GP character validation runs for both new reports and completed-match corrections

🤖 Generated with [Claude Code](https://claude.com/claude-code)