### PR TITLE
fix(standings): remove admin auth from GET to match TA public access (#488)

### DIFF
--- a/smkc-score-app/src/lib/api-factories/standings-route.ts
+++ b/smkc-score-app/src/lib/api-factories/standings-route.ts
@@ -82,11 +82,6 @@ export function createStandingsHandlers(config: StandingsConfig) {
     { params }: { params: Promise<{ id: string }> },
   ) {
     const logger = createLogger(config.loggerName);
-    const session = await auth();
-
-    if (!session?.user || session.user.role !== 'admin') {
-      return createErrorResponse('Forbidden', 403, 'FORBIDDEN');
-    }
 
     const { id } = await params;
     const tournamentId = await resolveTournamentId(id);


### PR DESCRIPTION
## Summary
- Remove admin auth requirement from BM/MR/GP standings GET
- Standings is tournament result data and should be public (consistent with TA and tournament detail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)