### PR TITLE
fix(report): handle OptimisticLockError in BM/GP auto-confirm catch (#489)

### DIFF
--- a/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/report/route.ts
@@ -307,6 +307,12 @@ export async function POST(
           autoConfirmed: true,
         }, "Scores confirmed and match completed");
       } catch (error) {
+        if (error instanceof OptimisticLockError) {
+          return createErrorResponse(
+            "This match was updated by another user. Please refresh and try again.",
+            409, "OPTIMISTIC_LOCK_ERROR", { requiresRefresh: true }
+          );
+        }
         return handleDatabaseError(error, "match completion");
       }
     }

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -409,6 +409,12 @@ export async function POST(
           autoConfirmed: true,
         }, "Scores confirmed and match completed");
       } catch (error) {
+        if (error instanceof OptimisticLockError) {
+          return createErrorResponse(
+            "This match was updated by another user. Please refresh and try again.",
+            409, "OPTIMISTIC_LOCK_ERROR", { requiresRefresh: true }
+          );
+        }
         return handleDatabaseError(error, "match completion");
       }
     }


### PR DESCRIPTION
## Summary
- BM/GP auto-confirm catch blocks now check for OptimisticLockError first
- Return 409 with requiresRefresh flag instead of generic handleDatabaseError
- Consistent with MR which already had this handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)