### PR TITLE
fix(bm): per-group Top-N selection for barrage playoff (#454)

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -604,14 +604,32 @@ describe('Finals Route Factory', () => {
      * Phase 2 (qual top-12 + 4 playoff winners). Each test exercises one
      * of those transitions or their guard rails. */
 
-    const createMockQualifications = (count = 24) =>
-      Array.from({ length: count }, (_, i) => ({
-        id: `qual-${i}`,
-        playerId: `player-${i}`,
-        group: 'A',
-        seeding: i + 1,
-        player: { id: `player-${i}`, name: `Player ${i + 1}` },
-      }));
+    /**
+     * Build mock qualifications split across groups (default 2 groups × 12 players).
+     * The returned array is ordered (group asc, within-group rank asc) — matching
+     * qualificationOrderBy = [{ group: 'asc' }, { score: 'desc' }, ...].
+     *
+     * Player ID mapping (2-group default):
+     *   group 'A' rank 1..12 → player-0..player-11
+     *   group 'B' rank 1..12 → player-12..player-23
+     * This makes "top-12 qualifiers" (player-0..player-11) span group A entirely,
+     * which matches the original absolute-ranking tests' intuition while satisfying
+     * the per-group split required by #454.
+     */
+    const createMockQualifications = (count = 24, groupCount = 2) => {
+      const perGroup = Math.ceil(count / groupCount);
+      const groupLetters = ['A', 'B', 'C', 'D'];
+      return Array.from({ length: count }, (_, i) => {
+        const groupIdx = Math.floor(i / perGroup);
+        return {
+          id: `qual-${i}`,
+          playerId: `player-${i}`,
+          group: groupLetters[Math.min(groupIdx, groupCount - 1)],
+          seeding: (i % perGroup) + 1,
+          player: { id: `player-${i}`, name: `Player ${i + 1}` },
+        };
+      });
+    };
 
     it('Phase 1: creates 8 playoff matches when no playoff exists yet', async () => {
       (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(24));
@@ -648,12 +666,19 @@ describe('Finals Route Factory', () => {
         (c: [{ data: { stage: string } }]) => c[0].data.stage,
       );
       expect(createdStages.every((s: string) => s === 'playoff')).toBe(true);
-      /* Playoff seeds 1-12 must map to qual positions 13-24 — i.e., the top
-       * 12 qualifiers are NOT in the playoff pool. */
+      /* Per issue #454 the barrage pool = each group's rank 7..12, interleaved.
+       * Top-6 of each group (A: player-0..5, B: player-12..17) must NOT appear
+       * as player1 in any playoff match — they advance directly to the Upper
+       * Bracket. Top 7-12 of each group (player-6..11, player-18..23) are the
+       * pool from which playoff player1Id values are drawn. */
       const createdPlayerIds = (prisma.bMMatch as any).create.mock.calls.map(
         (c: [{ data: { player1Id: string } }]) => c[0].data.player1Id,
       );
-      expect(createdPlayerIds.some((id: string) => ['player-0', 'player-11'].includes(id))).toBe(false);
+      const directAdvancers = [
+        'player-0', 'player-1', 'player-2', 'player-3', 'player-4', 'player-5',
+        'player-12', 'player-13', 'player-14', 'player-15', 'player-16', 'player-17',
+      ];
+      expect(createdPlayerIds.some((id: string) => directAdvancers.includes(id))).toBe(false);
     });
 
     it('returns 400 when fewer than 24 qualifiers exist', async () => {
@@ -790,9 +815,13 @@ describe('Finals Route Factory', () => {
       expect(seedMap.get(13)).toBe('player-15'); /* From playoff R2 match 6 */
       expect(seedMap.get(14)).toBe('player-14'); /* From playoff R2 match 7 */
       expect(seedMap.get(15)).toBe('player-13'); /* From playoff R2 match 8 */
-      /* Direct-advance qualifiers occupy seeds 1-12. */
+      /* Direct-advance qualifiers occupy seeds 1-12, interleaved by group rank (#454):
+       * seed 1 = A-rank-1 (player-0), seed 2 = B-rank-1 (player-12),
+       * seed 3 = A-rank-2 (player-1), ..., seed 12 = B-rank-6 (player-17). */
       expect(seedMap.get(1)).toBe('player-0');
-      expect(seedMap.get(12)).toBe('player-11');
+      expect(seedMap.get(2)).toBe('player-12');
+      expect(seedMap.get(11)).toBe('player-5');  /* A-rank-6 */
+      expect(seedMap.get(12)).toBe('player-17'); /* B-rank-6 */
     });
   });
 

--- a/smkc-score-app/__tests__/lib/finals-group-selection.test.ts
+++ b/smkc-score-app/__tests__/lib/finals-group-selection.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for finals-group-selection: per-group Top-N selection with interleaved seeding
+ *
+ * Spec (Issue #454):
+ *   2 groups: each group Top1-6 direct, Top7-12 barrage
+ *   3 groups: each group Top1-4 direct, Top5-8 barrage
+ *   4 groups: each group Top1-3 direct, Top4-6 barrage
+ *
+ * Interleave pattern for seeds (direct seeds 1-12, playoff seeds 1-12):
+ *   2 groups: A1, B1, A2, B2, A3, B3, A4, B4, A5, B5, A6, B6
+ *   3 groups: A1, B1, C1, A2, B2, C2, A3, B3, C3, A4, B4, C4
+ *   4 groups: A1, B1, C1, D1, A2, B2, C2, D2, A3, B3, C3, D3
+ */
+
+import { selectFinalsEntrantsByGroup } from '@/lib/finals-group-selection';
+
+type TestQual = { playerId: string; group: string; player: unknown };
+
+/**
+ * Build an ordered qualification list: grouped alphabetically, and within each group
+ * ordered by rank (rank 1 first). Player ID encodes group+rank (e.g. "A1", "B7").
+ */
+function buildQuals(groupSizes: Record<string, number>): TestQual[] {
+  const out: TestQual[] = [];
+  for (const group of Object.keys(groupSizes).sort()) {
+    for (let rank = 1; rank <= groupSizes[group]; rank++) {
+      const playerId = `${group}${rank}`;
+      out.push({ playerId, group, player: { id: playerId, name: playerId } });
+    }
+  }
+  return out;
+}
+
+describe('selectFinalsEntrantsByGroup', () => {
+  describe('2-group case (A=14, B=13)', () => {
+    const quals = buildQuals({ A: 14, B: 13 });
+    const result = selectFinalsEntrantsByGroup(quals);
+
+    it('reports groupCount=2', () => {
+      expect(result.groupCount).toBe(2);
+    });
+
+    it('direct[] is A1,B1,A2,B2,...,A6,B6 (12 players, interleaved)', () => {
+      expect(result.direct.map(q => q.playerId)).toEqual([
+        'A1', 'B1', 'A2', 'B2', 'A3', 'B3',
+        'A4', 'B4', 'A5', 'B5', 'A6', 'B6',
+      ]);
+    });
+
+    it('barrage[] is A7,B7,A8,B8,...,A12,B12 (12 players, interleaved)', () => {
+      expect(result.barrage.map(q => q.playerId)).toEqual([
+        'A7', 'B7', 'A8', 'B8', 'A9', 'B9',
+        'A10', 'B10', 'A11', 'B11', 'A12', 'B12',
+      ]);
+    });
+  });
+
+  describe('3-group case (A=9, B=9, C=9)', () => {
+    const quals = buildQuals({ A: 9, B: 9, C: 9 });
+    const result = selectFinalsEntrantsByGroup(quals);
+
+    it('reports groupCount=3', () => {
+      expect(result.groupCount).toBe(3);
+    });
+
+    it('direct[] is Top1-4 from each group, interleaved', () => {
+      expect(result.direct.map(q => q.playerId)).toEqual([
+        'A1', 'B1', 'C1',
+        'A2', 'B2', 'C2',
+        'A3', 'B3', 'C3',
+        'A4', 'B4', 'C4',
+      ]);
+    });
+
+    it('barrage[] is Top5-8 from each group, interleaved', () => {
+      expect(result.barrage.map(q => q.playerId)).toEqual([
+        'A5', 'B5', 'C5',
+        'A6', 'B6', 'C6',
+        'A7', 'B7', 'C7',
+        'A8', 'B8', 'C8',
+      ]);
+    });
+  });
+
+  describe('4-group case (A=B=C=D=6)', () => {
+    const quals = buildQuals({ A: 6, B: 6, C: 6, D: 6 });
+    const result = selectFinalsEntrantsByGroup(quals);
+
+    it('reports groupCount=4', () => {
+      expect(result.groupCount).toBe(4);
+    });
+
+    it('direct[] is Top1-3 from each group, interleaved', () => {
+      expect(result.direct.map(q => q.playerId)).toEqual([
+        'A1', 'B1', 'C1', 'D1',
+        'A2', 'B2', 'C2', 'D2',
+        'A3', 'B3', 'C3', 'D3',
+      ]);
+    });
+
+    it('barrage[] is Top4-6 from each group, interleaved', () => {
+      expect(result.barrage.map(q => q.playerId)).toEqual([
+        'A4', 'B4', 'C4', 'D4',
+        'A5', 'B5', 'C5', 'D5',
+        'A6', 'B6', 'C6', 'D6',
+      ]);
+    });
+  });
+
+  describe('uneven group sizes (barrage slots still filled to 12)', () => {
+    it('2 groups A=20, B=12: each contributes Top1-6 direct, Top7-12 barrage', () => {
+      const quals = buildQuals({ A: 20, B: 12 });
+      const result = selectFinalsEntrantsByGroup(quals);
+      expect(result.direct.map(q => q.playerId)).toEqual([
+        'A1', 'B1', 'A2', 'B2', 'A3', 'B3',
+        'A4', 'B4', 'A5', 'B5', 'A6', 'B6',
+      ]);
+      expect(result.barrage.map(q => q.playerId)).toEqual([
+        'A7', 'B7', 'A8', 'B8', 'A9', 'B9',
+        'A10', 'B10', 'A11', 'B11', 'A12', 'B12',
+      ]);
+    });
+  });
+
+  describe('error cases', () => {
+    it('throws when a group has fewer than perGroup*2 players (2 groups, B=11)', () => {
+      const quals = buildQuals({ A: 14, B: 11 });
+      expect(() => selectFinalsEntrantsByGroup(quals)).toThrow(/Not enough players in group B/);
+    });
+
+    it('throws when only 1 group is present', () => {
+      const quals = buildQuals({ A: 24 });
+      expect(() => selectFinalsEntrantsByGroup(quals)).toThrow(/Unsupported group count/);
+    });
+
+    it('throws when group count is not a divisor of 12', () => {
+      // 5 groups would need perGroup=2.4, not supported. Not reachable via GROUPS constant (max 4),
+      // but defensive check.
+      const quals: TestQual[] = [];
+      for (const g of ['A', 'B', 'C', 'D', 'E']) {
+        for (let r = 1; r <= 6; r++) {
+          quals.push({ playerId: `${g}${r}`, group: g, player: { id: `${g}${r}` } });
+        }
+      }
+      expect(() => selectFinalsEntrantsByGroup(quals)).toThrow(/Unsupported group count/);
+    });
+
+    it('throws when input is empty', () => {
+      expect(() => selectFinalsEntrantsByGroup([])).toThrow();
+    });
+  });
+
+  describe('input ordering is preserved within group', () => {
+    it('respects the caller-provided order even if scrambled across groups', () => {
+      // Caller provides interleaved A/B (out-of-group order). The function should still
+      // bucket by group while preserving per-group relative order.
+      const mk = (g: string, r: number): TestQual => ({
+        playerId: `${g}${r}`, group: g, player: { id: `${g}${r}` },
+      });
+      const quals: TestQual[] = [];
+      for (let r = 1; r <= 12; r++) {
+        quals.push(mk('A', r), mk('B', r));
+      }
+      const result = selectFinalsEntrantsByGroup(quals);
+      expect(result.direct.map(q => q.playerId)).toEqual([
+        'A1', 'B1', 'A2', 'B2', 'A3', 'B3',
+        'A4', 'B4', 'A5', 'B5', 'A6', 'B6',
+      ]);
+    });
+  });
+});

--- a/smkc-score-app/src/app/api/tournaments/[id]/bm/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/bm/finals/route.ts
@@ -13,7 +13,9 @@ const { GET, POST, PUT } = createFinalsHandlers({
   matchModel: 'bMMatch',
   qualificationModel: 'bMQualification',
   loggerName: 'bm-finals-api',
-  qualificationOrderBy: [{ score: 'desc' }, { points: 'desc' }, { winRounds: 'desc' }],
+  /* `group: 'asc'` is first so that Top-24 → Top-16 Playoff (#454) can pick
+   * per-group Top-N deterministically. Within-group order: score → points → winRounds. */
+  qualificationOrderBy: [{ group: 'asc' }, { score: 'desc' }, { points: 'desc' }, { winRounds: 'desc' }],
   getStyle: 'grouped',
   putScoreFields: { dbField1: 'score1', dbField2: 'score2' },
   targetWins: BM_FINALS_TARGET_WINS,

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -19,6 +19,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
 import { generateBracketStructure, generatePlayoffStructure, roundNames } from '@/lib/double-elimination';
+import { selectFinalsEntrantsByGroup } from '@/lib/finals-group-selection';
 import { paginate } from '@/lib/pagination';
 import { sanitizeInput } from '@/lib/sanitize';
 import { createLogger } from '@/lib/logger';
@@ -396,18 +397,40 @@ export function createFinalsHandlers(config: FinalsConfig) {
     const logger = createLogger(finalsConfig.loggerName);
 
     try {
-      /* Fetch Top 24 qualifiers — needed for both phases (Phase 1 picks 13-24 as
-       * playoff seeds; Phase 2 picks 1-12 as direct Upper-Bracket seeds). */
+      /* Fetch ALL qualifiers (not just Top 24). Per issue #454 the direct/barrage
+       * split is per-group (each group contributes perGroup=12/G direct and perGroup
+       * barrage players), so we need every group's full ranking to pick Top-1..2*perGroup
+       * from each. Caller's qualificationOrderBy is expected to put `group` first
+       * (BM: [{ group: 'asc' }, { score: 'desc' }, ...]); within-group ordering by
+       * score/points is preserved via stable insertion-order bucketing in
+       * selectFinalsEntrantsByGroup. */
       const qualifications = await qualificationModel(prisma).findMany({
         where: { tournamentId },
         include: { player: true },
         orderBy: finalsConfig.qualificationOrderBy,
-        take: 24,
       });
 
       if (qualifications.length < 24) {
         return handleValidationError(
           `Not enough players qualified. Need 24, found ${qualifications.length}`,
+          'qualifications',
+        );
+      }
+
+      /* Per-group Top-N selection with interleaved seed assignment (#454).
+       * Phase 1 and Phase 2 both re-derive the split; this relies on qualifications
+       * being frozen between the two calls. If scores are edited after Phase 1
+       * creates playoff rows, the Phase-2 direct/barrage computation can diverge
+       * from what Phase 1 used — acceptable since the admin workflow freezes
+       * qualification before finals. */
+      let selection: ReturnType<typeof selectFinalsEntrantsByGroup>;
+      try {
+        selection = selectFinalsEntrantsByGroup(
+          qualifications as Array<{ playerId: string; player: unknown; group: string }>,
+        );
+      } catch (err) {
+        return handleValidationError(
+          err instanceof Error ? err.message : 'Invalid group distribution',
           'qualifications',
         );
       }
@@ -421,14 +444,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
       if (existingPlayoff.length === 0) {
         const playoffStructure = generatePlayoffStructure(PLAYOFF_ENTRANT_COUNT);
 
-        /* Playoff-local seeds 1-12 map to qualification positions 13-24. */
-        const playoffSeededPlayers = qualifications
-          .slice(12, 24)
-          .map((q: { playerId: string; player: unknown }, index: number) => ({
-            seed: index + 1,
-            playerId: q.playerId,
-            player: q.player,
-          }));
+        /* Playoff-local seeds 1-12 are the barrage entrants, interleaved by group. */
+        const playoffSeededPlayers = selection.barrage.map((q, index) => ({
+          seed: index + 1,
+          playerId: q.playerId,
+          player: q.player,
+        }));
 
         const createdPlayoffMatches = [];
         for (const bracketMatch of playoffStructure) {
@@ -505,14 +526,13 @@ export function createFinalsHandlers(config: FinalsConfig) {
         });
       }
 
-      /* Build the 16 seeded players: 1-12 from qualification, 13-16 from playoff winners. */
-      const directPlayers = qualifications.slice(0, 12).map(
-        (q: { playerId: string; player: unknown }, index: number) => ({
-          seed: index + 1,
-          playerId: q.playerId,
-          player: q.player,
-        }),
-      );
+      /* Build the 16 seeded players: 1-12 from per-group direct advancers
+       * (interleaved by group rank, #454), 13-16 from playoff winners. */
+      const directPlayers = selection.direct.map((q, index) => ({
+        seed: index + 1,
+        playerId: q.playerId,
+        player: q.player,
+      }));
       const playoffWinnerSeeds = [13, 14, 15, 16].map((upperSeed) => {
         const winner = upperSeedToPlayer.get(upperSeed);
         if (!winner) {

--- a/smkc-score-app/src/lib/finals-group-selection.ts
+++ b/smkc-score-app/src/lib/finals-group-selection.ts
@@ -1,0 +1,114 @@
+/**
+ * Finals entrant selection with per-group Top-N + interleaved seeding.
+ *
+ * Spec (Issue #454, Top-24 → Top-16 flow):
+ *   - 12 direct advancers fill Upper Bracket seeds 1-12.
+ *   - 12 barrage entrants fill Playoff seeds 1-12 (single-elim R1+R2 → 4 winners → Upper 13-16).
+ *
+ * Per-group split (based on group count G):
+ *   perGroup = 12 / G (2→6, 3→4, 4→3)
+ *   Each group contributes: Top 1..perGroup direct, Top (perGroup+1)..(2*perGroup) barrage.
+ *
+ * Seeds are assigned by **interleaving groups round-robin**, so that strong players
+ * from different groups are spread across the bracket rather than clustered. This
+ * keeps group-rank-1 players (A1, B1, C1, D1) at the top of the direct bracket and
+ * prevents two group-1 players from meeting in the first round.
+ *
+ * Example (2 groups, A=14, B=13):
+ *   direct:  A1, B1, A2, B2, A3, B3, A4, B4, A5, B5, A6, B6
+ *   barrage: A7, B7, A8, B8, A9, B9, A10, B10, A11, B11, A12, B12
+ *
+ * Caller contract: `allQualifications` must already be ordered per-group by final
+ * ranking (score, tiebreakers, H2H). Group bucketing preserves caller-provided order.
+ */
+
+import { GROUPS } from './group-utils';
+
+/** Minimum shape required from a qualification record. */
+export interface FinalsQualInput {
+  playerId: string;
+  group: string;
+  player: unknown;
+}
+
+interface FinalsGroupSelection {
+  /** 12 direct advancers, ordered for Upper Bracket seeds 1-12 (interleaved). */
+  direct: FinalsQualInput[];
+  /** 12 barrage entrants, ordered for Playoff seeds 1-12 (interleaved). */
+  barrage: FinalsQualInput[];
+  /** Detected group count (2, 3, or 4). */
+  groupCount: 2 | 3 | 4;
+}
+
+const TOTAL_FINALS_SLOTS = 12;
+
+/**
+ * Select finals direct-advancers and barrage entrants from group-based qualifications.
+ *
+ * @throws Error if input is empty, if group count is not 2/3/4, or if any group
+ *   has fewer than `2 * perGroup` qualified players.
+ */
+export function selectFinalsEntrantsByGroup(
+  allQualifications: FinalsQualInput[],
+): FinalsGroupSelection {
+  if (allQualifications.length === 0) {
+    throw new Error('selectFinalsEntrantsByGroup: qualifications array is empty');
+  }
+
+  /* Bucket preserving caller-provided order within each group. */
+  const byGroup = new Map<string, FinalsQualInput[]>();
+  for (const q of allQualifications) {
+    const bucket = byGroup.get(q.group);
+    if (bucket) bucket.push(q);
+    else byGroup.set(q.group, [q]);
+  }
+
+  const groupCount = byGroup.size;
+  if (groupCount < 2 || groupCount > 4 || TOTAL_FINALS_SLOTS % groupCount !== 0) {
+    throw new Error(
+      `selectFinalsEntrantsByGroup: Unsupported group count ${groupCount} (must be 2, 3, or 4)`,
+    );
+  }
+
+  const perGroup = TOTAL_FINALS_SLOTS / groupCount;
+
+  /* Order group keys by the canonical GROUPS sequence (A, B, C, D) for deterministic
+   * interleave order; include only groups actually present. */
+  const orderedGroupKeys = (GROUPS as readonly string[]).filter(g => byGroup.has(g));
+  if (orderedGroupKeys.length !== groupCount) {
+    throw new Error(
+      `selectFinalsEntrantsByGroup: Unknown group key detected (expected one of ${GROUPS.join(', ')})`,
+    );
+  }
+
+  /* Snapshot each group's bucket so repeated lookups are cheap and we can drop the
+   * `byGroup.get(g)!` non-null assertions. */
+  const buckets: FinalsQualInput[][] = orderedGroupKeys.map(g => byGroup.get(g) as FinalsQualInput[]);
+
+  /* Verify each group has enough players for both direct (perGroup) and barrage (perGroup). */
+  for (let i = 0; i < orderedGroupKeys.length; i++) {
+    if (buckets[i].length < perGroup * 2) {
+      throw new Error(
+        `selectFinalsEntrantsByGroup: Not enough players in group ${orderedGroupKeys[i]} (need ${perGroup * 2}, found ${buckets[i].length})`,
+      );
+    }
+  }
+
+  /* Interleave round-robin: for slot k in [0, perGroup), take each group's k-th player.
+   *   2 groups: [A0,B0,A1,B1,...] → A1,B1,A2,B2,... (1-indexed in spec)
+   *   3 groups: [A0,B0,C0,A1,B1,C1,...] */
+  const direct: FinalsQualInput[] = [];
+  const barrage: FinalsQualInput[] = [];
+  for (let k = 0; k < perGroup; k++) {
+    for (const bucket of buckets) direct.push(bucket[k]);
+  }
+  for (let k = perGroup; k < perGroup * 2; k++) {
+    for (const bucket of buckets) barrage.push(bucket[k]);
+  }
+
+  return {
+    direct,
+    barrage,
+    groupCount: groupCount as 2 | 3 | 4,
+  };
+}


### PR DESCRIPTION
## Summary

- Issue [#454](https://github.com/azumag/JSMKC/issues/454) 再オープン: BM Top-24 → Top-16 pre-bracket playoff の直進 12 名 / barrage 12 名の選抜が**全体絶対ランキング** (`slice(0,12)` / `slice(12,24)`) になっており、**グループ毎 Top-N** 仕様 (2グループなら各 Top1-6 直進 / Top7-12 barrage、3グループ 4-4、4グループ 3-3) と乖離していた。
- 2グループ構成 (A=14/B=13) では `orderBy` が group-asc 先頭のためグループ A 全員が `slice(0,12)` に入ってしまい、B 勢が直進枠から締め出される実害があった。
- 新規 `selectFinalsEntrantsByGroup()` でグループ別バケット → `12/G` 抜き出し → グループ内順位でインターリーブ (A1,B1,A2,B2,... / A1,B1,C1,A2,B2,C2,...)。
- BM finals route config の `qualificationOrderBy` 先頭に `{ group: 'asc' }` を追加し、仕様をコードで表明。

## Files changed

- **(new)** `src/lib/finals-group-selection.ts` — `selectFinalsEntrantsByGroup`
- `src/lib/api-factories/finals-route.ts` — `handleTop24Post` Phase 1/2 を selection ベースに差し替え、バリデーションエラー時は 400 返却
- `src/app/api/tournaments/[id]/bm/finals/route.ts` — `qualificationOrderBy` に `group: 'asc'` 先頭追加
- **(new)** `__tests__/lib/finals-group-selection.test.ts` — 15 tests (2/3/4 group + uneven + error + input-order)
- `__tests__/lib/api-factories/finals-route.test.ts` — mock qualifications を 2 グループに変更、Phase 1/2 アサーション更新

## Out of scope

- Issue #454 コメントにある「Upper seed 9-16 から参入」案は別議論（現行 13-16 固定維持）
- 4 グループ構成での playoff 構造変更（12 人固定維持）
- Top-16 / Top-N (N≠24) ルートの挙動

## Test plan

- [x] `npm test -- finals-group-selection` → 15/15 pass
- [x] `npm test -- finals-route -t "Top 24 Playoff"` → 4/4 pass
- [x] 全体 jest: 144 failed (= main baseline, 事前存在の失敗) / 1640 passed (+15 new)
- [x] `next build` 成功
- [x] TypeScript strict check 新規/変更ファイルにエラーなし
- [ ] デプロイ後 production の 2 グループ構成で Phase 1 / Phase 2 API レスポンスを手動検証
- [ ] 既存 E2E (`node e2e/tc-all.js`) 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)