### PR TITLE
fix(ta): auto-recompute pairs when seeding changes

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/pair-utils.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/pair-utils.test.ts
@@ -1,4 +1,4 @@
-import { computeAutoPairs } from '@/lib/ta/pair-utils';
+import { applyAutoPairsToSetup, computeAutoPairs } from '@/lib/ta/pair-utils';
 
 /** Helper to make a minimal PairPlayer entry */
 const makeEntry = (id: string, playerId: string, seeding: number | null) => ({
@@ -83,5 +83,54 @@ describe('computeAutoPairs', () => {
     const original = [...players];
     computeAutoPairs(players);
     expect(players).toEqual(original);
+  });
+});
+
+describe('applyAutoPairsToSetup', () => {
+  it('assigns reciprocal partners to seeded entries using snake pairing', () => {
+    const result = applyAutoPairsToSetup<{ playerId: string; seeding?: number; partnerId?: string | null }>([
+      { playerId: 'p1', seeding: 1 },
+      { playerId: 'p2', seeding: 2 },
+      { playerId: 'p3', seeding: 3 },
+      { playerId: 'p4', seeding: 4 },
+    ]);
+
+    const byId = new Map(result.map((e) => [e.playerId, e.partnerId]));
+    // seed 1 ↔ seed 4, seed 2 ↔ seed 3
+    expect(byId.get('p1')).toBe('p4');
+    expect(byId.get('p4')).toBe('p1');
+    expect(byId.get('p2')).toBe('p3');
+    expect(byId.get('p3')).toBe('p2');
+  });
+
+  it('leaves unranked entries untouched so manual pairings survive seeding edits', () => {
+    const result = applyAutoPairsToSetup([
+      { playerId: 'p1', seeding: 1 },
+      { playerId: 'p2', seeding: 2 },
+      { playerId: 'p3', partnerId: 'p4' },
+      { playerId: 'p4', partnerId: 'p3' },
+    ]);
+
+    const byId = new Map(result.map((e) => [e.playerId, e.partnerId]));
+    // Seeded pair gets computed partnerId
+    expect(byId.get('p1')).toBe('p2');
+    expect(byId.get('p2')).toBe('p1');
+    // Unranked entries keep their prior partnerId
+    expect(byId.get('p3')).toBe('p4');
+    expect(byId.get('p4')).toBe('p3');
+  });
+
+  it('nulls the partner of the odd-player-out when seed count is odd', () => {
+    const result = applyAutoPairsToSetup([
+      { playerId: 'p1', seeding: 1, partnerId: 'p2' },
+      { playerId: 'p2', seeding: 2, partnerId: 'p1' },
+      { playerId: 'p3', seeding: 3, partnerId: 'p1' }, // stale partnerId
+    ]);
+
+    const byId = new Map(result.map((e) => [e.playerId, e.partnerId]));
+    // seed 1 ↔ seed 3 per snake pairing; seed 2 has no partner
+    expect(byId.get('p1')).toBe('p3');
+    expect(byId.get('p3')).toBe('p1');
+    expect(byId.get('p2')).toBeNull();
   });
 });

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
@@ -71,7 +71,7 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { COURSE_INFO, POLLING_INTERVAL, TOTAL_COURSES } from "@/lib/constants";
-import { computeAutoPairs } from "@/lib/ta/pair-utils";
+import { applyAutoPairsToSetup } from "@/lib/ta/pair-utils";
 import { extractArrayData } from "@/lib/api-response";
 import { autoFormatTime, generateRandomTimeString, msToDisplayTime, timeToMs } from "@/lib/ta/time-utils";
 import { usePolling } from "@/lib/hooks/usePolling";
@@ -328,21 +328,13 @@ export default function TimeAttackPage({
    * Compute snake pairs from the current setupEntries (local dialog state)
    * and apply them in-place. Operates on the in-flight dialog state rather
    * than the server so the admin can preview/adjust before saving.
+   *
+   * Also invoked automatically whenever a seeding input changes so the UI
+   * mirrors §3.1 without requiring an extra button click (previously users
+   * could save seeded entries with no partners assigned).
    */
   const handleAutoPair = () => {
-    // Only pair entries that have seeding set; entries without seeding stay unpaired.
-    const pairPlayers = setupEntries
-      .filter((s) => typeof s.seeding === "number")
-      .map((s) => ({ id: s.playerId, playerId: s.playerId, seeding: s.seeding ?? null }));
-    const rawPairs = computeAutoPairs(pairPlayers);
-    const partnerMap = new Map<string, string>();
-    rawPairs.forEach(([a, b]) => {
-      partnerMap.set(a.playerId, b.playerId);
-      partnerMap.set(b.playerId, a.playerId);
-    });
-    setSetupEntries((prev) =>
-      prev.map((s) => ({ ...s, partnerId: partnerMap.get(s.playerId) ?? null })),
-    );
+    setSetupEntries((prev) => applyAutoPairsToSetup(prev));
   };
 
   /**
@@ -965,9 +957,13 @@ export default function TimeAttackPage({
                                           val && !Number.isNaN(parsed) && parsed >= 1
                                             ? parsed
                                             : undefined;
+                                        /* Recompute snake pairs immediately so the partner
+                                         * column reflects §3.1 as soon as seedings change. */
                                         setSetupEntries((prev) =>
-                                          prev.map((p) =>
-                                            p.playerId === s.playerId ? { ...p, seeding } : p,
+                                          applyAutoPairsToSetup(
+                                            prev.map((p) =>
+                                              p.playerId === s.playerId ? { ...p, seeding } : p,
+                                            ),
                                           ),
                                         );
                                       }}

--- a/smkc-score-app/src/lib/ta/pair-utils.ts
+++ b/smkc-score-app/src/lib/ta/pair-utils.ts
@@ -43,3 +43,32 @@ export function computeAutoPairs<T extends PairPlayer>(players: T[]): Array<[T, 
   }
   return pairs;
 }
+
+/**
+ * Apply snake-pair computation over setup-dialog entries and return an updated
+ * list with `partnerId` set for every entry that has a numeric seeding.
+ *
+ * Entries without a seeding keep their existing `partnerId` untouched so that
+ * manual assignments for unranked rows survive a seeding edit elsewhere.
+ */
+export interface SetupEntryLike {
+  playerId: string;
+  seeding?: number;
+  partnerId?: string | null;
+}
+
+export function applyAutoPairsToSetup<T extends SetupEntryLike>(entries: T[]): T[] {
+  const seeded = entries
+    .filter((e) => typeof e.seeding === "number")
+    .map((e) => ({ id: e.playerId, playerId: e.playerId, seeding: e.seeding ?? null }));
+  const partnerMap = new Map<string, string>();
+  for (const [a, b] of computeAutoPairs(seeded)) {
+    partnerMap.set(a.playerId, b.playerId);
+    partnerMap.set(b.playerId, a.playerId);
+  }
+  return entries.map((e) =>
+    typeof e.seeding === "number"
+      ? { ...e, partnerId: partnerMap.get(e.playerId) ?? null }
+      : e,
+  );
+}


### PR DESCRIPTION
## Summary
- Report: 「TAプレイヤー追加で、シードを入力した後ペアが決定されていない」
- TA Setup/Edit Players ダイアログ内でシーディングを入力しても §3.1 のスネーク組に自動反映されず、別途「Auto Pair」ボタンを押さないとパートナーが未設定のまま保存できてしまっていた
- シーディング onChange で `applyAutoPairsToSetup` を即時適用し、パートナーカラムを同期更新
- 共通化した `applyAutoPairsToSetup` helper と新規テスト（snake pair / 奇数人数 / 未シーディング行の保持）を追加

## Test plan
- [x] `jest __tests__/lib/ta/pair-utils.test.ts` — 10 passed
- [x] `tsc --noEmit` — 変更ファイルに新規エラーなし
- [ ] 手動: Setup Players ダイアログで seed を編集 → パートナー欄が即時更新される
- [ ] 手動: パートナーを手動選択した未シーディング行が、他行の seed 編集後も保持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)