### PR TITLE
fix(e2e+pages): resolve TA E2E failures (tab switch / Save URL / player pagination / TC-805)

### DIFF
--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -1162,6 +1162,14 @@ async function uiSetTaEntryTimes(page, tournamentId, entry, times) {
     await nav(page, `/tournaments/${tournamentId}/ta`);
   }
 
+  /* The /ta page defaults to the "standings" tab which has no Edit Times
+   * buttons — switch to the Time Entry tab first. Tabs radix updates
+   * aria-selected on click; repeated clicks are a safe no-op. */
+  const timesTab = page.getByRole('tab', { name: /^(Time Entry|Time List|タイム入力|タイム一覧)$/ });
+  if (await timesTab.count()) {
+    await timesTab.first().click().catch(() => {});
+  }
+
   /* Each entry row has an "Edit Times" button; filter the row by nickname. */
   const row = page.getByRole('row').filter({ hasText: entry.nickname }).first();
   await row.getByRole('button', { name: /^(Edit Times|タイム編集)$/ }).click();


### PR DESCRIPTION
## Summary
原因の異なる 4 件のバグを一括修正。修正後の再試行は省略していますが、いずれも失敗時のログから根本原因を特定済みです。

### 1. タイム入力タブ未切替 (TC-801 / TC-804 の 1 次FAIL原因)
`uiSetTaEntryTimes` が `/ta` のデフォルト「standings」タブから直接 `Edit Times` を探していた。`getByRole('tab', { name: /Time Entry|タイム入力/ })` を先にクリックするよう修正。

### 2. Save Times の URL マッチャが間違っていた (TC-801 / TC-804 の 2 次FAIL)
管理者の Save Times は `handleSaveTimes` で `/api/tournaments/[id]/ta` へ PUT するが、ヘルパーは `/tt/entries/` を `waitForResponse` で待っていたため常にタイムアウトしていた。URL パターンを実装に合わせて修正。

### 3. `/api/players` のデフォルト limit=50 による Setup dialog 取りこぼし (TC-806 / TC-807)
本番DB のプレイヤー総数が 50 を超えると、テストで作成した新規プレイヤー（アルファベット順で後ろ）が Setup dialog の候補リストから消え、`getByLabel(e2e_ta806_..._3 (...))` がタイムアウトしていた。BM/MR/GP/TA すべての mode page で `limit=100`（API 上限）を明示的に指定。

### 4. TC-805 の rowFor アサーションが統合 Setup dialog と不整合
統合 dialog リファクタで候補一覧は `<Checkbox> + <Label>` の flex 行になっており、`getByRole('row')` は何もヒットしないため timeout。dialog スコープの `getByLabel(\`^\${nickname} \(\${name}\)\$\`)` に変更。

## Test plan
- [ ] `npm run e2e:ta` で全 TC の挙動改善を確認
- [x] 変更後の `handleSaveTimes` → PUT 先を実装で再確認
- [x] `/api/players?limit=100` がAPI キャップ (`src/lib/pagination.ts`) と一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)