### PR TITLE
fix(mr,gp): per-group barrage playoff parity with BM (#454)

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -825,6 +825,126 @@ describe('Finals Route Factory', () => {
     });
   });
 
+  /* MR/GP parity coverage: the Top-24 Playoff flow is mode-agnostic thanks to
+   * the api-factory pattern, but each mode declares its own orderBy shape
+   * (BM: [group,score,points,winRounds], MR: same, GP: [group,points,score]).
+   * These tests exercise Phase 1 with each mode's orderBy to prove the factory
+   * contract holds regardless of the within-group tiebreaker key order. */
+  describe.each([
+    {
+      mode: 'MR',
+      matchModel: 'mRMatch',
+      qualificationModel: 'mRQualification',
+      loggerName: 'mr-finals-api',
+      orderBy: [{ group: 'asc' }, { score: 'desc' }, { points: 'desc' }, { winRounds: 'desc' }],
+    },
+    {
+      mode: 'GP',
+      matchModel: 'gPMatch',
+      qualificationModel: 'gPQualification',
+      loggerName: 'gp-finals-api',
+      /* GP ranks by driver points (score in DB semantics differs across modes). */
+      orderBy: [{ group: 'asc' }, { points: 'desc' }, { score: 'desc' }],
+    },
+  ])('POST Handler — Top 24 Playoff — $mode parity', (modeConfig) => {
+    const createMockModeQuals = (count = 24, groupCount = 2) => {
+      const perGroup = Math.ceil(count / groupCount);
+      const groupLetters = ['A', 'B', 'C', 'D'];
+      return Array.from({ length: count }, (_, i) => {
+        const groupIdx = Math.floor(i / perGroup);
+        return {
+          id: `qual-${i}`,
+          playerId: `player-${i}`,
+          group: groupLetters[Math.min(groupIdx, groupCount - 1)],
+          seeding: (i % perGroup) + 1,
+          player: { id: `player-${i}`, name: `Player ${i + 1}` },
+        };
+      });
+    };
+
+    it(`Phase 1: creates 8 playoff matches with ${modeConfig.mode}-shape orderBy`, async () => {
+      /* Prisma is mocked to ignore orderBy, so this test validates that the
+       * factory accepts each mode's config shape and produces the same
+       * per-group interleaved selection — i.e., the Top-24 feature is not
+       * coupled to BM-specific field names. */
+      (prisma[modeConfig.qualificationModel as keyof typeof prisma] as any).findMany.mockResolvedValue(
+        createMockModeQuals(24),
+      );
+      (prisma[modeConfig.matchModel as keyof typeof prisma] as any).findMany.mockResolvedValue([]);
+      (prisma[modeConfig.matchModel as keyof typeof prisma] as any).create.mockImplementation(
+        ({ data }: { data: { matchNumber: number; round: string } }) => ({
+          id: `playoff-${data.matchNumber}`,
+          ...data,
+          player1: { id: data.matchNumber },
+          player2: { id: data.matchNumber },
+        }),
+      );
+
+      const config = createMockConfig({
+        matchModel: modeConfig.matchModel,
+        qualificationModel: modeConfig.qualificationModel,
+        loggerName: modeConfig.loggerName,
+        qualificationOrderBy: modeConfig.orderBy,
+      });
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 24 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(201);
+      const json = await response.json();
+      expect(json.data.phase).toBe('playoff');
+      expect(json.data.matches).toHaveLength(8);
+      /* Same per-group invariant as BM: top-6 of each group must NOT be in
+       * the playoff pool (they advance directly to the Upper Bracket). */
+      const createdPlayerIds = (prisma[modeConfig.matchModel as keyof typeof prisma] as any).create
+        .mock.calls.map((c: [{ data: { player1Id: string } }]) => c[0].data.player1Id);
+      const directAdvancers = [
+        'player-0', 'player-1', 'player-2', 'player-3', 'player-4', 'player-5',
+        'player-12', 'player-13', 'player-14', 'player-15', 'player-16', 'player-17',
+      ];
+      expect(createdPlayerIds.some((id: string) => directAdvancers.includes(id))).toBe(false);
+      /* Orderby is forwarded to prisma verbatim — proves the factory doesn't
+       * rewrite the caller's tiebreaker configuration. */
+      expect((prisma[modeConfig.qualificationModel as keyof typeof prisma] as any).findMany)
+        .toHaveBeenCalledWith(expect.objectContaining({ orderBy: modeConfig.orderBy }));
+    });
+
+    it(`returns 400 when group distribution is invalid (${modeConfig.mode})`, async () => {
+      /* Single-group 24 qualifiers cannot produce a 2/3/4-group barrage split.
+       * The factory must return 400 (not 500) with a meaningful message,
+       * identical behavior to BM. */
+      (prisma[modeConfig.qualificationModel as keyof typeof prisma] as any).findMany.mockResolvedValue(
+        createMockModeQuals(24, 1),
+      );
+      (prisma[modeConfig.matchModel as keyof typeof prisma] as any).findMany.mockResolvedValue([]);
+
+      const config = createMockConfig({
+        matchModel: modeConfig.matchModel,
+        qualificationModel: modeConfig.qualificationModel,
+        loggerName: modeConfig.loggerName,
+        qualificationOrderBy: modeConfig.orderBy,
+      });
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 24 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(400);
+      expect((prisma[modeConfig.matchModel as keyof typeof prisma] as any).create).not.toHaveBeenCalled();
+    });
+  });
+
   // ============================================================
   // PUT Handler Tests (15 cases)
   // ============================================================

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
@@ -11,8 +11,10 @@ const { GET, POST, PUT } = createFinalsHandlers({
   matchModel: 'gPMatch',
   qualificationModel: 'gPQualification',
   loggerName: 'gp-finals-api',
-  // GP uses drivers points as primary ranking criterion (per requirements.md Section 4.1)
-  qualificationOrderBy: [{ points: 'desc' }, { score: 'desc' }],
+  /* `group: 'asc'` is first so that Top-24 → Top-16 Playoff (#454) can pick
+   * per-group Top-N deterministically. Within-group order: driver points
+   * (primary ranking per requirements.md §4.1) → match score. */
+  qualificationOrderBy: [{ group: 'asc' }, { points: 'desc' }, { score: 'desc' }],
   getStyle: 'paginated',
   putScoreFields: { dbField1: 'points1', dbField2: 'points2' },
   getErrorMessage: 'Failed to fetch grand prix finals data',

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/finals/route.ts
@@ -12,7 +12,9 @@ const { GET, POST, PUT } = createFinalsHandlers({
   matchModel: 'mRMatch',
   qualificationModel: 'mRQualification',
   loggerName: 'mr-finals-api',
-  qualificationOrderBy: [{ score: 'desc' }, { points: 'desc' }, { winRounds: 'desc' }],
+  /* `group: 'asc'` is first so that Top-24 → Top-16 Playoff (#454) can pick
+   * per-group Top-N deterministically. Within-group order: score → points → winRounds. */
+  qualificationOrderBy: [{ group: 'asc' }, { score: 'desc' }, { points: 'desc' }, { winRounds: 'desc' }],
   getStyle: 'simple',
   putScoreFields: { dbField1: 'score1', dbField2: 'score2' },
   putAdditionalFields: ['rounds'],


### PR DESCRIPTION
## Summary

- 親 PR #493 (BM) で実装した per-group Top-N barrage 選抜 (`selectFinalsEntrantsByGroup`) を MR/GP にも適用。factory パターンのおかげでロジック自体は共通で、**各モードの finals route config が orderBy 先頭に `{ group: 'asc' }` を宣言するだけ** で有効になる。
- MR: `[{ score: 'desc' }, { points: 'desc' }, { winRounds: 'desc' }]` → `[{ group: 'asc' }, { score: 'desc' }, { points: 'desc' }, { winRounds: 'desc' }]`
- GP: `[{ points: 'desc' }, { score: 'desc' }]` → `[{ group: 'asc' }, { points: 'desc' }, { score: 'desc' }]` (driver points は §4.1 primary ranking として within-group で保持)
- standings/qualification の設定 (`src/lib/event-types/{mr,gp}-config.ts`) は **意図的に触らない** — 関心が異なる (ランキング表示 vs finals entry 選抜)

## Depends on

- #493 (BM Pre-Bracket Playoff の per-group 選抜実装)
- このブランチは #493 を親にしている。#493 マージ後は自動で main ベースに切り替わる。

## Files changed

- `src/app/api/tournaments/[id]/mr/finals/route.ts` — orderBy 先頭に `{ group: 'asc' }` + コメント
- `src/app/api/tournaments/[id]/gp/finals/route.ts` — orderBy 先頭に `{ group: 'asc' }` + コメント (driver points は primary で維持)
- `__tests__/lib/api-factories/finals-route.test.ts` — 新規 `describe.each` parametric ブロック (MR/GP × Phase 1 happy / error 400, 計 4 tests)

## Test plan

- [x] 新規 parity tests (4) すべて PASS
- [x] Top-24 Playoff 全体 (8): BM 4 + MR 2 + GP 2 すべて PASS
- [x] finals-route.test.ts: 30 passed / 16 pre-existing failures (同じく #493 と main にも存在)
- [x] 全体 jest: 144 failed (pre-existing), 1644 passed (+4 new)
- [x] `next build` 成功
- [x] TypeScript check 新規/修正ファイルにエラーなし
- [ ] 本番デプロイ後、MR/GP 2 グループ構成で manual Top-24 API 呼出し（UI は 8/16 のみのため curl 等で直接）
- [ ] 既存 E2E (`node e2e/tc-all.js`) 全パス

## Out of scope

- MR/GP UI に Top 24 ボタン追加（現状 8/16 のみ）
- standings / qualification route の orderBy 変更
- Issue #454 コメントの Upper seed 9-16 参入案 (現状 13-16 固定維持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)