### PR TITLE
fix(e2e): correct TA Save Times URL matcher

### DIFF
--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -1188,8 +1188,12 @@ async function uiSetTaEntryTimes(page, tournamentId, entry, times) {
     await inputs.nth(i).fill(value);
   }
 
+  /* The admin Edit Times dialog PUTs to /api/tournaments/[id]/ta with the
+   * entry id in the body (see handleSaveTimes in ta/page.tsx). The former
+   * matcher waited on /tt/entries/ which is only used by the single-entry
+   * detail route, and would never fire for this flow — tests timed out. */
   const responsePromise = page.waitForResponse((res) =>
-    res.url().includes(`/api/tournaments/${tournamentId}/tt/entries/`) &&
+    res.url().includes(`/api/tournaments/${tournamentId}/ta`) &&
     res.request().method() === 'PUT', { timeout: 30000 });
   await dialog.getByRole('button', { name: /^(Save Times|タイム保存|保存)$/ }).click();
   const response = await responsePromise;


### PR DESCRIPTION
## Summary
`uiSetTaEntryTimes` の `waitForResponse` が `/tt/entries/` を待っていたが、管理者の Save Times は `handleSaveTimes` (ta/page.tsx) で `/api/tournaments/[id]/ta` に PUT する。常にタイムアウトしていたので URL パターンを実装に合わせて修正。

TC-801 / TC-804 (setupTaQualViaUi 経由) の2次FAIL原因。

## Test plan
- [ ] `npm run e2e:ta` で TC-801 / TC-804 が PASS