### PR TITLE
fix(mode-pages): request /api/players with limit=100 to avoid Setup dialog truncation

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
@@ -149,7 +149,8 @@ export default function BattleModePage({
   const fetchTournamentData = useCallback(async () => {
     const [bmResponse, playersResponse] = await Promise.all([
       fetchWithRetry(`/api/tournaments/${tournamentId}/bm`),
-      fetchWithRetry("/api/players"),
+      /* limit=100 (API cap) avoids truncating the Setup dialog player list — see ta/page.tsx for rationale. */
+      fetchWithRetry("/api/players?limit=100"),
     ]);
 
     if (!bmResponse.ok) {

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
@@ -177,7 +177,8 @@ export default function GrandPrixPage({
   const fetchTournamentData = useCallback(async () => {
     const [gpResponse, playersResponse] = await Promise.all([
       fetchWithRetry(`/api/tournaments/${tournamentId}/gp`),
-      fetchWithRetry("/api/players"),
+      /* limit=100 (API cap) avoids truncating the Setup dialog player list — see ta/page.tsx for rationale. */
+      fetchWithRetry("/api/players?limit=100"),
     ]);
 
     if (!gpResponse.ok) {

--- a/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
@@ -152,7 +152,8 @@ export default function MatchRacePage({
   const fetchTournamentData = useCallback(async () => {
     const [mrResponse, playersResponse] = await Promise.all([
       fetchWithRetry(`/api/tournaments/${tournamentId}/mr`),
-      fetchWithRetry("/api/players"),
+      /* limit=100 (API cap) avoids truncating the Setup dialog player list — see ta/page.tsx for rationale. */
+      fetchWithRetry("/api/players?limit=100"),
     ]);
 
     if (!mrResponse.ok) {

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
@@ -253,7 +253,12 @@ export default function TimeAttackPage({
   const fetchTournamentData = useCallback(async () => {
     const [taResponse, playersResponse] = await Promise.all([
       fetchWithRetry(`/api/tournaments/${tournamentId}/ta?stage=qualification`),
-      fetchWithRetry("/api/players"),
+      /* limit=100 is the API's hard cap (src/lib/pagination.ts). The default of 50
+       * silently truncates the Setup Players search once the roster grows past
+       * that — newly-created players end up paginated out and can no longer be
+       * added from the dialog. Request the max in one hop; if a deployment
+       * ever needs >100, the dialog must switch to server-side search instead. */
+      fetchWithRetry("/api/players?limit=100"),
     ]);
 
     if (!taResponse.ok) {


### PR DESCRIPTION
## Summary
BM/MR/GP/TA の 4 mode page がすべて `fetchWithRetry(\"/api/players\")` をデフォルト limit=50 で呼んでおり、ロスターが 50 を超えると Setup dialog の候補一覧から新規プレイヤー（アルファベット順で後ろに回る）が消えていた。API のハードキャップである 100 を明示的に指定。

TC-806 / TC-807 の直接原因（28 shared + 28 test = 84 players → `_28` 以降が getByLabel で見つからずタイムアウト）。

100 を超える規模が必要になれば、dialog 側をサーバサイド検索に切り替える必要あり（コード内コメント参照）。

## Test plan
- [ ] `npm run e2e:ta` で TC-806 / TC-807 が PASS
- [x] limit=100 が `src/lib/pagination.ts` のキャップと一致