### PR TITLE
fix(finals): add qualification-confirmed lock to POST and PUT (#501)

### DIFF
--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -27,6 +27,7 @@ import { createErrorResponse, createSuccessResponse, handleValidationError, hand
 import { checkRateLimit } from '@/lib/rate-limit';
 import { getClientIdentifier } from '@/lib/request-utils';
 import { resolveTournamentId } from '@/lib/tournament-identifier';
+import { checkQualificationConfirmed } from '@/lib/qualification-confirmed-check';
 
 /**
  * Bracket size inference thresholds.
@@ -230,6 +231,10 @@ export function createFinalsHandlers(config: FinalsConfig) {
 
     const { id } = await params;
     const tournamentId = await resolveTournamentId(id);
+
+    /* Block finals operations when qualification results are confirmed */
+    const lockError = await checkQualificationConfirmed(prisma, tournamentId);
+    if (lockError) return lockError;
 
     try {
       /* Defense-in-depth: always sanitize user input */
@@ -620,6 +625,10 @@ export function createFinalsHandlers(config: FinalsConfig) {
 
     const { id } = await params;
     const tournamentId = await resolveTournamentId(id);
+
+    /* Block finals edits when qualification results are confirmed */
+    const lockError = await checkQualificationConfirmed(prisma, tournamentId);
+    if (lockError) return lockError;
 
     try {
       /* Defense-in-depth: always sanitize user input */


### PR DESCRIPTION
## Summary
- Add `checkQualificationConfirmed` call to finals-route POST and PUT handlers
- Blocks bracket creation and score edits when qualification results are confirmed

## Test plan
- [ ] Finals PUT returns lock error after qualification confirmed
- [ ] Finals POST returns lock error after qualification confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)