### PR TITLE
fix: localize View Tournament label

### DIFF
--- a/smkc-score-app/__tests__/i18n/messages.test.ts
+++ b/smkc-score-app/__tests__/i18n/messages.test.ts
@@ -1,0 +1,30 @@
+import enMessages from '../../messages/en.json';
+import jaMessages from '../../messages/ja.json';
+
+type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
+type JsonObject = { [key: string]: JsonValue };
+
+function flattenKeys(value: JsonValue, prefix = ''): string[] {
+  if (value === null || Array.isArray(value) || typeof value !== 'object') {
+    return prefix ? [prefix] : [];
+  }
+
+  return Object.entries(value).flatMap(([key, child]) => {
+    const nextPrefix = prefix ? `${prefix}.${key}` : key;
+    return flattenKeys(child, nextPrefix);
+  });
+}
+
+describe('translation messages', () => {
+  it('keeps the common namespace aligned between English and Japanese', () => {
+    const enKeys = new Set(flattenKeys(enMessages.common as JsonObject));
+    const jaKeys = new Set(flattenKeys(jaMessages.common as JsonObject));
+
+    expect(Array.from(enKeys).sort()).toEqual(Array.from(jaKeys).sort());
+  });
+
+  it('defines the viewTournament label in both locales', () => {
+    expect(enMessages.common.viewTournament).toBe('View Tournament');
+    expect(jaMessages.common.viewTournament).toBe('トーナメントを見る');
+  });
+});

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -54,6 +54,7 @@
     "saving": "Saving...",
     "confirmDeletePlayer": "Are you sure you want to delete this player?",
     "confirmDeleteTournament": "Are you sure you want to delete this tournament?",
+    "viewTournament": "View Tournament",
     "confirmRemovePlayer": "Are you sure you want to remove this player?",
     "addAtLeastOnePlayer": "Please add at least one player",
     "player1": "Player 1",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -54,6 +54,7 @@
     "saving": "保存中...",
     "confirmDeletePlayer": "このプレイヤーを削除してもよろしいですか？",
     "confirmDeleteTournament": "このトーナメントを削除してもよろしいですか？",
+    "viewTournament": "トーナメントを見る",
     "confirmRemovePlayer": "このプレイヤーを除外してもよろしいですか？",
     "addAtLeastOnePlayer": "少なくとも1人のプレイヤーを追加してください",
     "player1": "プレイヤー1",


### PR DESCRIPTION
## Summary
- add the missing `common.viewTournament` message in English and Japanese
- cover the `common` namespace key parity with a Jest test
- fix the untranslated label shown on BM/MR/GP qualification pages when finals already exist

Closes #523