### PR TITLE
fix: allow TV assignment up to 4

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/matches/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/matches/route.test.ts
@@ -203,6 +203,22 @@ describe('BM Finals Matches API Route - /api/tournaments/[id]/bm/finals/matches'
       });
     });
 
+    it('should reject tvNumber greater than 4', async () => {
+      const mockAuth = { user: { id: 'admin1', role: 'admin' } };
+      (auth as jest.Mock).mockResolvedValue(mockAuth);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm/finals/matches', {
+        player1Id: UUID_P1,
+        player2Id: UUID_P2,
+        tvNumber: 5,
+      });
+      const params = Promise.resolve({ id: 't1' });
+      const result = await POST(request, { params });
+
+      expect(result.status).toBe(400);
+      expect(prisma.bMMatch.create).not.toHaveBeenCalled();
+    });
+
     // Success case - Increments match number based on existing matches
     it('should calculate match number based on existing matches', async () => {
       const mockAuth = { user: { id: 'admin1', role: 'admin' } };

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/matches/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/matches/route.test.ts
@@ -179,6 +179,22 @@ describe('MR Finals Matches API Route - /api/tournaments/[id]/mr/finals/matches'
       );
     });
 
+    it('should reject tvNumber greater than 4', async () => {
+      const mockAuth = { user: { id: 'admin1', role: 'admin' } };
+      (auth as jest.Mock).mockResolvedValue(mockAuth);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals/matches', {
+        player1Id: UUID_P1,
+        player2Id: UUID_P2,
+        tvNumber: 5,
+      });
+      const params = Promise.resolve({ id: 't1' });
+      const result = await POST(request, { params });
+
+      expect(result.status).toBe(400);
+      expect(prisma.mRMatch.create).not.toHaveBeenCalled();
+    });
+
     // Success case - Increments match number correctly
     it('should increment match number correctly', async () => {
       const mockAuth = { user: { id: 'admin1', role: 'admin' } };

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -1160,7 +1160,7 @@ describe('Qualification Route Factory', () => {
       expect(json.error).toBe('matchId is required');
     });
 
-    it('should return 400 when tvNumber is invalid (negative, fractional)', async () => {
+    it('should return 400 when tvNumber is invalid (negative, fractional, too large)', async () => {
       mockAuth.mockResolvedValue({ user: { id: 'user-1', role: 'admin' } });
 
       const config = createMockConfig();
@@ -1180,6 +1180,16 @@ describe('Qualification Route Factory', () => {
       request = new NextRequest('http://localhost:3000', {
         method: 'PATCH',
         body: JSON.stringify({ matchId: 'match-1', tvNumber: 1.5 }),
+      });
+      response = await PATCH(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+      expect(response.status).toBe(400);
+
+      /* Larger than supported TV count */
+      request = new NextRequest('http://localhost:3000', {
+        method: 'PATCH',
+        body: JSON.stringify({ matchId: 'match-1', tvNumber: 5 }),
       });
       response = await PATCH(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
@@ -1221,6 +1231,37 @@ describe('Qualification Route Factory', () => {
       expect((prisma.bMMatch as any).update).toHaveBeenCalledWith({
         where: { id: 'match-1', tournamentId: 'tournament-123' },
         data: { tvNumber: 2 },
+        include: { player1: true, player2: true },
+      });
+    });
+
+    it('should allow assigning TV number 4', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'user-1', role: 'admin' } });
+
+      const mockMatch = {
+        id: 'match-1',
+        tvNumber: 4,
+        player1: { id: 'p1', nickname: 'Alice' },
+        player2: { id: 'p2', nickname: 'Bob' },
+      };
+      (prisma.bMMatch as any).findFirst.mockResolvedValue(mockMatch);
+      (prisma.bMMatch as any).update.mockResolvedValue(mockMatch);
+
+      const config = createMockConfig();
+      const { PATCH } = createQualificationHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'PATCH',
+        body: JSON.stringify({ matchId: 'match-1', tvNumber: 4 }),
+      });
+      const response = await PATCH(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect((prisma.bMMatch as any).update).toHaveBeenCalledWith({
+        where: { id: 'match-1', tournamentId: 'tournament-123' },
+        data: { tvNumber: 4 },
         include: { player1: true, player2: true },
       });
     });

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
@@ -59,7 +59,7 @@ import { GroupSetupDialog } from "@/components/tournament/group-setup-dialog";
 import { RankCell } from "@/components/tournament/rank-cell";
 import { TieWarningBanner } from "@/components/tournament/tie-warning-banner";
 import { computeTieAwareRanks, findUnresolvedTies, filterActiveTiedIds } from "@/lib/ranking-utils";
-import { POLLING_INTERVAL } from "@/lib/constants";
+import { POLLING_INTERVAL, TV_NUMBER_OPTIONS } from "@/lib/constants";
 import { extractArrayData } from "@/lib/api-response";
 import { usePolling } from "@/lib/hooks/usePolling";
 import { useQualificationActions } from "@/lib/hooks/useQualificationActions";
@@ -796,8 +796,11 @@ export default function BattleModePage({
                                         }}
                                       >
                                         <option value="">-</option>
-                                        <option value="1">1</option>
-                                        <option value="2">2</option>
+                                        {TV_NUMBER_OPTIONS.map((tvNumber) => (
+                                          <option key={tvNumber} value={tvNumber}>
+                                            {tvNumber}
+                                          </option>
+                                        ))}
                                       </select>
                                     ) : (
                                       match.tvNumber ? `${match.tvNumber}` : "-"

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
@@ -62,7 +62,7 @@ import { RankCell } from "@/components/tournament/rank-cell";
 import { TieWarningBanner } from "@/components/tournament/tie-warning-banner";
 import { computeTieAwareRanks, findUnresolvedTies, filterActiveTiedIds } from "@/lib/ranking-utils";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { COURSE_INFO, CUPS, CUP_SUBSTITUTIONS, GP_POSITION_OPTIONS, POLLING_INTERVAL, TOTAL_GP_RACES, getDriverPoints, type CourseAbbr } from "@/lib/constants";
+import { COURSE_INFO, CUPS, CUP_SUBSTITUTIONS, GP_POSITION_OPTIONS, POLLING_INTERVAL, TOTAL_GP_RACES, TV_NUMBER_OPTIONS, getDriverPoints, type CourseAbbr } from "@/lib/constants";
 import { formatGpPosition } from "@/lib/gp-utils";
 import { extractArrayData } from "@/lib/api-response";
 import { usePolling } from "@/lib/hooks/usePolling";
@@ -890,8 +890,11 @@ export default function GrandPrixPage({
                                         }}
                                       >
                                         <option value="">-</option>
-                                        <option value="1">1</option>
-                                        <option value="2">2</option>
+                                        {TV_NUMBER_OPTIONS.map((tvNumber) => (
+                                          <option key={tvNumber} value={tvNumber}>
+                                            {tvNumber}
+                                          </option>
+                                        ))}
                                       </select>
                                     ) : (
                                       match.tvNumber ? `${match.tvNumber}` : "-"

--- a/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
@@ -57,7 +57,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { COURSE_INFO, POLLING_INTERVAL, TOTAL_MR_RACES, type CourseAbbr } from "@/lib/constants";
+import { COURSE_INFO, POLLING_INTERVAL, TOTAL_MR_RACES, TV_NUMBER_OPTIONS, type CourseAbbr } from "@/lib/constants";
 import { extractArrayData } from "@/lib/api-response";
 import { usePolling } from "@/lib/hooks/usePolling";
 import { useQualificationActions } from "@/lib/hooks/useQualificationActions";
@@ -800,8 +800,11 @@ export default function MatchRacePage({
                                         }}
                                       >
                                         <option value="">-</option>
-                                        <option value="1">1</option>
-                                        <option value="2">2</option>
+                                        {TV_NUMBER_OPTIONS.map((tvNumber) => (
+                                          <option key={tvNumber} value={tvNumber}>
+                                            {tvNumber}
+                                          </option>
+                                        ))}
                                       </select>
                                     ) : (
                                       match.tvNumber ? `${match.tvNumber}` : "-"

--- a/smkc-score-app/src/lib/api-factories/finals-matches-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-matches-route.ts
@@ -22,6 +22,7 @@ import { createErrorResponse, createSuccessResponse, handleValidationError, hand
 import { checkRateLimit } from '@/lib/rate-limit';
 import { getClientIdentifier } from '@/lib/request-utils';
 import { resolveTournamentId } from '@/lib/tournament-identifier';
+import { MAX_TV_NUMBER } from '@/lib/constants';
 
 /**
  * Zod schema for validating match creation requests.
@@ -33,7 +34,7 @@ const CreateMatchSchema = z.object({
   player2Id: z.string().min(1),
   player1Side: z.number().int().min(1).max(2).optional().default(1),
   player2Side: z.number().int().min(1).max(2).optional().default(2),
-  tvNumber: z.number().int().optional(),
+  tvNumber: z.number().int().min(1).max(MAX_TV_NUMBER).optional(),
   bracket: z.enum(['winners', 'losers', 'grand_final']).default('winners'),
   bracketPosition: z.string().optional(),
   isGrandFinal: z.boolean().default(false),

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -29,7 +29,7 @@ import {
   getByeMatchData,
   BREAK_PLAYER_ID,
 } from '@/lib/round-robin';
-import { COURSES, TOTAL_MR_RACES } from '@/lib/constants';
+import { COURSES, MAX_TV_NUMBER, TOTAL_MR_RACES } from '@/lib/constants';
 
 /**
  * Shuffle an array using the Fisher-Yates algorithm.
@@ -600,10 +600,10 @@ export function createQualificationHandlers(config: EventTypeConfig) {
         return handleValidationError('matchId is required', 'matchId');
       }
 
-      /* tvNumber must be a positive integer or null (to remove assignment) */
+      /* tvNumber must be between 1 and the supported TV count, or null to clear it. */
       if (tvNumber !== null && tvNumber !== undefined &&
-          (typeof tvNumber !== 'number' || tvNumber < 1 || !Number.isInteger(tvNumber))) {
-        return handleValidationError('tvNumber must be a positive integer or null', 'tvNumber');
+          (typeof tvNumber !== 'number' || tvNumber < 1 || tvNumber > MAX_TV_NUMBER || !Number.isInteger(tvNumber))) {
+        return handleValidationError(`tvNumber must be an integer between 1 and ${MAX_TV_NUMBER}, or null`, 'tvNumber');
       }
 
       /*

--- a/smkc-score-app/src/lib/constants.ts
+++ b/smkc-score-app/src/lib/constants.ts
@@ -183,6 +183,10 @@ export const DRIVER_POINTS = [0, 9, 6, 3, 1, 0, 0, 0, 0] as const;
 /** GP UI/API position options for normal race finishes. */
 export const GP_POSITION_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8] as const;
 
+/** Broadcast TV numbers that can be assigned to a match. */
+export const TV_NUMBER_OPTIONS = [1, 2, 3, 4] as const;
+export const MAX_TV_NUMBER = TV_NUMBER_OPTIONS[TV_NUMBER_OPTIONS.length - 1];
+
 /**
  * Convert a finishing position (1-8) to driver points.
  * Returns 0 for legacy position 0 and any invalid/out-of-range values.


### PR DESCRIPTION
## Summary
- extend BM/MR/GP qualification TV selectors from 2 options to 4
- centralize supported TV numbers in constants and cap API validation at 4
- add regression coverage for qualification TV updates and finals match creation

## Testing
- `npx --no-install jest --runInBand '__tests__/lib/api-factories/qualification-route.test.ts' '__tests__/app/api/tournaments/[id]/bm/finals/matches/route.test.ts' '__tests__/app/api/tournaments/[id]/mr/finals/matches/route.test.ts'` *(could not run in this worktree because `node_modules/.bin/jest` is missing)*

Closes #526