### PR TITLE
fix(finals): support per-round FT targets

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/route.test.ts
@@ -522,7 +522,7 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
       (prisma.bMMatch.findFirst as jest.Mock)
         .mockResolvedValueOnce(mockResetMatch); // grand_final_reset round lookup
 
-      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm/finals', { matchId: 'm16', score1: 1, score2: 5 });
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm/finals', { matchId: 'm16', score1: 1, score2: 7 });
       const params = Promise.resolve({ id: 't1' });
       const _result = await PUT(request, { params });
 
@@ -552,7 +552,7 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
       (prisma.bMMatch.update as jest.Mock).mockResolvedValue({ ...mockMatch, completed: true });
       (prisma.bMMatch.findFirst as jest.Mock).mockResolvedValue(null);
 
-      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm/finals', { matchId: 'm16', score1: 5, score2: 1 });
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm/finals', { matchId: 'm16', score1: 7, score2: 1 });
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
@@ -579,7 +579,7 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
       (prisma.bMMatch.update as jest.Mock).mockResolvedValue({ ...mockMatch, completed: true });
       (prisma.bMMatch.findFirst as jest.Mock).mockResolvedValue(null);
 
-      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm/finals', { matchId: 'm17', score1: 5, score2: 2 });
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm/finals', { matchId: 'm17', score1: 7, score2: 2 });
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
@@ -658,6 +658,30 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
 
       expect(result.data).toEqual({ success: false, error: 'Match must have a winner (first to 5)', code: 'VALIDATION_ERROR', details: { field: 'score' } });
       expect(result.status).toBe(400);
+    });
+
+    it('should allow BM playoff round 1 results to finish at first to 3', async () => {
+      const mockMatch = {
+        id: 'm1',
+        tournamentId: 't1',
+        stage: 'playoff',
+        round: 'playoff_r1',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        player1: { id: 'p1' },
+        player2: { id: 'p2' },
+      };
+
+      (prisma.bMMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+      (prisma.bMMatch.update as jest.Mock).mockResolvedValue({ ...mockMatch, score1: 3, score2: 2, completed: true });
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm/finals', { matchId: 'm1', score1: 3, score2: 2 });
+      const params = Promise.resolve({ id: 't1' });
+      const result = await PUT(request, { params });
+
+      expect(result.status).toBe(200);
+      expect(result.data.stage).toBe('playoff');
+      expect(result.data.winnerId).toBe('p1');
     });
 
     // Not found case - Returns 404 when match not found

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -604,8 +604,33 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const result = await PUT(request, { params });
 
       /* Error message updated: finals-route.ts now uses dynamic "first to N" format */
-      expect(result.data).toEqual({ success: false, error: 'Match must have a winner (first to 3)', code: 'VALIDATION_ERROR', details: { field: 'score' } });
+      expect(result.data).toEqual({ success: false, error: 'Match must have a winner (first to 2)', code: 'VALIDATION_ERROR', details: { field: 'score' } });
       expect(result.status).toBe(400);
+    });
+
+    it('should allow GP playoff round 1 results to finish at first to 1', async () => {
+      const mockMatch = {
+        id: 'm1',
+        tournamentId: 't1',
+        matchNumber: 1,
+        round: 'playoff_r1',
+        stage: 'playoff',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        player1: { id: 'p1', name: 'Player 1' },
+        player2: { id: 'p2', name: 'Player 2' },
+      };
+
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+      (prisma.gPMatch.update as jest.Mock).mockResolvedValue({ ...mockMatch, points1: 1, points2: 0, completed: true });
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/finals', { matchId: 'm1', score1: 1, score2: 0 });
+      const params = Promise.resolve({ id: 't1' });
+      const result = await PUT(request, { params });
+
+      expect(result.status).toBe(200);
+      expect(result.data.stage).toBe('playoff');
+      expect(result.data.winnerId).toBe('p1');
     });
 
     // Error case - Returns 500 when database operation fails

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
@@ -431,6 +431,27 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
       expect(result.status).toBe(400);
     });
 
+    it('should return 400 when a score exceeds the configured target wins', async () => {
+      const mockMatch = {
+        id: 'm1',
+        round: 'grand_final',
+        stage: 'finals',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        player1: { id: 'p1' },
+        player2: { id: 'p2' },
+      };
+
+      (prisma.mRMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', { matchId: 'm1', score1: 10, score2: 7 });
+      const params = Promise.resolve({ id: 't1' });
+      const result = await PUT(request, { params });
+
+      expect(result.data).toEqual({ success: false, error: 'Match must have a winner (first to 9)', code: 'VALIDATION_ERROR', details: { field: 'score' } });
+      expect(result.status).toBe(400);
+    });
+
     // Validation error case - Returns 400 when required fields missing
     it('should return 400 when required fields are missing', async () => {
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', {});

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
@@ -321,13 +321,13 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
         player2: { id: 'p8', name: 'Player 8' },
       };
 
-      const mockUpdatedMatch = { ...mockMatch, score1: 3, score2: 1, completed: true };
+      const mockUpdatedMatch = { ...mockMatch, score1: 5, score2: 2, completed: true };
 
       (prisma.mRMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
       (prisma.mRMatch.update as jest.Mock).mockResolvedValue(mockUpdatedMatch);
       (prisma.mRMatch.findFirst as jest.Mock).mockResolvedValue({ id: 'm5' });
 
-      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', { matchId: 'm1', score1: 3, score2: 1 });
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', { matchId: 'm1', score1: 5, score2: 2 });
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
@@ -355,7 +355,7 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
         player2: { id: 'p2', name: 'Player 2' },
       };
 
-      const mockUpdatedMatch = { ...mockMatch, score1: 3, score2: 1, completed: true };
+      const mockUpdatedMatch = { ...mockMatch, score1: 9, score2: 7, completed: true };
 
       /* Override bracket structure to include the grand final match at matchNumber 15 */
       (generateBracketStructure as jest.Mock).mockReturnValue([
@@ -366,7 +366,7 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
       (prisma.mRMatch.update as jest.Mock).mockResolvedValue(mockUpdatedMatch);
       (prisma.mRMatch.findFirst as jest.Mock).mockResolvedValue({ id: 'm16', round: 'grand_final_reset' });
 
-      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', { matchId: 'm1', score1: 3, score2: 1 });
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', { matchId: 'm1', score1: 9, score2: 7 });
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
@@ -427,7 +427,7 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
       const result = await PUT(request, { params });
 
       /* Error message updated: finals-route.ts now uses dynamic "first to N" format */
-      expect(result.data).toEqual({ success: false, error: 'Match must have a winner (first to 3)', code: 'VALIDATION_ERROR', details: { field: 'score' } });
+      expect(result.data).toEqual({ success: false, error: 'Match must have a winner (first to 5)', code: 'VALIDATION_ERROR', details: { field: 'score' } });
       expect(result.status).toBe(400);
     });
 
@@ -467,7 +467,7 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
         player2: { id: 'p8' },
       };
 
-      const mockUpdatedMatch = { ...mockMatch, score1: 3, score2: 1, completed: true };
+      const mockUpdatedMatch = { ...mockMatch, score1: 5, score2: 2, completed: true };
 
       (prisma.mRMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
       (prisma.mRMatch.update as jest.Mock).mockResolvedValue(mockUpdatedMatch);
@@ -475,7 +475,7 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
         .mockResolvedValueOnce({ id: 'm5' })
         .mockResolvedValueOnce({ id: 'm9' });
 
-      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', { matchId: 'm1', score1: 3, score2: 1 });
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', { matchId: 'm1', score1: 5, score2: 2 });
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
@@ -496,18 +496,41 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
         player2: { id: 'p2' },
       };
 
-      const mockUpdatedMatch = { ...mockMatch, score1: 1, score2: 3, completed: true };
+      const mockUpdatedMatch = { ...mockMatch, score1: 7, score2: 9, completed: true };
       const mockResetMatch = { id: 'm16', round: 'grand_final_reset' };
 
       (prisma.mRMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
       (prisma.mRMatch.update as jest.Mock).mockResolvedValue(mockUpdatedMatch);
       (prisma.mRMatch.findFirst as jest.Mock).mockResolvedValue(mockResetMatch);
 
-      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', { matchId: 'm15', score1: 1, score2: 3 });
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', { matchId: 'm15', score1: 7, score2: 9 });
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
       expect(result.status).toBe(200);
+    });
+
+    it('should allow MR playoff round 2 results to finish at first to 4', async () => {
+      const mockMatch = {
+        id: 'm5',
+        matchNumber: 5,
+        round: 'playoff_r2',
+        stage: 'playoff',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        player1: { id: 'p1' },
+        player2: { id: 'p2' },
+      };
+
+      (prisma.mRMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+      (prisma.mRMatch.update as jest.Mock).mockResolvedValue({ ...mockMatch, score1: 4, score2: 2, completed: true });
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', { matchId: 'm5', score1: 4, score2: 2 });
+      const params = Promise.resolve({ id: 't1' });
+      const result = await PUT(request, { params });
+
+      expect(result.status).toBe(200);
+      expect(result.data.stage).toBe('playoff');
     });
   });
 });

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/route.test.ts
@@ -317,6 +317,66 @@ describe('MR Match API Route - /api/tournaments/[id]/mr/match/[matchId]', () => 
       expect(updateMRMatchScore).not.toHaveBeenCalled();
     });
 
+    it('should accept finals single-match updates that reach the round target', async () => {
+      const mockUpdatedMatch = {
+        id: 'm1',
+        round: 'winners_sf',
+        stage: 'finals',
+        score1: 7,
+        score2: 5,
+        completed: true,
+        player1: { id: 'p1', name: 'Player 1' },
+        player2: { id: 'p2', name: 'Player 2' },
+      };
+
+      (prisma.mRMatch.findUnique as jest.Mock)
+        .mockResolvedValueOnce({ stage: 'finals', round: 'winners_sf', tournamentId: 't1' })
+        .mockResolvedValueOnce(mockUpdatedMatch);
+      (updateMRMatchScore as jest.Mock).mockResolvedValue({ version: 2 });
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/match/m1', {
+        score1: 7,
+        score2: 5,
+        completed: true,
+        rounds: [],
+        version: 1,
+      });
+      const params = Promise.resolve({ id: 't1', matchId: 'm1' });
+      const result = await PUT(request, { params });
+
+      expect(result).toEqual({
+        data: { match: mockUpdatedMatch, version: 2 },
+        status: 200,
+      });
+      expect(updateMRMatchScore).toHaveBeenCalledWith(
+        prisma, 'm1', 1, 7, 5, true, []
+      );
+    });
+
+    it('should reject finals single-match updates below the round target', async () => {
+      (prisma.mRMatch.findUnique as jest.Mock).mockResolvedValueOnce({
+        stage: 'finals',
+        round: 'winners_sf',
+        tournamentId: 't1',
+      });
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/match/m1', {
+        score1: 5,
+        score2: 3,
+        completed: true,
+        rounds: [],
+        version: 1,
+      });
+      const params = Promise.resolve({ id: 't1', matchId: 'm1' });
+      const result = await PUT(request, { params });
+
+      expect(result).toEqual({
+        data: { error: 'One player must reach exactly 7 wins', field: 'scores' },
+        status: 400,
+      });
+      expect(updateMRMatchScore).not.toHaveBeenCalled();
+    });
+
     // Validation error case - Rejects negative MR score
     it('should return 400 when score is negative', async () => {
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/match/m1', { score1: -1, score2: 4, version: 1 });

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1344,6 +1344,28 @@ describe('Finals Route Factory', () => {
       expect(json.error).toBe('Match must have a winner (first to 3)');
     });
 
+    it('should return 400 when losing score also reaches or exceeds target wins', async () => {
+      const requestBody = createMockRequestBody({ score1: 9, score2: 10 });
+      const mockMatch = createMockMatch({ round: 'grand_final' });
+
+      (prisma.bMMatch as any).findUnique.mockResolvedValue(mockMatch);
+
+      const config = createMockConfig({ getTargetWins: () => 9 });
+      const { PUT } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+      });
+      const response = await PUT(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.error).toBe('Match must have a winner (first to 9)');
+    });
+
     it('should return 404 when matchId not found', async () => {
       const requestBody = createMockRequestBody();
 

--- a/smkc-score-app/__tests__/lib/api-factories/match-detail-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/match-detail-route.test.ts
@@ -362,7 +362,7 @@ describe('Match Detail Route Factory', () => {
       const mockRequestBody = { score1: 5, score2: 2, completed: true, version: 1, rounds: [] };
 
       // Stage = finals → validateFinalsScores is used instead of validateScores
-      (prisma.bMMatch as any).findUnique.mockResolvedValue({ stage: 'finals' });
+      (prisma.bMMatch as any).findUnique.mockResolvedValue({ stage: 'finals', round: 'winners_sf' });
 
       const config = {
         ...baseConfig,
@@ -382,7 +382,10 @@ describe('Match Detail Route Factory', () => {
       });
 
       expect(config.validateScores).not.toHaveBeenCalled();
-      expect(config.validateFinalsScores).toHaveBeenCalledWith(5, 2);
+      expect(config.validateFinalsScores).toHaveBeenCalledWith(5, 2, {
+        round: 'winners_sf',
+        stage: 'finals',
+      });
     });
 
     it('should prefer validateFinalsScoresWithMatch for finals matches', async () => {
@@ -424,7 +427,7 @@ describe('Match Detail Route Factory', () => {
     it('should return 400 when validateFinalsScores rejects (finals match)', async () => {
       const mockRequestBody = { score1: 4, score2: 3, completed: true, version: 1, rounds: [] };
 
-      (prisma.bMMatch as any).findUnique.mockResolvedValue({ stage: 'finals' });
+      (prisma.bMMatch as any).findUnique.mockResolvedValue({ stage: 'finals', round: 'winners_sf' });
 
       const config = {
         ...baseConfig,
@@ -443,7 +446,10 @@ describe('Match Detail Route Factory', () => {
         params: Promise.resolve({ id: 'tournament-1', matchId: 'match-123' }),
       });
 
-      expect(config.validateFinalsScores).toHaveBeenCalledWith(4, 3);
+      expect(config.validateFinalsScores).toHaveBeenCalledWith(4, 3, {
+        round: 'winners_sf',
+        stage: 'finals',
+      });
       expect(config.validateScores).not.toHaveBeenCalled();
       expect(mockHandleValidationError).toHaveBeenCalledWith('One player must reach 5 wins', 'scores');
       expect(config.updateMatchScore).not.toHaveBeenCalled();

--- a/smkc-score-app/__tests__/lib/api-factories/match-detail-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/match-detail-route.test.ts
@@ -385,6 +385,42 @@ describe('Match Detail Route Factory', () => {
       expect(config.validateFinalsScores).toHaveBeenCalledWith(5, 2);
     });
 
+    it('should prefer validateFinalsScoresWithMatch for finals matches', async () => {
+      const mockRequestBody = { score1: 7, score2: 5, completed: true, version: 1, rounds: [] };
+
+      (prisma.bMMatch as any).findUnique.mockResolvedValue({
+        stage: 'finals',
+        round: 'winners_sf',
+        tournamentId: 'tournament-1',
+      });
+
+      const config = {
+        ...baseConfig,
+        validateScores: jest.fn(),
+        validateFinalsScores: jest.fn(),
+        validateFinalsScoresWithMatch: jest.fn().mockReturnValue({ isValid: true }),
+        updateMatchScore: jest.fn().mockResolvedValue({ version: 2 }),
+      };
+
+      const { PUT } = createMatchDetailHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'PUT',
+        body: JSON.stringify(mockRequestBody),
+      });
+      await PUT(request, {
+        params: Promise.resolve({ id: 'tournament-1', matchId: 'match-123' }),
+      });
+
+      expect(config.validateScores).not.toHaveBeenCalled();
+      expect(config.validateFinalsScores).not.toHaveBeenCalled();
+      expect(config.validateFinalsScoresWithMatch).toHaveBeenCalledWith(
+        7,
+        5,
+        expect.objectContaining({ stage: 'finals', round: 'winners_sf' }),
+      );
+    });
+
     it('should return 400 when validateFinalsScores rejects (finals match)', async () => {
       const mockRequestBody = { score1: 4, score2: 3, completed: true, version: 1, rounds: [] };
 

--- a/smkc-score-app/__tests__/lib/finals-target-wins.test.ts
+++ b/smkc-score-app/__tests__/lib/finals-target-wins.test.ts
@@ -1,0 +1,38 @@
+import {
+  getBmFinalsTargetWins,
+  getGpFinalsTargetWins,
+  getMrFinalsMaxRounds,
+  getMrFinalsTargetWins,
+} from '@/lib/finals-target-wins';
+
+describe('finals-target-wins', () => {
+  it('returns BM target wins for playoff and finals rounds', () => {
+    expect(getBmFinalsTargetWins({ stage: 'playoff', round: 'playoff_r1' })).toBe(3);
+    expect(getBmFinalsTargetWins({ stage: 'playoff', round: 'playoff_r2' })).toBe(4);
+    expect(getBmFinalsTargetWins({ round: 'winners_r1' })).toBe(5);
+    expect(getBmFinalsTargetWins({ round: 'winners_sf' })).toBe(7);
+    expect(getBmFinalsTargetWins({ round: 'grand_final' })).toBe(7);
+  });
+
+  it('returns MR target wins for playoff and finals rounds', () => {
+    expect(getMrFinalsTargetWins({ stage: 'playoff', round: 'playoff_r1' })).toBe(3);
+    expect(getMrFinalsTargetWins({ stage: 'playoff', round: 'playoff_r2' })).toBe(4);
+    expect(getMrFinalsTargetWins({ round: 'winners_r1' })).toBe(5);
+    expect(getMrFinalsTargetWins({ round: 'winners_sf' })).toBe(7);
+    expect(getMrFinalsTargetWins({ round: 'grand_final' })).toBe(9);
+    expect(getMrFinalsTargetWins({ round: 'grand_final_reset' })).toBe(9);
+  });
+
+  it('returns GP target wins for playoff and finals rounds', () => {
+    expect(getGpFinalsTargetWins({ stage: 'playoff', round: 'playoff_r1' })).toBe(1);
+    expect(getGpFinalsTargetWins({ round: 'winners_r1' })).toBe(2);
+    expect(getGpFinalsTargetWins({ round: 'grand_final' })).toBe(3);
+  });
+
+  it('maps MR target wins to max round counts', () => {
+    expect(getMrFinalsMaxRounds({ stage: 'playoff', round: 'playoff_r1' })).toBe(5);
+    expect(getMrFinalsMaxRounds({ stage: 'playoff', round: 'playoff_r2' })).toBe(7);
+    expect(getMrFinalsMaxRounds({ round: 'winners_sf' })).toBe(13);
+    expect(getMrFinalsMaxRounds({ round: 'grand_final' })).toBe(17);
+  });
+});

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -464,6 +464,9 @@
     "failedUpdateMatch": "Failed to update match",
     "fiveRaces": "5 Races:",
     "fiveRacesDesc": "Each match consists of 5 unique courses",
+    "mrEnteredRacesDesc": "Select courses only for the races you actually played.",
+    "mrFtByRound": "FT by round:",
+    "mrFtByRoundDesc": "Playoff FT3/4, early bracket FT5, semis FT7, finals FT9.",
     "firstTo3": "First to 3:",
     "firstTo3Desc": "First player to win 3 races wins the match"
   },

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -463,6 +463,9 @@
     "failedUpdateMatch": "試合の更新に失敗しました",
     "fiveRaces": "5レース：",
     "fiveRacesDesc": "各試合は5つの異なるコースで構成",
+    "mrEnteredRacesDesc": "実際に行ったレース分だけコースを入力してください。",
+    "mrFtByRound": "ラウンド別FT：",
+    "mrFtByRoundDesc": "プレーオフは FT3/4、序盤ブラケットは FT5、準決勝帯は FT7、決勝帯は FT9 です。",
     "firstTo3": "3勝先取：",
     "firstTo3Desc": "先に3勝したプレイヤーが勝利"
   },

--- a/smkc-score-app/src/app/api/tournaments/[id]/bm/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/bm/finals/route.ts
@@ -7,7 +7,7 @@
  */
 
 import { createFinalsHandlers } from '@/lib/api-factories/finals-route';
-import { BM_FINALS_TARGET_WINS } from '@/lib/constants';
+import { getBmFinalsTargetWins } from '@/lib/finals-target-wins';
 
 const { GET, POST, PUT } = createFinalsHandlers({
   matchModel: 'bMMatch',
@@ -18,7 +18,7 @@ const { GET, POST, PUT } = createFinalsHandlers({
   qualificationOrderBy: [{ group: 'asc' }, { score: 'desc' }, { points: 'desc' }, { winRounds: 'desc' }],
   getStyle: 'grouped',
   putScoreFields: { dbField1: 'score1', dbField2: 'score2' },
-  targetWins: BM_FINALS_TARGET_WINS,
+  getTargetWins: getBmFinalsTargetWins,
   getErrorMessage: 'Failed to fetch finals data',
   postErrorMessage: 'Failed to create finals bracket',
   postRequiresAuth: true,

--- a/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/route.ts
@@ -10,8 +10,33 @@
  */
 
 import { createMatchDetailHandlers } from '@/lib/api-factories/match-detail-route';
+import { getBmFinalsTargetWins } from '@/lib/finals-target-wins';
 import { updateBMMatchScore } from '@/lib/optimistic-locking';
 import { validateBattleModeScores, validateBattleModeFinalScores } from '@/lib/score-validation';
+
+function validateRoundAwareBmFinalsScores(
+  score1: number,
+  score2: number,
+  match: { stage?: string | null; round?: string | null },
+) {
+  const targetWins = getBmFinalsTargetWins({ stage: match.stage, round: match.round });
+
+  if (!Number.isInteger(score1) || !Number.isInteger(score2)) {
+    return { isValid: false, error: "Battle Mode finals scores must be integers" };
+  }
+
+  if (score1 < 0 || score1 > targetWins || score2 < 0 || score2 > targetWins) {
+    return { isValid: false, error: `Finals score must be between 0 and ${targetWins}` };
+  }
+
+  const player1Wins = score1 === targetWins && score2 < targetWins;
+  const player2Wins = score2 === targetWins && score1 < targetWins;
+  if (!player1Wins && !player2Wins) {
+    return { isValid: false, error: `One player must reach exactly ${targetWins} wins` };
+  }
+
+  return { isValid: true };
+}
 
 /* recalcStatsConfig mirrors BM_RECALC_CONFIG in the dual-report route so
  * admin single-match PUT edits keep bMQualification wins/losses/round
@@ -25,6 +50,7 @@ const { GET, PUT } = createMatchDetailHandlers({
     updateBMMatchScore(prisma, matchId, version, val1, val2, completed, detail),
   validateScores: validateBattleModeScores,
   validateFinalsScores: validateBattleModeFinalScores,
+  validateFinalsScoresWithMatch: validateRoundAwareBmFinalsScores,
   sanitizeBody: true,
   putRequiresAuth: true,
   getRequiresAuth: true,

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { createFinalsHandlers } from '@/lib/api-factories/finals-route';
+import { getGpFinalsTargetWins } from '@/lib/finals-target-wins';
 
 const { GET, POST, PUT } = createFinalsHandlers({
   matchModel: 'gPMatch',
@@ -17,6 +18,7 @@ const { GET, POST, PUT } = createFinalsHandlers({
   qualificationOrderBy: [{ group: 'asc' }, { points: 'desc' }, { score: 'desc' }],
   getStyle: 'paginated',
   putScoreFields: { dbField1: 'points1', dbField2: 'points2' },
+  getTargetWins: getGpFinalsTargetWins,
   getErrorMessage: 'Failed to fetch grand prix finals data',
   postErrorMessage: 'Failed to create grand prix finals bracket',
   postRequiresAuth: true,

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/finals/route.ts
@@ -7,6 +7,7 @@
  */
 
 import { createFinalsHandlers } from '@/lib/api-factories/finals-route';
+import { getMrFinalsTargetWins } from '@/lib/finals-target-wins';
 
 const { GET, POST, PUT } = createFinalsHandlers({
   matchModel: 'mRMatch',
@@ -18,6 +19,7 @@ const { GET, POST, PUT } = createFinalsHandlers({
   getStyle: 'simple',
   putScoreFields: { dbField1: 'score1', dbField2: 'score2' },
   putAdditionalFields: ['rounds'],
+  getTargetWins: getMrFinalsTargetWins,
   getErrorMessage: 'Failed to fetch finals data',
   postErrorMessage: 'Failed to create finals bracket',
   postRequiresAuth: true,

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/route.ts
@@ -9,8 +9,33 @@
  */
 
 import { createMatchDetailHandlers } from '@/lib/api-factories/match-detail-route';
+import { getMrFinalsTargetWins } from '@/lib/finals-target-wins';
 import { updateMRMatchScore } from '@/lib/optimistic-locking';
 import { validateMatchRaceScores } from '@/lib/score-validation';
+
+function validateRoundAwareMrFinalsScores(
+  score1: number,
+  score2: number,
+  match: { stage?: string | null; round?: string | null },
+) {
+  const targetWins = getMrFinalsTargetWins({ stage: match.stage, round: match.round });
+
+  if (!Number.isInteger(score1) || !Number.isInteger(score2)) {
+    return { isValid: false, error: 'Match Race finals scores must be integers' };
+  }
+
+  if (score1 < 0 || score1 > targetWins || score2 < 0 || score2 > targetWins) {
+    return { isValid: false, error: `Finals score must be between 0 and ${targetWins}` };
+  }
+
+  const player1Wins = score1 === targetWins && score2 < targetWins;
+  const player2Wins = score2 === targetWins && score1 < targetWins;
+  if (!player1Wins && !player2Wins) {
+    return { isValid: false, error: `One player must reach exactly ${targetWins} wins` };
+  }
+
+  return { isValid: true };
+}
 
 /* recalcStatsConfig mirrors MR_RECALC_CONFIG in the dual-report route so
  * admin single-match PUT edits keep mRQualification wins/losses/round
@@ -23,6 +48,7 @@ const { GET, PUT } = createMatchDetailHandlers({
   updateMatchScore: (prisma, matchId, version, val1, val2, completed, detail) =>
     updateMRMatchScore(prisma, matchId, version, val1, val2, completed, detail),
   validateScores: validateMatchRaceScores,
+  validateFinalsScoresWithMatch: validateRoundAwareMrFinalsScores,
   sanitizeBody: true,
   putRequiresAuth: true,
   getRequiresAuth: true,

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -62,7 +62,8 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
 import { PlayoffBracket } from "@/components/tournament/playoff-bracket";
-import { POLLING_INTERVAL, BM_FINALS_TARGET_WINS } from "@/lib/constants";
+import { POLLING_INTERVAL } from "@/lib/constants";
+import { getBmFinalsTargetWins } from "@/lib/finals-target-wins";
 import { usePolling } from "@/lib/hooks/usePolling";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
 import { LoadingOverlay } from "@/components/ui/loading-overlay";
@@ -83,6 +84,7 @@ interface BMMatch {
   id: string;
   matchNumber: number;
   round: string | null;
+  stage?: string | null;
   player1Id: string;
   player2Id: string;
   score1: number;
@@ -191,6 +193,7 @@ export default function BattleModeFinals({
   const [isScoreDialogOpen, setIsScoreDialogOpen] = useState(false);
   const [selectedMatch, setSelectedMatch] = useState<BMMatch | null>(null);
   const [scoreForm, setScoreForm] = useState({ score1: 0, score2: 0 });
+  const selectedMatchTargetWins = selectedMatch ? getBmFinalsTargetWins(selectedMatch) : getBmFinalsTargetWins();
 
   /* Tournament completion state */
   const [champion, setChampion] = useState<Player | null>(null);
@@ -631,7 +634,7 @@ export default function BattleModeFinals({
               bracketStructure={bracketStructure}
               roundNames={roundNames}
               seededPlayers={seededPlayers}
-              targetWins={BM_FINALS_TARGET_WINS}
+              getTargetWins={(match, bracketMatch) => getBmFinalsTargetWins({ stage: match?.stage, round: match?.round ?? bracketMatch.round })}
               onMatchClick={isAdmin ? openScoreDialog : undefined}
             />
           </TabsContent>
@@ -642,7 +645,7 @@ export default function BattleModeFinals({
               roundNames={roundNames}
               seededPlayers={playoffSeededPlayers}
               onMatchClick={isAdmin ? openScoreDialog : undefined}
-              targetWins={BM_FINALS_TARGET_WINS}
+              getTargetWins={(match, bracketMatch) => getBmFinalsTargetWins({ stage: match?.stage ?? 'playoff', round: match?.round ?? bracketMatch.round })}
             />
           </TabsContent>
         </Tabs>
@@ -655,7 +658,7 @@ export default function BattleModeFinals({
             roundNames={roundNames}
             seededPlayers={playoffSeededPlayers}
             onMatchClick={isAdmin ? openScoreDialog : undefined}
-            targetWins={BM_FINALS_TARGET_WINS}
+            getTargetWins={(match, bracketMatch) => getBmFinalsTargetWins({ stage: match?.stage ?? 'playoff', round: match?.round ?? bracketMatch.round })}
           />
           {playoffComplete && isAdmin && (
             <Card className="border-green-500/50 bg-green-500/10">
@@ -677,7 +680,7 @@ export default function BattleModeFinals({
           bracketStructure={bracketStructure}
           roundNames={roundNames}
           seededPlayers={seededPlayers}
-          targetWins={BM_FINALS_TARGET_WINS}
+          getTargetWins={(match, bracketMatch) => getBmFinalsTargetWins({ stage: match?.stage, round: match?.round ?? bracketMatch.round })}
           onMatchClick={isAdmin ? openScoreDialog : undefined}
         />
       )}
@@ -707,6 +710,7 @@ export default function BattleModeFinals({
                       {roundNames[selectedMatch.round] || selectedMatch.round}
                     </span>
                   )}
+                  <span className="block text-xs mt-1">FT{selectedMatchTargetWins}</span>
                 </>
               )}
             </DialogDescription>
@@ -722,7 +726,7 @@ export default function BattleModeFinals({
                    id={`score1-${selectedMatch?.id}`}
                    type="number"
                    min={0}
-                   max={BM_FINALS_TARGET_WINS}
+                   max={selectedMatchTargetWins}
                    value={scoreForm.score1}
                    onChange={(e) =>
                      setScoreForm({
@@ -744,7 +748,7 @@ export default function BattleModeFinals({
                    id={`score2-${selectedMatch?.id}`}
                    type="number"
                    min={0}
-                   max={BM_FINALS_TARGET_WINS}
+                   max={selectedMatchTargetWins}
                    value={scoreForm.score2}
                    onChange={(e) =>
                      setScoreForm({
@@ -773,8 +777,8 @@ export default function BattleModeFinals({
                Always rendered to reserve vertical space and prevent layout shift. */}
             <p className={`text-sm text-center ${
               scoreForm.score1 + scoreForm.score2 > 0 &&
-              scoreForm.score1 < BM_FINALS_TARGET_WINS &&
-              scoreForm.score2 < BM_FINALS_TARGET_WINS
+              scoreForm.score1 < selectedMatchTargetWins &&
+              scoreForm.score2 < selectedMatchTargetWins
                 ? 'text-yellow-600' : 'invisible'
             }`}>
               {tFinals('matchNeedWinner')}
@@ -784,7 +788,7 @@ export default function BattleModeFinals({
             {/* Submit button disabled until a valid winner score is entered (first to 5) */}
             <Button
               onClick={handleScoreSubmit}
-              disabled={scoreForm.score1 < BM_FINALS_TARGET_WINS && scoreForm.score2 < BM_FINALS_TARGET_WINS}
+              disabled={scoreForm.score1 < selectedMatchTargetWins && scoreForm.score2 < selectedMatchTargetWins}
             >
               {tCommon('saveScore')}
             </Button>

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -56,6 +56,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
 import { PlayoffBracket } from "@/components/tournament/playoff-bracket";
 import { POLLING_INTERVAL } from "@/lib/constants";
+import { getGpFinalsTargetWins } from "@/lib/finals-target-wins";
 import { usePolling } from "@/lib/hooks/usePolling";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
@@ -70,6 +71,7 @@ interface GPMatch {
   id: string;
   matchNumber: number;
   round: string | null;
+  stage?: string | null;
   player1Id: string;
   player2Id: string;
   score1: number;
@@ -175,6 +177,7 @@ export default function GrandPrixFinals({
   const [selectedMatch, setSelectedMatch] = useState<GPMatch | null>(null);
   const [scoreForm, setScoreForm] = useState({ score1: 0, score2: 0 });
   const [champion, setChampion] = useState<Player | null>(null);
+  const selectedMatchTargetWins = selectedMatch ? getGpFinalsTargetWins(selectedMatch) : getGpFinalsTargetWins();
 
   /** Fetch finals data including matches, bracket structure, and round names */
   const fetchFinalsData = useCallback(async () => {
@@ -398,7 +401,6 @@ export default function GrandPrixFinals({
   const completedMatches = matches.filter((m) => m.completed).length;
   const totalMatches = matches.length;
   const qualificationConfirmed = pollData?.qualificationConfirmed ?? false;
-
   if (loading) {
     return (
       <div className="space-y-6">
@@ -548,6 +550,7 @@ export default function GrandPrixFinals({
               bracketStructure={bracketStructure}
               roundNames={roundNames}
               seededPlayers={seededPlayers}
+              getTargetWins={(match, bracketMatch) => getGpFinalsTargetWins({ stage: match?.stage, round: match?.round ?? bracketMatch.round })}
               onMatchClick={isAdmin ? openScoreDialog : undefined}
             />
           </TabsContent>
@@ -557,6 +560,7 @@ export default function GrandPrixFinals({
               playoffStructure={playoffStructure}
               roundNames={roundNames}
               seededPlayers={playoffSeededPlayers}
+              getTargetWins={(match, bracketMatch) => getGpFinalsTargetWins({ stage: match?.stage ?? 'playoff', round: match?.round ?? bracketMatch.round })}
               onMatchClick={isAdmin ? openScoreDialog : undefined}
             />
           </TabsContent>
@@ -568,6 +572,7 @@ export default function GrandPrixFinals({
             playoffStructure={playoffStructure}
             roundNames={roundNames}
             seededPlayers={playoffSeededPlayers}
+            getTargetWins={(match, bracketMatch) => getGpFinalsTargetWins({ stage: match?.stage ?? 'playoff', round: match?.round ?? bracketMatch.round })}
             onMatchClick={isAdmin ? openScoreDialog : undefined}
           />
           {playoffComplete && isAdmin && (
@@ -585,6 +590,7 @@ export default function GrandPrixFinals({
           bracketStructure={bracketStructure}
           roundNames={roundNames}
           seededPlayers={seededPlayers}
+          getTargetWins={(match, bracketMatch) => getGpFinalsTargetWins({ stage: match?.stage, round: match?.round ?? bracketMatch.round })}
           onMatchClick={isAdmin ? openScoreDialog : undefined}
         />
       )}
@@ -605,12 +611,13 @@ export default function GrandPrixFinals({
                       {roundNames[selectedMatch.round] || selectedMatch.round}
                     </span>
                   )}
+                  <span className="block text-xs mt-1">FT{selectedMatchTargetWins}</span>
                 </>
               )}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-4">
-            {/* Score input: best of 5 (first to 3 wins) */}
+            {/* Score input: FT varies by round/stage. */}
             <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-end gap-3 sm:gap-4">
               <div className="min-w-0 text-center">
                 <Label className="block truncate" title={selectedMatch?.player1.nickname}>
@@ -619,7 +626,7 @@ export default function GrandPrixFinals({
                 <Input
                   type="number"
                   min={0}
-                  max={4}
+                  max={selectedMatchTargetWins}
                   value={scoreForm.score1}
                   onChange={(e) =>
                     setScoreForm({
@@ -638,7 +645,7 @@ export default function GrandPrixFinals({
                 <Input
                   type="number"
                   min={0}
-                  max={4}
+                  max={selectedMatchTargetWins}
                   value={scoreForm.score2}
                   onChange={(e) =>
                     setScoreForm({
@@ -654,8 +661,8 @@ export default function GrandPrixFinals({
                Always rendered to reserve vertical space and prevent layout shift. */}
             <p className={`text-sm text-center ${
               scoreForm.score1 + scoreForm.score2 > 0 &&
-              scoreForm.score1 < 3 &&
-              scoreForm.score2 < 3
+              scoreForm.score1 < selectedMatchTargetWins &&
+              scoreForm.score2 < selectedMatchTargetWins
                 ? 'text-yellow-600' : 'invisible'
             }`}>
               {tFinals('matchNeedWinner')}
@@ -664,7 +671,7 @@ export default function GrandPrixFinals({
           <DialogFooter>
             <Button
               onClick={handleScoreSubmit}
-              disabled={scoreForm.score1 < 3 && scoreForm.score2 < 3}
+              disabled={scoreForm.score1 < selectedMatchTargetWins && scoreForm.score2 < selectedMatchTargetWins}
             >
               {tCommon('saveScore')}
             </Button>

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -773,6 +773,18 @@ export default function MatchRaceFinals({
                         <span className="min-w-0 max-w-28 truncate text-sm" title={selectedMatch?.player2.nickname}>
                           {selectedMatch?.player2.nickname}
                         </span>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="ml-auto"
+                          onClick={() => {
+                            const newRounds = [...rounds];
+                            newRounds[index] = { course: "", winner: null };
+                            setRounds(newRounds);
+                          }}
+                        >
+                          {tCommon('clearScores')}
+                        </Button>
                       </div>
                     </TableCell>
                   </TableRow>

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -147,24 +147,34 @@ function createEmptyRounds(count: number): Round[] {
 }
 
 function buildInitialRounds(match: MRMatch): Round[] {
-  if (match.rounds && match.rounds.length === 5) {
-    return match.rounds as Round[];
+  const maxRounds = getMrFinalsMaxRounds(match);
+  const existingRounds = Array.isArray(match.rounds) ? match.rounds : [];
+  if (existingRounds.length > 0) {
+    return [
+      ...existingRounds.slice(0, maxRounds).map((round) => ({
+        course: typeof round?.course === "string" ? (round.course as CourseAbbr | "") : "",
+        winner: round?.winner === 1 || round?.winner === 2 ? round.winner : null,
+      })),
+      ...createEmptyRounds(Math.max(maxRounds - existingRounds.length, 0)),
+    ];
   }
 
-  if (Array.isArray(match.assignedCourses) && match.assignedCourses.length === 5) {
-    return match.assignedCourses.map((course) => ({
-      course: course as CourseAbbr,
-      winner: null,
-    }));
+  const assignedCourses = Array.isArray(match.assignedCourses) ? match.assignedCourses : [];
+  if (assignedCourses.length > 0) {
+    return [
+      ...assignedCourses.slice(0, maxRounds).map((course) => ({
+        course: course as CourseAbbr,
+        winner: null,
+      })),
+      ...createEmptyRounds(Math.max(maxRounds - assignedCourses.length, 0)),
+    ];
   }
 
-  return [
-    { course: "", winner: null },
-    { course: "", winner: null },
-    { course: "", winner: null },
-    { course: "", winner: null },
-    { course: "", winner: null },
-  ];
+  return createEmptyRounds(maxRounds);
+}
+
+function countWins(rounds: Round[], side: 1 | 2): number {
+  return rounds.filter((round) => round.winner === side).length;
 }
 
 export default function MatchRaceFinals({
@@ -386,16 +396,7 @@ export default function MatchRaceFinals({
    */
   const openMatchDialog = (match: MRMatch) => {
     setSelectedMatch(match);
-<<<<<<< HEAD
     setRounds(buildInitialRounds(match));
-=======
-    const maxRounds = getMrFinalsMaxRounds(match);
-    const existingRounds = (match.rounds as Round[] | undefined) ?? [];
-    setRounds([
-      ...existingRounds,
-      ...createEmptyRounds(Math.max(maxRounds - existingRounds.length, 0)),
-    ]);
->>>>>>> 6c73a05 (fix(finals): support per-round FT targets)
     setIsMatchDialogOpen(true);
   };
 
@@ -421,8 +422,8 @@ export default function MatchRaceFinals({
     }
 
     /* Count wins and validate a winner */
-    const winnerCount = playedRounds.filter(r => r.winner === 1).length;
-    const loserCount = playedRounds.filter(r => r.winner === 2).length;
+    const winnerCount = countWins(playedRounds, 1);
+    const loserCount = countWins(playedRounds, 2);
 
     if (!hasExactMatchWinner(winnerCount, loserCount)) {
       alert(tCommon('matchMustHaveWinner'));
@@ -477,14 +478,7 @@ export default function MatchRaceFinals({
     }
   };
 
-<<<<<<< HEAD
-  /* Track tournament progress */
-  const completedMatches = matches.filter((m) => m.completed).length;
-  const totalMatches = matches.length;
   const qualificationConfirmed = pollData?.qualificationConfirmed ?? false;
-
-=======
->>>>>>> 6c73a05 (fix(finals): support per-round FT targets)
   /* Loading skeleton */
   if (loading) {
     return (
@@ -617,8 +611,8 @@ export default function MatchRaceFinals({
           <CardContent>
             <p className="text-muted-foreground">{tFinals('bracketExplanation')}</p>
             <ul className="list-disc list-inside mt-4 space-y-2 text-sm text-muted-foreground">
-              <li><strong>{tFinals('fiveRaces')}</strong> Select courses only for the races you actually played.</li>
-              <li><strong>FT by round</strong> Playoff FT3/4, early bracket FT5, semis FT7, finals FT9.</li>
+              <li><strong>{tFinals('fiveRaces')}</strong> {tFinals('mrEnteredRacesDesc')}</li>
+              <li><strong>{tFinals('mrFtByRound')}</strong> {tFinals('mrFtByRoundDesc')}</li>
               <li><strong>{tFinals('winnersBracket')}</strong> {tFinals('winnersBracketDesc')}</li>
               <li><strong>{tFinals('losersBracket')}</strong> {tFinals('losersBracketDesc')}</li>
               <li><strong>{tFinals('grandFinal')}</strong> {tFinals('grandFinalDesc')}</li>
@@ -797,8 +791,8 @@ export default function MatchRaceFinals({
             <Button
               onClick={handleMatchSubmit}
               disabled={!hasExactMatchWinner(
-                rounds.filter(r => r.winner === 1).length,
-                rounds.filter(r => r.winner === 2).length,
+                countWins(rounds, 1),
+                countWins(rounds, 2),
               )}
             >
               {tCommon('saveResult')}

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -69,6 +69,7 @@ import {
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
 import { PlayoffBracket } from "@/components/tournament/playoff-bracket";
 import { COURSE_INFO, POLLING_INTERVAL, type CourseAbbr } from "@/lib/constants";
+import { getMrFinalsMaxRounds, getMrFinalsTargetWins } from "@/lib/finals-target-wins";
 import { usePolling } from "@/lib/hooks/usePolling";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
@@ -83,6 +84,7 @@ interface MRMatch {
   id: string;
   matchNumber: number;
   round: string | null;
+  stage?: string | null;
   player1Id: string;
   player2Id: string;
   score1: number;
@@ -138,6 +140,10 @@ function getCompletedChampion(matches: MRMatch[]): Player | null {
 interface Round {
   course: CourseAbbr | "";
   winner: number | null;
+}
+
+function createEmptyRounds(count: number): Round[] {
+  return Array.from({ length: count }, () => ({ course: "", winner: null }));
 }
 
 function buildInitialRounds(match: MRMatch): Round[] {
@@ -205,15 +211,9 @@ export default function MatchRaceFinals({
   const [playoffComplete, setPlayoffComplete] = useState(false);
   const [isMatchDialogOpen, setIsMatchDialogOpen] = useState(false);
   const [selectedMatch, setSelectedMatch] = useState<MRMatch | null>(null);
-  /* Initialize 5 empty rounds for match result dialog */
-  const [rounds, setRounds] = useState<Round[]>([
-    { course: "", winner: null },
-    { course: "", winner: null },
-    { course: "", winner: null },
-    { course: "", winner: null },
-    { course: "", winner: null },
-  ]);
+  const [rounds, setRounds] = useState<Round[]>(createEmptyRounds(getMrFinalsMaxRounds()));
   const [champion, setChampion] = useState<Player | null>(null);
+  const selectedMatchTargetWins = selectedMatch ? getMrFinalsTargetWins(selectedMatch) : getMrFinalsTargetWins();
 
   /**
    * Fetch finals bracket data including matches,
@@ -383,7 +383,16 @@ export default function MatchRaceFinals({
    */
   const openMatchDialog = (match: MRMatch) => {
     setSelectedMatch(match);
+<<<<<<< HEAD
     setRounds(buildInitialRounds(match));
+=======
+    const maxRounds = getMrFinalsMaxRounds(match);
+    const existingRounds = (match.rounds as Round[] | undefined) ?? [];
+    setRounds([
+      ...existingRounds,
+      ...createEmptyRounds(Math.max(maxRounds - existingRounds.length, 0)),
+    ]);
+>>>>>>> 6c73a05 (fix(finals): support per-round FT targets)
     setIsMatchDialogOpen(true);
   };
 
@@ -395,18 +404,24 @@ export default function MatchRaceFinals({
   const handleMatchSubmit = async () => {
     if (!selectedMatch) return;
 
-    /* Validate 5 unique courses */
-    const usedCourses = rounds.map(r => r.course).filter(c => c !== "");
-    if (usedCourses.length !== 5 || new Set(usedCourses).size !== 5) {
+    const playedRounds = rounds.filter((round) => round.course !== "" || round.winner !== null);
+    const hasPartialRound = playedRounds.some((round) => round.course === "" || round.winner === null);
+    if (hasPartialRound) {
+      alert('Complete every entered race before saving.');
+      return;
+    }
+
+    const usedCourses = playedRounds.map((round) => round.course).filter((course): course is CourseAbbr => course !== "");
+    if (usedCourses.length !== playedRounds.length || new Set(usedCourses).size !== usedCourses.length) {
       alert(tCommon('select5UniqueCourses'));
       return;
     }
 
     /* Count wins and validate a winner */
-    const winnerCount = rounds.filter(r => r.winner === 1).length;
-    const loserCount = rounds.filter(r => r.winner === 2).length;
+    const winnerCount = playedRounds.filter(r => r.winner === 1).length;
+    const loserCount = playedRounds.filter(r => r.winner === 2).length;
 
-    if (winnerCount < 3 && loserCount < 3) {
+    if (winnerCount < selectedMatchTargetWins && loserCount < selectedMatchTargetWins) {
       alert(tCommon('matchMustHaveWinner'));
       return;
     }
@@ -419,7 +434,7 @@ export default function MatchRaceFinals({
           matchId: selectedMatch.id,
           score1: winnerCount,
           score2: loserCount,
-          rounds,
+          rounds: playedRounds,
         }),
       });
 
@@ -428,13 +443,7 @@ export default function MatchRaceFinals({
         const data = unwrapApiData<{ isComplete?: boolean; champion?: string; playoffComplete?: boolean }>(json);
         setIsMatchDialogOpen(false);
         setSelectedMatch(null);
-        setRounds([
-          { course: "", winner: null },
-          { course: "", winner: null },
-          { course: "", winner: null },
-          { course: "", winner: null },
-          { course: "", winner: null },
-        ]);
+        setRounds(createEmptyRounds(getMrFinalsMaxRounds()));
         if (data.playoffComplete !== undefined) {
           setPlayoffComplete(data.playoffComplete);
         }
@@ -465,11 +474,14 @@ export default function MatchRaceFinals({
     }
   };
 
+<<<<<<< HEAD
   /* Track tournament progress */
   const completedMatches = matches.filter((m) => m.completed).length;
   const totalMatches = matches.length;
   const qualificationConfirmed = pollData?.qualificationConfirmed ?? false;
 
+=======
+>>>>>>> 6c73a05 (fix(finals): support per-round FT targets)
   /* Loading skeleton */
   if (loading) {
     return (
@@ -602,8 +614,8 @@ export default function MatchRaceFinals({
           <CardContent>
             <p className="text-muted-foreground">{tFinals('bracketExplanation')}</p>
             <ul className="list-disc list-inside mt-4 space-y-2 text-sm text-muted-foreground">
-              <li><strong>{tFinals('fiveRaces')}</strong> {tFinals('fiveRacesDesc')}</li>
-              <li><strong>{tFinals('firstTo3')}</strong> {tFinals('firstTo3Desc')}</li>
+              <li><strong>{tFinals('fiveRaces')}</strong> Select courses only for the races you actually played.</li>
+              <li><strong>FT by round</strong> Playoff FT3/4, early bracket FT5, semis FT7, finals FT9.</li>
               <li><strong>{tFinals('winnersBracket')}</strong> {tFinals('winnersBracketDesc')}</li>
               <li><strong>{tFinals('losersBracket')}</strong> {tFinals('losersBracketDesc')}</li>
               <li><strong>{tFinals('grandFinal')}</strong> {tFinals('grandFinalDesc')}</li>
@@ -623,6 +635,7 @@ export default function MatchRaceFinals({
               bracketStructure={bracketStructure}
               roundNames={roundNames}
               seededPlayers={seededPlayers}
+              getTargetWins={(match, bracketMatch) => getMrFinalsTargetWins({ stage: match?.stage, round: match?.round ?? bracketMatch.round })}
               onMatchClick={isAdmin ? openMatchDialog : undefined}
             />
           </TabsContent>
@@ -632,6 +645,7 @@ export default function MatchRaceFinals({
               playoffStructure={playoffStructure}
               roundNames={roundNames}
               seededPlayers={playoffSeededPlayers}
+              getTargetWins={(match, bracketMatch) => getMrFinalsTargetWins({ stage: match?.stage ?? 'playoff', round: match?.round ?? bracketMatch.round })}
               onMatchClick={isAdmin ? openMatchDialog : undefined}
             />
           </TabsContent>
@@ -643,6 +657,7 @@ export default function MatchRaceFinals({
             playoffStructure={playoffStructure}
             roundNames={roundNames}
             seededPlayers={playoffSeededPlayers}
+            getTargetWins={(match, bracketMatch) => getMrFinalsTargetWins({ stage: match?.stage ?? 'playoff', round: match?.round ?? bracketMatch.round })}
             onMatchClick={isAdmin ? openMatchDialog : undefined}
           />
           {playoffComplete && isAdmin && (
@@ -660,6 +675,7 @@ export default function MatchRaceFinals({
           bracketStructure={bracketStructure}
           roundNames={roundNames}
           seededPlayers={seededPlayers}
+          getTargetWins={(match, bracketMatch) => getMrFinalsTargetWins({ stage: match?.stage, round: match?.round ?? bracketMatch.round })}
           onMatchClick={isAdmin ? openMatchDialog : undefined}
         />
       )}
@@ -681,6 +697,7 @@ export default function MatchRaceFinals({
                       {roundNames[selectedMatch.round] || selectedMatch.round}
                     </span>
                   )}
+                  <span className="block text-xs mt-1">FT{selectedMatchTargetWins}</span>
                 </>
               )}
             </DialogDescription>
@@ -765,8 +782,8 @@ export default function MatchRaceFinals({
             <Button
               onClick={handleMatchSubmit}
               disabled={
-                rounds.filter(r => r.winner === 1).length < 3 &&
-                rounds.filter(r => r.winner === 2).length < 3
+                rounds.filter(r => r.winner === 1).length < selectedMatchTargetWins &&
+                rounds.filter(r => r.winner === 2).length < selectedMatchTargetWins
               }
             >
               {tCommon('saveResult')}

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -214,6 +214,9 @@ export default function MatchRaceFinals({
   const [rounds, setRounds] = useState<Round[]>(createEmptyRounds(getMrFinalsMaxRounds()));
   const [champion, setChampion] = useState<Player | null>(null);
   const selectedMatchTargetWins = selectedMatch ? getMrFinalsTargetWins(selectedMatch) : getMrFinalsTargetWins();
+  const hasExactMatchWinner = (player1Wins: number, player2Wins: number) =>
+    (player1Wins === selectedMatchTargetWins && player2Wins < selectedMatchTargetWins)
+    || (player2Wins === selectedMatchTargetWins && player1Wins < selectedMatchTargetWins);
 
   /**
    * Fetch finals bracket data including matches,
@@ -421,7 +424,7 @@ export default function MatchRaceFinals({
     const winnerCount = playedRounds.filter(r => r.winner === 1).length;
     const loserCount = playedRounds.filter(r => r.winner === 2).length;
 
-    if (winnerCount < selectedMatchTargetWins && loserCount < selectedMatchTargetWins) {
+    if (!hasExactMatchWinner(winnerCount, loserCount)) {
       alert(tCommon('matchMustHaveWinner'));
       return;
     }
@@ -781,10 +784,10 @@ export default function MatchRaceFinals({
             {/* i18n: Save result button */}
             <Button
               onClick={handleMatchSubmit}
-              disabled={
-                rounds.filter(r => r.winner === 1).length < selectedMatchTargetWins &&
-                rounds.filter(r => r.winner === 2).length < selectedMatchTargetWins
-              }
+              disabled={!hasExactMatchWinner(
+                rounds.filter(r => r.winner === 1).length,
+                rounds.filter(r => r.winner === 2).length,
+              )}
             >
               {tCommon('saveResult')}
             </Button>

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -34,6 +34,7 @@ interface BMMatch {
   id: string;
   matchNumber: number;
   round: string | null;
+  stage?: string | null;
   player1Id: string;
   player2Id: string;
   score1: number;
@@ -65,7 +66,7 @@ interface DoubleEliminationBracketProps {
   /** Optional seeded player data for displaying seed numbers */
   seededPlayers?: { seed: number; playerId: string; player: Player }[];
   /** Number of wins required to highlight a completed match winner. */
-  targetWins?: number;
+  getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
 }
 
 /**
@@ -85,14 +86,14 @@ function MatchCard({
   seededPlayers,
   onClick,
   isTBD,
-  targetWins,
+  getTargetWins,
 }: {
   match?: BMMatch;
   bracketMatch: BracketMatch;
   seededPlayers?: { seed: number; playerId: string; player: Player }[];
   onClick?: () => void;
   isTBD: boolean;
-  targetWins: number;
+  getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
 }) {
   /* Look up seeded players for displaying seed numbers in first-round matches */
   const seededPlayer1 = bracketMatch.player1Seed
@@ -106,8 +107,9 @@ function MatchCard({
   const player1: Player | undefined = match?.player1 || seededPlayer1;
   const player2: Player | undefined = match?.player2 || seededPlayer2;
 
-  const isWinner1 = match?.completed && match.score1 >= targetWins;
-  const isWinner2 = match?.completed && match.score2 >= targetWins;
+  const targetWins = getTargetWins?.(match, bracketMatch) ?? 3;
+  const isWinner1 = !!match?.completed && match.score1 >= targetWins && match.score1 > match.score2;
+  const isWinner2 = !!match?.completed && match.score2 >= targetWins && match.score2 > match.score1;
 
   /*
    * Determine if this match should show "TBD" for players.
@@ -251,7 +253,7 @@ export function DoubleEliminationBracket({
   bracketStructure,
   onMatchClick,
   seededPlayers,
-  targetWins = 3,
+  getTargetWins,
 }: DoubleEliminationBracketProps) {
   /** Look up a match by its bracket match number */
   const getMatch = (matchNumber: number) =>
@@ -328,7 +330,7 @@ export function DoubleEliminationBracket({
                       if (match && onMatchClick) onMatchClick(match);
                     }}
                     isTBD={isTBD(b.matchNumber)}
-                    targetWins={targetWins}
+                    getTargetWins={getTargetWins}
                   />
                 ))}
               </div>
@@ -352,7 +354,7 @@ export function DoubleEliminationBracket({
                     if (match && onMatchClick) onMatchClick(match);
                   }}
                   isTBD={isTBD(b.matchNumber)}
-                  targetWins={targetWins}
+                  getTargetWins={getTargetWins}
                 />
               ))}
             </div>
@@ -375,7 +377,7 @@ export function DoubleEliminationBracket({
                     if (match && onMatchClick) onMatchClick(match);
                   }}
                   isTBD={isTBD(b.matchNumber)}
-                  targetWins={targetWins}
+                  getTargetWins={getTargetWins}
                 />
               ))}
             </div>
@@ -396,7 +398,7 @@ export function DoubleEliminationBracket({
                     if (match && onMatchClick) onMatchClick(match);
                   }}
                   isTBD={isTBD(b.matchNumber)}
-                  targetWins={targetWins}
+                  getTargetWins={getTargetWins}
                 />
               ))}
             </div>
@@ -427,7 +429,7 @@ export function DoubleEliminationBracket({
                     if (match && onMatchClick) onMatchClick(match);
                   }}
                   isTBD={isTBD(b.matchNumber)}
-                  targetWins={targetWins}
+                  getTargetWins={getTargetWins}
                 />
               ))}
             </div>
@@ -450,7 +452,7 @@ export function DoubleEliminationBracket({
                     if (match && onMatchClick) onMatchClick(match);
                   }}
                   isTBD={isTBD(b.matchNumber)}
-                  targetWins={targetWins}
+                  getTargetWins={getTargetWins}
                 />
               ))}
             </div>
@@ -473,7 +475,7 @@ export function DoubleEliminationBracket({
                     if (match && onMatchClick) onMatchClick(match);
                   }}
                   isTBD={isTBD(b.matchNumber)}
-                  targetWins={targetWins}
+                  getTargetWins={getTargetWins}
                 />
               ))}
             </div>
@@ -497,7 +499,7 @@ export function DoubleEliminationBracket({
                       if (match && onMatchClick) onMatchClick(match);
                     }}
                     isTBD={isTBD(b.matchNumber)}
-                    targetWins={targetWins}
+                    getTargetWins={getTargetWins}
                   />
                 ))}
               </div>
@@ -521,7 +523,7 @@ export function DoubleEliminationBracket({
                     if (match && onMatchClick) onMatchClick(match);
                   }}
                   isTBD={isTBD(b.matchNumber)}
-                  targetWins={targetWins}
+                  getTargetWins={getTargetWins}
                 />
               ))}
             </div>
@@ -542,7 +544,7 @@ export function DoubleEliminationBracket({
                     if (match && onMatchClick) onMatchClick(match);
                   }}
                   isTBD={isTBD(b.matchNumber)}
-                  targetWins={targetWins}
+                  getTargetWins={getTargetWins}
                 />
               ))}
             </div>
@@ -571,7 +573,7 @@ export function DoubleEliminationBracket({
                   if (match && onMatchClick) onMatchClick(match);
                 }}
                 isTBD={isTBD(b.matchNumber)}
-                targetWins={targetWins}
+                getTargetWins={getTargetWins}
               />
             ))}
           </div>
@@ -596,7 +598,7 @@ export function DoubleEliminationBracket({
                   if (match && onMatchClick) onMatchClick(match);
                 }}
                 isTBD={isTBD(b.matchNumber)}
-                targetWins={targetWins}
+                getTargetWins={getTargetWins}
               />
             ))}
           </div>

--- a/smkc-score-app/src/components/tournament/playoff-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/playoff-bracket.tsx
@@ -29,6 +29,7 @@ interface BMMatch {
   id: string;
   matchNumber: number;
   round: string | null;
+  stage?: string | null;
   player1Id: string;
   player2Id: string;
   score1: number;
@@ -61,8 +62,8 @@ interface PlayoffBracketProps {
   onMatchClick?: (match: BMMatch) => void;
   /** Seeded player data for displaying seed numbers */
   seededPlayers?: { seed: number; playerId: string; player: Player }[];
-  /** Number of wins required to highlight a completed match winner (BM finals: 5) */
-  targetWins?: number;
+  /** Number of wins required to highlight a completed match winner */
+  getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
 }
 
 /**
@@ -77,7 +78,7 @@ function PlayoffMatchCard({
   onClick,
   isPlayer1TBD,
   isPlayer2TBD,
-  targetWins,
+  getTargetWins,
 }: {
   match?: BMMatch;
   bracketMatch: BracketMatch;
@@ -85,7 +86,7 @@ function PlayoffMatchCard({
   onClick?: () => void;
   isPlayer1TBD: boolean;
   isPlayer2TBD: boolean;
-  targetWins: number;
+  getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
 }) {
   const seededPlayer1 = bracketMatch.player1Seed
     ? seededPlayers?.find((p) => p.seed === bracketMatch.player1Seed)?.player
@@ -97,8 +98,9 @@ function PlayoffMatchCard({
   const player1: Player | undefined = match?.player1 || seededPlayer1;
   const player2: Player | undefined = match?.player2 || seededPlayer2;
 
-  const isWinner1 = match?.completed && match.score1 >= targetWins;
-  const isWinner2 = match?.completed && match.score2 >= targetWins;
+  const targetWins = getTargetWins?.(match, bracketMatch) ?? 3;
+  const isWinner1 = !!match?.completed && match.score1 >= targetWins && match.score1 > match.score2;
+  const isWinner2 = !!match?.completed && match.score2 >= targetWins && match.score2 > match.score1;
 
   return (
     <div
@@ -186,7 +188,7 @@ export function PlayoffBracket({
   roundNames,
   onMatchClick,
   seededPlayers,
-  targetWins = 5,
+  getTargetWins,
 }: PlayoffBracketProps) {
   const getMatch = (matchNumber: number) =>
     playoffMatches.find((m) => m.matchNumber === matchNumber);
@@ -267,7 +269,7 @@ export function PlayoffBracket({
                   }}
                   isPlayer1TBD={isTBD(b.matchNumber, 1)}
                   isPlayer2TBD={isTBD(b.matchNumber, 2)}
-                  targetWins={targetWins}
+                  getTargetWins={getTargetWins}
                 />
               ))}
             </div>
@@ -291,7 +293,7 @@ export function PlayoffBracket({
                   }}
                   isPlayer1TBD={isTBD(b.matchNumber, 1)}
                   isPlayer2TBD={isTBD(b.matchNumber, 2)}
-                  targetWins={targetWins}
+                  getTargetWins={getTargetWins}
                 />
               ))}
             </div>

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -756,8 +756,8 @@ export function createFinalsHandlers(config: FinalsConfig) {
       }
 
       const targetWins = config.getTargetWins?.(match) ?? config.targetWins ?? 3;
-      const player1ReachedTarget = score1 === targetWins;
-      const player2ReachedTarget = score2 === targetWins;
+      const player1ReachedTarget = score1 === targetWins && score2 < targetWins;
+      const player2ReachedTarget = score2 === targetWins && score1 < targetWins;
 
       if (player1ReachedTarget === player2ReachedTarget) {
         return handleValidationError(`Match must have a winner (first to ${targetWins})`, 'score');

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -756,8 +756,8 @@ export function createFinalsHandlers(config: FinalsConfig) {
       }
 
       const targetWins = config.getTargetWins?.(match) ?? config.targetWins ?? 3;
-      const player1ReachedTarget = score1 >= targetWins;
-      const player2ReachedTarget = score2 >= targetWins;
+      const player1ReachedTarget = score1 === targetWins;
+      const player2ReachedTarget = score2 === targetWins;
 
       if (player1ReachedTarget === player2ReachedTarget) {
         return handleValidationError(`Match must have a winner (first to ${targetWins})`, 'score');

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -65,6 +65,8 @@ export interface FinalsConfig {
   putAdditionalFields?: string[];
   /** Number of wins required to complete a finals match. Defaults to 3. */
   targetWins?: number;
+  /** Resolve number of wins required for a specific match. */
+  getTargetWins?: (match: { round?: string | null; stage?: string | null }) => number;
   /** Error message returned when GET fails */
   getErrorMessage: string;
   /** Error message returned when POST fails */
@@ -753,7 +755,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
         return createErrorResponse('Finals match not found', 404, 'NOT_FOUND');
       }
 
-      const targetWins = config.targetWins ?? 3;
+      const targetWins = config.getTargetWins?.(match) ?? config.targetWins ?? 3;
       const player1ReachedTarget = score1 >= targetWins;
       const player2ReachedTarget = score2 >= targetWins;
 

--- a/smkc-score-app/src/lib/api-factories/match-detail-route.ts
+++ b/smkc-score-app/src/lib/api-factories/match-detail-route.ts
@@ -76,6 +76,16 @@ export interface MatchDetailConfig {
    */
   validateFinalsScores?: (val1: number, val2: number) => { isValid: boolean; error?: string };
   /**
+   * Optional finals validator that needs match context such as the bracket round.
+   * When provided, it takes precedence over validateFinalsScores for finals-stage
+   * matches so routes can enforce round-specific target wins.
+   */
+  validateFinalsScoresWithMatch?: (
+    val1: number,
+    val2: number,
+    match: { stage?: string | null; round?: string | null },
+  ) => { isValid: boolean; error?: string };
+  /**
    * Optional qualification-stats recalculation config. When provided, a
    * successful qualification-stage PUT also refreshes the per-player
    * qualification record (wins/ties/losses/points) for both players in the
@@ -193,7 +203,7 @@ export function createMatchDetailHandlers(config: MatchDetailConfig) {
        * by the stage-aware validation below so there's no wasted DB call. */
       const matchMeta = await model(prisma).findUnique({
         where: { id: matchId },
-        select: { stage: true, tournamentId: true },
+        select: { stage: true, round: true, tournamentId: true },
       });
       if (!matchMeta || (matchMeta.tournamentId && matchMeta.tournamentId !== tournamentId)) {
         return createErrorResponse('Match not found', 404, 'NOT_FOUND');
@@ -207,15 +217,23 @@ export function createMatchDetailHandlers(config: MatchDetailConfig) {
        * BM qualification: 4 rounds, sum=4, max=4; BM finals: best-of-9, max=5.
        * Only fetch stage when a separate finals validator exists; otherwise use
        * the single validateScores for all stages (avoids an extra DB read). */
-      if (config.validateFinalsScores) {
+      if (config.validateFinalsScores || config.validateFinalsScoresWithMatch) {
         /* Reuse matchMeta already fetched above to avoid extra DB read */
         const matchForStage = matchMeta;
         // All bracket matches (including grand final / reset) use stage='finals';
         // the `round` field distinguishes bracket position. Default to qualification.
         const isFinalsMatch = matchForStage?.stage === 'finals';
-        const validator = isFinalsMatch ? config.validateFinalsScores : config.validateScores;
+        const validator = isFinalsMatch
+          ? config.validateFinalsScoresWithMatch
+            ? () => config.validateFinalsScoresWithMatch!(val1, val2, matchForStage)
+            : config.validateFinalsScores
+              ? () => config.validateFinalsScores!(val1, val2)
+              : null
+          : config.validateScores
+            ? () => config.validateScores!(val1, val2)
+            : null;
         if (validator) {
-          const scoreValidation = validator(val1, val2);
+          const scoreValidation = validator();
           if (!scoreValidation.isValid) {
             return handleValidationError(scoreValidation.error ?? 'Invalid scores', 'scores');
           }

--- a/smkc-score-app/src/lib/api-factories/match-detail-route.ts
+++ b/smkc-score-app/src/lib/api-factories/match-detail-route.ts
@@ -74,7 +74,11 @@ export interface MatchDetailConfig {
    * If omitted, no validation is performed on finals scores.
    * BM finals use best-of-9 (max score = 5) which differs from qualification (max 4, sum = 4).
    */
-  validateFinalsScores?: (val1: number, val2: number) => { isValid: boolean; error?: string };
+  validateFinalsScores?: (
+    val1: number,
+    val2: number,
+    context?: { round?: string | null; stage?: string | null }
+  ) => { isValid: boolean; error?: string };
   /**
    * Optional finals validator that needs match context such as the bracket round.
    * When provided, it takes precedence over validateFinalsScores for finals-stage

--- a/smkc-score-app/src/lib/api-factories/match-detail-route.ts
+++ b/smkc-score-app/src/lib/api-factories/match-detail-route.ts
@@ -217,17 +217,16 @@ export function createMatchDetailHandlers(config: MatchDetailConfig) {
         if (lockError) return lockError;
       }
 
-      /* Stage-aware score validation: qualification and finals have different rules.
-       * BM qualification: 4 rounds, sum=4, max=4; BM finals: best-of-9, max=5.
+      /* Stage-aware score validation: qualification and bracket matches have different rules.
+       * BM qualification: 4 rounds, sum=4, max=4; BM playoff/finals: first-to-N.
        * Only fetch stage when a separate finals validator exists; otherwise use
        * the single validateScores for all stages (avoids an extra DB read). */
       if (config.validateFinalsScores || config.validateFinalsScoresWithMatch) {
         /* Reuse matchMeta already fetched above to avoid extra DB read */
         const matchForStage = matchMeta;
-        // All bracket matches (including grand final / reset) use stage='finals';
-        // the `round` field distinguishes bracket position. Default to qualification.
-        const isFinalsMatch = matchForStage?.stage === 'finals';
-        const validator = isFinalsMatch
+        // Bracket matches use finals-style validation for both playoff and finals stages.
+        const isBracketMatch = matchForStage?.stage === 'finals' || matchForStage?.stage === 'playoff';
+        const validator = isBracketMatch
           ? config.validateFinalsScoresWithMatch
             ? () => config.validateFinalsScoresWithMatch!(val1, val2, matchForStage)
             : config.validateFinalsScores

--- a/smkc-score-app/src/lib/api-factories/match-detail-route.ts
+++ b/smkc-score-app/src/lib/api-factories/match-detail-route.ts
@@ -231,7 +231,7 @@ export function createMatchDetailHandlers(config: MatchDetailConfig) {
           ? config.validateFinalsScoresWithMatch
             ? () => config.validateFinalsScoresWithMatch!(val1, val2, matchForStage)
             : config.validateFinalsScores
-              ? () => config.validateFinalsScores!(val1, val2)
+              ? () => config.validateFinalsScores!(val1, val2, matchForStage)
               : null
           : config.validateScores
             ? () => config.validateScores!(val1, val2)

--- a/smkc-score-app/src/lib/finals-target-wins.ts
+++ b/smkc-score-app/src/lib/finals-target-wins.ts
@@ -1,0 +1,66 @@
+export interface FinalsTargetContext {
+  round?: string | null;
+  stage?: string | null;
+}
+
+function isEarlyUpperRound(round?: string | null): boolean {
+  return round === 'winners_r1' || round === 'winners_qf';
+}
+
+function isEarlyLowerRound(round?: string | null): boolean {
+  return round === 'losers_r1' || round === 'losers_r2';
+}
+
+function isMidLowerRound(round?: string | null): boolean {
+  return round === 'losers_r3' || round === 'losers_r4' || round === 'losers_sf';
+}
+
+function isFinalRound(round?: string | null): boolean {
+  return round === 'winners_final'
+    || round === 'losers_final'
+    || round === 'grand_final'
+    || round === 'grand_final_reset';
+}
+
+export function getBmFinalsTargetWins(context?: FinalsTargetContext): number {
+  if (context?.stage === 'playoff') {
+    return context.round === 'playoff_r2' ? 4 : 3;
+  }
+  if (isEarlyUpperRound(context?.round) || isEarlyLowerRound(context?.round)) {
+    return 5;
+  }
+  if (context?.round === 'winners_sf' || isMidLowerRound(context?.round) || isFinalRound(context?.round)) {
+    return 7;
+  }
+  return 5;
+}
+
+export function getMrFinalsTargetWins(context?: FinalsTargetContext): number {
+  if (context?.stage === 'playoff') {
+    return context.round === 'playoff_r2' ? 4 : 3;
+  }
+  if (isEarlyUpperRound(context?.round) || isEarlyLowerRound(context?.round)) {
+    return 5;
+  }
+  if (context?.round === 'winners_sf' || isMidLowerRound(context?.round)) {
+    return 7;
+  }
+  if (isFinalRound(context?.round)) {
+    return 9;
+  }
+  return 5;
+}
+
+export function getGpFinalsTargetWins(context?: FinalsTargetContext): number {
+  if (context?.stage === 'playoff') {
+    return 1;
+  }
+  if (isFinalRound(context?.round)) {
+    return 3;
+  }
+  return 2;
+}
+
+export function getMrFinalsMaxRounds(context?: FinalsTargetContext): number {
+  return getMrFinalsTargetWins(context) * 2 - 1;
+}


### PR DESCRIPTION
## Summary
- add shared BM/MR/GP finals target-win mapping by round and playoff stage
- apply round-aware FT validation in finals PUT handlers and bracket winner highlighting
- update BM/MR/GP finals UIs for dynamic FT input limits, including MR dynamic race rows

## Verification
- `npx eslint 'src/lib/finals-target-wins.ts' 'src/lib/api-factories/finals-route.ts' 'src/app/api/tournaments/[id]/bm/finals/route.ts' 'src/app/api/tournaments/[id]/mr/finals/route.ts' 'src/app/api/tournaments/[id]/gp/finals/route.ts' 'src/components/tournament/double-elimination-bracket.tsx' 'src/components/tournament/playoff-bracket.tsx' 'src/app/tournaments/[id]/bm/finals/page.tsx' 'src/app/tournaments/[id]/mr/finals/page.tsx' 'src/app/tournaments/[id]/gp/finals/page.tsx'`
- `npx tsc --noEmit` still reports pre-existing repo-wide type errors outside this change
- `npm test -- --runTestsByPath ...` is currently blocked by the repo's existing `jest.config.ts` parse failure (`registeredCompiler.enabled is not a function`)

Closes #528