### PR TITLE
fix(finals): share MR courses and GP cups by round

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -52,7 +52,7 @@ import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
 import { createLogger } from '@/lib/logger';
 import { GET, POST, PUT } from '@/app/api/tournaments/[id]/gp/finals/route';
-import { generateBracketStructure, roundNames } from '@/lib/double-elimination';
+import { generateBracketStructure, generatePlayoffStructure, roundNames } from '@/lib/double-elimination';
 import { paginate } from '@/lib/pagination';
 import { configureNextResponseMock } from '../../../../../../helpers/next-response-mock';
 
@@ -348,6 +348,43 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
 
       // Source returns 201 for successful resource creation (POST)
       expect(result.status).toBe(201);
+    });
+
+    it('should assign the same cup to every playoff match in a round', async () => {
+      const mockQualifications = Array.from({ length: 24 }, (_, index) => ({
+        id: `q${index + 1}`,
+        playerId: `p${index + 1}`,
+        group: index < 12 ? 'A' : 'B',
+        score: 24 - index,
+        points: (24 - index) * 3,
+        player: { id: `p${index + 1}`, name: `Player ${index + 1}` },
+      }));
+      const playoffStructure = [
+        { matchNumber: 1, round: 'playoff_r1', player1Seed: 1, player2Seed: 8 },
+        { matchNumber: 2, round: 'playoff_r1', player1Seed: 4, player2Seed: 5 },
+        { matchNumber: 5, round: 'playoff_r2', player1Seed: 1, player2Seed: null, advancesToUpperSeed: 16 },
+      ];
+
+      (prisma.gPQualification.findMany as jest.Mock).mockResolvedValue(mockQualifications);
+      (prisma.gPMatch.findMany as jest.Mock)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      (prisma.gPMatch.create as jest.Mock).mockImplementation(({ data }: { data: Record<string, unknown> }) => Promise.resolve({
+        id: `m${data.matchNumber}`,
+        ...data,
+        player1: { id: data.player1Id },
+        player2: { id: data.player2Id },
+      }));
+      (generatePlayoffStructure as jest.Mock).mockReturnValue(playoffStructure);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/finals', { topN: 24 });
+      const params = Promise.resolve({ id: 't1' });
+      const result = await POST(request, { params });
+
+      expect(result.status).toBe(201);
+      const createCalls = (prisma.gPMatch.create as jest.Mock).mock.calls.map(([arg]) => arg.data);
+      expect(createCalls[0].cup).toBe(createCalls[1].cup);
+      expect(createCalls[0].cup).not.toBe(createCalls[2].cup);
     });
   });
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
@@ -680,6 +680,84 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
       expect(prisma.gPMatch.update).not.toHaveBeenCalled();
     });
 
+    it('should reject non-completed reports with malformed race cards from the assigned cup', async () => {
+      const mockMatch = {
+        id: 'm1',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        cup: 'Flower',
+        player1: { userId: null },
+        player2: { userId: null },
+        completed: false,
+        player1ReportedPoints1: null,
+        player1ReportedPoints2: null,
+        player2ReportedPoints1: null,
+        player2ReportedPoints2: null,
+      };
+
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValueOnce(mockMatch);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/match/m1/report', {
+        reportingPlayer: 1,
+        races: [
+          { course: 'CI1', position1: 1, position2: 2 },
+          { course: 'CI1', position1: 1, position2: 2 },
+          { course: 'CI1', position1: 1, position2: 2 },
+          { course: 'CI1', position1: 1, position2: 2 },
+          { course: 'CI1', position1: 1, position2: 2 },
+        ],
+      });
+      const params = Promise.resolve({ id: 't1', matchId: 'm1' });
+      const result = await POST(request, { params });
+
+      expect(result).toEqual({
+        data: { error: 'Submitted races do not match the assigned cup for this match', field: 'races' },
+        status: 400,
+      });
+      expect(handleValidationError).toHaveBeenCalledWith(
+        'Submitted races do not match the assigned cup for this match',
+        'races'
+      );
+      expect(prisma.gPMatch.update).not.toHaveBeenCalled();
+    });
+
+    it('should reject completed-match corrections with unknown courses mixed into one cup', async () => {
+      const mockMatch = {
+        id: 'm1',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        cup: 'Mushroom',
+        player1: { userId: null },
+        player2: { userId: null },
+        completed: true,
+      };
+
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValueOnce(mockMatch);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/match/m1/report', {
+        reportingPlayer: 1,
+        races: [
+          { course: 'MC1', position1: 1, position2: 2 },
+          { course: 'XXX', position1: 1, position2: 2 },
+          { course: 'XXX', position1: 1, position2: 2 },
+          { course: 'XXX', position1: 1, position2: 2 },
+          { course: 'XXX', position1: 1, position2: 2 },
+        ],
+      });
+      const params = Promise.resolve({ id: 't1', matchId: 'm1' });
+      const result = await POST(request, { params });
+
+      expect(result).toEqual({
+        data: { error: 'Submitted races do not match the assigned cup for this match', field: 'races' },
+        status: 400,
+      });
+      expect(handleValidationError).toHaveBeenCalledWith(
+        'Submitted races do not match the assigned cup for this match',
+        'races'
+      );
+      expect(prisma.gPMatch.update).not.toHaveBeenCalled();
+    });
+
     // Error case - Returns 500 when database operation fails
     it('should return 500 when database operation fails', async () => {
       (prisma.gPMatch.findUnique as jest.Mock).mockRejectedValue(new Error('Database error'));

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
@@ -27,6 +27,7 @@ jest.mock('@/lib/constants', () => ({
   SMK_CHARACTERS: ['mario', 'luigi', 'peach', 'toad', 'yoshi', 'bowser', 'donkey_kong', 'koopa'],
   DRIVER_POINTS: [0, 9, 6, 3, 1, 0, 0, 0, 0],
   COURSE_INFO: [
+<<<<<<< HEAD
     { abbr: 'MC1', name: 'Mario Circuit 1', cup: 'Mushroom' },
     { abbr: 'DP1', name: 'Donut Plains 1', cup: 'Mushroom' },
     { abbr: 'GV1', name: 'Ghost Valley 1', cup: 'Mushroom' },
@@ -37,6 +38,14 @@ jest.mock('@/lib/constants', () => ({
     { abbr: 'DP2', name: 'Donut Plains 2', cup: 'Flower' },
     { abbr: 'BC2', name: 'Bowser Castle 2', cup: 'Flower' },
     { abbr: 'MC3', name: 'Mario Circuit 3', cup: 'Flower' },
+=======
+    { abbr: 'Mario Circuit 1', cup: 'Mushroom Cup' },
+    { abbr: 'Donut Plains 1', cup: 'Mushroom Cup' },
+    { abbr: 'Ghost Valley 1', cup: 'Mushroom Cup' },
+    { abbr: 'Bowser Castle 1', cup: 'Mushroom Cup' },
+    { abbr: 'Mario Circuit 2', cup: 'Mushroom Cup' },
+    { abbr: 'Choco Island 1', cup: 'Star Cup' },
+>>>>>>> e484926 (fix(finals): preserve legacy MR/GP scoring paths)
   ],
   TOTAL_GP_RACES: 5,
   getDriverPoints: (pos: number) => [0, 9, 6, 3, 1, 0, 0, 0, 0][pos] ?? 0,
@@ -556,7 +565,11 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
         player1: { userId: null },
         player2: { userId: null },
         completed: true,
+<<<<<<< HEAD
         cup: 'Mushroom',
+=======
+        cup: 'Mushroom Cup',
+>>>>>>> e484926 (fix(finals): preserve legacy MR/GP scoring paths)
       };
 
       const correctedMatch = {
@@ -605,7 +618,11 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
       expect(prisma.gPQualification.updateMany).toHaveBeenCalledTimes(2);
     });
 
+<<<<<<< HEAD
     it('should reject correction races that do not match the assigned cup', async () => {
+=======
+    it('should reject completed-match corrections that use a cup outside the assigned cup', async () => {
+>>>>>>> e484926 (fix(finals): preserve legacy MR/GP scoring paths)
       const mockMatch = {
         id: 'm1',
         player1Id: 'p1',
@@ -613,19 +630,33 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
         player1: { userId: null },
         player2: { userId: null },
         completed: true,
+<<<<<<< HEAD
         cup: 'Mushroom',
       };
 
       (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+=======
+        cup: 'Mushroom Cup',
+      };
+
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValueOnce(mockMatch);
+>>>>>>> e484926 (fix(finals): preserve legacy MR/GP scoring paths)
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/match/m1/report', {
         reportingPlayer: 1,
         races: [
           { course: 'Choco Island 1', position1: 1, position2: 2 },
+<<<<<<< HEAD
           { course: 'Ghost Valley 2', position1: 1, position2: 2 },
           { course: 'Donut Plains 2', position1: 1, position2: 2 },
           { course: 'Bowser Castle 2', position1: 1, position2: 2 },
           { course: 'Mario Circuit 3', position1: 1, position2: 2 },
+=======
+          { course: 'Choco Island 1', position1: 1, position2: 2 },
+          { course: 'Choco Island 1', position1: 1, position2: 2 },
+          { course: 'Choco Island 1', position1: 1, position2: 2 },
+          { course: 'Choco Island 1', position1: 1, position2: 2 },
+>>>>>>> e484926 (fix(finals): preserve legacy MR/GP scoring paths)
         ],
       });
       const params = Promise.resolve({ id: 't1', matchId: 'm1' });
@@ -640,7 +671,11 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
       });
       expect(handleValidationError).toHaveBeenCalledWith(
         'Submitted races do not match the assigned cup for this match',
+<<<<<<< HEAD
         'races'
+=======
+        'races',
+>>>>>>> e484926 (fix(finals): preserve legacy MR/GP scoring paths)
       );
       expect(prisma.gPMatch.update).not.toHaveBeenCalled();
     });

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
@@ -721,6 +721,47 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
       expect(prisma.gPMatch.update).not.toHaveBeenCalled();
     });
 
+    it('should reject non-completed reports with shuffled assigned-cup course order', async () => {
+      const mockMatch = {
+        id: 'm1',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        cup: 'Mushroom',
+        player1: { userId: null },
+        player2: { userId: null },
+        completed: false,
+        player1ReportedPoints1: null,
+        player1ReportedPoints2: null,
+        player2ReportedPoints1: null,
+        player2ReportedPoints2: null,
+      };
+
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValueOnce(mockMatch);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/match/m1/report', {
+        reportingPlayer: 1,
+        races: [
+          { course: 'GV2', position1: 1, position2: 2 },
+          { course: 'MC1', position1: 1, position2: 2 },
+          { course: 'DP2', position1: 1, position2: 2 },
+          { course: 'BC2', position1: 1, position2: 2 },
+          { course: 'MC3', position1: 1, position2: 2 },
+        ],
+      });
+      const params = Promise.resolve({ id: 't1', matchId: 'm1' });
+      const result = await POST(request, { params });
+
+      expect(result).toEqual({
+        data: { error: 'Submitted races do not match the assigned cup for this match', field: 'races' },
+        status: 400,
+      });
+      expect(handleValidationError).toHaveBeenCalledWith(
+        'Submitted races do not match the assigned cup for this match',
+        'races'
+      );
+      expect(prisma.gPMatch.update).not.toHaveBeenCalled();
+    });
+
     it('should reject completed-match corrections with unknown courses mixed into one cup', async () => {
       const mockMatch = {
         id: 'm1',

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
@@ -48,7 +48,7 @@ jest.mock('@/lib/qualification-confirmed-check', () => ({
 import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
 import { createLogger } from '@/lib/logger';
-import { generateBracketStructure } from '@/lib/double-elimination';
+import { generateBracketStructure, generatePlayoffStructure } from '@/lib/double-elimination';
 import { GET, POST, PUT } from '@/app/api/tournaments/[id]/mr/finals/route';
 import { configureNextResponseMock } from '../../../../../../helpers/next-response-mock';
 
@@ -280,6 +280,45 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
       expect(result.data).toEqual({ success: false, error: 'Failed to create finals bracket', code: 'INTERNAL_ERROR' });
       expect(result.status).toBe(500);
       expect(loggerMock.error).toHaveBeenCalledWith('Failed to create finals', { error: expect.any(Error), tournamentId: 't1' });
+    });
+
+    it('should assign the same courses to every playoff match in a round', async () => {
+      const mockQualifications = Array.from({ length: 24 }, (_, index) => ({
+        id: `q${index + 1}`,
+        playerId: `p${index + 1}`,
+        group: index < 12 ? 'A' : 'B',
+        score: 24 - index,
+        points: (24 - index) * 2,
+        winRounds: (24 - index) * 3,
+        player: { id: `p${index + 1}`, name: `Player ${index + 1}` },
+      }));
+      const playoffStructure = [
+        { matchNumber: 1, round: 'playoff_r1', player1Seed: 1, player2Seed: 8 },
+        { matchNumber: 2, round: 'playoff_r1', player1Seed: 4, player2Seed: 5 },
+        { matchNumber: 5, round: 'playoff_r2', player1Seed: 1, player2Seed: null, advancesToUpperSeed: 16 },
+      ];
+
+      (prisma.mRQualification.findMany as jest.Mock).mockResolvedValue(mockQualifications);
+      (prisma.mRMatch.findMany as jest.Mock)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      (prisma.mRMatch.create as jest.Mock).mockImplementation(({ data }: { data: Record<string, unknown> }) => Promise.resolve({
+        id: `m${data.matchNumber}`,
+        ...data,
+        player1: { id: data.player1Id },
+        player2: { id: data.player2Id },
+      }));
+      (generatePlayoffStructure as jest.Mock).mockReturnValue(playoffStructure);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/finals', { topN: 24 });
+      const params = Promise.resolve({ id: 't1' });
+      const result = await POST(request, { params });
+
+      expect(result.status).toBe(201);
+      const createCalls = (prisma.mRMatch.create as jest.Mock).mock.calls.map(([arg]) => arg.data);
+      expect(createCalls[0].assignedCourses).toEqual(createCalls[1].assignedCourses);
+      expect(createCalls[0].assignedCourses).toHaveLength(5);
+      expect(createCalls[2].assignedCourses).toHaveLength(7);
     });
   });
 

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
@@ -21,6 +21,7 @@ const { GET, POST, PUT } = createFinalsHandlers({
   postErrorMessage: 'Failed to create grand prix finals bracket',
   postRequiresAuth: true,
   putRequiresAuth: true,
+  assignGpCupByRound: true,
 });
 
 export { GET, POST, PUT };

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -166,6 +166,11 @@ export async function POST(
         }
       }
 
+      const submittedCup = getSubmittedCup(races);
+      if (!submittedCup || !isValidCupChoice(match.cup, submittedCup)) {
+        return handleValidationError("Submitted races do not match the assigned cup for this match", "races");
+      }
+
       /* Process races: convert finishing positions to driver points (same as normal flow) */
       let totalPoints1 = 0;
       let totalPoints2 = 0;
@@ -249,12 +254,8 @@ export async function POST(
       }
     }
 
-    const submittedCups = [...new Set(
-      races
-        .map((race: { course: string }) => COURSE_INFO.find((course) => course.abbr === race.course)?.cup)
-        .filter((cup): cup is string => Boolean(cup))
-    )];
-    if (submittedCups.length !== 1 || !isValidCupChoice(match.cup, submittedCups[0])) {
+    const submittedCup = getSubmittedCup(races);
+    if (!submittedCup || !isValidCupChoice(match.cup, submittedCup)) {
       return handleValidationError("Submitted races do not match the assigned cup for this match", "races");
     }
 

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -60,17 +60,32 @@ const GP_RECALC_CONFIG: RecalculateStatsConfig = {
   useRoundDifferential: false,
 };
 
-function validateSubmittedCup(
-  assignedCup: string | null | undefined,
-  races: Array<{ course: string }>
-) {
-  const submittedCups = [...new Set(
-    races
-      .map((race) => COURSE_INFO.find((course) => course.abbr === race.course || course.name === race.course)?.cup)
-      .filter((cup): cup is string => Boolean(cup))
-  )];
+function getSubmittedCup(
+  races: Array<{ course: string }>,
+): string | null {
+  if (races.length !== TOTAL_GP_RACES) return null;
 
-  return submittedCups.length === 1 && isValidCupChoice(assignedCup, submittedCups[0]);
+  const submittedCourses = races.map((race) =>
+    COURSE_INFO.find((course) => course.abbr === race.course)
+  );
+  if (submittedCourses.some((course) => !course)) return null;
+
+  const cups = [...new Set(submittedCourses.map((course) => course!.cup))];
+  if (cups.length !== 1) return null;
+
+  const cupCourses = COURSE_INFO
+    .filter((course) => course.cup === cups[0])
+    .map((course) => course.abbr);
+  const submittedCourseAbbrs = submittedCourses.map((course) => course!.abbr);
+
+  if (
+    new Set(submittedCourseAbbrs).size !== TOTAL_GP_RACES ||
+    submittedCourseAbbrs.some((course) => !cupCourses.includes(course))
+  ) {
+    return null;
+  }
+
+  return cups[0];
 }
 
 
@@ -166,8 +181,10 @@ export async function POST(
         }
       }
 
-      const cupValidationError = validateSubmittedCup(match.cup, races);
-      if (cupValidationError) return cupValidationError;
+      const submittedCup = getSubmittedCup(races);
+      if (!submittedCup || !isValidCupChoice(match.cup, submittedCup)) {
+        return handleValidationError("Submitted races do not match the assigned cup for this match", "races");
+      }
 
       /* Process races: convert finishing positions to driver points (same as normal flow) */
       let totalPoints1 = 0;
@@ -252,8 +269,10 @@ export async function POST(
       }
     }
 
-    const cupValidationError = validateSubmittedCup(match.cup, races);
-    if (cupValidationError) return cupValidationError;
+    const submittedCup = getSubmittedCup(races);
+    if (!submittedCup || !isValidCupChoice(match.cup, submittedCup)) {
+      return handleValidationError("Submitted races do not match the assigned cup for this match", "races");
+    }
 
     /* Process races: convert finishing positions to driver points */
     let totalPoints1 = 0;

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -249,6 +249,15 @@ export async function POST(
       }
     }
 
+    const submittedCups = [...new Set(
+      races
+        .map((race: { course: string }) => COURSE_INFO.find((course) => course.abbr === race.course)?.cup)
+        .filter((cup): cup is string => Boolean(cup))
+    )];
+    if (submittedCups.length !== 1 || !isValidCupChoice(match.cup, submittedCups[0])) {
+      return handleValidationError("Submitted races do not match the assigned cup for this match", "races");
+    }
+
     /* Process races: convert finishing positions to driver points */
     let totalPoints1 = 0;
     let totalPoints2 = 0;

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -80,12 +80,20 @@ function getSubmittedCup(
 
   if (
     new Set(submittedCourseAbbrs).size !== TOTAL_GP_RACES ||
-    submittedCourseAbbrs.some((course) => !cupCourses.includes(course))
+    submittedCourseAbbrs.some((course, index) => course !== cupCourses[index])
   ) {
     return null;
   }
 
   return cups[0];
+}
+
+function validateSubmittedCup(
+  assignedCup: string | null | undefined,
+  races: Array<{ course: string }>,
+): boolean {
+  const submittedCup = getSubmittedCup(races);
+  return !!submittedCup && isValidCupChoice(assignedCup, submittedCup);
 }
 
 

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -166,10 +166,8 @@ export async function POST(
         }
       }
 
-      const submittedCup = getSubmittedCup(races);
-      if (!submittedCup || !isValidCupChoice(match.cup, submittedCup)) {
-        return handleValidationError("Submitted races do not match the assigned cup for this match", "races");
-      }
+      const cupValidationError = validateSubmittedCup(match.cup, races);
+      if (cupValidationError) return cupValidationError;
 
       /* Process races: convert finishing positions to driver points (same as normal flow) */
       let totalPoints1 = 0;
@@ -254,10 +252,8 @@ export async function POST(
       }
     }
 
-    const submittedCup = getSubmittedCup(races);
-    if (!submittedCup || !isValidCupChoice(match.cup, submittedCup)) {
-      return handleValidationError("Submitted races do not match the assigned cup for this match", "races");
-    }
+    const cupValidationError = validateSubmittedCup(match.cup, races);
+    if (cupValidationError) return cupValidationError;
 
     /* Process races: convert finishing positions to driver points */
     let totalPoints1 = 0;

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/finals/route.ts
@@ -22,6 +22,7 @@ const { GET, POST, PUT } = createFinalsHandlers({
   postErrorMessage: 'Failed to create finals bracket',
   postRequiresAuth: true,
   putRequiresAuth: true,
+  assignMrCoursesByRound: true,
 });
 
 export { GET, POST, PUT };

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -129,6 +129,10 @@ function getCompletedChampion(matches: GPMatch[]): Player | null {
   return grandFinal.player1;
 }
 
+function hasValidGpFinalsWinner(score1: number, score2: number): boolean {
+  return (score1 === 3 && score2 < 3) || (score2 === 3 && score1 < 3);
+}
+
 export default function GrandPrixFinals({
   params,
 }: {
@@ -398,6 +402,7 @@ export default function GrandPrixFinals({
   const completedMatches = matches.filter((m) => m.completed).length;
   const totalMatches = matches.length;
   const qualificationConfirmed = pollData?.qualificationConfirmed ?? false;
+  const scoreHasWinner = hasValidGpFinalsWinner(scoreForm.score1, scoreForm.score2);
 
   if (loading) {
     return (
@@ -619,7 +624,7 @@ export default function GrandPrixFinals({
                 <Input
                   type="number"
                   min={0}
-                  max={4}
+                  max={3}
                   value={scoreForm.score1}
                   onChange={(e) =>
                     setScoreForm({
@@ -638,7 +643,7 @@ export default function GrandPrixFinals({
                 <Input
                   type="number"
                   min={0}
-                  max={4}
+                  max={3}
                   value={scoreForm.score2}
                   onChange={(e) =>
                     setScoreForm({
@@ -654,8 +659,7 @@ export default function GrandPrixFinals({
                Always rendered to reserve vertical space and prevent layout shift. */}
             <p className={`text-sm text-center ${
               scoreForm.score1 + scoreForm.score2 > 0 &&
-              scoreForm.score1 < 3 &&
-              scoreForm.score2 < 3
+              !scoreHasWinner
                 ? 'text-yellow-600' : 'invisible'
             }`}>
               {tFinals('matchNeedWinner')}
@@ -664,7 +668,7 @@ export default function GrandPrixFinals({
           <DialogFooter>
             <Button
               onClick={handleScoreSubmit}
-              disabled={scoreForm.score1 < 3 && scoreForm.score2 < 3}
+              disabled={!scoreHasWinner}
             >
               {tCommon('saveScore')}
             </Button>

--- a/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
@@ -166,6 +166,19 @@ export default function GPMatchPage({
     setLoading(pollLoading);
   }, [pollLoading]);
 
+  useEffect(() => {
+    if (!activeCup) return;
+    setRaces((prev) => {
+      const cupCourses = COURSE_INFO.filter((course) => course.cup === activeCup).map((course) => course.abbr);
+      if (cupCourses.length !== TOTAL_GP_RACES) return prev;
+      return cupCourses.map((course, index) => ({
+        course,
+        position1: prev[index]?.position1 ?? null,
+        position2: prev[index]?.position2 ?? null,
+      }));
+    });
+  }, [activeCup]);
+
   /**
    * Submit the race results for the selected player.
    * Validates that 5 unique courses are selected and all positions are filled.
@@ -301,8 +314,6 @@ export default function GPMatchPage({
                         const sub = CUP_SUBSTITUTIONS[match.cup!];
                         const next = activeCup === match.cup ? (sub ?? null) : (match.cup ?? null);
                         setActiveCup(next);
-                        /* Clear course selections when switching cups since courses differ */
-                        setRaces(Array.from({ length: TOTAL_GP_RACES }, () => ({ course: "" as CourseAbbr | "", position1: null, position2: null })));
                       }}
                     >
                       {activeCup === match.cup
@@ -387,29 +398,9 @@ export default function GPMatchPage({
                           <span className="text-sm font-medium w-20">
                             {tMatch('raceN', { n: index + 1 })}
                           </span>
-                          <Select
-                            value={race.course}
-                            onValueChange={(value) => {
-                              const newRaces = [...races];
-                              newRaces[index].course = value as CourseAbbr;
-                              setRaces(newRaces);
-                            }}
-                          >
-                            <SelectTrigger className="flex-1">
-                              <SelectValue placeholder={tCommon('selectCourse')} />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {/* §7.4 + §7.1: Filter courses by active cup (may be a substitute) */}
-                              {(activeCup
-                                ? COURSE_INFO.filter((c) => c.cup === activeCup)
-                                : COURSE_INFO
-                              ).map((course) => (
-                                <SelectItem key={course.abbr} value={course.abbr}>
-                                  {course.name}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
+                          <span className="flex-1 rounded-md border bg-muted px-3 py-2 text-sm text-muted-foreground">
+                            {race.course ? getCourseName(race.course) : "—"}
+                          </span>
                         </div>
                         <div className="grid gap-2 sm:grid-cols-2">
                           <div className="space-y-1">

--- a/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
@@ -424,9 +424,31 @@ export default function GPMatchPage({
                           <span className="text-sm font-medium w-20">
                             {tMatch('raceN', { n: index + 1 })}
                           </span>
-                          <span className="flex-1 rounded-md border bg-muted px-3 py-2 text-sm text-muted-foreground">
-                            {race.course ? getCourseName(race.course) : "—"}
-                          </span>
+                          {activeCup ? (
+                            <span className="flex-1 rounded-md border bg-muted px-3 py-2 text-sm text-muted-foreground">
+                              {race.course ? getCourseName(race.course) : "—"}
+                            </span>
+                          ) : (
+                            <Select
+                              value={race.course}
+                              onValueChange={(value) => {
+                                const newRaces = [...races];
+                                newRaces[index].course = value as CourseAbbr;
+                                setRaces(newRaces);
+                              }}
+                            >
+                              <SelectTrigger className="flex-1">
+                                <SelectValue placeholder={tCommon('selectCourse')} />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {COURSE_INFO.map((course) => (
+                                  <SelectItem key={course.abbr} value={course.abbr}>
+                                    {course.name}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          )}
                         </div>
                         <div className="grid gap-2 sm:grid-cols-2">
                           <div className="space-y-1">

--- a/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
@@ -73,6 +73,16 @@ interface GPMatch {
   player1ReportedPoints2?: number;
   player2ReportedPoints1?: number;
   player2ReportedPoints2?: number;
+  player1ReportedRaces?: {
+    course: string;
+    position1: number;
+    position2: number;
+  }[];
+  player2ReportedRaces?: {
+    course: string;
+    position1: number;
+    position2: number;
+  }[];
 }
 
 interface Tournament {
@@ -167,7 +177,23 @@ export default function GPMatchPage({
   }, [pollLoading]);
 
   useEffect(() => {
-    if (!activeCup) return;
+    if (!match) return;
+
+    if (!activeCup) {
+      const existingRaces =
+        match.races ??
+        (selectedPlayer === 1 ? match.player1ReportedRaces : selectedPlayer === 2 ? match.player2ReportedRaces : undefined);
+
+      if (existingRaces && existingRaces.length === TOTAL_GP_RACES) {
+        setRaces(existingRaces.map((race) => ({
+          course: race.course as CourseAbbr,
+          position1: race.position1,
+          position2: race.position2,
+        })));
+      }
+      return;
+    }
+
     setRaces((prev) => {
       const cupCourses = COURSE_INFO.filter((course) => course.cup === activeCup).map((course) => course.abbr);
       if (cupCourses.length !== TOTAL_GP_RACES) return prev;
@@ -177,7 +203,7 @@ export default function GPMatchPage({
         position2: prev[index]?.position2 ?? null,
       }));
     });
-  }, [activeCup]);
+  }, [activeCup, match, selectedPlayer]);
 
   /**
    * Submit the race results for the selected player.

--- a/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
@@ -20,7 +20,7 @@ import { fetchWithRetry } from "@/lib/fetch-with-retry";
  * - Real-time polling at the standard interval
  */
 
-import { useState, useEffect, useCallback, use } from "react";
+import { useState, useEffect, useCallback, useRef, use } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
@@ -129,6 +129,7 @@ export default function GPMatchPage({
    * Initialized from match.cup, togglable when a substitute exists.
    */
   const [activeCup, setActiveCup] = useState<string | null>(null);
+  const initializedCupRef = useRef<string | null>(null);
 
   /** Fetch match and tournament data in parallel */
   const fetchMatchData = useCallback(async () => {
@@ -179,11 +180,12 @@ export default function GPMatchPage({
   useEffect(() => {
     if (!match) return;
 
-    if (!activeCup) {
-      const existingRaces =
-        match.races ??
-        (selectedPlayer === 1 ? match.player1ReportedRaces : selectedPlayer === 2 ? match.player2ReportedRaces : undefined);
+    const existingRaces =
+      match.races ??
+      (selectedPlayer === 1 ? match.player1ReportedRaces : selectedPlayer === 2 ? match.player2ReportedRaces : undefined);
 
+    if (!activeCup) {
+      initializedCupRef.current = null;
       if (existingRaces && existingRaces.length === TOTAL_GP_RACES) {
         setRaces(existingRaces.map((race) => ({
           course: race.course as CourseAbbr,
@@ -197,10 +199,17 @@ export default function GPMatchPage({
     setRaces((prev) => {
       const cupCourses = COURSE_INFO.filter((course) => course.cup === activeCup).map((course) => course.abbr);
       if (cupCourses.length !== TOTAL_GP_RACES) return prev;
+      const previousCup = initializedCupRef.current;
+      const shouldHydrateExistingCup =
+        previousCup === null &&
+        existingRaces?.length === TOTAL_GP_RACES &&
+        existingRaces.every((race, index) => race.course === cupCourses[index]);
+      initializedCupRef.current = activeCup;
+
       return cupCourses.map((course, index) => ({
         course,
-        position1: prev[index]?.position1 ?? null,
-        position2: prev[index]?.position2 ?? null,
+        position1: shouldHydrateExistingCup ? existingRaces[index].position1 : previousCup === activeCup ? (prev[index]?.position1 ?? null) : null,
+        position2: shouldHydrateExistingCup ? existingRaces[index].position2 : previousCup === activeCup ? (prev[index]?.position2 ?? null) : null,
       }));
     });
   }, [activeCup, match, selectedPlayer]);

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -59,6 +59,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
 import { PlayoffBracket } from "@/components/tournament/playoff-bracket";
 import { COURSE_INFO, POLLING_INTERVAL, type CourseAbbr } from "@/lib/constants";
@@ -165,6 +172,10 @@ function buildInitialRounds(match: MRMatch): Round[] {
   }
 
   return createEmptyRounds(maxRounds);
+}
+
+function hasFixedAssignedCourses(match: MRMatch | null): boolean {
+  return Boolean(match && Array.isArray(match.assignedCourses) && match.assignedCourses.length > 0);
 }
 
 export default function MatchRaceFinals({
@@ -396,6 +407,12 @@ export default function MatchRaceFinals({
     if (!selectedMatch) return;
 
     if (rounds.some((round) => round.course === "")) {
+      alert(tCommon('select5UniqueCourses'));
+      return;
+    }
+
+    const usedCourses = rounds.map((round) => round.course).filter((course) => course !== "");
+    if (new Set(usedCourses).size !== usedCourses.length) {
       alert(tCommon('select5UniqueCourses'));
       return;
     }
@@ -696,11 +713,33 @@ export default function MatchRaceFinals({
                     {/* i18n: Race number label */}
                     <TableCell className="font-medium">{tCommon('race')} {index + 1}</TableCell>
                     <TableCell>
-                      <span className="block rounded-md border bg-muted px-3 py-2 text-sm text-muted-foreground">
-                        {round.course
-                          ? `${COURSE_INFO.find((course) => course.abbr === round.course)?.name || round.course} (${COURSE_INFO.find((course) => course.abbr === round.course)?.cup || ""})`
-                          : "—"}
-                      </span>
+                      {hasFixedAssignedCourses(selectedMatch) ? (
+                        <span className="block rounded-md border bg-muted px-3 py-2 text-sm text-muted-foreground">
+                          {round.course
+                            ? `${COURSE_INFO.find((course) => course.abbr === round.course)?.name || round.course} (${COURSE_INFO.find((course) => course.abbr === round.course)?.cup || ""})`
+                            : "—"}
+                        </span>
+                      ) : (
+                        <Select
+                          value={round.course}
+                          onValueChange={(value) => {
+                            const newRounds = [...rounds];
+                            newRounds[index].course = value as CourseAbbr;
+                            setRounds(newRounds);
+                          }}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder={tCommon('selectCourse')} />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {COURSE_INFO.map((course) => (
+                              <SelectItem key={course.abbr} value={course.abbr}>
+                                {course.name} ({course.cup})
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      )}
                     </TableCell>
                     <TableCell>
                       <div className="flex flex-wrap items-center gap-2">

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -140,21 +140,31 @@ function createEmptyRounds(count: number): Round[] {
 }
 
 function buildInitialRounds(match: MRMatch): Round[] {
+  const maxRounds = getMrFinalsMaxRounds(match);
+
   if (match.rounds && match.rounds.length > 0) {
-    return match.rounds.map((round) => ({
+    const existingRounds = match.rounds.map((round) => ({
       course: (round.course as CourseAbbr) ?? "",
       winner: round.winner,
     }));
+    return [
+      ...existingRounds,
+      ...createEmptyRounds(Math.max(0, maxRounds - existingRounds.length)),
+    ];
   }
 
   if (Array.isArray(match.assignedCourses) && match.assignedCourses.length > 0) {
-    return match.assignedCourses.map((course) => ({
+    const assignedRounds = match.assignedCourses.map((course) => ({
       course: course as CourseAbbr,
       winner: null,
     }));
+    return [
+      ...assignedRounds,
+      ...createEmptyRounds(Math.max(0, maxRounds - assignedRounds.length)),
+    ];
   }
 
-  return createEmptyRounds(getMrFinalsMaxRounds(match));
+  return createEmptyRounds(maxRounds);
 }
 
 export default function MatchRaceFinals({

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -59,16 +59,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
 import { PlayoffBracket } from "@/components/tournament/playoff-bracket";
 import { COURSE_INFO, POLLING_INTERVAL, type CourseAbbr } from "@/lib/constants";
+import { getMrFinalsMaxRounds, getMrFinalsTargetWins } from "@/lib/finals-target-wins";
 import { usePolling } from "@/lib/hooks/usePolling";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
@@ -83,6 +77,7 @@ interface MRMatch {
   id: string;
   matchNumber: number;
   round: string | null;
+  stage?: string | null;
   player1Id: string;
   player2Id: string;
   score1: number;
@@ -140,25 +135,26 @@ interface Round {
   winner: number | null;
 }
 
+function createEmptyRounds(count: number): Round[] {
+  return Array.from({ length: count }, () => ({ course: "", winner: null }));
+}
+
 function buildInitialRounds(match: MRMatch): Round[] {
-  if (match.rounds && match.rounds.length === 5) {
-    return match.rounds as Round[];
+  if (match.rounds && match.rounds.length > 0) {
+    return match.rounds.map((round) => ({
+      course: (round.course as CourseAbbr) ?? "",
+      winner: round.winner,
+    }));
   }
 
-  if (Array.isArray(match.assignedCourses) && match.assignedCourses.length === 5) {
+  if (Array.isArray(match.assignedCourses) && match.assignedCourses.length > 0) {
     return match.assignedCourses.map((course) => ({
       course: course as CourseAbbr,
       winner: null,
     }));
   }
 
-  return [
-    { course: "", winner: null },
-    { course: "", winner: null },
-    { course: "", winner: null },
-    { course: "", winner: null },
-    { course: "", winner: null },
-  ];
+  return createEmptyRounds(getMrFinalsMaxRounds(match));
 }
 
 export default function MatchRaceFinals({
@@ -205,15 +201,9 @@ export default function MatchRaceFinals({
   const [playoffComplete, setPlayoffComplete] = useState(false);
   const [isMatchDialogOpen, setIsMatchDialogOpen] = useState(false);
   const [selectedMatch, setSelectedMatch] = useState<MRMatch | null>(null);
-  /* Initialize 5 empty rounds for match result dialog */
-  const [rounds, setRounds] = useState<Round[]>([
-    { course: "", winner: null },
-    { course: "", winner: null },
-    { course: "", winner: null },
-    { course: "", winner: null },
-    { course: "", winner: null },
-  ]);
+  const [rounds, setRounds] = useState<Round[]>(createEmptyRounds(getMrFinalsMaxRounds()));
   const [champion, setChampion] = useState<Player | null>(null);
+  const selectedMatchTargetWins = selectedMatch ? getMrFinalsTargetWins(selectedMatch) : getMrFinalsTargetWins();
 
   /**
    * Fetch finals bracket data including matches,
@@ -395,9 +385,7 @@ export default function MatchRaceFinals({
   const handleMatchSubmit = async () => {
     if (!selectedMatch) return;
 
-    /* Validate 5 unique courses */
-    const usedCourses = rounds.map(r => r.course).filter(c => c !== "");
-    if (usedCourses.length !== 5 || new Set(usedCourses).size !== 5) {
+    if (rounds.some((round) => round.course === "")) {
       alert(tCommon('select5UniqueCourses'));
       return;
     }
@@ -406,7 +394,10 @@ export default function MatchRaceFinals({
     const winnerCount = rounds.filter(r => r.winner === 1).length;
     const loserCount = rounds.filter(r => r.winner === 2).length;
 
-    if (winnerCount < 3 && loserCount < 3) {
+    if (
+      (winnerCount !== selectedMatchTargetWins || loserCount >= selectedMatchTargetWins) &&
+      (loserCount !== selectedMatchTargetWins || winnerCount >= selectedMatchTargetWins)
+    ) {
       alert(tCommon('matchMustHaveWinner'));
       return;
     }
@@ -428,13 +419,7 @@ export default function MatchRaceFinals({
         const data = unwrapApiData<{ isComplete?: boolean; champion?: string; playoffComplete?: boolean }>(json);
         setIsMatchDialogOpen(false);
         setSelectedMatch(null);
-        setRounds([
-          { course: "", winner: null },
-          { course: "", winner: null },
-          { course: "", winner: null },
-          { course: "", winner: null },
-          { course: "", winner: null },
-        ]);
+        setRounds(createEmptyRounds(getMrFinalsMaxRounds()));
         if (data.playoffComplete !== undefined) {
           setPlayoffComplete(data.playoffComplete);
         }
@@ -701,25 +686,11 @@ export default function MatchRaceFinals({
                     {/* i18n: Race number label */}
                     <TableCell className="font-medium">{tCommon('race')} {index + 1}</TableCell>
                     <TableCell>
-                      <Select
-                        value={round.course}
-                        onValueChange={(value) => {
-                          const newRounds = [...rounds];
-                          newRounds[index].course = value as CourseAbbr;
-                          setRounds(newRounds);
-                        }}
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder={tCommon('selectCourse')} />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {COURSE_INFO.map((course) => (
-                            <SelectItem key={course.abbr} value={course.abbr}>
-                              {course.name} ({course.cup})
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <span className="block rounded-md border bg-muted px-3 py-2 text-sm text-muted-foreground">
+                        {round.course
+                          ? `${COURSE_INFO.find((course) => course.abbr === round.course)?.name || round.course} (${COURSE_INFO.find((course) => course.abbr === round.course)?.cup || ""})`
+                          : "—"}
+                      </span>
                     </TableCell>
                     <TableCell>
                       <div className="flex flex-wrap items-center gap-2">
@@ -765,8 +736,14 @@ export default function MatchRaceFinals({
             <Button
               onClick={handleMatchSubmit}
               disabled={
-                rounds.filter(r => r.winner === 1).length < 3 &&
-                rounds.filter(r => r.winner === 2).length < 3
+                (
+                  rounds.filter(r => r.winner === 1).length !== selectedMatchTargetWins ||
+                  rounds.filter(r => r.winner === 2).length >= selectedMatchTargetWins
+                ) &&
+                (
+                  rounds.filter(r => r.winner === 2).length !== selectedMatchTargetWins ||
+                  rounds.filter(r => r.winner === 1).length >= selectedMatchTargetWins
+                )
               }
             >
               {tCommon('saveResult')}

--- a/smkc-score-app/src/components/tournament/playoff-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/playoff-bracket.tsx
@@ -33,6 +33,7 @@ interface BMMatch {
   player2Id: string;
   score1: number;
   score2: number;
+  cup?: string | null;
   completed: boolean;
   player1: Player;
   player2: Player;
@@ -121,6 +122,11 @@ function PlayoffMatchCard({
       <div className="text-xs text-muted-foreground mb-1">
         M{bracketMatch.matchNumber}
       </div>
+      {match?.cup && (
+        <div className="mb-1 text-[11px] text-blue-600">
+          {match.cup} Cup
+        </div>
+      )}
 
       {/* Player 1 row */}
       <div

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -20,7 +20,7 @@ import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
 import { generateBracketStructure, generatePlayoffStructure, roundNames } from '@/lib/double-elimination';
 import { selectFinalsEntrantsByGroup } from '@/lib/finals-group-selection';
-import { getMrFinalsMaxRounds } from '@/lib/finals-target-wins';
+import { getMrFinalsMaxRounds, getMrFinalsTargetWins } from '@/lib/finals-target-wins';
 import { paginate } from '@/lib/pagination';
 import { sanitizeInput } from '@/lib/sanitize';
 import { createLogger } from '@/lib/logger';
@@ -840,9 +840,11 @@ export function createFinalsHandlers(config: FinalsConfig) {
         return createErrorResponse('Finals match not found', 404, 'NOT_FOUND');
       }
 
-      const targetWins = config.targetWins ?? 3;
-      const player1ReachedTarget = score1 >= targetWins;
-      const player2ReachedTarget = score2 >= targetWins;
+      const targetWins = config.assignMrCoursesByRound
+        ? getMrFinalsTargetWins({ round: match.round, stage: match.stage })
+        : config.targetWins ?? 3;
+      const player1ReachedTarget = score1 === targetWins && score2 < targetWins;
+      const player2ReachedTarget = score2 === targetWins && score1 < targetWins;
 
       if (player1ReachedTarget === player2ReachedTarget) {
         return handleValidationError(`Match must have a winner (first to ${targetWins})`, 'score');

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -20,6 +20,7 @@ import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
 import { generateBracketStructure, generatePlayoffStructure, roundNames } from '@/lib/double-elimination';
 import { selectFinalsEntrantsByGroup } from '@/lib/finals-group-selection';
+import { getMrFinalsMaxRounds } from '@/lib/finals-target-wins';
 import { paginate } from '@/lib/pagination';
 import { sanitizeInput } from '@/lib/sanitize';
 import { createLogger } from '@/lib/logger';
@@ -27,6 +28,8 @@ import { createErrorResponse, createSuccessResponse, handleValidationError, hand
 import { checkRateLimit } from '@/lib/rate-limit';
 import { getClientIdentifier } from '@/lib/request-utils';
 import { resolveTournamentId } from '@/lib/tournament-identifier';
+import { checkQualificationConfirmed } from '@/lib/qualification-confirmed-check';
+import { COURSES, CUPS } from '@/lib/constants';
 
 /**
  * Bracket size inference thresholds.
@@ -41,6 +44,53 @@ const BRACKET_SIZE_THRESHOLD = 20;
  * positions 13-24 competing for the 4 Upper-Bracket seats 13-16.
  */
 const PLAYOFF_ENTRANT_COUNT = 12;
+
+function fisherYatesShuffle<T>(arr: readonly T[]): T[] {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+function getOrderedRounds(
+  bracketStructure: Array<{ round: string }>,
+): string[] {
+  return [...new Set(bracketStructure.map((match) => match.round))];
+}
+
+function createMrRoundAssignments(
+  bracketStructure: Array<{ round: string }>,
+  stage: 'playoff' | 'finals',
+): Map<string, string[]> {
+  const shuffledCourses = fisherYatesShuffle(COURSES);
+  const assignments = new Map<string, string[]>();
+  let cursor = 0;
+
+  for (const round of getOrderedRounds(bracketStructure)) {
+    const roundsNeeded = getMrFinalsMaxRounds({ round, stage });
+    const assignedCourses = Array.from({ length: roundsNeeded }, (_, index) =>
+      shuffledCourses[(cursor + index) % shuffledCourses.length]
+    );
+    assignments.set(round, assignedCourses);
+    cursor = (cursor + roundsNeeded) % shuffledCourses.length;
+  }
+
+  return assignments;
+}
+
+function createGpRoundAssignments(
+  bracketStructure: Array<{ round: string }>,
+): Map<string, string> {
+  const shuffledCups = fisherYatesShuffle(CUPS);
+  return new Map(
+    getOrderedRounds(bracketStructure).map((round, index) => [
+      round,
+      shuffledCups[index % shuffledCups.length],
+    ]),
+  );
+}
 
 /**
  * Configuration for a finals route handler set.
@@ -73,6 +123,10 @@ export interface FinalsConfig {
   postRequiresAuth?: boolean;
   /** Whether PUT endpoint requires admin authentication */
   putRequiresAuth?: boolean;
+  /** Whether finals/playoff matches should receive shared MR course assignments */
+  assignMrCoursesByRound?: boolean;
+  /** Whether finals/playoff matches should receive shared GP cup assignments */
+  assignGpCupByRound?: boolean;
 }
 
 /**
@@ -86,6 +140,17 @@ export function createFinalsHandlers(config: FinalsConfig) {
   const model = (p: any) => p[config.matchModel];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const qualModel = (p: any) => p[config.qualificationModel];
+
+  function getRoundAssignmentData(
+    round: string,
+    mrAssignments?: Map<string, string[]>,
+    gpAssignments?: Map<string, string>,
+  ): Record<string, unknown> {
+    return {
+      ...(config.assignMrCoursesByRound ? { assignedCourses: mrAssignments?.get(round) ?? [] } : {}),
+      ...(config.assignGpCupByRound ? { cup: gpAssignments?.get(round) ?? null } : {}),
+    };
+  }
 
   /**
    * GET handler: Fetch finals bracket data for a tournament.
@@ -383,6 +448,13 @@ export function createFinalsHandlers(config: FinalsConfig) {
        * inserted rows, so we re-fetch with includes after insertion to
        * preserve the existing response shape (player1/player2 relations).
        */
+      const mrAssignments = config.assignMrCoursesByRound
+        ? createMrRoundAssignments(bracketStructure, 'finals')
+        : undefined;
+      const gpAssignments = config.assignGpCupByRound
+        ? createGpRoundAssignments(bracketStructure)
+        : undefined;
+
       const matchPlans = bracketStructure.map((bracketMatch) => {
         const player1 = bracketMatch.player1Seed
           ? seededPlayers.find((p: { seed: number }) => p.seed === bracketMatch.player1Seed)
@@ -402,6 +474,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
             player1Id: player1?.playerId || seededPlayers[0].playerId,
             player2Id: player2?.playerId || player1?.playerId || seededPlayers[0].playerId,
             completed: false,
+            ...getRoundAssignmentData(bracketMatch.round, mrAssignments, gpAssignments),
           },
         };
       });
@@ -546,6 +619,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
           });
         }
         const playoffStructure = generatePlayoffStructure(PLAYOFF_ENTRANT_COUNT);
+        const playoffMrAssignments = config.assignMrCoursesByRound
+          ? createMrRoundAssignments(playoffStructure, 'playoff')
+          : undefined;
+        const playoffGpAssignments = config.assignGpCupByRound
+          ? createGpRoundAssignments(playoffStructure)
+          : undefined;
 
         /* Playoff-local seeds 1-12 are the barrage entrants, interleaved by group. */
         const playoffSeededPlayers = selection.barrage.map((q, index) => ({
@@ -574,6 +653,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
               player1Id: player1?.playerId || playoffSeededPlayers[0].playerId,
               player2Id: player2?.playerId || player1?.playerId || playoffSeededPlayers[0].playerId,
               completed: false,
+              ...getRoundAssignmentData(bracketMatch.round, playoffMrAssignments, playoffGpAssignments),
             },
             include: { player1: true, player2: true },
           });
@@ -647,6 +727,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
       const seededPlayers = [...directPlayers, ...playoffWinnerSeeds];
 
       const bracketStructure = generateBracketStructure(16);
+      const finalsMrAssignments = config.assignMrCoursesByRound
+        ? createMrRoundAssignments(bracketStructure, 'finals')
+        : undefined;
+      const finalsGpAssignments = config.assignGpCupByRound
+        ? createGpRoundAssignments(bracketStructure)
+        : undefined;
 
       /* Clean slate on any previous finals for reset scenarios.
        * Keep playoff stage rows intact so the admin can still view the
@@ -674,6 +760,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
             player1Id: player1?.playerId || seededPlayers[0].playerId,
             player2Id: player2?.playerId || player1?.playerId || seededPlayers[0].playerId,
             completed: false,
+            ...getRoundAssignmentData(bracketMatch.round, finalsMrAssignments, finalsGpAssignments),
           },
           include: { player1: true, player2: true },
         });

--- a/smkc-score-app/src/lib/finals-target-wins.ts
+++ b/smkc-score-app/src/lib/finals-target-wins.ts
@@ -1,0 +1,66 @@
+export interface FinalsTargetContext {
+  round?: string | null;
+  stage?: string | null;
+}
+
+function isEarlyUpperRound(round?: string | null): boolean {
+  return round === 'winners_r1' || round === 'winners_qf';
+}
+
+function isEarlyLowerRound(round?: string | null): boolean {
+  return round === 'losers_r1' || round === 'losers_r2';
+}
+
+function isMidLowerRound(round?: string | null): boolean {
+  return round === 'losers_r3' || round === 'losers_r4' || round === 'losers_sf';
+}
+
+function isFinalRound(round?: string | null): boolean {
+  return round === 'winners_final'
+    || round === 'losers_final'
+    || round === 'grand_final'
+    || round === 'grand_final_reset';
+}
+
+export function getBmFinalsTargetWins(context?: FinalsTargetContext): number {
+  if (context?.stage === 'playoff') {
+    return context.round === 'playoff_r2' ? 4 : 3;
+  }
+  if (isEarlyUpperRound(context?.round) || isEarlyLowerRound(context?.round)) {
+    return 5;
+  }
+  if (context?.round === 'winners_sf' || isMidLowerRound(context?.round) || isFinalRound(context?.round)) {
+    return 7;
+  }
+  return 5;
+}
+
+export function getMrFinalsTargetWins(context?: FinalsTargetContext): number {
+  if (context?.stage === 'playoff') {
+    return context.round === 'playoff_r2' ? 4 : 3;
+  }
+  if (isEarlyUpperRound(context?.round) || isEarlyLowerRound(context?.round)) {
+    return 5;
+  }
+  if (context?.round === 'winners_sf' || isMidLowerRound(context?.round)) {
+    return 7;
+  }
+  if (isFinalRound(context?.round)) {
+    return 9;
+  }
+  return 5;
+}
+
+export function getGpFinalsTargetWins(context?: FinalsTargetContext): number {
+  if (context?.stage === 'playoff') {
+    return 1;
+  }
+  if (isFinalRound(context?.round)) {
+    return 3;
+  }
+  return 2;
+}
+
+export function getMrFinalsMaxRounds(context?: FinalsTargetContext): number {
+  return getMrFinalsTargetWins(context) * 2 - 1;
+}


### PR DESCRIPTION
## Summary
- assign MR `assignedCourses` once per playoff/finals round so every match in the same round shares the same course card
- assign GP `cup` once per playoff/finals round and lock the public GP match report flow to that cup's fixed course order
- update MR/GP finals regression tests to verify round-shared playoff assignments

## Testing
- `git diff --check`
- Jest/ESLint could not be run in this worktree because `smkc-score-app/node_modules/.bin/{jest,eslint}` is missing

Closes #527