### PR TITLE
fix(gp): enforce assigned cup on completed corrections

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
@@ -26,6 +26,18 @@ jest.mock('@/lib/sanitize', () => ({ sanitizeInput: jest.fn((data) => data) }));
 jest.mock('@/lib/constants', () => ({
   SMK_CHARACTERS: ['mario', 'luigi', 'peach', 'toad', 'yoshi', 'bowser', 'donkey_kong', 'koopa'],
   DRIVER_POINTS: [0, 9, 6, 3, 1, 0, 0, 0, 0],
+  COURSE_INFO: [
+    { abbr: 'MC1', name: 'Mario Circuit 1', cup: 'Mushroom' },
+    { abbr: 'DP1', name: 'Donut Plains 1', cup: 'Mushroom' },
+    { abbr: 'GV1', name: 'Ghost Valley 1', cup: 'Mushroom' },
+    { abbr: 'BC1', name: 'Bowser Castle 1', cup: 'Mushroom' },
+    { abbr: 'MC2', name: 'Mario Circuit 2', cup: 'Mushroom' },
+    { abbr: 'CI1', name: 'Choco Island 1', cup: 'Flower' },
+    { abbr: 'GV2', name: 'Ghost Valley 2', cup: 'Flower' },
+    { abbr: 'DP2', name: 'Donut Plains 2', cup: 'Flower' },
+    { abbr: 'BC2', name: 'Bowser Castle 2', cup: 'Flower' },
+    { abbr: 'MC3', name: 'Mario Circuit 3', cup: 'Flower' },
+  ],
   TOTAL_GP_RACES: 5,
   getDriverPoints: (pos: number) => [0, 9, 6, 3, 1, 0, 0, 0, 0][pos] ?? 0,
 }));
@@ -544,6 +556,7 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
         player1: { userId: null },
         player2: { userId: null },
         completed: true,
+        cup: 'Mushroom',
       };
 
       const correctedMatch = {
@@ -590,6 +603,46 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
        * correction — the route calls recalculatePlayerStats twice, each
        * call fires an updateMany under the hood. */
       expect(prisma.gPQualification.updateMany).toHaveBeenCalledTimes(2);
+    });
+
+    it('should reject correction races that do not match the assigned cup', async () => {
+      const mockMatch = {
+        id: 'm1',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        player1: { userId: null },
+        player2: { userId: null },
+        completed: true,
+        cup: 'Mushroom',
+      };
+
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/match/m1/report', {
+        reportingPlayer: 1,
+        races: [
+          { course: 'Choco Island 1', position1: 1, position2: 2 },
+          { course: 'Ghost Valley 2', position1: 1, position2: 2 },
+          { course: 'Donut Plains 2', position1: 1, position2: 2 },
+          { course: 'Bowser Castle 2', position1: 1, position2: 2 },
+          { course: 'Mario Circuit 3', position1: 1, position2: 2 },
+        ],
+      });
+      const params = Promise.resolve({ id: 't1', matchId: 'm1' });
+      const result = await POST(request, { params });
+
+      expect(result).toEqual({
+        data: {
+          error: 'Submitted races do not match the assigned cup for this match',
+          field: 'races',
+        },
+        status: 400,
+      });
+      expect(handleValidationError).toHaveBeenCalledWith(
+        'Submitted races do not match the assigned cup for this match',
+        'races'
+      );
+      expect(prisma.gPMatch.update).not.toHaveBeenCalled();
     });
 
     // Error case - Returns 500 when database operation fails

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -31,7 +31,8 @@ import {
   type RecalculateStatsConfig,
 } from "@/lib/api-factories/score-report-helpers";
 import { validateGPRacePosition } from "@/lib/score-validation";
-import { getDriverPoints, TOTAL_GP_RACES } from "@/lib/constants";
+import { COURSE_INFO, getDriverPoints, TOTAL_GP_RACES } from "@/lib/constants";
+import { isValidCupChoice } from "@/lib/event-types/gp-config";
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -58,6 +59,19 @@ const GP_RECALC_CONFIG: RecalculateStatsConfig = {
     myPoints > oppPoints ? 'win' : myPoints < oppPoints ? 'loss' : 'tie',
   useRoundDifferential: false,
 };
+
+function validateSubmittedCup(
+  assignedCup: string | null | undefined,
+  races: Array<{ course: string }>
+) {
+  const submittedCups = [...new Set(
+    races
+      .map((race) => COURSE_INFO.find((course) => course.abbr === race.course || course.name === race.course)?.cup)
+      .filter((cup): cup is string => Boolean(cup))
+  )];
+
+  return submittedCups.length === 1 && isValidCupChoice(assignedCup, submittedCups[0]);
+}
 
 
 /**
@@ -123,6 +137,13 @@ export async function POST(
       return handleValidationError("Invalid character", "character");
     }
 
+    if (!Array.isArray(races) || races.length !== TOTAL_GP_RACES) {
+      return handleValidationError(`races must be an array of ${TOTAL_GP_RACES} entries`, "races");
+    }
+    if (!validateSubmittedCup(match.cup, races)) {
+      return handleValidationError("Submitted races do not match the assigned cup for this match", "races");
+    }
+
     /*
      * Correction path: let a participant fix a GP score after the match has
      * already been confirmed. Keep the match completed, update the final score
@@ -130,9 +151,6 @@ export async function POST(
      */
     if (match.completed) {
       /* Validate GP race positions are in legal range (0-8) before processing */
-      if (!Array.isArray(races) || races.length !== TOTAL_GP_RACES) {
-        return handleValidationError(`races must be an array of ${TOTAL_GP_RACES} entries`, "races");
-      }
       for (let i = 0; i < races.length; i++) {
         const race = races[i] as { position1: number; position2: number; course: string };
         const pos1Result = validateGPRacePosition(race.position1);
@@ -216,9 +234,6 @@ export async function POST(
     const reportingPlayerId = reportingPlayer === 1 ? match.player1Id : match.player2Id;
 
     /* Validate GP race positions are in legal range (0-8) before processing */
-    if (!Array.isArray(races) || races.length !== TOTAL_GP_RACES) {
-      return handleValidationError(`races must be an array of ${TOTAL_GP_RACES} entries`, "races");
-    }
     for (let i = 0; i < races.length; i++) {
       const race = races[i] as { position1: number; position2: number; course: string };
       const pos1Result = validateGPRacePosition(race.position1);


### PR DESCRIPTION
## Summary
- enforce GP assigned-cup validation before both initial reports and completed-match corrections
- accept either course abbreviations or stored course names when mapping reported races back to a cup
- add regression coverage for rejecting completed-match corrections submitted from a different cup

## Testing
- `git diff --check`
- Jest could not be run in this worktree because `smkc-score-app` does not currently have a runnable `jest` binary (`jest: command not found`)

Closes #533