### PR TITLE
fix(mr): preload finals courses when assigned

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -88,6 +88,7 @@ interface MRMatch {
   score1: number;
   score2: number;
   completed: boolean;
+  assignedCourses?: string[];
   rounds?: { course: string; winner: number }[];
   player1: Player;
   player2: Player;
@@ -137,6 +138,27 @@ function getCompletedChampion(matches: MRMatch[]): Player | null {
 interface Round {
   course: CourseAbbr | "";
   winner: number | null;
+}
+
+function buildInitialRounds(match: MRMatch): Round[] {
+  if (match.rounds && match.rounds.length === 5) {
+    return match.rounds as Round[];
+  }
+
+  if (Array.isArray(match.assignedCourses) && match.assignedCourses.length === 5) {
+    return match.assignedCourses.map((course) => ({
+      course: course as CourseAbbr,
+      winner: null,
+    }));
+  }
+
+  return [
+    { course: "", winner: null },
+    { course: "", winner: null },
+    { course: "", winner: null },
+    { course: "", winner: null },
+    { course: "", winner: null },
+  ];
 }
 
 export default function MatchRaceFinals({
@@ -359,17 +381,7 @@ export default function MatchRaceFinals({
    */
   const openMatchDialog = (match: MRMatch) => {
     setSelectedMatch(match);
-    if (match.rounds && match.rounds.length === 5) {
-      setRounds(match.rounds as Round[]);
-    } else {
-      setRounds([
-        { course: "", winner: null },
-        { course: "", winner: null },
-        { course: "", winner: null },
-        { course: "", winner: null },
-        { course: "", winner: null },
-      ]);
-    }
+    setRounds(buildInitialRounds(match));
     setIsMatchDialogOpen(true);
   };
 


### PR DESCRIPTION
## Summary
- preload MR finals/playoff dialog courses from `assignedCourses` when that assignment exists
- keep the existing manual course selector fallback for legacy matches without assignments

## Testing
- `git diff --check`
- Jest could not be run in this worktree because `smkc-score-app/node_modules/.bin/jest` is missing

Closes #536