### PR TITLE
feat(gp-finals): support sudden-death tiebreaks

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -612,6 +612,62 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       expect(result.status).toBe(400);
     });
 
+    it('should return 400 when tied GP points use a non-match sudden-death winner', async () => {
+      const mockMatch = {
+        id: 'm1',
+        stage: 'finals',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        player1: { id: 'p1', name: 'Player 1' },
+        player2: { id: 'p2', name: 'Player 2' },
+      };
+
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+
+      const request = new MockNextRequest(
+        'http://localhost:3000/api/tournaments/t1/gp/finals',
+        { matchId: 'm1', score1: 2, score2: 2, suddenDeathWinnerId: 'p3' },
+      );
+      const params = Promise.resolve({ id: 't1' });
+      const result = await PUT(request, { params });
+
+      expect(result.data).toEqual({
+        success: false,
+        error: 'Sudden-death winner must be one of the match players',
+        code: 'VALIDATION_ERROR',
+        details: { field: 'suddenDeathWinnerId' },
+      });
+      expect(result.status).toBe(400);
+    });
+
+    it('should return 400 when GP finals scores are not integers', async () => {
+      const mockMatch = {
+        id: 'm1',
+        stage: 'finals',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        player1: { id: 'p1', name: 'Player 1' },
+        player2: { id: 'p2', name: 'Player 2' },
+      };
+
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+
+      const request = new MockNextRequest(
+        'http://localhost:3000/api/tournaments/t1/gp/finals',
+        { matchId: 'm1', score1: 2.5, score2: 2 },
+      );
+      const params = Promise.resolve({ id: 't1' });
+      const result = await PUT(request, { params });
+
+      expect(result.data).toEqual({
+        success: false,
+        error: 'Driver points must be non-negative integers',
+        code: 'VALIDATION_ERROR',
+        details: { field: 'score' },
+      });
+      expect(result.status).toBe(400);
+    });
+
     it('should accept tied GP points when a sudden-death winner is provided', async () => {
       const mockMatch = {
         id: 'm1',

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -13,8 +13,8 @@
  *   validation for exactly 8 players, and bracket structure generation.
  * - PUT: Updating finals match scores with winner/loser advancement,
  *   grand final logic (winners bracket player wins outright, losers bracket
- *   player triggers reset match), grand final reset completion, best-of-5
- *   validation, and loser bracket placement.
+ *   player triggers reset match), grand final reset completion, tied-score
+ *   sudden-death validation, and loser bracket placement.
  */
 // @ts-nocheck
 
@@ -586,8 +586,8 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       expect(result.status).toBe(404);
     });
 
-    // Validation error case - Returns 400 when match has no winner (best of 5)
-    it('should return 400 when match has no winner (best of 5)', async () => {
+    // Validation error case - Returns 400 when tied GP points omit sudden-death winner
+    it('should return 400 when tied GP points omit sudden-death winner', async () => {
       const mockMatch = {
         id: 'm1',
         stage: 'finals',
@@ -603,9 +603,56 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
-      /* Error message updated: finals-route.ts now uses dynamic "first to N" format */
-      expect(result.data).toEqual({ success: false, error: 'Match must have a winner (first to 3)', code: 'VALIDATION_ERROR', details: { field: 'score' } });
+      expect(result.data).toEqual({
+        success: false,
+        error: 'Tied GP finals scores require a sudden-death winner',
+        code: 'VALIDATION_ERROR',
+        details: { field: 'suddenDeathWinnerId' },
+      });
       expect(result.status).toBe(400);
+    });
+
+    it('should accept tied GP points when a sudden-death winner is provided', async () => {
+      const mockMatch = {
+        id: 'm1',
+        tournamentId: 't1',
+        matchNumber: 16,
+        round: 'grand_final',
+        stage: 'finals',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        player1: { id: 'p1', name: 'Player 1' },
+        player2: { id: 'p2', name: 'Player 2' },
+      };
+
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+      (prisma.gPMatch.update as jest.Mock).mockResolvedValue({
+        ...mockMatch,
+        points1: 28,
+        points2: 28,
+        suddenDeathWinnerId: 'p2',
+        completed: true,
+      });
+      (prisma.gPMatch.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const request = new MockNextRequest(
+        'http://localhost:3000/api/tournaments/t1/gp/finals',
+        { matchId: 'm1', score1: 28, score2: 28, suddenDeathWinnerId: 'p2' },
+      );
+      const params = Promise.resolve({ id: 't1' });
+      const result = await PUT(request, { params });
+
+      expect(result.status).toBe(200);
+      expect(prisma.gPMatch.update).toHaveBeenCalledWith(expect.objectContaining({
+        where: { id: 'm1' },
+        data: expect.objectContaining({
+          points1: 28,
+          points2: 28,
+          suddenDeathWinnerId: 'p2',
+          completed: true,
+        }),
+      }));
+      expect(result.data.data.winnerId).toBe('p2');
     });
 
     // Error case - Returns 500 when database operation fails

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -446,6 +446,8 @@
     "resetMatchDesc": "If Losers champion wins Grand Final, a reset match determines the true champion",
     "enterMatchScore": "Enter Match Score",
     "matchNeedWinner": "Match needs a winner (first to 5)",
+    "suddenDeathWinner": "Sudden-death winner",
+    "gpTieNeedsWinner": "Select the sudden-death winner when GP points are tied",
     "startCourse": "Start Course",
     "startCourseDesc": "Battle courses rotate: BC1→BC2→BC3→BC4. Select starting course for this match.",
     "battleCourse": "Battle Course {number}",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -445,6 +445,8 @@
     "resetMatchDesc": "敗者ブラケットの優勝者がグランドファイナルに勝った場合、決定戦で真のチャンピオンを決定",
     "enterMatchScore": "試合スコア入力",
     "matchNeedWinner": "勝者が必要です（5勝先取）",
+    "suddenDeathWinner": "サドンデス勝者",
+    "gpTieNeedsWinner": "同点なのでサドンデス勝者を選択してください",
     "startCourse": "開始コース",
     "startCourseDesc": "バトルコースはBC1→BC2→BC3→BC4の順に回ります。この試合の開始コースを選択してください。",
     "battleCourse": "バトルコース {number}",

--- a/smkc-score-app/prisma/migrations/0003_gp_match_sudden_death_winner/migration.sql
+++ b/smkc-score-app/prisma/migrations/0003_gp_match_sudden_death_winner/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "GPMatch"
+ADD COLUMN "suddenDeathWinnerId" TEXT;

--- a/smkc-score-app/prisma/schema.prisma
+++ b/smkc-score-app/prisma/schema.prisma
@@ -352,6 +352,7 @@ model GPMatch {
   points1      Int        @default(0) // Driver points for player 1
   points2      Int        @default(0) // Driver points for player 2
   completed    Boolean    @default(false)
+  suddenDeathWinnerId String? // Tied cup resolved by a one-race sudden-death playoff
   races        Json? // [{course: "MC1", position1: 1, position2: 2, points1: 9, points2: 6}, ...]
 
   // Player-reported scores (for participant score entry)

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
@@ -21,6 +21,42 @@ const { GET, POST, PUT } = createFinalsHandlers({
   postErrorMessage: 'Failed to create grand prix finals bracket',
   postRequiresAuth: true,
   putRequiresAuth: true,
+  resolveMatchResult: (match, score1, score2, body) => {
+    if (![score1, score2].every((score) => Number.isInteger(score) && score >= 0)) {
+      return { error: 'Driver points must be non-negative integers', field: 'score' };
+    }
+
+    if (score1 !== score2) {
+      return {
+        winnerId: score1 > score2 ? match.player1Id as string : match.player2Id as string,
+        loserId: score1 > score2 ? match.player2Id as string : match.player1Id as string,
+        updateData: { suddenDeathWinnerId: null },
+      };
+    }
+
+    const suddenDeathWinnerId = body.suddenDeathWinnerId;
+    if (typeof suddenDeathWinnerId !== 'string' || suddenDeathWinnerId.length === 0) {
+      return {
+        error: 'Tied GP finals scores require a sudden-death winner',
+        field: 'suddenDeathWinnerId',
+      };
+    }
+
+    if (suddenDeathWinnerId !== match.player1Id && suddenDeathWinnerId !== match.player2Id) {
+      return {
+        error: 'Sudden-death winner must be one of the match players',
+        field: 'suddenDeathWinnerId',
+      };
+    }
+
+    return {
+      winnerId: suddenDeathWinnerId,
+      loserId: suddenDeathWinnerId === match.player1Id
+        ? match.player2Id as string
+        : match.player1Id as string,
+      updateData: { suddenDeathWinnerId },
+    };
+  },
 });
 
 export { GET, POST, PUT };

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -65,7 +65,7 @@ import type { Player } from "@/lib/types";
 /** Client-side logger for error tracking */
 const logger = createLogger({ serviceName: 'tournaments-gp-finals' });
 
-/** GP finals match with score (score1/score2 = game wins in best-of-5) */
+/** GP finals match scored by total driver points, with optional sudden-death winner on ties. */
 interface GPMatch {
   id: string;
   matchNumber: number;
@@ -76,6 +76,7 @@ interface GPMatch {
   score2: number;
   points1?: number;
   points2?: number;
+  suddenDeathWinnerId?: string | null;
   completed: boolean;
   player1: Player;
   player2: Player;
@@ -117,6 +118,8 @@ function getMatchWinner(match: GPMatch): Player | null {
   const score2 = getGpScore(match, 2);
   if (score1 > score2) return match.player1;
   if (score2 > score1) return match.player2;
+  if (match.suddenDeathWinnerId === match.player1Id) return match.player1;
+  if (match.suddenDeathWinnerId === match.player2Id) return match.player2;
   return null;
 }
 
@@ -173,7 +176,7 @@ export default function GrandPrixFinals({
   const [playoffComplete, setPlayoffComplete] = useState(false);
   const [isScoreDialogOpen, setIsScoreDialogOpen] = useState(false);
   const [selectedMatch, setSelectedMatch] = useState<GPMatch | null>(null);
-  const [scoreForm, setScoreForm] = useState({ score1: 0, score2: 0 });
+  const [scoreForm, setScoreForm] = useState({ score1: 0, score2: 0, suddenDeathWinnerId: "" });
   const [champion, setChampion] = useState<Player | null>(null);
 
   /** Fetch finals data including matches, bracket structure, and round names */
@@ -335,7 +338,11 @@ export default function GrandPrixFinals({
   /** Open score entry dialog for a specific match */
   const openScoreDialog = (match: GPMatch) => {
     setSelectedMatch(match);
-    setScoreForm({ score1: getGpScore(match, 1), score2: getGpScore(match, 2) });
+    setScoreForm({
+      score1: getGpScore(match, 1),
+      score2: getGpScore(match, 2),
+      suddenDeathWinnerId: match.suddenDeathWinnerId ?? "",
+    });
     setIsScoreDialogOpen(true);
   };
 
@@ -355,6 +362,9 @@ export default function GrandPrixFinals({
           matchId: selectedMatch.id,
           score1: scoreForm.score1,
           score2: scoreForm.score2,
+          suddenDeathWinnerId: scoreForm.score1 === scoreForm.score2
+            ? scoreForm.suddenDeathWinnerId || null
+            : null,
         }),
       });
 
@@ -363,7 +373,7 @@ export default function GrandPrixFinals({
         const data = unwrapApiData<{ isComplete?: boolean; champion?: string; playoffComplete?: boolean }>(json);
         setIsScoreDialogOpen(false);
         setSelectedMatch(null);
-        setScoreForm({ score1: 0, score2: 0 });
+        setScoreForm({ score1: 0, score2: 0, suddenDeathWinnerId: "" });
         if (data.playoffComplete !== undefined) {
           setPlayoffComplete(data.playoffComplete);
         }
@@ -607,7 +617,7 @@ export default function GrandPrixFinals({
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-4">
-            {/* Score input: best of 5 (first to 3 wins) */}
+            {/* GP finals use total driver points; tied totals require a sudden-death winner. */}
             <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-end gap-3 sm:gap-4">
               <div className="min-w-0 text-center">
                 <Label className="block truncate" title={selectedMatch?.player1.nickname}>
@@ -616,7 +626,6 @@ export default function GrandPrixFinals({
                 <Input
                   type="number"
                   min={0}
-                  max={4}
                   value={scoreForm.score1}
                   onChange={(e) =>
                     setScoreForm({
@@ -635,7 +644,6 @@ export default function GrandPrixFinals({
                 <Input
                   type="number"
                   min={0}
-                  max={4}
                   value={scoreForm.score2}
                   onChange={(e) =>
                     setScoreForm({
@@ -647,21 +655,49 @@ export default function GrandPrixFinals({
                 />
               </div>
             </div>
-            {/* Warning when neither player has reached 3 wins yet.
-               Always rendered to reserve vertical space and prevent layout shift. */}
+            {scoreForm.score1 === scoreForm.score2 && (
+              <div className="space-y-2">
+                <Label>{tFinals('suddenDeathWinner')}</Label>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  <Button
+                    type="button"
+                    variant={scoreForm.suddenDeathWinnerId === selectedMatch?.player1Id ? "default" : "outline"}
+                    onClick={() => setScoreForm((current) => ({
+                      ...current,
+                      suddenDeathWinnerId: selectedMatch?.player1Id ?? "",
+                    }))}
+                  >
+                    {selectedMatch?.player1.nickname}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={scoreForm.suddenDeathWinnerId === selectedMatch?.player2Id ? "default" : "outline"}
+                    onClick={() => setScoreForm((current) => ({
+                      ...current,
+                      suddenDeathWinnerId: selectedMatch?.player2Id ?? "",
+                    }))}
+                  >
+                    {selectedMatch?.player2.nickname}
+                  </Button>
+                </div>
+              </div>
+            )}
             <p className={`text-sm text-center ${
-              scoreForm.score1 + scoreForm.score2 > 0 &&
-              scoreForm.score1 < 3 &&
-              scoreForm.score2 < 3
+              scoreForm.score1 === scoreForm.score2 &&
+              !scoreForm.suddenDeathWinnerId
                 ? 'text-yellow-600' : 'invisible'
             }`}>
-              {tFinals('matchNeedWinner')}
+              {tFinals('gpTieNeedsWinner')}
             </p>
           </div>
           <DialogFooter>
             <Button
               onClick={handleScoreSubmit}
-              disabled={scoreForm.score1 < 3 && scoreForm.score2 < 3}
+              disabled={
+                scoreForm.score1 < 0 ||
+                scoreForm.score2 < 0 ||
+                (scoreForm.score1 === scoreForm.score2 && !scoreForm.suddenDeathWinnerId)
+              }
             >
               {tCommon('saveScore')}
             </Button>

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -128,8 +128,8 @@ function getCompletedChampion(matches: GPMatch[]): Player | null {
   if (reset) return getMatchWinner(reset);
 
   const grandFinal = matches.find((m) => m.round === "grand_final" && m.completed);
-  if (!grandFinal || getGpScore(grandFinal, 1) <= getGpScore(grandFinal, 2)) return null;
-  return grandFinal.player1;
+  if (!grandFinal) return null;
+  return getMatchWinner(grandFinal);
 }
 
 export default function GrandPrixFinals({
@@ -655,7 +655,7 @@ export default function GrandPrixFinals({
                 />
               </div>
             </div>
-            {scoreForm.score1 === scoreForm.score2 && (
+            {scoreForm.score1 + scoreForm.score2 > 0 && scoreForm.score1 === scoreForm.score2 && (
               <div className="space-y-2">
                 <Label>{tFinals('suddenDeathWinner')}</Label>
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -683,6 +683,7 @@ export default function GrandPrixFinals({
               </div>
             )}
             <p className={`text-sm text-center ${
+              scoreForm.score1 + scoreForm.score2 > 0 &&
               scoreForm.score1 === scoreForm.score2 &&
               !scoreForm.suddenDeathWinnerId
                 ? 'text-yellow-600' : 'invisible'

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -74,6 +74,20 @@ export interface FinalsConfig {
   postRequiresAuth?: boolean;
   /** Whether PUT endpoint requires admin authentication */
   putRequiresAuth?: boolean;
+  /** Optional custom winner resolution for formats that do not use first-to-N. */
+  resolveMatchResult?: (
+    match: Record<string, unknown>,
+    score1: number,
+    score2: number,
+    body: Record<string, unknown>,
+    targetWins: number,
+  ) => {
+    winnerId?: string;
+    loserId?: string;
+    error?: string;
+    field?: string;
+    updateData?: Record<string, unknown>;
+  };
 }
 
 /**
@@ -760,21 +774,40 @@ export function createFinalsHandlers(config: FinalsConfig) {
       }
 
       const targetWins = config.targetWins ?? 3;
-      const player1ReachedTarget = score1 >= targetWins;
-      const player2ReachedTarget = score2 >= targetWins;
+      const resolution = config.resolveMatchResult
+        ? config.resolveMatchResult(match, score1, score2, body, targetWins)
+        : (() => {
+          const player1ReachedTarget = score1 >= targetWins;
+          const player2ReachedTarget = score2 >= targetWins;
 
-      if (player1ReachedTarget === player2ReachedTarget) {
-        return handleValidationError(`Match must have a winner (first to ${targetWins})`, 'score');
+          if (player1ReachedTarget === player2ReachedTarget) {
+            return {
+              error: `Match must have a winner (first to ${targetWins})`,
+              field: 'score',
+            };
+          }
+
+          return {
+            winnerId: player1ReachedTarget ? match.player1Id as string : match.player2Id as string,
+            loserId: player1ReachedTarget ? match.player2Id as string : match.player1Id as string,
+          };
+        })();
+
+      if (resolution.error || !resolution.winnerId || !resolution.loserId) {
+        return handleValidationError(
+          resolution.error ?? 'Match must have a winner',
+          resolution.field ?? 'score',
+        );
       }
 
-      const winnerId = player1ReachedTarget ? match.player1Id : match.player2Id;
-      const loserId = player1ReachedTarget ? match.player2Id : match.player1Id;
+      const { winnerId, loserId } = resolution;
 
       /* Build update data with configurable score field names */
       const updateData: Record<string, unknown> = {
         [config.putScoreFields.dbField1]: score1,
         [config.putScoreFields.dbField2]: score2,
         completed: true,
+        ...(resolution.updateData ?? {}),
       };
 
       if (config.putAdditionalFields) {


### PR DESCRIPTION
## Summary
- allow GP finals matches to record a sudden-death winner when driver points are tied
- use the sudden-death winner for bracket progression and champion resolution
- update the GP finals admin dialog and API tests for tied-score submission flows

## Testing
- `git diff --check`
- Jest/TypeScript could not be run in this worktree because `smkc-score-app/node_modules/.bin/{jest,tsc}` is missing

Closes #531