### PR TITLE
fix(match): allow public match detail pages

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/match-detail-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/match-detail-route.test.ts
@@ -160,6 +160,40 @@ describe('Match Detail Route Factory', () => {
       expect(mockResolveTournamentId).toHaveBeenCalledWith('tournament-1');
     });
 
+    it('should allow unauthenticated GET by default', async () => {
+      const mockMatch = createMockMatch();
+      mockAuth.mockResolvedValue(null);
+      (prisma.bMMatch as any).findUnique.mockResolvedValue(mockMatch);
+
+      const { GET } = createMatchDetailHandlers({ ...baseConfig });
+
+      const request = new NextRequest('http://localhost:3000');
+      await GET(request, {
+        params: Promise.resolve({ id: 'tournament-1', matchId: 'match-123' }),
+      });
+
+      expect(mockAuth).not.toHaveBeenCalled();
+      expect(mockCreateSuccessResponse).toHaveBeenCalledWith(mockMatch);
+    });
+
+    it('should return 401 when getRequiresAuth and user is not authenticated', async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const { GET } = createMatchDetailHandlers({
+        ...baseConfig,
+        getRequiresAuth: true,
+      });
+
+      const request = new NextRequest('http://localhost:3000');
+      await GET(request, {
+        params: Promise.resolve({ id: 'tournament-1', matchId: 'match-123' }),
+      });
+
+      expect(mockAuth).toHaveBeenCalled();
+      expect(mockCreateErrorResponse).toHaveBeenCalledWith('Unauthorized', 401, 'UNAUTHORIZED');
+      expect((prisma.bMMatch as any).findUnique).not.toHaveBeenCalled();
+    });
+
     it('should resolve slug identifiers before fetching the match', async () => {
       const mockMatch = createMockMatch({ tournamentId: 'resolved-tournament-1' });
       mockResolveTournamentId.mockResolvedValue('resolved-tournament-1');

--- a/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/route.ts
@@ -27,7 +27,7 @@ const { GET, PUT } = createMatchDetailHandlers({
   validateFinalsScores: validateBattleModeFinalScores,
   sanitizeBody: true,
   putRequiresAuth: true,
-  getRequiresAuth: true,
+  getRequiresAuth: false,
   recalcStatsConfig: {
     matchModel: 'bMMatch',
     qualificationModel: 'bMQualification',

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/route.ts
@@ -23,7 +23,7 @@ const { GET, PUT } = createMatchDetailHandlers({
     updateGPMatchScore(prisma, matchId, version, val1, val2, completed, detail),
   sanitizeBody: true,
   putRequiresAuth: true,
-  getRequiresAuth: true,
+  getRequiresAuth: false,
   recalcStatsConfig: {
     matchModel: 'gPMatch',
     qualificationModel: 'gPQualification',

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/route.ts
@@ -25,7 +25,7 @@ const { GET, PUT } = createMatchDetailHandlers({
   validateScores: validateMatchRaceScores,
   sanitizeBody: true,
   putRequiresAuth: true,
-  getRequiresAuth: true,
+  getRequiresAuth: false,
   recalcStatsConfig: {
     matchModel: 'mRMatch',
     qualificationModel: 'mRQualification',


### PR DESCRIPTION
## Summary
- allow anonymous GET access on BM/MR/GP single-match detail routes so shareable `/match/` pages can load
- keep PUT/report auth unchanged so only authorized users can submit or edit scores
- add regression coverage for public GET defaults and the authenticated GET branch in the shared factory

## Testing
- `git diff --check`
- Jest could not be run in this worktree because `smkc-score-app/node_modules/.bin/jest` is missing

Closes #553