### PR TITLE
fix(match): guide admins from shared MR/GP pages

### DIFF
--- a/smkc-score-app/__tests__/lib/shared-match-access-state.test.ts
+++ b/smkc-score-app/__tests__/lib/shared-match-access-state.test.ts
@@ -1,0 +1,75 @@
+import { getSharedMatchAccessState } from "@/lib/shared-match-access-state";
+
+describe("getSharedMatchAccessState", () => {
+  it("hides access messaging while the session is loading", () => {
+    expect(
+      getSharedMatchAccessState({
+        canReport: false,
+        isAdmin: false,
+        isSessionLoading: true,
+        isCompleted: false,
+        isSubmitted: false,
+      }),
+    ).toBe("hidden");
+  });
+
+  it("shows the unauthorized state for non-participants after session load", () => {
+    expect(
+      getSharedMatchAccessState({
+        canReport: false,
+        isAdmin: false,
+        isSessionLoading: false,
+        isCompleted: false,
+        isSubmitted: false,
+      }),
+    ).toBe("unauthorized");
+  });
+
+  it("shows admin guidance for admins on in-progress shared pages", () => {
+    expect(
+      getSharedMatchAccessState({
+        canReport: true,
+        isAdmin: true,
+        isSessionLoading: false,
+        isCompleted: false,
+        isSubmitted: false,
+      }),
+    ).toBe("admin-guidance");
+  });
+
+  it("shows the report form for participating players", () => {
+    expect(
+      getSharedMatchAccessState({
+        canReport: true,
+        isAdmin: false,
+        isSessionLoading: false,
+        isCompleted: false,
+        isSubmitted: false,
+      }),
+    ).toBe("report-form");
+  });
+
+  it("hides access state when the match is already completed", () => {
+    expect(
+      getSharedMatchAccessState({
+        canReport: true,
+        isAdmin: true,
+        isSessionLoading: false,
+        isCompleted: true,
+        isSubmitted: false,
+      }),
+    ).toBe("hidden");
+  });
+
+  it("hides access state after the current user submits a result", () => {
+    expect(
+      getSharedMatchAccessState({
+        canReport: true,
+        isAdmin: false,
+        isSessionLoading: false,
+        isCompleted: false,
+        isSubmitted: true,
+      }),
+    ).toBe("hidden");
+  });
+});

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -515,7 +515,9 @@
     "cupRaceResults": "{cup} Cup - Race Results",
     "totalPoints": "Total Points: {points1} - {points2}",
     "pts": "{points} pts",
-    "notAuthorized": "You are not authorized to enter scores for this match. Please log in as one of the players."
+    "notAuthorized": "You are not authorized to enter scores for this match. Please log in as one of the players.",
+    "adminSharedPageGuidance": "Admins can view this shared page, but score entry for in-progress matches happens on the participant/admin score entry page.",
+    "openParticipantScoreEntry": "Open score entry page"
   },
   "participant": {
     "scoreEntry": "Participant Score Entry",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -514,7 +514,9 @@
     "cupRaceResults": "{cup}カップ - レース結果",
     "totalPoints": "合計ポイント: {points1} - {points2}",
     "pts": "{points} pts",
-    "notAuthorized": "この試合のスコアを入力する権限がありません。試合の当事者としてログインしてください。"
+    "notAuthorized": "この試合のスコアを入力する権限がありません。試合の当事者としてログインしてください。",
+    "adminSharedPageGuidance": "管理者はこの共有ページを閲覧できますが、進行中の試合のスコア入力は参加者・管理者用の入力ページから行ってください。",
+    "openParticipantScoreEntry": "スコア入力ページを開く"
   },
   "participant": {
     "scoreEntry": "参加者スコア入力",

--- a/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/match/[matchId]/page.tsx
@@ -45,7 +45,9 @@ import { usePolling } from "@/lib/hooks/usePolling";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
+import { SharedMatchAdminGuidance } from "@/components/tournament/shared-match-admin-guidance";
 import { useMatchReportAuth } from "@/lib/hooks/useMatchReportAuth";
+import { getSharedMatchAccessState } from "@/lib/shared-match-access-state";
 
 import type { Player } from "@/lib/types";
 
@@ -241,6 +243,13 @@ export default function GPMatchPage({
     (sum, r) => sum + (r.position2 ? getDriverPoints(r.position2) : 0),
     0
   );
+  const accessState = getSharedMatchAccessState({
+    canReport,
+    isAdmin,
+    isSessionLoading,
+    isCompleted: match.completed,
+    isSubmitted: submitted,
+  });
 
   if (loading) {
     return (
@@ -325,7 +334,7 @@ export default function GPMatchPage({
 
         {/* Not authorized message - shown to users who are not match participants.
             Guarded by !isSessionLoading to avoid flash during session fetch. */}
-        {!match.completed && !canReport && !isSessionLoading && (
+        {accessState === "unauthorized" && (
           <Card>
             <CardContent className="py-8 text-center">
               <p className="text-muted-foreground">{tMatch('notAuthorized')}</p>
@@ -333,9 +342,17 @@ export default function GPMatchPage({
           </Card>
         )}
 
+        {accessState === "admin-guidance" && (
+          <SharedMatchAdminGuidance
+            href={`/tournaments/${tournamentId}/gp/participant`}
+            description={tMatch('adminSharedPageGuidance')}
+            ctaLabel={tMatch('openParticipantScoreEntry')}
+          />
+        )}
+
         {/* Result entry form (shown when match is not complete and user is authorized)
             Admins should not see the score entry form here — they use the /gp/participant page. */}
-        {!match.completed && !submitted && canReport && !isAdmin && (
+        {accessState === "report-form" && (
           <Card>
             <CardHeader>
               <CardTitle>{tMatch('enterResult')}</CardTitle>

--- a/smkc-score-app/src/app/tournaments/[id]/mr/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/match/[matchId]/page.tsx
@@ -44,7 +44,9 @@ import { usePolling } from "@/lib/hooks/usePolling";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
+import { SharedMatchAdminGuidance } from "@/components/tournament/shared-match-admin-guidance";
 import { useMatchReportAuth } from "@/lib/hooks/useMatchReportAuth";
+import { getSharedMatchAccessState } from "@/lib/shared-match-access-state";
 
 import type { Player } from "@/lib/types";
 
@@ -287,6 +289,13 @@ export default function MatchDetailPage({
   /* Calculate current score from rounds for display */
   const p1Wins = rounds.filter(r => r.winner === 1).length;
   const p2Wins = rounds.filter(r => r.winner === 2).length;
+  const accessState = getSharedMatchAccessState({
+    canReport,
+    isAdmin,
+    isSessionLoading,
+    isCompleted: match.completed,
+    isSubmitted: submitted,
+  });
 
   return (
     <div className="min-h-screen bg-background p-4">
@@ -321,7 +330,7 @@ export default function MatchDetailPage({
 
         {/* Not authorized message - shown to users who are not match participants.
             Guarded by !isSessionLoading to avoid flash during session fetch. */}
-        {!match.completed && !canReport && !isSessionLoading && (
+        {accessState === "unauthorized" && (
           <Card>
             <CardContent className="py-8 text-center">
               <p className="text-muted-foreground">{tMatch('notAuthorized')}</p>
@@ -329,9 +338,17 @@ export default function MatchDetailPage({
           </Card>
         )}
 
+        {accessState === "admin-guidance" && (
+          <SharedMatchAdminGuidance
+            href={`/tournaments/${tournamentId}/mr/participant`}
+            description={tMatch('adminSharedPageGuidance')}
+            ctaLabel={tMatch('openParticipantScoreEntry')}
+          />
+        )}
+
         {/* Score entry form (shown when match is not completed and user is authorized)
             Admins should not see the score entry form here — they use the /mr/participant page. */}
-        {!match.completed && !submitted && canReport && !isAdmin && (
+        {accessState === "report-form" && (
           <Card>
             <CardHeader>
               {/* i18n: Score entry form header */}

--- a/smkc-score-app/src/components/tournament/shared-match-admin-guidance.tsx
+++ b/smkc-score-app/src/components/tournament/shared-match-admin-guidance.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface SharedMatchAdminGuidanceProps {
+  href: string;
+  description: string;
+  ctaLabel: string;
+}
+
+export function SharedMatchAdminGuidance({
+  href,
+  description,
+  ctaLabel,
+}: SharedMatchAdminGuidanceProps) {
+  return (
+    <Card>
+      <CardContent className="py-8 text-center space-y-4">
+        <p className="text-muted-foreground">{description}</p>
+        <Button asChild variant="outline">
+          <Link href={href}>{ctaLabel}</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/smkc-score-app/src/lib/shared-match-access-state.ts
+++ b/smkc-score-app/src/lib/shared-match-access-state.ts
@@ -1,0 +1,31 @@
+export type SharedMatchAccessState =
+  | "hidden"
+  | "unauthorized"
+  | "admin-guidance"
+  | "report-form";
+
+interface SharedMatchAccessInput {
+  canReport: boolean;
+  isAdmin: boolean;
+  isSessionLoading: boolean;
+  isCompleted: boolean;
+  isSubmitted: boolean;
+}
+
+export function getSharedMatchAccessState({
+  canReport,
+  isAdmin,
+  isSessionLoading,
+  isCompleted,
+  isSubmitted,
+}: SharedMatchAccessInput): SharedMatchAccessState {
+  if (isCompleted || isSubmitted) {
+    return "hidden";
+  }
+
+  if (!canReport) {
+    return isSessionLoading ? "hidden" : "unauthorized";
+  }
+
+  return isAdmin ? "admin-guidance" : "report-form";
+}


### PR DESCRIPTION
## Summary
- show an explicit admin guidance card on the MR/GP shared match pages instead of falling into a blank action area
- centralize shared-page access-state handling so unauthorized, admin-guidance, and participant-form states stay consistent
- add regression coverage for the shared-page access-state helper

## Testing
- `git diff --check`
- Jest could not be run in this worktree because `smkc-score-app/node_modules/.bin/jest` is missing

Closes #555