### PR TITLE
[codex] test(match): cover public single-match GET access

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/match/[matchId]/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/match/[matchId]/route.test.ts
@@ -76,6 +76,35 @@ describe('BM Match API Route - /api/tournaments/[id]/bm/match/[matchId]', () => 
   });
 
   describe('GET - Retrieve a single battle mode match', () => {
+    it('should allow unauthenticated users to fetch a public match', async () => {
+      const mockMatch = {
+        id: 'm1',
+        tournamentId: 't1',
+        matchNumber: 1,
+        stage: 'qualification',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        score1: 3,
+        score2: 1,
+        completed: true,
+        player1: { id: 'p1', name: 'Player 1' },
+        player2: { id: 'p2', name: 'Player 2' },
+      };
+
+      (auth as jest.Mock).mockResolvedValue(null);
+      (prisma.bMMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+
+      const request = new MockNextRequest();
+      const params = Promise.resolve({ id: 't1', matchId: 'm1' });
+      const result = await GET(request, { params });
+
+      expect(result).toEqual({
+        data: mockMatch,
+        message: undefined,
+        status: 200
+      });
+    });
+
     // Success case - Returns match with player details when match exists
     it('should return match with player1 and player2 details', async () => {
       const mockMatch = {

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/route.test.ts
@@ -68,6 +68,30 @@ describe('GP Match API Route - /api/tournaments/[id]/gp/match/[matchId]', () => 
   });
 
   describe('GET - Fetch single grand prix match', () => {
+    it('should allow unauthenticated users to fetch a public match', async () => {
+      const mockMatch = {
+        id: 'm1',
+        tournamentId: 't1',
+        matchNumber: 1,
+        stage: 'qualification',
+        player1: { id: 'p1', name: 'Player 1' },
+        player2: { id: 'p2', name: 'Player 2' },
+        points1: 18,
+        points2: 6,
+        completed: true,
+      };
+
+      (auth as jest.Mock).mockResolvedValue(null);
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/match/m1');
+      const params = Promise.resolve({ id: 't1', matchId: 'm1' });
+      const result = await GET(request, { params });
+
+      expect(result).toEqual({ data: mockMatch, status: 200 });
+      expect(createSuccessResponse).toHaveBeenCalledWith(mockMatch);
+    });
+
     // Success case - Returns match with valid match ID
     it('should return match with valid match ID', async () => {
       const mockMatch = {

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/route.test.ts
@@ -92,6 +92,30 @@ describe('MR Match API Route - /api/tournaments/[id]/mr/match/[matchId]', () => 
   });
 
   describe('GET - Fetch single match', () => {
+    it('should allow unauthenticated users to fetch a public match', async () => {
+      const mockMatch = {
+        id: 'm1',
+        tournamentId: 't1',
+        matchNumber: 1,
+        stage: 'qualification',
+        score1: 3,
+        score2: 1,
+        completed: true,
+        player1: { id: 'p1', name: 'Player 1' },
+        player2: { id: 'p2', name: 'Player 2' },
+      };
+
+      (auth as jest.Mock).mockResolvedValue(null);
+      (prisma.mRMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/match/m1');
+      const params = Promise.resolve({ id: 't1', matchId: 'm1' });
+      const result = await GET(request, { params });
+
+      expect(result).toEqual({ data: mockMatch, status: 200 });
+      expect(createSuccessResponse).toHaveBeenCalledWith(mockMatch);
+    });
+
     // Success case - Returns match with player details
     it('should return match with player details for valid matchId', async () => {
       const mockMatch = {


### PR DESCRIPTION
## Summary
- add BM/MR/GP route tests that verify anonymous users can fetch public single-match pages
- lock in the existing `getRequiresAuth: false` behavior for shared match links

## Why
`main` already contains the route-level fix for public match detail pages, but it did not have route coverage to prevent GET auth regressions. This PR fixes that gap for issue #553.

## Testing
- `git diff --check`
- `npm test -- --runInBand '__tests__/app/api/tournaments/[id]/bm/match/[matchId]/route.test.ts' '__tests__/app/api/tournaments/[id]/mr/match/[matchId]/route.test.ts' '__tests__/app/api/tournaments/[id]/gp/match/[matchId]/route.test.ts'` *(fails in this worktree because `jest` is not installed / `node_modules` is missing)*

Refs #553