### PR TITLE
fix(bm): guide participants from shared match page to score entry

### DIFF
--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -520,7 +520,10 @@
     "pts": "{points} pts",
     "notAuthorized": "You are not authorized to enter scores for this match. Please log in as one of the players.",
     "adminSharedPageGuidance": "Admins can view this shared page, but score entry for in-progress matches happens on the participant/admin score entry page.",
-    "openParticipantScoreEntry": "Open score entry page"
+    "openParticipantScoreEntry": "Open score entry page",
+    "scoreEntryGuidance": "Score entry is on the participant page",
+    "goToScoreEntry": "Go to Score Entry",
+    "signInToReportScores": "Sign in to report scores"
   },
   "participant": {
     "scoreEntry": "Participant Score Entry",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -519,7 +519,10 @@
     "pts": "{points} pts",
     "notAuthorized": "この試合のスコアを入力する権限がありません。試合の当事者としてログインしてください。",
     "adminSharedPageGuidance": "管理者はこの共有ページを閲覧できますが、進行中の試合のスコア入力は参加者・管理者用の入力ページから行ってください。",
-    "openParticipantScoreEntry": "スコア入力ページを開く"
+    "openParticipantScoreEntry": "スコア入力ページを開く",
+    "scoreEntryGuidance": "スコア入力は参加者ページで行えます",
+    "goToScoreEntry": "スコア入力へ",
+    "signInToReportScores": "スコアを報告するにはログインしてください"
   },
   "participant": {
     "scoreEntry": "参加者スコア入力",

--- a/smkc-score-app/src/app/tournaments/[id]/bm/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/match/[matchId]/page.tsx
@@ -75,7 +75,7 @@ export default function MatchDetailPage({
   const [match, setMatch] = useState<BMMatch | null>(null);
   const [tournament, setTournament] = useState<Tournament | null>(null);
   const [loading, setLoading] = useState(true);
-  const { data: session } = useSession();
+  const { data: session, status: sessionStatus } = useSession();
 
   /**
    * Fetch match and tournament data in parallel.
@@ -212,21 +212,33 @@ export default function MatchDetailPage({
           <Card>
             <CardContent className="py-6 text-center space-y-4">
               <p className="text-muted-foreground">{tMatch('matchInProgress')}</p>
-              {(session?.user?.playerId) ? (
-                <div className="space-y-2">
+              {/*
+                Only show the CTA when the session is fully loaded.
+                useSession returns null while status === 'loading', so
+                rendering during loading would flash the unauthenticated
+                message to an already-authenticated user.
+
+                We check playerId (not just any authenticated session) because
+                the participant score-entry page is player-only. Admins have
+                their own entry path via the main BM page.
+              */}
+              {sessionStatus !== 'loading' && (
+                session?.user?.playerId ? (
+                  <div className="space-y-2">
+                    <p className="text-sm text-muted-foreground">
+                      {tMatch('scoreEntryGuidance')}
+                    </p>
+                    <Button asChild>
+                      <Link href={`/tournaments/${tournamentId}/bm/participant`}>
+                        {tMatch('goToScoreEntry')}
+                      </Link>
+                    </Button>
+                  </div>
+                ) : (
                   <p className="text-sm text-muted-foreground">
-                    Score entry is on the participant page
+                    {tMatch('signInToReportScores')}
                   </p>
-                  <Button asChild>
-                    <Link href={`/tournaments/${tournamentId}/bm/participant`}>
-                      Go to Score Entry
-                    </Link>
-                  </Button>
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  Sign in to report scores
-                </p>
+                )
               )}
             </CardContent>
           </Card>

--- a/smkc-score-app/src/app/tournaments/[id]/bm/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/match/[matchId]/page.tsx
@@ -212,34 +212,25 @@ export default function MatchDetailPage({
           <Card>
             <CardContent className="py-6 text-center space-y-4">
               <p className="text-muted-foreground">{tMatch('matchInProgress')}</p>
-              {/*
-                Only show the CTA when the session is fully loaded.
-                useSession returns null while status === 'loading', so
-                rendering during loading would flash the unauthenticated
-                message to an already-authenticated user.
-
-                We check playerId (not just any authenticated session) because
-                the participant score-entry page is player-only. Admins have
-                their own entry path via the main BM page.
-              */}
-              {sessionStatus !== 'loading' && (
-                session?.user?.playerId ? (
-                  <div className="space-y-2">
-                    <p className="text-sm text-muted-foreground">
-                      {tMatch('scoreEntryGuidance')}
-                    </p>
-                    <Button asChild>
-                      <Link href={`/tournaments/${tournamentId}/bm/participant`}>
-                        {tMatch('goToScoreEntry')}
-                      </Link>
-                    </Button>
-                  </div>
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    {tMatch('signInToReportScores')}
-                  </p>
-                )
-              )}
+              {/* Show CTA only when session is loaded to avoid loading flash */}
+               {sessionStatus !== 'loading' && (
+                 !session ? (
+                   <p className="text-sm text-muted-foreground">
+                     {tMatch('signInToReportScores')}
+                   </p>
+                 ) : session.user?.playerId ? (
+                   <div className="space-y-2">
+                     <p className="text-sm text-muted-foreground">
+                       {tMatch('scoreEntryGuidance')}
+                     </p>
+                     <Button asChild>
+                       <Link href={`/tournaments/${tournamentId}/bm/participant`}>
+                         {tMatch('goToScoreEntry')}
+                       </Link>
+                     </Button>
+                   </div>
+                 ) : null
+               )}
             </CardContent>
           </Card>
         )}

--- a/smkc-score-app/src/app/tournaments/[id]/bm/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/match/[matchId]/page.tsx
@@ -16,6 +16,7 @@ import { fetchWithRetry } from "@/lib/fetch-with-retry";
 
 import { useState, useEffect, useCallback, use } from "react";
 import { useTranslations } from "next-intl";
+import { useSession } from "next-auth/react";
 import Link from "next/link";
 import {
   Card,
@@ -24,6 +25,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { POLLING_INTERVAL } from "@/lib/constants";
 import { usePolling } from "@/lib/hooks/usePolling";
@@ -73,6 +75,7 @@ export default function MatchDetailPage({
   const [match, setMatch] = useState<BMMatch | null>(null);
   const [tournament, setTournament] = useState<Tournament | null>(null);
   const [loading, setLoading] = useState(true);
+  const { data: session } = useSession();
 
   /**
    * Fetch match and tournament data in parallel.
@@ -207,8 +210,24 @@ export default function MatchDetailPage({
         {/* In-progress state */}
         {!match.completed && (
           <Card>
-            <CardContent className="py-8 text-center">
+            <CardContent className="py-6 text-center space-y-4">
               <p className="text-muted-foreground">{tMatch('matchInProgress')}</p>
+              {(session?.user?.playerId) ? (
+                <div className="space-y-2">
+                  <p className="text-sm text-muted-foreground">
+                    Score entry is on the participant page
+                  </p>
+                  <Button asChild>
+                    <Link href={`/tournaments/${tournamentId}/bm/participant`}>
+                      Go to Score Entry
+                    </Link>
+                  </Button>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Sign in to report scores
+                </p>
+              )}
             </CardContent>
           </Card>
         )}


### PR DESCRIPTION
## Summary
- Issue #568: in-progress BM shared match pages now show guidance to the participant score-entry page
- Authenticated participants/admins see a "Go to Score Entry" button linking to `/tournaments/[id]/bm/participant`
- Unauthenticated users see a "Sign in to report scores" message

## Changes
- Added `useSession` from `next-auth/react` to detect authenticated players
- Added `Button` import from UI components
- In the in-progress state, conditionally render CTA based on session state