### PR TITLE
fix(bracket): render losers_r1 as TBD after bracket generation (#574)

### DIFF
--- a/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
@@ -70,3 +70,102 @@ describe("DoubleEliminationBracket horizontal overflow (issue #424)", () => {
     });
   });
 });
+
+describe("DoubleEliminationBracket TBD rendering (issue #574)", () => {
+  /* Right after bracket generation, losers-bracket matches have no real
+   * players yet -- the DB schema requires non-null player ids so the API
+   * fills both slots with the seed-1 player as a placeholder (see
+   * finals-route.ts POST handler fallback). The UI must render those slots
+   * as "TBD" rather than showing seed 1 on both sides, which misled users
+   * into thinking the top seed was dropping straight into the losers bracket. */
+  const seed1 = { id: "p1", nickname: "Alice" };
+  const seed2 = { id: "p2", nickname: "Bob" };
+  const seed3 = { id: "p3", nickname: "Carol" };
+  const seed4 = { id: "p4", nickname: "Dan" };
+  const seed5 = { id: "p5", nickname: "Eve" };
+  const seed6 = { id: "p6", nickname: "Frank" };
+  const seed7 = { id: "p7", nickname: "Grace" };
+  const seed8 = { id: "p8", nickname: "Heidi" };
+
+  const seededPlayers = [seed1, seed2, seed3, seed4, seed5, seed6, seed7, seed8].map(
+    (player, i) => ({ seed: i + 1, playerId: player.id, player }),
+  );
+
+  /* Build match rows as the POST /finals handler would immediately after
+   * bracket creation: winners QF matches get their two seeds; every other
+   * slot is filled with seed 1 on both sides. */
+  const buildInitialMatches = () => {
+    const seedPairs: Record<number, [typeof seed1, typeof seed1]> = {
+      1: [seed1, seed8],
+      2: [seed4, seed5],
+      3: [seed2, seed7],
+      4: [seed3, seed6],
+    };
+    return build8PlayerStructure().map((b) => {
+      const pair = seedPairs[b.matchNumber];
+      const player1 = pair ? pair[0] : seed1;
+      const player2 = pair ? pair[1] : seed1;
+      return {
+        id: `m${b.matchNumber}`,
+        matchNumber: b.matchNumber,
+        round: b.round,
+        stage: "finals",
+        player1Id: player1.id,
+        player2Id: player2.id,
+        score1: 0,
+        score2: 0,
+        completed: false,
+        player1,
+        player2,
+      };
+    });
+  };
+
+  it("renders losers_r1 slots as TBD right after bracket generation", () => {
+    const { container } = render(
+      <DoubleEliminationBracket
+        matches={buildInitialMatches()}
+        bracketStructure={build8PlayerStructure()}
+        roundNames={{}}
+        seededPlayers={seededPlayers}
+      />,
+    );
+
+    /* Locate losers_r1 cards (match 8 and 9) by their match-number label. */
+    const losersR1Cards = Array.from(
+      container.querySelectorAll<HTMLElement>("[role='button']"),
+    ).filter((el) => {
+      const label = el.querySelector("div.text-xs");
+      return label && (label.textContent === "M8" || label.textContent === "M9");
+    });
+
+    expect(losersR1Cards).toHaveLength(2);
+
+    for (const card of losersR1Cards) {
+      /* Both player rows should say TBD, and neither should display the
+       * seed-1 placeholder name that the DB stored. */
+      expect(card.textContent).toContain("TBD");
+      expect(card.textContent).not.toContain(seed1.nickname);
+    }
+  });
+
+  it("keeps winners_qf first-round matches showing seeded player names", () => {
+    const { container } = render(
+      <DoubleEliminationBracket
+        matches={buildInitialMatches()}
+        bracketStructure={build8PlayerStructure()}
+        roundNames={{}}
+        seededPlayers={seededPlayers}
+      />,
+    );
+
+    /* Match 1 is Seed 1 vs Seed 8 -- must not be TBD. */
+    const winnersQF1 = Array.from(
+      container.querySelectorAll<HTMLElement>("[role='button']"),
+    ).find((el) => el.querySelector("div.text-xs")?.textContent === "M1");
+
+    expect(winnersQF1).toBeDefined();
+    expect(winnersQF1!.textContent).toContain(seed1.nickname);
+    expect(winnersQF1!.textContent).toContain(seed8.nickname);
+  });
+});

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -113,11 +113,14 @@ function MatchCard({
 
   /*
    * Determine if this match should show "TBD" for players.
-   * First-round matches (winners_qf, losers_r1) always show actual players.
-   * Later rounds show TBD until players are determined from previous results.
+   * Winners first-round matches (winners_qf, winners_r1) always have real
+   * players from direct seeding. losers_r1 is populated from winners-side
+   * losers so its players are unknown until those matches complete — issue
+   * #574: immediately after bracket generation both slots were filled with
+   * seed 1 as a placeholder and it needs to render as TBD.
    */
   const isFirstRound =
-    bracketMatch.round === "winners_r1" || bracketMatch.round === "winners_qf" || bracketMatch.round === "losers_r1";
+    bracketMatch.round === "winners_r1" || bracketMatch.round === "winners_qf";
   const showTBD = !isFirstRound && isTBD;
 
   return (


### PR DESCRIPTION
## Summary
- Fixes #574: losers-bracket R1 was displaying the seed-1 player on both sides immediately after bracket generation because the UI treated `losers_r1` as a first-round match with real seeded players.
- The DB schema requires non-null `player1Id` / `player2Id`, so the POST /finals handler fills every unseeded slot with the seed-1 player as a placeholder. Only `winners_qf` / `winners_r1` genuinely come from seeding, so the "first round" exception is narrowed to those two rounds. losers_r1 now falls through to the existing TBD heuristic (`!completed && player1Id === player2Id`) and renders TBD until winners-side matches feed real players via `getNextMatchInfo`.

## Test plan
- [x] New unit test: after bracket generation, losers_r1 cards render "TBD" and do not show seed-1 nickname
- [x] Regression test: winners_qf still shows seeded player names
- [x] `npx jest __tests__/components/tournament/double-elimination-bracket.test.tsx` passes
- [ ] Manually verify on production that newly-created finals bracket shows TBD in losers R1