### PR TITLE
chore: gitignore ad-hoc E2E runner and debug scripts

### DIFF
--- a/smkc-score-app/.gitignore
+++ b/smkc-score-app/.gitignore
@@ -56,3 +56,12 @@ __tests__.bak/
 *.db
 *.db-journal
 .opencode/
+
+# Ephemeral E2E runners/debug scripts. Once a TC passes it is absorbed
+# into the per-mode tc-bm.js/tc-mr.js/tc-gp.js/tc-ta.js files and wired
+# through tc-all.js (see CLAUDE.md). Ad-hoc runners created while
+# iterating should not be committed (see commit ba33492).
+e2e/*-debug.js
+e2e/run-*-suite.js
+e2e/tc-??-[0-9][0-9][0-9].js
+e2e/tc-???-[0-9][0-9][0-9].js


### PR DESCRIPTION
## Summary
- Adds gitignore patterns for ad-hoc E2E runners (`e2e/run-*-suite.js`, `e2e/tc-??-NNN.js`, `e2e/tc-???-NNN.js`) and any `-debug.js` helper scripts.
- The workflow is: spin up a quick runner to iterate on a new test case, then absorb the passing TC into the per-mode `tc-*.js` file wired through `tc-all.js` (documented in `CLAUDE.md`). The standalone runner is no longer needed at that point.
- Commit ba33492 already cleaned up previously-committed debug files; this patterns the cleanup so it doesn't happen again.

## Test plan
- [x] \`git status\` no longer lists \`e2e/run-gp-suite.js\`, \`e2e/tc-gp-821.js\`, \`e2e/tc-gp-821-debug.js\`, \`e2e/tc-mr-820-debug.js\`
- [x] Legitimate committed files (\`tc-bm.js\`, \`tc-mr.js\`, \`tc-gp.js\`, \`tc-ta.js\`, \`tc-all.js\`, \`cleanup.js\`, \`lib/\`) are still tracked