### PR TITLE
fix(bm): guide admins from shared match pages (#568)

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/bm/match/[matchId]/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/match/[matchId]/page.tsx
@@ -229,6 +229,17 @@ export default function MatchDetailPage({
                        </Link>
                      </Button>
                    </div>
+                 ) : session.user?.role === 'admin' ? (
+                   <div className="space-y-2">
+                     <p className="text-sm text-muted-foreground">
+                       {tMatch('adminSharedPageGuidance')}
+                     </p>
+                     <Button asChild>
+                       <Link href={`/tournaments/${tournamentId}/bm`}>
+                         {tMatch('openParticipantScoreEntry')}
+                       </Link>
+                     </Button>
+                   </div>
                  ) : null
                )}
             </CardContent>


### PR DESCRIPTION
## Summary
- Adds an admin CTA on the BM shared match page in-progress state, linking to `/tournaments/<id>/bm`.
- Previously, admins (session user with `role === 'admin'` and no `playerId`) saw nothing — only participants got a CTA.

Closes #568.

## Test plan
- [ ] Sign in as admin, open an in-progress BM shared match URL — verify "Open score entry page" button appears and links to `/tournaments/<id>/bm`
- [ ] Sign in as participant (with `playerId`), verify existing behavior is unchanged (CTA to `/bm/participant`)
- [ ] Signed-out user still sees the sign-in prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)