### PR TITLE
fix(gp-finals): backfill per-round cups server-side for legacy matches

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -70,7 +70,7 @@ import {
 } from "@/components/ui/select";
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
 import { PlayoffBracket } from "@/components/tournament/playoff-bracket";
-import { COURSE_INFO, CUPS, CUP_SUBSTITUTIONS, GP_POSITION_OPTIONS, POLLING_INTERVAL, TOTAL_GP_RACES, getDriverPoints, type CourseAbbr } from "@/lib/constants";
+import { COURSE_INFO, CUP_SUBSTITUTIONS, GP_POSITION_OPTIONS, POLLING_INTERVAL, TOTAL_GP_RACES, getDriverPoints, type CourseAbbr } from "@/lib/constants";
 import { formatGpPosition } from "@/lib/gp-utils";
 import { usePolling } from "@/lib/hooks/usePolling";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
@@ -397,10 +397,11 @@ export default function GrandPrixFinals({
   /** Open score entry dialog for a specific match */
   const openScoreDialog = (match: GPMatch) => {
     setSelectedMatch(match);
-    /* Fall back to a random cup for legacy matches that were created before
-     * per-round cup assignment landed (match.cup === null). Without a cup the
-     * race table never renders and the admin can't enter scores. */
-    const cup = match.cup || CUPS[Math.floor(Math.random() * CUPS.length)];
+    /* The server backfills per-round cups on GET for legacy rows, so by the
+     * time the admin can click a match it is guaranteed to have one. The
+     * fallback empty-string is kept only to satisfy the TS type and to avoid
+     * crashing if the refetch races the click. */
+    const cup = match.cup || "";
     let races: Race[];
     if (match.races && match.races.length === TOTAL_GP_RACES) {
       /* Pre-fill with existing race data for editing */
@@ -409,9 +410,11 @@ export default function GrandPrixFinals({
         position1: r.position1,
         position2: r.position2,
       }));
-    } else {
+    } else if (cup) {
       /* Auto-fill courses from the assigned cup's fixed sequence */
       races = getCupCourses(cup).map((course) => ({ course, position1: null, position2: null }));
+    } else {
+      races = Array.from({ length: TOTAL_GP_RACES }, () => ({ course: "" as CourseAbbr, position1: null, position2: null }));
     }
     setScoreForm({
       suddenDeathWinnerId: match.suddenDeathWinnerId ?? "",

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -104,6 +104,60 @@ function createGpRoundAssignments(
 }
 
 /**
+ * Backfill per-round GP cup assignments for legacy matches that were created
+ * before the per-round cup feature landed (those rows carry cup=null).
+ *
+ * Rule (#582 follow-up): within Playoff and Finals, every match in the same
+ * round shares one cup. We pick one cup per round here, persist it, and from
+ * that point on the admin score dialog always has a cup to render the race
+ * table with — no dropdown, no random-on-each-open behaviour.
+ *
+ * Returns true when at least one row was updated, so the caller can re-fetch.
+ */
+async function backfillMissingCupsByRound(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  modelInstance: any,
+  tournamentId: string,
+  stage: 'finals' | 'playoff',
+  matches: Array<{ cup?: string | null; round?: string | null }>,
+): Promise<boolean> {
+  const existingCupByRound = new Map<string, string>();
+  const roundsNeedingCup = new Set<string>();
+
+  for (const match of matches) {
+    if (!match.round) continue;
+    if (match.cup) {
+      existingCupByRound.set(match.round, match.cup);
+    } else {
+      roundsNeedingCup.add(match.round);
+    }
+  }
+
+  if (roundsNeedingCup.size === 0) return false;
+
+  /* Reuse already-assigned cups for rounds where some matches have cups and
+   * others don't (avoids the mixed-state case diverging). For rounds with no
+   * existing cup, pick from a freshly shuffled CUPS list so assignments stay
+   * random across tournaments while being fixed per round. */
+  const shuffledCups = fisherYatesShuffle(CUPS);
+  let cursor = 0;
+  const assignments = new Map<string, string>();
+  for (const round of roundsNeedingCup) {
+    const existing = existingCupByRound.get(round);
+    assignments.set(round, existing ?? shuffledCups[cursor++ % shuffledCups.length]);
+  }
+
+  for (const [round, cup] of assignments) {
+    await modelInstance.updateMany({
+      where: { tournamentId, stage, round, cup: null },
+      data: { cup },
+    });
+  }
+
+  return true;
+}
+
+/**
  * Configuration for a finals route handler set.
  *
  * Each event type (BM, MR, GP) supplies its own config to produce
@@ -198,11 +252,30 @@ export function createFinalsHandlers(config: FinalsConfig) {
        * When present, we also regenerate the bracket structure and reconstruct
        * seed-to-player mappings so the frontend can render the bracket without
        * relying on state from a previous POST response. */
-      const playoffMatches = await model(prisma).findMany({
+      let playoffMatches = await model(prisma).findMany({
         where: { tournamentId, stage: 'playoff' },
         include: { player1: true, player2: true },
         orderBy: { matchNumber: 'asc' },
       });
+
+      /* Backfill per-round cup assignments for legacy playoff rows (pre-#565).
+       * Without this the admin score dialog has no cup and the race table
+       * never renders — see #582/#583. */
+      if (config.assignGpCupByRound && playoffMatches.length > 0) {
+        const backfilled = await backfillMissingCupsByRound(
+          model(prisma),
+          tournamentId,
+          'playoff',
+          playoffMatches,
+        );
+        if (backfilled) {
+          playoffMatches = await model(prisma).findMany({
+            where: { tournamentId, stage: 'playoff' },
+            include: { player1: true, player2: true },
+            orderBy: { matchNumber: 'asc' },
+          });
+        }
+      }
 
       const playoffStructure = playoffMatches.length > 0
         ? generatePlayoffStructure(PLAYOFF_ENTRANT_COUNT)
@@ -263,6 +336,24 @@ export function createFinalsHandlers(config: FinalsConfig) {
       const phase = hasFinals > 0 ? 'finals' as const
         : playoffMatches.length > 0 ? 'playoff' as const
         : 'finals' as const;
+
+      /* Backfill per-round cup assignments for legacy finals rows before
+       * paginating or simple/grouped fetches, so every branch sees the
+       * backfilled state (see playoff branch above). */
+      if (config.assignGpCupByRound) {
+        const legacyFinals = await model(prisma).findMany({
+          where: { tournamentId, stage: 'finals' },
+          select: { id: true, round: true, cup: true },
+        });
+        if (legacyFinals.length > 0) {
+          await backfillMissingCupsByRound(
+            model(prisma),
+            tournamentId,
+            'finals',
+            legacyFinals,
+          );
+        }
+      }
 
       if (config.getStyle === 'paginated') {
         const { searchParams } = new URL(request.url);


### PR DESCRIPTION
## Summary
- Follow-up to #583. Playoff and Finals are supposed to fix cups **per round**, but legacy matches created before per-round cup assignment landed (#565) still have `cup: null`, breaking the admin score dialog (no cup → no race table → Save permanently disabled).
- Server-side backfill on GET: group matches by round, pick one cup per round (random across tournaments, fixed per round), persist via `updateMany`. Once run the DB is clean and every subsequent GET returns fully populated rows.
- Runs for both Playoff and Finals stages. Gated on `config.assignGpCupByRound` so only the GP route triggers it.
- Client: drops the random-on-each-open fallback and the now-unused `CUPS` import. Dialog goes straight to the race table.

## Test plan
- [ ] Open `/tournaments/<id>/gp/finals` as admin on a legacy tournament (e.g. `cmo986w1q0000zv1vnn4afnvd`, whose playoff matches all have `cup: null`) → first GET backfills → dialog shows cup badge + race table → Save succeeds
- [ ] Reload the page → GET sees non-null cups → no further writes, cups stable on every reopen
- [ ] Open a freshly generated bracket → existing cup assignments preserved, substitution toggle still shown
- [ ] Confirm all 4 matches in the same round (e.g. `winners_qf`) display the same cup

🤖 Generated with [Claude Code](https://claude.com/claude-code)