### PR TITLE
Fix silent truncation of decimal/exponential scores in manual overrides

### DIFF
--- a/smkc-score-app/__tests__/lib/parse-manual-score.test.ts
+++ b/smkc-score-app/__tests__/lib/parse-manual-score.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @module __tests__/lib/parse-manual-score.test.ts
+ * @description Strict-parse guard for the admin manual-score override form.
+ *
+ * Regression: using `Number.parseInt` on the raw input string silently
+ * truncates values like `"12.5"` or `"1e2"` to `12` and `1`. Those coerced
+ * integers passed the downstream `Number.isInteger`/non-negative checks and
+ * could commit a different score than the admin typed, changing
+ * winner/tiebreak outcomes for finals matches. See PR #589 review.
+ */
+import { parseManualScore } from '@/lib/parse-manual-score';
+
+describe('parseManualScore', () => {
+  describe('accepts valid non-negative integers', () => {
+    test.each([
+      ['0', 0],
+      ['1', 1],
+      ['5', 5],
+      ['12', 12],
+      ['100', 100],
+      ['  7  ', 7], // tolerates surrounding whitespace
+    ])('parses %j as %d', (input, expected) => {
+      expect(parseManualScore(input)).toBe(expected);
+    });
+  });
+
+  describe('rejects silently-truncated numeric notation', () => {
+    // These are exactly the regressions called out in the PR review: each one
+    // parses to a clean integer under parseInt but would misrepresent the
+    // operator's intent.
+    test.each([
+      ['12.5'], // parseInt → 12
+      ['5.9'],  // parseInt → 5
+      ['0.1'],  // parseInt → 0
+      ['1e2'],  // parseInt → 1
+      ['1E2'],  // parseInt → 1
+    ])('rejects %j', (input) => {
+      expect(parseManualScore(input)).toBeNull();
+    });
+  });
+
+  describe('rejects non-numeric and signed input', () => {
+    test.each([
+      [''],
+      ['   '],
+      ['abc'],
+      ['-1'],
+      ['+1'],
+      ['1.0'],
+      ['1 2'],
+      ['0x10'],
+      ['NaN'],
+      ['Infinity'],
+    ])('rejects %j', (input) => {
+      expect(parseManualScore(input)).toBeNull();
+    });
+  });
+
+  test('rejects values beyond the safe-integer range', () => {
+    // 2^53 would silently lose precision once stored as a JS number.
+    const unsafe = String(Number.MAX_SAFE_INTEGER) + '0';
+    expect(parseManualScore(unsafe)).toBeNull();
+  });
+});

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -77,6 +77,7 @@ import { usePolling } from "@/lib/hooks/usePolling";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
+import { parseManualScore } from "@/lib/parse-manual-score";
 import type { Player } from "@/lib/types";
 
 /** Client-side logger for error tracking */
@@ -455,12 +456,16 @@ export default function GrandPrixFinals({
     const body: Record<string, unknown> = { matchId: selectedMatch.id };
 
     if (manualScoreEnabled) {
-      points1 = Number.parseInt(manualPoints1, 10);
-      points2 = Number.parseInt(manualPoints2, 10);
-      if (!Number.isInteger(points1) || !Number.isInteger(points2) || points1 < 0 || points2 < 0) {
+      /* Strict parse: reject "12.5", "1e2", etc. that parseInt would
+       * silently truncate into a valid-looking integer. */
+      const parsed1 = parseManualScore(manualPoints1);
+      const parsed2 = parseManualScore(manualPoints2);
+      if (parsed1 === null || parsed2 === null) {
         alert(tGp('manualScoreValidation'));
         return;
       }
+      points1 = parsed1;
+      points2 = parsed2;
       body.score1 = points1;
       body.score2 = points2;
     } else {
@@ -546,18 +551,15 @@ export default function GrandPrixFinals({
     (acc, r) => acc + (r.position2 ? getDriverPoints(r.position2) : 0),
     0
   );
-  const manualPointsParsed1 = Number.parseInt(manualPoints1, 10);
-  const manualPointsParsed2 = Number.parseInt(manualPoints2, 10);
+  const manualPointsParsed1 = parseManualScore(manualPoints1);
+  const manualPointsParsed2 = parseManualScore(manualPoints2);
   const manualPointsValid =
-    Number.isInteger(manualPointsParsed1) &&
-    Number.isInteger(manualPointsParsed2) &&
-    manualPointsParsed1 >= 0 &&
-    manualPointsParsed2 >= 0;
+    manualPointsParsed1 !== null && manualPointsParsed2 !== null;
   const livePoints1 = manualScoreEnabled
-    ? (Number.isFinite(manualPointsParsed1) ? manualPointsParsed1 : 0)
+    ? (manualPointsParsed1 ?? 0)
     : racePoints1;
   const livePoints2 = manualScoreEnabled
-    ? (Number.isFinite(manualPointsParsed2) ? manualPointsParsed2 : 0)
+    ? (manualPointsParsed2 ?? 0)
     : racePoints2;
   /* Pre-tiebreak readiness: the inputs are filled in enough that a submit
    * is imminent. Used to decide when to surface the sudden-death picker

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
@@ -77,6 +77,7 @@ import { useQualificationActions } from "@/lib/hooks/useQualificationActions";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
+import { parseManualScore } from "@/lib/parse-manual-score";
 import { canCreateFinalsFromQualification } from "@/lib/finals-action-availability";
 
 import type { Player } from "@/lib/types";
@@ -398,10 +399,12 @@ export default function GrandPrixPage({
     }
 
     if (manualScoreEnabled) {
-      const points1 = Number.parseInt(manualPoints1, 10);
-      const points2 = Number.parseInt(manualPoints2, 10);
+      /* Strict parse: reject "12.5", "1e2", etc. that parseInt would
+       * silently truncate into a valid-looking integer. */
+      const points1 = parseManualScore(manualPoints1);
+      const points2 = parseManualScore(manualPoints2);
 
-      if (!Number.isInteger(points1) || !Number.isInteger(points2) || points1 < 0 || points2 < 0) {
+      if (points1 === null || points2 === null) {
         alert(t('manualScoreValidation'));
         return;
       }

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -77,6 +77,7 @@ import { usePolling } from "@/lib/hooks/usePolling";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
+import { parseManualScore } from "@/lib/parse-manual-score";
 import type { Player } from "@/lib/types";
 
 /** Client-side logger for error tracking */
@@ -425,9 +426,12 @@ export default function MatchRaceFinals({
     const body: Record<string, unknown> = { matchId: selectedMatch.id };
 
     if (manualScoreEnabled) {
-      const score1 = Number.parseInt(manualScore1, 10);
-      const score2 = Number.parseInt(manualScore2, 10);
-      if (!Number.isInteger(score1) || !Number.isInteger(score2) || score1 < 0 || score2 < 0) {
+      /* Strict parse: reject "5.9", "1e2", etc. that parseInt would
+       * silently truncate into a valid-looking integer and slip past the
+       * target-wins check below. */
+      const score1 = parseManualScore(manualScore1);
+      const score2 = parseManualScore(manualScore2);
+      if (score1 === null || score2 === null) {
         alert(tMr('manualScoreValidation'));
         return;
       }
@@ -875,9 +879,9 @@ export default function MatchRaceFinals({
               onClick={handleMatchSubmit}
               disabled={(() => {
                 if (manualScoreEnabled) {
-                  const s1 = Number.parseInt(manualScore1, 10);
-                  const s2 = Number.parseInt(manualScore2, 10);
-                  if (!Number.isInteger(s1) || !Number.isInteger(s2) || s1 < 0 || s2 < 0) return true;
+                  const s1 = parseManualScore(manualScore1);
+                  const s2 = parseManualScore(manualScore2);
+                  if (s1 === null || s2 === null) return true;
                   const target = selectedMatchTargetWins;
                   const validWinner =
                     (s1 === target && s2 < target) || (s2 === target && s1 < target);

--- a/smkc-score-app/src/lib/parse-manual-score.ts
+++ b/smkc-score-app/src/lib/parse-manual-score.ts
@@ -1,0 +1,20 @@
+/**
+ * Strictly parse a manual-score text input into a non-negative integer.
+ *
+ * Rationale: `Number.parseInt` silently truncates fractional and exponential
+ * notation ("12.5" → 12, "1e2" → 1), and those truncated values still pass
+ * `Number.isInteger` / non-negative checks. For admin override flows where a
+ * mis-typed value decides a match outcome, that silent coercion is unsafe.
+ *
+ * This helper only accepts a digit string (optionally surrounded by
+ * whitespace) so any decimal point, sign, exponent, or non-numeric character
+ * is rejected up-front.
+ *
+ * @returns the parsed integer, or `null` for any invalid input.
+ */
+export function parseManualScore(input: string): number | null {
+  const trimmed = input.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const value = Number(trimmed);
+  return Number.isSafeInteger(value) ? value : null;
+}


### PR DESCRIPTION
## Summary
Fixes a critical bug where `Number.parseInt()` silently truncates decimal and exponential notation in manual score overrides, potentially changing match outcomes. For example, `"12.5"` would be parsed as `12` and `"1e2"` as `1`, passing validation checks but committing a different score than the admin intended.

## Changes
- **New utility function** `parseManualScore()` in `src/lib/parse-manual-score.ts`:
  - Strictly validates input as a digit-only string (with optional whitespace)
  - Rejects decimal points, signs, exponents, and non-numeric characters upfront
  - Validates against `Number.isSafeInteger()` to prevent precision loss
  - Returns `number | null` instead of relying on `Number.isInteger()` checks

- **Updated three tournament pages** to use the new parser:
  - `src/app/tournaments/[id]/gp/page.ts` (Grand Prix qualification)
  - `src/app/tournaments/[id]/gp/finals/page.tsx` (Grand Prix finals)
  - `src/app/tournaments/[id]/mr/finals/page.tsx` (Match Race finals)
  
  Replaced all `Number.parseInt()` calls with `parseManualScore()` for manual score validation and live score calculations.

- **Comprehensive test suite** in `__tests__/lib/parse-manual-score.test.ts`:
  - Validates acceptance of clean integers and whitespace tolerance
  - Explicitly tests the regression cases (`"12.5"`, `"1e2"`, etc.)
  - Covers edge cases (empty strings, signed numbers, hex notation, unsafe integers)

## Implementation Details
The parser uses a simple regex (`/^\d+$/`) to enforce strict digit-only format before numeric conversion, eliminating the silent truncation vulnerability while maintaining a clear, auditable validation path for admin-critical operations.

https://claude.ai/code/session_01TLHs1XYZFpf8wNZDVo2igB