### PR TITLE
fix: extend strict score parsing to BM/TA + realign drifted API tests

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/match/[matchId]/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/match/[matchId]/route.test.ts
@@ -309,13 +309,14 @@ describe('BM Match API Route - /api/tournaments/[id]/bm/match/[matchId]', () => 
         undefined,
         undefined
       );
-      /* PUT calls findUnique twice — once for stage pre-check, once for the
-       * player-relation re-fetch. Neither currently includes tournamentId in
-       * the where-clause (only the GET path does), so assert on the pre-check
-       * variant with its original shape. */
+      /* PUT calls findUnique twice — once for the stage/round/tournamentId
+       * pre-check (reused by the round-aware finals validator) and once for
+       * the player-relation re-fetch. Neither currently scopes the where-
+       * clause to tournamentId (only the GET path does), so assert on the
+       * pre-check variant's current shape. */
       expect(prisma.bMMatch.findUnique).toHaveBeenCalledWith({
         where: { id: 'm1' },
-        select: { stage: true, tournamentId: true },
+        select: { stage: true, round: true, tournamentId: true },
       });
     });
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
@@ -40,6 +40,12 @@ jest.mock('@/lib/constants', () => ({
   ],
   TOTAL_GP_RACES: 5,
   getDriverPoints: (pos: number) => [0, 9, 6, 3, 1, 0, 0, 0, 0][pos] ?? 0,
+  /* CUPS / CUP_SUBSTITUTIONS are consumed transitively by gp-config's
+   * isValidCupChoice. Without mocking them, the module default of
+   * `undefined` crashes the cup-mismatch rejection path with a 500
+   * instead of the expected 400. */
+  CUPS: ['Mushroom', 'Flower', 'Star', 'Special'],
+  CUP_SUBSTITUTIONS: { Star: 'Mushroom', Special: 'Flower' },
 }));
 jest.mock('@/lib/logger', () => ({ createLogger: jest.fn(() => ({ error: jest.fn(), warn: jest.fn() })) }));
 jest.mock('@/lib/optimistic-locking', () => ({

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1601,7 +1601,7 @@ describe('Finals Route Factory', () => {
       (prisma.bMMatch as any).findUnique.mockResolvedValue(playoffMatch);
       (prisma.bMMatch as any).update.mockResolvedValue({
         ...playoffMatch,
-        score1: 5,
+        score1: 3,
         score2: 0,
         completed: true,
       });
@@ -1611,9 +1611,13 @@ describe('Finals Route Factory', () => {
       const config = createMockConfig();
       const { PUT } = createFinalsHandlers(config);
 
+      /* playoff_r1 uses the factory default target-wins of 3 (matches
+       * getBmFinalsTargetWins for playoff non-R2). 3-0 passes the
+       * "exactly-reached target" guard so the bracket-advancement path is
+       * reachable, which is what this issue #454 regression is asserting. */
       const request = new NextRequest('http://localhost:3000', {
         method: 'PUT',
-        body: JSON.stringify({ matchId: 'playoff-1', score1: 5, score2: 0 }),
+        body: JSON.stringify({ matchId: 'playoff-1', score1: 3, score2: 0 }),
       });
       const response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -69,6 +69,7 @@ import { UpdateIndicator } from "@/components/ui/update-indicator";
 import { LoadingOverlay } from "@/components/ui/loading-overlay";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
+import { parseManualScore } from "@/lib/parse-manual-score";
 
 /**
  * Client-side logger for the finals page.
@@ -729,9 +730,11 @@ export default function BattleModeFinals({
                    max={selectedMatchTargetWins}
                    value={scoreForm.score1}
                    onChange={(e) =>
+                     /* Strict parse: reject "2.5"/"1e2" that parseInt would
+                      * silently coerce into a valid-looking target-wins value. */
                      setScoreForm({
                        ...scoreForm,
-                       score1: parseInt(e.target.value) || 0,
+                       score1: parseManualScore(e.target.value) ?? 0,
                      })
                    }
                    className="w-20 text-center text-2xl"
@@ -753,7 +756,7 @@ export default function BattleModeFinals({
                    onChange={(e) =>
                      setScoreForm({
                        ...scoreForm,
-                       score2: parseInt(e.target.value) || 0,
+                       score2: parseManualScore(e.target.value) ?? 0,
                      })
                    }
                    className="w-20 text-center text-2xl"

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
@@ -73,6 +73,7 @@ import { useQualificationActions } from "@/lib/hooks/useQualificationActions";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
+import { parseManualScore } from "@/lib/parse-manual-score";
 import { canCreateFinalsFromQualification } from "@/lib/finals-action-availability";
 import type { Player } from "@/lib/types";
 
@@ -923,9 +924,12 @@ export default function BattleModePage({
                   max={4}
                   value={scoreForm.score1}
                   onChange={(e) =>
+                    /* Strict parse: reject "2.5"/"1e2" that parseInt would
+                     * silently coerce into a valid-looking integer and pass
+                     * the "sum === 4" check at submit. */
                     setScoreForm({
                       ...scoreForm,
-                      score1: parseInt(e.target.value) || 0,
+                      score1: parseManualScore(e.target.value) ?? 0,
                     })
                   }
                   className="w-20 text-center text-2xl"
@@ -945,7 +949,7 @@ export default function BattleModePage({
                   onChange={(e) =>
                     setScoreForm({
                       ...scoreForm,
-                      score2: parseInt(e.target.value) || 0,
+                      score2: parseManualScore(e.target.value) ?? 0,
                     })
                   }
                   className="w-20 text-center text-2xl"

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
@@ -79,6 +79,7 @@ import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { Dice5, ChevronDown, ChevronRight, Eye, Lock, Unlock } from "lucide-react";
 import { toast } from "sonner";
 import { createLogger } from "@/lib/client-logger";
+import { parseManualScore } from "@/lib/parse-manual-score";
 
 const logger = createLogger({ serviceName: 'tournaments-ta' });
 
@@ -955,12 +956,11 @@ export default function TimeAttackPage({
                                     placeholder="#"
                                     value={s.seeding ?? ""}
                                     onChange={(e) => {
-                                      const val = e.target.value;
-                                      const parsed = parseInt(val, 10);
+                                      /* Strict parse: reject "1.5"/"1e2" that parseInt
+                                       * would silently truncate before `>= 1` passes. */
+                                      const parsed = parseManualScore(e.target.value);
                                       const seeding =
-                                        val && !Number.isNaN(parsed) && parsed >= 1
-                                          ? parsed
-                                          : undefined;
+                                        parsed !== null && parsed >= 1 ? parsed : undefined;
                                       /* Recompute snake pairs immediately so the partner
                                        * column reflects §3.1 as soon as seedings change. */
                                       setSetupEntries((prev) =>


### PR DESCRIPTION
## Summary

PR #590 のフォローアップ + CI グリーン化。

### 1. `parseManualScore` を残りの入力箇所に適用 (`04cba6e`)

#590 で GP/MR finals と GP 予選の手動スコア入力を `parseManualScore` 経由にしたが、同じ silent-truncation パターンが以下にも残っていた:

- `bm/page.tsx` — BM 予選スコア (`score1`, `score2`)
- `bm/finals/page.tsx` — BM 決勝スコア (`score1`, `score2`)
- `ta/page.tsx` — TA セットアップの seeding

`parseInt(...) || 0` は `"2.5" → 2`, `"1e2" → 1` を silent に受け入れるため、BM の「合計=4」や target-wins チェック、TA の `>= 1` seeding チェックを汚染されたデータで通過しうる。すべて `parseManualScore` に差し替えて型式拒否。

### 2. 既存テスト 3 件の再整合 (`f0a95c9`)

main 上で production コードの変更に追従していなかった assertion 3 件を修正（本番コード変更なし）:

- **BM match PUT テスト** — `findUnique` select 期待値に `round: true` を追加（ラウンド別 finals validator 導入時に既に select へ追加されていた）
- **GP score-report テスト** — `@/lib/constants` のモックに `CUPS` / `CUP_SUBSTITUTIONS` を追加（未モックで `isValidCupChoice` 内 `undefined[...]` が throw → 500 に。期待は 400）
- **finals-route playoff R1 (#454 regression)** — モック config のデフォルト `targetWins=3` に合わせて `5-0 → 3-0` に変更（本テストが検証したいのは bracket advancement であってスコア値ではない）

## Test plan

- [x] `npm test` — 96 suites / 1905 tests pass
- [x] `npm run build` — エラーなし
- [x] `npm run lint` — 変更ファイルで新規エラー 0（既存の警告のみ）
- [ ] E2E (`node e2e/tc-all.js`) — production deploy 後に検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLHs1XYZFpf8wNZDVo2igB)_