### PR TITLE
fix: i18n hardcoded strings, add CI workflow, reset-password test, E2E doc update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "smkc-score-app/**"
+  pull_request:
+    paths:
+      - "smkc-score-app/**"
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-test:
+    name: Lint & Test
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: smkc-score-app
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: smkc-score-app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test -- --ci --forceExit
+        env:
+          SKIP_OPENNEXT_CLOUDFLARE_DEV: "1"
+          NODE_ENV: test
+          NODE_OPTIONS: "--max-old-space-size=4096"

--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -411,6 +411,40 @@
   6. クリーンアップ
 - **期待結果**: rankOverride 設定後の同城解决に応じてバーが消える
 
+## TC-325: プロフィールページのセッション・プレイヤー情報表示
+- **URL**: /profile
+- **authRequired**: true (player or admin)
+- **背景**: プレイヤーセッションでログインした際、プロフィールページにセッション情報とプレイヤー関連情報が正しく表示されること
+- **手順**:
+  1. プレイヤーまたは管理者としてログインする
+  2. `/profile` にアクセスする
+  3. ユーザー情報（name, role）が表示されることを確認
+  4. プレイヤーセッションの場合、nickname と country が表示されることを確認
+- **期待結果**: セッション種別に応じた情報が正しく表示される
+
+## TC-326: トーナメントエクスポート API が有効な CSV を返す
+- **URL**: /api/tournaments/[id]/export
+- **authRequired**: true (admin)
+- **背景**: 全モードのスコアを UTF-8 BOM 付き CSV でエクスポートできる
+- **手順**:
+  1. 管理者で `GET /api/tournaments/[id]/export` を呼び出す
+  2. レスポンスステータスが 200 であることを確認
+  3. `Content-Type: text/csv` ヘッダーが設定されていることを確認
+  4. UTF-8 BOM (0xEF 0xBB 0xBF) がレスポンス先頭に付いていることを確認
+  5. CSVの内容（プレイヤー名、スコア等）が空でないことを確認
+- **期待結果**: UTF-8 BOM 付き CSV が返され Excelで正常に表示される
+
+## TC-327: セッション状態 API がセッション情報を返す
+- **URL**: /api/auth/session-status
+- **authRequired**: false
+- **背景**: 現在のセッション状態（認証の有無、ユーザー種別）を返す軽量なエンドポイント
+- **手順**:
+  1. 未認証状態で `GET /api/auth/session-status` を呼び出す
+  2. レスポンスステータスが 200 であり、`authenticated: false` が含まれることを確認
+  3. 管理者としてログイン後、同エンドポイントを呼び出す
+  4. `authenticated: true` が含まれることを確認
+- **期待結果**: セッション状態が正しくレスポンスに反映される
+
 ## TC-320: BM/MR/GP マッチリスト行レベルのスコア入力リンク非表示化 ✅ FIXED (PR #407)
 - **URL**: /tournaments/[temp-id]/bm, /mr, /gp → Matches タブ
 - **authRequired**: true (admin)
@@ -444,6 +478,17 @@
   3. プレイヤーセッションでマッチページを開く → "Score entry is on the participant page" ガイダンスと「Go to Score Entry」ボタンが表示されることを確認
   4. クリーンアップ
 - **期待結果**: 未認証/管理者/プレイヤーそれぞれに適切なガイダンスが表示される
+
+## TC-512: BM TV番号割り当て検証 (tvNumber 1〜4 のみ許可)
+- **URL**: /api/tournaments/[id]/bm (PATCH)
+- **authRequired**: true (admin)
+- **背景**: issue #529 — tvNumber は 1〜4 のみ有効。5 以上は 422 で拒否される
+- **手順**:
+  1. テスト用トーナメントで BM を設定し、non-BYE マッチを取得
+  2. `PATCH /api/tournaments/[id]/bm` で `tvNumber: 4` を送信 → 200 が返ること
+  3. 同マッチに `tvNumber: 5` を送信 → 422 が返ること
+  4. `tvNumber: null` を送信 → 200 が返り TV 割り当てがクリアされること
+- **期待結果**: tvNumber 1〜4 は受け入れられ、5 以上は拒否される
 
 ## BM フルワークフロー設計方針
 - **予選プレイヤー数**: 28名（4グループ × 7名、7はオッドのため各グループに BYE が混在）
@@ -997,6 +1042,29 @@
   4. `GET` で M1 を再取得し、`points1=15`、`points2=12`、`cup` と `races` は手順 2 で保存した値のまま残っていることを確認
   5. クリーンアップ
 - **期待結果**: 手動合計スコア PUT で score1/score2 は上書きされ、cup と races はクリアされない
+
+## TC-710: GP カップ不一致修正の拒否
+- **URL**: /api/tournaments/[temp-id]/gp (PATCH with correction)
+- **authRequired**: true (player)
+- **背景**: プレイヤーが修正スコアを送信する際、元のカップと異なるカップを指定した場合は拒否されなければならない
+- **手順**:
+  1. 2名プレイヤーで GP を設定し、マッチにスコアを入力（cup=Mushroom）
+  2. プレイヤーとしてログインし、同マッチに cup=Flower で修正スコアを送信
+  3. 422 エラーが返ること（カップ不一致）
+  4. クリーンアップ
+- **期待結果**: 修正スコア送信時にカップが一致しない場合は 422 で拒否される
+
+## TC-712: GP 決勝 Grand Final サドンデス タイブレーク
+- **URL**: /tournaments/[temp-id]/gp/finals (PUT M16)
+- **authRequired**: true (admin)
+- **背景**: Grand Final で GP ポイントが同点の場合、サドンデス勝者を指定する必要がある
+- **手順**:
+  1. 28名予選 + 決勝ブラケット生成
+  2. M1〜M15 を API で入力して Grand Final (M16) まで進める
+  3. M16 に同点スコア（score1=score2）で PUT → サドンデス勝者が設定されていなければ 400 が返ること
+  4. `suddenDeathWinner` を含めて再 PUT → 200 が返り、チャンピオンが確定すること
+  5. クリーンアップ
+- **期待結果**: GP Grand Final 同点時のサドンデス勝者指定が正しく機能する
 
 ## TC-820: MR match/[matchId] ページがview-onlyであることを確認
 - **URL**: /tournaments/[temp-id]/mr/match/[matchId]

--- a/smkc-score-app/__tests__/app/api/players/[id]/reset-password/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/players/[id]/reset-password/route.test.ts
@@ -1,0 +1,245 @@
+/**
+ * @module Test Suite: POST /api/players/[id]/reset-password
+ *
+ * Tests for the player password reset API route.
+ * Verifies:
+ * - Admin can reset a player's password and receives the plaintext password once
+ * - Non-admin and unauthenticated requests are rejected with 403
+ * - 404 is returned when the player does not exist
+ * - Prisma P2025 (record not found) is mapped to 404
+ * - Audit log is written on success
+ * - Server errors produce 500
+ *
+ * Dependencies mocked:
+ * - @/lib/auth: session/auth
+ * - @/lib/prisma: database client
+ * - @/lib/password-utils: generateSecurePassword, hashPassword
+ * - @/lib/audit-log: createAuditLog, AUDIT_ACTIONS
+ * - @/lib/rate-limit: getServerSideIdentifier
+ * - @/lib/logger: createLogger
+ *
+ * IMPORTANT: jest.mock() calls use the global jest (not @jest/globals) because
+ * babel-jest hoisting does not work correctly when jest is imported from @jest/globals.
+ */
+// @ts-nocheck
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock('@/lib/password-utils', () => ({
+  generateSecurePassword: jest.fn(() => 'generated-plain-pw'),
+  hashPassword: jest.fn(() => Promise.resolve('hashed-pw')),
+}));
+
+jest.mock('@/lib/audit-log', () => ({
+  createAuditLog: jest.fn(),
+  AUDIT_ACTIONS: {
+    RESET_PLAYER_PASSWORD: 'RESET_PLAYER_PASSWORD',
+  },
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  getServerSideIdentifier: jest.fn(() => Promise.resolve('127.0.0.1')),
+}));
+
+const mockLoggerInstance = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+};
+
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => mockLoggerInstance),
+}));
+
+jest.mock('next/server', () => {
+  const mockJson = jest.fn();
+  class MockNextRequest {
+    constructor(url, init = {}) {
+      this.url = url;
+      this.method = init.method || 'POST';
+      this._body = init.body;
+      const h = init.headers || {};
+      this.headers = {
+        get: (key) => {
+          if (h instanceof Headers) return h.get(key);
+          if (h instanceof Map) return h.get(key);
+          return h[key] || null;
+        },
+      };
+    }
+    async json() {
+      if (typeof this._body === 'string') return JSON.parse(this._body);
+      return this._body;
+    }
+  }
+  return {
+    NextRequest: MockNextRequest,
+    NextResponse: { json: mockJson },
+    __esModule: true,
+  };
+});
+
+import { NextRequest } from 'next/server';
+import prisma from '@/lib/prisma';
+import { auth } from '@/lib/auth';
+import { generateSecurePassword, hashPassword } from '@/lib/password-utils';
+import { createAuditLog } from '@/lib/audit-log';
+
+const loggerMock = jest.requireMock('@/lib/logger');
+
+describe('POST /api/players/[id]/reset-password', () => {
+  const { NextResponse } = jest.requireMock('next/server');
+
+  const adminSession = { user: { id: 'admin-1', role: 'admin' } };
+  const playerParams = { params: Promise.resolve({ id: 'player-1' }) };
+  const mockPlayer = { id: 'player-1', nickname: 'TestPlayer' };
+
+  function makeRequest() {
+    return new NextRequest('http://localhost:3000/api/players/player-1/reset-password', {
+      method: 'POST',
+    });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    loggerMock.createLogger.mockReturnValue(mockLoggerInstance);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('Success Cases', () => {
+    it('should generate a new password and return it once to the admin', async () => {
+      auth.mockResolvedValue(adminSession);
+      prisma.player.findUnique.mockResolvedValue(mockPlayer);
+      prisma.player.update.mockResolvedValue({ ...mockPlayer, password: 'hashed-pw' });
+
+      const route = (await import('@/app/api/players/[id]/reset-password/route')).POST;
+      await route(makeRequest(), playerParams);
+
+      expect(generateSecurePassword).toHaveBeenCalledWith(12);
+      expect(hashPassword).toHaveBeenCalledWith('generated-plain-pw');
+      expect(prisma.player.update).toHaveBeenCalledWith({
+        where: { id: 'player-1' },
+        data: { password: 'hashed-pw' },
+      });
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: { temporaryPassword: 'generated-plain-pw' },
+        }),
+      );
+    });
+
+    it('should write an audit log entry on success', async () => {
+      auth.mockResolvedValue(adminSession);
+      prisma.player.findUnique.mockResolvedValue(mockPlayer);
+      prisma.player.update.mockResolvedValue(mockPlayer);
+
+      const route = (await import('@/app/api/players/[id]/reset-password/route')).POST;
+      await route(makeRequest(), playerParams);
+
+      expect(createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'RESET_PLAYER_PASSWORD',
+          targetId: 'player-1',
+          targetType: 'Player',
+          details: expect.objectContaining({ playerNickname: 'TestPlayer', passwordRegenerated: true }),
+        }),
+      );
+    });
+
+    it('should continue and return success even if audit log throws', async () => {
+      auth.mockResolvedValue(adminSession);
+      prisma.player.findUnique.mockResolvedValue(mockPlayer);
+      prisma.player.update.mockResolvedValue(mockPlayer);
+      createAuditLog.mockRejectedValue(new Error('DB down'));
+
+      const route = (await import('@/app/api/players/[id]/reset-password/route')).POST;
+      await route(makeRequest(), playerParams);
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true }),
+      );
+      expect(mockLoggerInstance.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('Authorization', () => {
+    it('should return 403 when unauthenticated', async () => {
+      auth.mockResolvedValue(null);
+
+      const route = (await import('@/app/api/players/[id]/reset-password/route')).POST;
+      await route(makeRequest(), playerParams);
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ status: 403 }),
+      );
+      expect(prisma.player.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('should return 403 for a non-admin player session', async () => {
+      auth.mockResolvedValue({ user: { id: 'player-1', role: 'player' } });
+
+      const route = (await import('@/app/api/players/[id]/reset-password/route')).POST;
+      await route(makeRequest(), playerParams);
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ status: 403 }),
+      );
+    });
+  });
+
+  describe('Not Found', () => {
+    it('should return 404 when player does not exist', async () => {
+      auth.mockResolvedValue(adminSession);
+      prisma.player.findUnique.mockResolvedValue(null);
+
+      const route = (await import('@/app/api/players/[id]/reset-password/route')).POST;
+      await route(makeRequest(), playerParams);
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'Player not found' }),
+        expect.objectContaining({ status: 404 }),
+      );
+    });
+
+    it('should return 404 when Prisma throws P2025 (record not found)', async () => {
+      auth.mockResolvedValue(adminSession);
+      prisma.player.findUnique.mockResolvedValue(mockPlayer);
+      const prismaNotFound = Object.assign(new Error('Not found'), { code: 'P2025' });
+      prisma.player.update.mockRejectedValue(prismaNotFound);
+
+      const route = (await import('@/app/api/players/[id]/reset-password/route')).POST;
+      await route(makeRequest(), playerParams);
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'Player not found' }),
+        expect.objectContaining({ status: 404 }),
+      );
+    });
+  });
+
+  describe('Server Error', () => {
+    it('should return 500 on unexpected database error', async () => {
+      auth.mockResolvedValue(adminSession);
+      prisma.player.findUnique.mockResolvedValue(mockPlayer);
+      prisma.player.update.mockRejectedValue(new Error('DB connection lost'));
+
+      const route = (await import('@/app/api/players/[id]/reset-password/route')).POST;
+      await route(makeRequest(), playerParams);
+
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'Failed to reset password' }),
+        expect.objectContaining({ status: 500 }),
+      );
+      expect(mockLoggerInstance.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -318,9 +318,57 @@ async function runTc511(adminPage) {
 }
 
 /* ───────── TC-512: TV assignment up to 4 ─────────
- * Validates #529: tvNumber=4 is accepted, tvNumber=5 is rejected. */
+ * Validates #529: tvNumber=4 is accepted, tvNumber=5 is rejected at API level.
+ * Uses the shared BM fixture tournament to avoid creating extra test data. */
 async function runTc512(adminPage) {
-  // existing code...
+  if (!sharedFixture) throw new Error('Shared BM fixture is not initialized');
+  const { normalTournament, players } = sharedFixture;
+  const tournamentId = normalTournament.id;
+
+  try {
+    await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: false });
+    await setupModePlayersViaUi(adminPage, 'bm', tournamentId, players.slice(0, 2));
+
+    const bmData = await apiFetchBm(adminPage, tournamentId);
+    const match = (bmData.matches || []).find((m) => !m.isBye);
+    if (!match) throw new Error('No non-BYE match found for TC-512');
+
+    /* PATCH with tvNumber=4 — must return 200 */
+    const ok4 = await adminPage.evaluate(async ([tid, mid]) => {
+      const r = await fetch(`/api/tournaments/${tid}/bm`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ matchId: mid, tvNumber: 4 }),
+      });
+      return r.status;
+    }, [tournamentId, match.id]);
+
+    /* PATCH with tvNumber=5 — must return 422 */
+    const bad5 = await adminPage.evaluate(async ([tid, mid]) => {
+      const r = await fetch(`/api/tournaments/${tid}/bm`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ matchId: mid, tvNumber: 5 }),
+      });
+      return r.status;
+    }, [tournamentId, match.id]);
+
+    /* PATCH with tvNumber=null — must return 200 (clear TV) */
+    const okNull = await adminPage.evaluate(async ([tid, mid]) => {
+      const r = await fetch(`/api/tournaments/${tid}/bm`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ matchId: mid, tvNumber: null }),
+      });
+      return r.status;
+    }, [tournamentId, match.id]);
+
+    const pass = ok4 === 200 && bad5 === 422 && okNull === 200;
+    log('TC-512', pass ? 'PASS' : 'FAIL',
+      !pass ? `tvNumber=4 → ${ok4}, tvNumber=5 → ${bad5}, tvNumber=null → ${okNull}` : '');
+  } catch (err) {
+    log('TC-512', 'FAIL', err instanceof Error ? err.message : 'TC-512 TV assignment test failed');
+  }
 }
 
 /* ───────── TC-513: BM match page session-based guidance ─────────

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -483,7 +483,14 @@
     "mrFtByRound": "FT by round:",
     "mrFtByRoundDesc": "Playoff FT3/4, early bracket FT5, semis FT7, finals FT9.",
     "firstTo3": "First to 3:",
-    "firstTo3Desc": "First player to win 3 races wins the match"
+    "firstTo3Desc": "First player to win 3 races wins the match",
+    "top8": "Top 8",
+    "top16": "Top 16",
+    "top24": "Top 24",
+    "playoffPhase": "Playoff Phase",
+    "playoffComplete": "Playoff Complete!",
+    "createUpperBracket": "Create Upper Bracket",
+    "allPlayoffMatchesComplete": "All playoff matches complete! Create the upper bracket to continue."
   },
   "match": {
     "enterScore": "Enter Score",
@@ -693,7 +700,12 @@
     "undoing": "Undoing...",
     "courseOverrideLabel": "Course Selection (optional)",
     "randomCourse": "Random (default)",
-    "manualCourseOverride": "Manual"
+    "manualCourseOverride": "Manual",
+    "eliminated": "Eliminated",
+    "invalidTimeFor": "Invalid time for {name}. Enter M:SS.mm format.",
+    "needAtLeast2Players": "Need at least 2 players to submit results",
+    "timePlaceholder": "M:SS.mm",
+    "retryPenalty": "Mark as retry (penalty: 9:59.990)"
   },
   "revival": {
     "round1Title": "Loser's Revival Round 1",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -482,7 +482,14 @@
     "mrFtByRound": "ラウンド別FT：",
     "mrFtByRoundDesc": "プレーオフは FT3/4、序盤ブラケットは FT5、準決勝帯は FT7、決勝帯は FT9 です。",
     "firstTo3": "3勝先取：",
-    "firstTo3Desc": "先に3勝したプレイヤーが勝利"
+    "firstTo3Desc": "先に3勝したプレイヤーが勝利",
+    "top8": "Top 8",
+    "top16": "Top 16",
+    "top24": "Top 24",
+    "playoffPhase": "プレーオフフェーズ",
+    "playoffComplete": "プレーオフ完了！",
+    "createUpperBracket": "上位ブラケット作成",
+    "allPlayoffMatchesComplete": "全プレーオフ試合が完了しました！上位ブラケットを作成してください。"
   },
   "match": {
     "enterScore": "スコア入力",
@@ -692,7 +699,12 @@
     "undoing": "取り消し中...",
     "courseOverrideLabel": "コース選択（任意）",
     "randomCourse": "ランダム（デフォルト）",
-    "manualCourseOverride": "手動選択"
+    "manualCourseOverride": "手動選択",
+    "eliminated": "敗退",
+    "invalidTimeFor": "{name}のタイムが無効です。M:SS.mm形式で入力してください。",
+    "needAtLeast2Players": "結果を提出するには少なくとも2名必要です",
+    "timePlaceholder": "M:SS.mm",
+    "retryPenalty": "リトライとしてマーク（ペナルティ: 9:59.990）"
   },
   "revival": {
     "round1Title": "敗者復活戦 ラウンド1",

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -495,21 +495,21 @@ export default function BattleModeFinals({
                     variant={bracketSize === 8 ? "default" : "outline"}
                     onClick={() => setBracketSize(8)}
                   >
-                    Top 8
+                    {tFinals('top8')}
                   </Button>
                   <Button
                     size="sm"
                     variant={bracketSize === 16 ? "default" : "outline"}
                     onClick={() => setBracketSize(16)}
                   >
-                    Top 16
+                    {tFinals('top16')}
                   </Button>
                   <Button
                     size="sm"
                     variant={bracketSize === 24 ? "default" : "outline"}
                     onClick={() => setBracketSize(24)}
                   >
-                    Top 24
+                    {tFinals('top24')}
                   </Button>
                 </div>
                 <AlertDialogFooter>
@@ -581,13 +581,13 @@ export default function BattleModeFinals({
       {phase === 'playoff' && (
         <div className="flex items-center gap-4">
           <Badge variant="outline" className="text-sm border-blue-500/50 text-blue-500">
-            Playoff Phase
+            {tFinals('playoffPhase')}
           </Badge>
           <Badge variant="outline" className="text-sm">
             {playoffMatches.filter((m) => m.completed).length} / {playoffMatches.length} matches
           </Badge>
           {playoffComplete && (
-            <Badge className="bg-green-500">Playoff Complete!</Badge>
+            <Badge className="bg-green-500">{tFinals('playoffComplete')}</Badge>
           )}
         </div>
       )}
@@ -665,10 +665,10 @@ export default function BattleModeFinals({
             <Card className="border-green-500/50 bg-green-500/10">
               <CardContent className="py-4 text-center">
                 <p className="text-sm text-muted-foreground mb-3">
-                  All playoff matches complete! Create the upper bracket to continue.
+                  {tFinals('allPlayoffMatchesComplete')}
                 </p>
                 <Button onClick={handleCreateUpperBracket}>
-                  Create Upper Bracket
+                  {tFinals('createUpperBracket')}
                 </Button>
               </CardContent>
             </Card>

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -619,9 +619,9 @@ export default function GrandPrixFinals({
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <div className="flex gap-2 justify-center py-2">
-                  <Button size="sm" variant={bracketSize === 8 ? "default" : "outline"} onClick={() => setBracketSize(8)}>Top 8</Button>
-                  <Button size="sm" variant={bracketSize === 16 ? "default" : "outline"} onClick={() => setBracketSize(16)}>Top 16</Button>
-                  <Button size="sm" variant={bracketSize === 24 ? "default" : "outline"} onClick={() => setBracketSize(24)}>Top 24</Button>
+                  <Button size="sm" variant={bracketSize === 8 ? "default" : "outline"} onClick={() => setBracketSize(8)}>{tFinals('top8')}</Button>
+                  <Button size="sm" variant={bracketSize === 16 ? "default" : "outline"} onClick={() => setBracketSize(16)}>{tFinals('top16')}</Button>
+                  <Button size="sm" variant={bracketSize === 24 ? "default" : "outline"} onClick={() => setBracketSize(24)}>{tFinals('top24')}</Button>
                 </div>
                 <AlertDialogFooter>
                   <AlertDialogCancel>{tCommon('cancel')}</AlertDialogCancel>
@@ -682,13 +682,13 @@ export default function GrandPrixFinals({
       {phase === 'playoff' && (
         <div className="flex items-center gap-4">
           <Badge variant="outline" className="text-sm border-blue-500/50 text-blue-500">
-            Playoff Phase
+            {tFinals('playoffPhase')}
           </Badge>
           <Badge variant="outline" className="text-sm">
             {playoffMatches.filter((m) => m.completed).length} / {playoffMatches.length} matches
           </Badge>
           {playoffComplete && (
-            <Badge className="bg-green-500">Playoff Complete!</Badge>
+            <Badge className="bg-green-500">{tFinals('playoffComplete')}</Badge>
           )}
         </div>
       )}
@@ -747,8 +747,8 @@ export default function GrandPrixFinals({
           {playoffComplete && isAdmin && (
             <Card className="border-green-500/50 bg-green-500/10">
               <CardContent className="py-4 text-center">
-                <p className="text-sm text-muted-foreground mb-3">All playoff matches complete! Create the upper bracket to continue.</p>
-                <Button onClick={handleCreateUpperBracket}>Create Upper Bracket</Button>
+                <p className="text-sm text-muted-foreground mb-3">{tFinals('allPlayoffMatchesComplete')}</p>
+                <Button onClick={handleCreateUpperBracket}>{tFinals('createUpperBracket')}</Button>
               </CardContent>
             </Card>
           )}

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -574,9 +574,9 @@ export default function MatchRaceFinals({
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <div className="flex gap-2 justify-center py-2">
-                  <Button size="sm" variant={bracketSize === 8 ? "default" : "outline"} onClick={() => setBracketSize(8)}>Top 8</Button>
-                  <Button size="sm" variant={bracketSize === 16 ? "default" : "outline"} onClick={() => setBracketSize(16)}>Top 16</Button>
-                  <Button size="sm" variant={bracketSize === 24 ? "default" : "outline"} onClick={() => setBracketSize(24)}>Top 24</Button>
+                  <Button size="sm" variant={bracketSize === 8 ? "default" : "outline"} onClick={() => setBracketSize(8)}>{tFinals('top8')}</Button>
+                  <Button size="sm" variant={bracketSize === 16 ? "default" : "outline"} onClick={() => setBracketSize(16)}>{tFinals('top16')}</Button>
+                  <Button size="sm" variant={bracketSize === 24 ? "default" : "outline"} onClick={() => setBracketSize(24)}>{tFinals('top24')}</Button>
                 </div>
                 <AlertDialogFooter>
                   <AlertDialogCancel>{tCommon('cancel')}</AlertDialogCancel>
@@ -638,13 +638,13 @@ export default function MatchRaceFinals({
       {phase === 'playoff' && (
         <div className="flex items-center gap-4">
           <Badge variant="outline" className="text-sm border-blue-500/50 text-blue-500">
-            Playoff Phase
+            {tFinals('playoffPhase')}
           </Badge>
           <Badge variant="outline" className="text-sm">
             {playoffMatches.filter((m) => m.completed).length} / {playoffMatches.length} matches
           </Badge>
           {playoffComplete && (
-            <Badge className="bg-green-500">Playoff Complete!</Badge>
+            <Badge className="bg-green-500">{tFinals('playoffComplete')}</Badge>
           )}
         </div>
       )}
@@ -705,8 +705,8 @@ export default function MatchRaceFinals({
           {playoffComplete && isAdmin && (
             <Card className="border-green-500/50 bg-green-500/10">
               <CardContent className="py-4 text-center">
-                <p className="text-sm text-muted-foreground mb-3">All playoff matches complete! Create the upper bracket to continue.</p>
-                <Button onClick={handleCreateUpperBracket}>Create Upper Bracket</Button>
+                <p className="text-sm text-muted-foreground mb-3">{tFinals('allPlayoffMatchesComplete')}</p>
+                <Button onClick={handleCreateUpperBracket}>{tFinals('createUpperBracket')}</Button>
               </CardContent>
             </Card>
           )}

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -113,10 +113,11 @@ interface PhaseRound {
 /**
  * Render visual lives indicator with heart icons.
  * Hearts turn red when only 1 life remains (danger state).
+ * eliminatedLabel is a translated string passed from the component to avoid i18n hooks at module scope.
  */
-function renderLives(lives: number, eliminated: boolean) {
+function renderLives(lives: number, eliminated: boolean, eliminatedLabel: string) {
   if (eliminated) {
-    return <span className="text-gray-400">Eliminated</span>;
+    return <span className="text-gray-400">{eliminatedLabel}</span>;
   }
   const hearts = [];
   for (let i = 0; i < lives; i++) {
@@ -489,7 +490,7 @@ export default function TimeAttackFinals({
           const timeMs = timeToMs(timeStr);
           if (timeMs === null) {
             setSaveError(
-              `Invalid time for ${entry.player.nickname}. Enter M:SS.mm format.`
+              tTaFinals('invalidTimeFor', { name: entry.player.nickname })
             );
             setSubmitting(false);
             return;
@@ -499,7 +500,7 @@ export default function TimeAttackFinals({
       }
 
       if (results.length < 2) {
-        setSaveError("Need at least 2 players to submit results");
+        setSaveError(tTaFinals('needAtLeast2Players'));
         setSubmitting(false);
         return;
       }
@@ -736,12 +737,12 @@ export default function TimeAttackFinals({
                         {entry.player.nickname}
                       </Label>
                       <div className="text-xs text-muted-foreground">
-                        {renderLives(entry.lives, entry.eliminated)}
+                        {renderLives(entry.lives, entry.eliminated, tTaFinals('eliminated'))}
                       </div>
                     </div>
                     <Input
                       type="text"
-                      placeholder="M:SS.mm"
+                      placeholder={tTaFinals('timePlaceholder')}
                       value={courseTimes[entry.playerId] || ""}
                       onChange={(e) =>
                         handleTimeChange(entry.playerId, e.target.value)
@@ -757,7 +758,7 @@ export default function TimeAttackFinals({
                       }
                       size="sm"
                       onClick={() => handleRetryToggle(entry.playerId)}
-                      title="Mark as retry (penalty: 9:59.990)"
+                      title={tTaFinals('retryPenalty')}
                     >
                       {tCommon('retry')}
                     </Button>
@@ -976,7 +977,7 @@ export default function TimeAttackFinals({
                     )}
                   </TableCell>
                   <TableCell className="text-center">
-                    {renderLives(entry.lives, entry.eliminated)}
+                    {renderLives(entry.lives, entry.eliminated, tTaFinals('eliminated'))}
                   </TableCell>
                   {/* Admin-only: manual elimination button */}
                   {isAdmin && (


### PR DESCRIPTION
## Summary

- **Issue #591** CI workflow 追加 — `smkc-score-app/**` の変更時に lint + unit test を自動実行
- **Issue #586** BM/MR/GP/TA finals の hardcoded 英語文字列を i18n キーに置換（7キー追加）
- **Issue #587** E2E_TEST_CASES.md に未文書化の TC-325/326/327/512/710/712 を追加
- **未カバーAPI** `POST /api/players/[id]/reset-password` の単体テスト追加（8ケース）
- **TC-512 実装** tc-bm.js の stub を API レベル TV 番号検証テストに置き換え

## 変更詳細

### CI (.github/workflows/ci.yml)
- `smkc-score-app/**` 変更時のみトリガー（不要なCI実行を抑制）
- `npm run lint` + `npm test -- --ci --forceExit` を順次実行

### i18n 修正 (Issue #586)
`finals` namespace に追加:
- `top8`, `top16`, `top24` — ブラケットサイズ選択ボタン（BM/MR/GP finals 共通）
- `playoffPhase`, `playoffComplete` — プレーオフ状態バッジ
- `createUpperBracket`, `allPlayoffMatchesComplete` — 上位ブラケット作成CTA

`taFinals` namespace に追加:
- `eliminated` — `renderLives()` 関数の敗退ラベル
- `invalidTimeFor`, `needAtLeast2Players` — バリデーションエラーメッセージ
- `timePlaceholder`, `retryPenalty` — 入力フォームのプレースホルダーとtooltip

### unit test 追加
`__tests__/app/api/players/[id]/reset-password/route.test.ts`:
- admin 成功（新パスワード生成・返却）
- audit log 記録
- audit log 失敗時の継続動作
- 403（未認証 / player セッション）
- 404（プレイヤー不存在 / Prisma P2025）
- 500（DB エラー）

### TC-512 実装 (e2e/tc-bm.js)
スタブ `// existing code...` を実装:
- `tvNumber: 4` → 200
- `tvNumber: 5` → 422
- `tvNumber: null` → 200（クリア）

## Test plan

- [x] 全 unit test パス (97/97 suites, 1914 tests)
- [x] i18n JSON 構文検証 OK
- [x] TypeScript 型安全: `renderLives` に `eliminatedLabel: string` 追加、呼び出し側を更新

https://claude.ai/code/session_014dM3HkMKgWbC7X4vUVyiwV

---
_Generated by [Claude Code](https://claude.ai/code/session_014dM3HkMKgWbC7X4vUVyiwV)_