### PR TITLE
test: add unit tests for uncovered lib modules + E2E doc for undocumented TCs

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -358,6 +358,19 @@
   7. クリーンアップ
 - **期待結果**: update_seeding PUT → GET で永続化が確認できる
 
+## TC-318: TA ペア割り当て — set_partner + パートナーが互いのタイムを編集できる
+- **URL**: /api/tournaments/[temp-id]/ta (PUT set_partner) + /api/tournaments/[temp-id]/ta/entries/[entryId]
+- **authRequired**: true (admin + player)
+- **背景**: TA 予選ではペア制（partnerId）を採用しており、ペアになったプレイヤー同士は互いのタイムを代理入力できる。TC-803 のカバレッジ範囲
+- **手順**:
+  1. 管理者セッションで一時トーナメントとプレイヤー2名（メイン + パートナー）を作成し、TA エントリーを追加する
+  2. `PUT /api/tournaments/[id]/ta` `{ action: 'set_partner', entryId, partnerId }` を実行し、200 が返ることを確認する（step1）
+  3. GET /ta で entry1.partnerId === partnerId かつ entry2.partnerId === mainPlayerId の双方向ペアが設定されていることを確認する（step2）
+  4. 別の一時ブラウザでパートナーとしてログインし、メインプレイヤーのエントリー（entry1）の MC1 タイムを `PUT .../entries/[entry1.id]` で編集する → 200 が返ること（step3）
+  5. GET /ta でメインプレイヤーの MC1 タイムが更新されていることを確認する（step4）
+  6. クリーンアップ（トーナメント + プレイヤー削除）
+- **期待結果**: set_partner が双方向に反映され、パートナーがペアの相手のタイムを代理入力できる
+
 ## TC-319: TA taPlayerSelfEdit フラグ toggle — false でセルフ編集ブロック
 - **URL**: /api/tournaments/[temp-id]/ta + /api/tournaments/[temp-id]/ta/entries/[entryId]
 - **authRequired**: true (admin)
@@ -490,6 +503,19 @@
   4. `tvNumber: null` を送信 → 200 が返り TV 割り当てがクリアされること
 - **期待結果**: tvNumber 1〜4 は受け入れられ、5 以上は拒否される
 
+## TC-511: BM スラッグ URL からマッチ詳細ページが正常に表示される
+- **URL**: /tournaments/[slug]/bm/match/[matchId]
+- **authRequired**: true (admin)
+- **背景**: トーナメントがスラッグ（`/tournaments/my-slug/bm`）経由で開かれたとき、マッチ詳細ページ（`/tournaments/[slug]/bm/match/[matchId]`）が正常にロードされること。スラッグ → UUID 変換が match detail ルートで動作するかの回帰テスト
+- **手順**:
+  1. 管理者セッションでスラッグ付き一時トーナメント（`e2e-bm-match-slug-TIMESTAMP`）とプレイヤー2名を作成、BM グループ設定を行う
+  2. BM マッチ一覧 API で non-BYE マッチを取得する
+  3. `/tournaments/[slug]/bm` → Matches タブ → `a[href="/tournaments/[slug]/bm/match/[matchId]"]` リンクをクリックする
+  4. URL が `/tournaments/[slug]/bm/match/[matchId]` に遷移することを確認する
+  5. ページ内に player1.nickname と player2.nickname が表示されていること、かつ「試合が見つかりません / Match not found」が表示されていないことを確認する
+  6. クリーンアップ
+- **期待結果**: スラッグ URL でマッチ詳細ページが正常にレンダリングされる（スラッグ→ID 変換が機能する）
+
 ## BM フルワークフロー設計方針
 - **予選プレイヤー数**: 28名（4グループ × 7名、7はオッドのため各グループに BYE が混在）
 - **予選試合数**: 7名RR = 21試合 × 4グループ = **84試合**（API一括投入）
@@ -590,6 +616,34 @@
   4. 両カードの両プレイヤーが "TBD" と表示されていることを確認
   5. クリーンアップ
 - **期待結果**: winners-side の試合が完了する前、losers_r1 はプレイヤー名ではなく TBD を表示する
+
+## TC-515: BM Top-24 Playoff UI フロー
+- **URL**: /tournaments/[temp-id]/bm → /bm/finals
+- **authRequired**: true (admin)
+- **背景**: `topN=24` で BM 決勝生成するとまず 8 試合（playoff_r1 4試合 + playoff_r2 4試合）のバラッジが生成される。UI が以下の流れを正しく提示すること: 予選ページ「Start Playoff」ボタン → Finals ページ Playoff ブラケット表示 → playoff_r2 完了で playoffComplete=true → Phase 2（Upper Bracket）生成
+- **手順**:
+  1. 28名予選完了状態のトーナメントで qualificationConfirmed=true にする
+  2. 既存ブラケットをリセットし、予選ページ（`/bm`）に「Start Playoff (バラッジ開始)」ボタンが表示されることを確認する
+  3. API で `POST /bm/finals { topN: 24 }` を実行し playoff ブラケットを生成する
+  4. `/bm/finals` に遷移し「Playoff (Barrage)」ラベルと M1 が表示されることを確認する
+  5. playoff_r1 M1〜M4 を 3-0、playoff_r2 M5〜M8 を 4-0 で API 入力する
+  6. 最後の PUT レスポンスで `playoffComplete=true` になることを確認する
+  7. 再度 `POST /bm/finals { topN: 24 }` で Phase 2（Upper Bracket）を生成し、`phase='finals'` が返ることを確認する
+  8. `/bm/finals` に戻り「Upper Bracket / アッパーブラケット」が表示されることを確認する
+  9. クリーンアップ
+- **期待結果**: BM Top-24 バラッジの UI フローが全段階で正常動作する
+
+## TC-516: BM 予選ページの決勝ブラケット存在状態 + リセット
+- **URL**: /tournaments/[temp-id]/bm
+- **authRequired**: true (admin)
+- **背景**: 決勝ブラケット生成後に予選ページを再訪すると「View Tournament / トーナメントを見る」と「Reset Bracket / ブラケットリセット」が表示され、リセット後は「Generate Finals Bracket / Start Playoff」に戻る
+- **手順**:
+  1. 28名予選完了状態のトーナメントで qualificationConfirmed=true にし、Top-8 ブラケットを生成する
+  2. 予選ページ（`/bm`）を開き「View Tournament」が表示されることを確認する
+  3. 「Reset Bracket」ボタンをクリックし、確認ダイアログで OK を選択する
+  4. リセット後に「Start Playoff / Generate Finals Bracket」ボタンが再表示されることを確認する
+  5. クリーンアップ
+- **期待結果**: ブラケット生成後は「View Tournament + Reset Bracket」、リセット後は「Generate / Start Playoff」に戻る
 
 ## TC-505: BM Grand Final → チャンピオン決定（28名予選後）
 - **URL**: /tournaments/[temp-id]/bm/finals
@@ -857,6 +911,33 @@
   7. クリーンアップ
 - **期待結果**: MR でも BM/GP と同じく rankOverride 設定後に同順位バーが消える
 
+## TC-615: MR Top-24 Playoff UI フロー
+- **URL**: /tournaments/[temp-id]/mr → /mr/finals
+- **authRequired**: true (admin)
+- **背景**: BM TC-515 の MR 版。`topN=24` で MR 決勝生成するとまず 8 試合のバラッジが生成される。UI が以下の流れを正しく提示すること: 予選ページ「Start Playoff」→ sessionStorage に `mr_finals_topN=24` 保存 → Finals ページ Playoff ブラケット表示 → playoff_r2 完了で playoffComplete=true → Phase 2（Upper Bracket）生成
+- **手順**:
+  1. 28名予選完了状態のトーナメントで qualificationConfirmed=true にし、既存ブラケットをリセットする
+  2. 予選ページ（`/mr`）で「Start Playoff (バラッジ開始)」ボタンが表示されることを確認する
+  3. ボタンをクリックし、sessionStorage の `mr_finals_topN` が `"24"` に設定されることを確認する
+  4. `/mr/finals` に遷移し「Playoff (Barrage)」ラベルと M1 が表示されることを確認する
+  5. playoff_r1 M1〜M4 を 3-0、playoff_r2 M5〜M8 を 3-0 で API 入力し、`playoffComplete=true` を確認する
+  6. `POST /mr/finals { topN: 24 }` で Phase 2（Upper Bracket）を生成し `phase='finals'` が返ることを確認する
+  7. `/mr/finals` に戻り「Upper Bracket / アッパーブラケット」が表示されることを確認する
+  8. クリーンアップ
+- **期待結果**: MR Top-24 バラッジの UI フローが全段階で正常動作する（sessionStorage 経由の topN 引き継ぎを含む）
+
+## TC-616: MR 予選ページの決勝ブラケット存在状態 + リセット
+- **URL**: /tournaments/[temp-id]/mr
+- **authRequired**: true (admin)
+- **背景**: BM TC-516 の MR 版。決勝ブラケット生成後に予選ページを再訪すると「View Tournament」と「Reset Bracket」が表示され、リセット後は「Generate Finals Bracket / Start Playoff」に戻る
+- **手順**:
+  1. 28名予選完了状態のトーナメントで qualificationConfirmed=true にし、Top-8 ブラケットを生成する
+  2. 予選ページ（`/mr`）を開き「View Tournament / トーナメントを見る」が表示されることを確認する
+  3. 「Reset Bracket / ブラケットリセット」ボタンをクリックし、確認ダイアログで OK を選択する
+  4. リセット後に「Start Playoff / Generate Finals Bracket」ボタンが再表示されることを確認する
+  5. クリーンアップ
+- **期待結果**: ブラケット生成後は「View Tournament + Reset Bracket」、リセット後は「Generate / Start Playoff」に戻る
+
 ## TC-812: TA 予選同着解決 — 同タイムで average 課題ポイント
 - **URL**: /tournaments/[temp-id]/ta
 - **authRequired**: true (admin)
@@ -1065,6 +1146,46 @@
   4. `suddenDeathWinner` を含めて再 PUT → 200 が返り、チャンピオンが確定すること
   5. クリーンアップ
 - **期待結果**: GP Grand Final 同点時のサドンデス勝者指定が正しく機能する
+
+## TC-713: GP 予選同着解決 — 同順位バーが rankOverride 設定後に消える
+- **URL**: /tournaments/[temp-id]/gp
+- **authRequired**: true (admin)
+- **背景**: BM TC-324 / MR TC-620 の GP 版。全プレイヤーが同一ドライバーポイントでタイとなる場合に「Tied ranks detected / 同順位が検出されました」バナーが表示され、resolveAllTies で全員に distinct な rankOverride を設定すると消えることを検証する
+- **手順**:
+  1. プレイヤー3名 + トーナメントを作成し、GP グループ設定を行う
+  2. 全ての non-BYE マッチで P1 が 5 レース全勝（9pt × 5 = 45pt）するスコアを入力する（全員同着状態を作る）
+  3. `/gp` を開き、順位表タブで「同順位が検出されました / Tied ranks detected」バナーが表示されることを確認する（hasBannerBefore）
+  4. `resolveAllTies(adminPage, tournamentId, 'gp')` で N 人全員に distinct な `rankOverride` を PATCH する
+  5. `/gp` を再訪問し、バナーが消えていることを確認する（hasBannerAfter=false）
+  6. クリーンアップ
+- **期待結果**: GP でも rankOverride 設定後に同順位バーが消える
+
+## TC-715: GP Top-24 Playoff UI フロー
+- **URL**: /tournaments/[temp-id]/gp → /gp/finals
+- **authRequired**: true (admin)
+- **背景**: BM TC-515 / MR TC-615 の GP 版。`topN=24` で GP 決勝生成するとまず 8 試合のバラッジが生成される。UI が以下の流れを正しく提示すること: 予選ページ「Start Playoff」→ sessionStorage に `gp_finals_topN=24` 保存 → Finals ページ Playoff ブラケット表示 → playoff_r2 完了で playoffComplete=true → Phase 2（Upper Bracket）生成
+- **手順**:
+  1. 28名予選完了状態のトーナメントで qualificationConfirmed=true にし、既存ブラケットをリセットする
+  2. 予選ページ（`/gp`）で「Start Playoff (バラッジ開始)」ボタンが表示されることを確認する
+  3. ボタンをクリックし、sessionStorage の `gp_finals_topN` が `"24"` に設定されることを確認する
+  4. `/gp/finals` に遷移し「Playoff (Barrage)」ラベルと M1 が表示されることを確認する
+  5. playoff_r1 M1〜M4 を 9-0、playoff_r2 M5〜M8 を 9-0 で API 入力し、`playoffComplete=true` を確認する
+  6. `POST /gp/finals { topN: 24 }` で Phase 2（Upper Bracket）を生成し `phase='finals'` が返ることを確認する
+  7. `/gp/finals` に戻り「Upper Bracket / アッパーブラケット」が表示されることを確認する
+  8. クリーンアップ
+- **期待結果**: GP Top-24 バラッジの UI フローが全段階で正常動作する（sessionStorage 経由の topN 引き継ぎを含む）
+
+## TC-716: GP 予選ページの決勝ブラケット存在状態 + リセット
+- **URL**: /tournaments/[temp-id]/gp
+- **authRequired**: true (admin)
+- **背景**: BM TC-516 / MR TC-616 の GP 版。決勝ブラケット生成後に予選ページを再訪すると「View Tournament」と「Reset Bracket」が表示され、リセット後は「Generate Finals Bracket / Start Playoff」に戻る
+- **手順**:
+  1. 28名予選完了状態のトーナメントで qualificationConfirmed=true にし、Top-8 ブラケットを生成する
+  2. 予選ページ（`/gp`）を開き「View Tournament / トーナメントを見る」が表示されることを確認する
+  3. 「Reset Bracket / ブラケットリセット」ボタンをクリックし、確認ダイアログで OK を選択する
+  4. リセット後に「Start Playoff / Generate Finals Bracket」ボタンが再表示されることを確認する
+  5. クリーンアップ
+- **期待結果**: ブラケット生成後は「View Tournament + Reset Bracket」、リセット後は「Generate / Start Playoff」に戻る
 
 ## TC-820: MR match/[matchId] ページがview-onlyであることを確認
 - **URL**: /tournaments/[temp-id]/mr/match/[matchId]

--- a/smkc-score-app/__tests__/lib/event-types/bm-config.test.ts
+++ b/smkc-score-app/__tests__/lib/event-types/bm-config.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for BM-specific configuration logic.
+ *
+ * Covers:
+ * - calculateMatchResult: 0-0 is no_contest, invalid sums, 3-1/2-2 outcomes
+ * - aggregatePlayerStats: 0-0 matches skipped, scoring formula (2*wins + ties)
+ * - parsePutBody: required field validation, score-rule validation
+ */
+
+const { bmConfig } = require('@/lib/event-types/bm-config');
+
+const { calculateMatchResult, aggregatePlayerStats, parsePutBody } = bmConfig;
+
+describe('calculateMatchResult', () => {
+  // 0-0 is a cleared/voided match — no_contest, not tie
+  it('returns no_contest for 0-0 (cleared match)', () => {
+    const result = calculateMatchResult(0, 0);
+    expect(result.winner).toBeNull();
+    expect(result.result1).toBe('no_contest');
+    expect(result.result2).toBe('no_contest');
+  });
+
+  // Sum !== 4 is also invalid (should not occur if validation works, but guard is present)
+  it.each([
+    [1, 0],
+    [2, 1],
+    [5, 0],
+    [3, 0],
+  ])('returns no_contest for invalid total rounds (%i-%i, sum≠4)', (s1, s2) => {
+    const result = calculateMatchResult(s1, s2);
+    expect(result.winner).toBeNull();
+    expect(result.result1).toBe('no_contest');
+    expect(result.result2).toBe('no_contest');
+  });
+
+  // §4.1: player 1 wins when score1 >= 3 and total = 4
+  it('returns player 1 win for 3-1', () => {
+    const result = calculateMatchResult(3, 1);
+    expect(result.winner).toBe(1);
+    expect(result.result1).toBe('win');
+    expect(result.result2).toBe('loss');
+  });
+
+  it('returns player 1 win for 4-0', () => {
+    const result = calculateMatchResult(4, 0);
+    expect(result.winner).toBe(1);
+    expect(result.result1).toBe('win');
+    expect(result.result2).toBe('loss');
+  });
+
+  // §4.1: player 2 wins when score2 >= 3 and total = 4
+  it('returns player 2 win for 1-3', () => {
+    const result = calculateMatchResult(1, 3);
+    expect(result.winner).toBe(2);
+    expect(result.result1).toBe('loss');
+    expect(result.result2).toBe('win');
+  });
+
+  it('returns player 2 win for 0-4', () => {
+    const result = calculateMatchResult(0, 4);
+    expect(result.winner).toBe(2);
+    expect(result.result1).toBe('loss');
+    expect(result.result2).toBe('win');
+  });
+
+  // §4.1: 2-2 is a valid draw (tie)
+  it('returns tie for 2-2', () => {
+    const result = calculateMatchResult(2, 2);
+    expect(result.winner).toBeNull();
+    expect(result.result1).toBe('tie');
+    expect(result.result2).toBe('tie');
+  });
+});
+
+describe('aggregatePlayerStats', () => {
+  const player1Id = 'p1';
+  const player2Id = 'p2';
+
+  function makeMatch(score1: number, score2: number) {
+    return {
+      id: 'm1',
+      tournamentId: 't1',
+      stage: 'qualification',
+      completed: true,
+      player1Id,
+      player2Id,
+      score1,
+      score2,
+    };
+  }
+
+  // 0-0 matches must be skipped (admin-cleared)
+  it('skips 0-0 matches (no_contest)', () => {
+    const matches = [makeMatch(0, 0), makeMatch(2, 2), makeMatch(3, 1)];
+    const result = aggregatePlayerStats(matches, player1Id, calculateMatchResult);
+    // 0-0 skipped; 2-2 → tie; 3-1 → win
+    expect(result.stats.mp).toBe(2);
+    expect(result.stats.wins).toBe(1);
+    expect(result.stats.ties).toBe(1);
+    expect(result.stats.losses).toBe(0);
+  });
+
+  // Scoring formula: 2*wins + ties
+  it('computes score as 2*wins + ties', () => {
+    const matches = [makeMatch(3, 1), makeMatch(1, 3), makeMatch(2, 2)];
+    const result = aggregatePlayerStats(matches, player1Id, calculateMatchResult);
+    expect(result.score).toBe(3); // 1 win * 2 + 1 tie
+  });
+
+  // Round differential is the tiebreaker (points field in qualificationData)
+  it('computes round differential correctly', () => {
+    const matches = [makeMatch(4, 0), makeMatch(3, 1), makeMatch(0, 4)];
+    const result = aggregatePlayerStats(matches, player1Id, calculateMatchResult);
+    expect(result.stats.winRounds).toBe(7); // 4+3+0
+    expect(result.stats.lossRounds).toBe(5); // 0+1+4
+    expect(result.qualificationData.points).toBe(2); // 7 - 5
+    expect(result.score).toBe(4); // 2 wins * 2 + 0 ties
+  });
+
+  // Player 2 perspective: stats are correctly flipped
+  it('accumulates stats correctly for player2 perspective', () => {
+    const matches = [makeMatch(3, 1)]; // player1 wins, player2 loses
+    const result = aggregatePlayerStats(matches, player2Id, calculateMatchResult);
+    expect(result.stats.wins).toBe(0);
+    expect(result.stats.losses).toBe(1);
+    expect(result.stats.winRounds).toBe(1); // player2 won 1 round
+    expect(result.stats.lossRounds).toBe(3); // player2 lost 3 rounds
+  });
+
+  // All cleared matches → mp stays 0
+  it('returns zero mp when all matches are 0-0', () => {
+    const matches = [makeMatch(0, 0), makeMatch(0, 0)];
+    const result = aggregatePlayerStats(matches, player1Id, calculateMatchResult);
+    expect(result.stats.mp).toBe(0);
+    expect(result.score).toBe(0);
+  });
+});
+
+describe('parsePutBody', () => {
+  it('returns valid result for correct BM scores', () => {
+    const result = parsePutBody({ matchId: 'abc', score1: 3, score2: 1 });
+    expect(result.valid).toBe(true);
+    expect(result.data).toMatchObject({ matchId: 'abc', score1: 3, score2: 1 });
+  });
+
+  it('passes rounds through when provided', () => {
+    const rounds = [{ course: 1, winner: 1 }];
+    const result = parsePutBody({ matchId: 'abc', score1: 2, score2: 2, rounds });
+    expect(result.valid).toBe(true);
+    expect(result.data?.rounds).toEqual(rounds);
+  });
+
+  it('rejects missing matchId', () => {
+    const result = parsePutBody({ score1: 3, score2: 1 });
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects missing score1', () => {
+    const result = parsePutBody({ matchId: 'abc', score2: 1 });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects missing score2', () => {
+    const result = parsePutBody({ matchId: 'abc', score1: 3 });
+    expect(result.valid).toBe(false);
+  });
+
+  // §4.1: BM scores must be non-negative integers summing to 4 (or 0-0)
+  it('rejects invalid BM score (sum ≠ 4 and not 0-0)', () => {
+    const result = parsePutBody({ matchId: 'abc', score1: 5, score2: 0 });
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('rejects negative scores', () => {
+    const result = parsePutBody({ matchId: 'abc', score1: -1, score2: 5 });
+    expect(result.valid).toBe(false);
+  });
+
+  it('accepts 0-0 (admin-cleared match)', () => {
+    const result = parsePutBody({ matchId: 'abc', score1: 0, score2: 0 });
+    expect(result.valid).toBe(true);
+  });
+});

--- a/smkc-score-app/__tests__/lib/fetch-with-retry.test.ts
+++ b/smkc-score-app/__tests__/lib/fetch-with-retry.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for fetchWithRetry.
+ *
+ * Covers:
+ * - Returns immediately on 2xx success
+ * - Returns immediately on 4xx client error (no retry)
+ * - Retries on 500+ and returns last response after exhausting retries
+ * - Retries on network error and re-throws on last attempt
+ *
+ * We spy on setTimeout to resolve instantly, avoiding real 500ms delays.
+ */
+
+import { fetchWithRetry } from '@/lib/fetch-with-retry';
+
+function makeResponse(status: number, ok?: boolean): Response {
+  return {
+    status,
+    ok: ok ?? (status >= 200 && status < 300),
+  } as Response;
+}
+
+describe('fetchWithRetry', () => {
+  let fetchSpy: jest.SpyInstance;
+  let setTimeoutSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(globalThis, 'fetch');
+    // Make setTimeout call callback synchronously to avoid real delays
+    setTimeoutSpy = jest
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((fn: TimerHandler) => {
+        if (typeof fn === 'function') fn();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns 200 response immediately without retrying', async () => {
+    fetchSpy.mockResolvedValue(makeResponse(200));
+
+    const res = await fetchWithRetry('/api/test');
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 4xx response immediately without retrying', async () => {
+    fetchSpy.mockResolvedValue(makeResponse(404, false));
+
+    const res = await fetchWithRetry('/api/test');
+
+    expect(res.status).toBe(404);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 500 and returns last 500 after MAX_RETRIES attempts', async () => {
+    // MAX_RETRIES = 2 in fetch-with-retry.ts
+    fetchSpy.mockResolvedValue(makeResponse(500, false));
+
+    const res = await fetchWithRetry('/api/test');
+
+    expect(res.status).toBe(500);
+    expect(fetchSpy).toHaveBeenCalledTimes(2); // 2 attempts total
+  });
+
+  it('returns success if second attempt succeeds after 500', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(makeResponse(500, false))
+      .mockResolvedValueOnce(makeResponse(200));
+
+    const res = await fetchWithRetry('/api/test');
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes init options to every fetch call', async () => {
+    fetchSpy.mockResolvedValue(makeResponse(200));
+
+    const init = { method: 'POST', headers: { 'Content-Type': 'application/json' } };
+    await fetchWithRetry('/api/test', init);
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/test', init);
+  });
+
+  it('re-throws network error after exhausting retries', async () => {
+    fetchSpy.mockRejectedValue(new Error('Network failure'));
+
+    await expect(fetchWithRetry('/api/test')).rejects.toThrow('Network failure');
+    expect(fetchSpy).toHaveBeenCalledTimes(2); // 2 attempts
+  });
+
+  it('succeeds if second attempt resolves after network error', async () => {
+    fetchSpy
+      .mockRejectedValueOnce(new Error('Network failure'))
+      .mockResolvedValueOnce(makeResponse(200));
+
+    const res = await fetchWithRetry('/api/test');
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not delay after the final failed attempt', async () => {
+    fetchSpy.mockResolvedValue(makeResponse(500, false));
+
+    await fetchWithRetry('/api/test');
+
+    // setTimeout called once: only between attempt 0 and attempt 1 (not after last)
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/smkc-score-app/__tests__/lib/qualification-confirmed-check.test.ts
+++ b/smkc-score-app/__tests__/lib/qualification-confirmed-check.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for checkQualificationConfirmed.
+ *
+ * Covers:
+ * - Returns null when qualification is not confirmed (edits allowed)
+ * - Returns 403 NextResponse when qualification is confirmed (edits locked)
+ * - Returns 404 NextResponse when tournament is not found
+ */
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: jest.fn((body, init) => ({ body, status: init?.status ?? 200 })),
+  },
+}));
+
+import { checkQualificationConfirmed } from '@/lib/qualification-confirmed-check';
+
+function makePrisma(tournament: { qualificationConfirmed: boolean } | null) {
+  return {
+    tournament: {
+      findUnique: jest.fn().mockResolvedValue(tournament),
+    },
+  } as unknown as Parameters<typeof checkQualificationConfirmed>[0];
+}
+
+describe('checkQualificationConfirmed', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null when qualification is not confirmed (edits allowed)', async () => {
+    const prisma = makePrisma({ qualificationConfirmed: false });
+    const result = await checkQualificationConfirmed(prisma, 'tournament-1');
+    expect(result).toBeNull();
+  });
+
+  it('returns 403 response when qualification is confirmed (edits locked)', async () => {
+    const prisma = makePrisma({ qualificationConfirmed: true });
+    const result = await checkQualificationConfirmed(prisma, 'tournament-1') as { status: number; body: unknown };
+    expect(result).not.toBeNull();
+    expect(result.status).toBe(403);
+  });
+
+  it('returns 404 response when tournament is not found', async () => {
+    const prisma = makePrisma(null);
+    const result = await checkQualificationConfirmed(prisma, 'nonexistent-id') as { status: number };
+    expect(result).not.toBeNull();
+    expect(result.status).toBe(404);
+  });
+
+  it('queries the correct tournament by id', async () => {
+    const prisma = makePrisma({ qualificationConfirmed: false });
+    await checkQualificationConfirmed(prisma, 'my-tournament');
+    expect(prisma.tournament.findUnique).toHaveBeenCalledWith({
+      where: { id: 'my-tournament' },
+      select: { qualificationConfirmed: true },
+    });
+  });
+});

--- a/smkc-score-app/__tests__/lib/request-utils.test.ts
+++ b/smkc-score-app/__tests__/lib/request-utils.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for request-utils: getClientIdentifier and getUserAgent.
+ *
+ * Covers:
+ * - CF header takes priority over x-real-ip and x-forwarded-for
+ * - x-real-ip takes priority over x-forwarded-for
+ * - x-forwarded-for extracts first IP in comma-separated list
+ * - Falls back to 'unknown' when no header is present
+ * - getUserAgent returns header value or 'unknown'
+ *
+ * Note: We mock next/server to control NextRequest's headers.get behavior
+ * so each test runs against a predictable header map rather than the real
+ * NextRequest's internal header resolution (which injects x-forwarded-for: 127.0.0.1).
+ */
+
+// jest.setup.js globally mocks @/lib/request-utils for factory tests.
+// Unmock it here so we exercise the real implementation.
+jest.unmock('@/lib/request-utils');
+// getServerSideIdentifier uses next/headers; mock it to avoid import errors
+jest.mock('next/headers', () => ({ headers: jest.fn() }));
+jest.mock('@/lib/logger', () => ({ createLogger: () => ({ debug: jest.fn(), error: jest.fn() }) }));
+
+import { getClientIdentifier, getUserAgent } from '@/lib/request-utils';
+
+/** Minimal NextRequest-shaped object with only the headers.get the unit cares about. */
+function makeRequest(entries: Record<string, string>) {
+  // Lowercase all keys so that case-insensitive lookup in the impl always matches.
+  const map = new Map<string, string>(
+    Object.entries(entries).map(([k, v]) => [k.toLowerCase(), v])
+  );
+  return {
+    headers: { get: (name: string) => map.get(name.toLowerCase()) ?? null },
+  } as Parameters<typeof getClientIdentifier>[0];
+}
+
+describe('getClientIdentifier', () => {
+  it('returns cf-connecting-ip when present (highest priority)', () => {
+    const req = makeRequest({
+      'cf-connecting-ip': '1.2.3.4',
+      'x-real-ip': '5.6.7.8',
+      'x-forwarded-for': '9.10.11.12',
+    });
+    expect(getClientIdentifier(req)).toBe('1.2.3.4');
+  });
+
+  it('returns x-real-ip when cf-connecting-ip is absent', () => {
+    const req = makeRequest({
+      'x-real-ip': '5.6.7.8',
+      'x-forwarded-for': '9.10.11.12',
+    });
+    expect(getClientIdentifier(req)).toBe('5.6.7.8');
+  });
+
+  it('returns first IP from x-forwarded-for when higher-priority headers are absent', () => {
+    const req = makeRequest({ 'x-forwarded-for': '9.10.11.12, 13.14.15.16' });
+    expect(getClientIdentifier(req)).toBe('9.10.11.12');
+  });
+
+  it('trims whitespace from x-forwarded-for first IP', () => {
+    const req = makeRequest({ 'x-forwarded-for': '  9.10.11.12  , 13.14.15.16' });
+    expect(getClientIdentifier(req)).toBe('9.10.11.12');
+  });
+
+  it('returns "unknown" when no identifying header is present', () => {
+    const req = makeRequest({});
+    expect(getClientIdentifier(req)).toBe('unknown');
+  });
+});
+
+describe('getUserAgent', () => {
+  it('returns user-agent header value', () => {
+    const req = makeRequest({ 'user-agent': 'Mozilla/5.0 Playwright' });
+    expect(getUserAgent(req)).toBe('Mozilla/5.0 Playwright');
+  });
+
+  it('returns "unknown" when user-agent header is absent', () => {
+    const req = makeRequest({});
+    expect(getUserAgent(req)).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Summary

- **4 new unit test files** covering previously untested lib modules (42 new test cases, all passing)
- **E2E_TEST_CASES.md updated** with documentation for 9 implemented-but-undocumented TCs (closes #587)

### Unit Tests Added

| File | Module | Coverage |
|------|--------|----------|
| `__tests__/lib/event-types/bm-config.test.ts` | `bm-config.ts` | `calculateMatchResult` (0-0 cleared, sum≠4, 3-1/4-0 win, 2-2 tie), `aggregatePlayerStats` (0-0 skip, scoring formula, round diff), `parsePutBody` (validation) |
| `__tests__/lib/fetch-with-retry.test.ts` | `fetch-with-retry.ts` | 200/4xx return immediately, 500 retried up to MAX_RETRIES, network error rethrown on last attempt, success on 2nd attempt, single delay between attempts |
| `__tests__/lib/request-utils.test.ts` | `request-utils.ts` | cf-connecting-ip > x-real-ip > x-forwarded-for priority, comma-list trimming, unknown fallback, getUserAgent |
| `__tests__/lib/qualification-confirmed-check.test.ts` | `qualification-confirmed-check.ts` | null when not confirmed, 403 when confirmed, 404 when tournament not found |

### E2E_TEST_CASES.md: 9 TCs Documented (closes #587)

TCs implemented in `tc-all.js`, `tc-bm.js`, `tc-mr.js`, `tc-gp.js` but missing from the specification document:

- **TC-318**: TA pair assignment — set_partner + partner can edit each other's times
- **TC-511**: BM slug URL → match detail page (regression for slug-based routing)
- **TC-515**: BM Top-24 Playoff UI flow (Start Playoff → Barrage bracket → Phase 2)
- **TC-516**: BM qualification page finals-exists state + reset
- **TC-615**: MR Top-24 Playoff UI flow (mirrors TC-515 for MR, with sessionStorage)
- **TC-616**: MR qualification page finals-exists state + reset
- **TC-713**: GP qualification tie resolution (tie banner appears then disappears)
- **TC-715**: GP Top-24 Playoff UI flow (mirrors TC-515/TC-615 for GP)
- **TC-716**: GP qualification page finals-exists state + reset

## Test plan

- [x] `npm test -- --ci --forceExit` → 101 test suites pass, 1956 tests pass
- [x] New test files verified individually before running full suite
- [x] E2E_TEST_CASES.md checked — all 9 new sections visible via `grep "^## TC-"` 

https://claude.ai/code/session_01CXaTtZhmyopqGUk3NiVrd5

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXaTtZhmyopqGUk3NiVrd5)_