### PR TITLE
test: add E2E TC-331/332/333 for uncovered API endpoints

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -489,6 +489,39 @@
   4. `/tournaments/[id]/ta/phase2` にリダイレクトされることを確認
 - **期待結果**: 旧 revival-* URL が正しく phase* URL にリダイレクトされる
 
+## TC-331: tt/entries 単一エントリ GET — player・tournament 関連データを含むレスポンス確認
+- **URL**: /api/tournaments/[id]/tt/entries/[entryId]
+- **authRequired**: true (admin)
+- **背景**: `GET /api/tournaments/[id]/tt/entries/[entryId]` は個別の TTEntry を取得する。IDOR 保護（tournamentId が一致しない場合 404）と、関連 player・tournament を include した shape を返すことを確認する。また楽観的ロック (`version` フィールド) が存在することも検証する
+- **手順**:
+  1. 管理者セッションで一時トーナメントとプレイヤー1名を作成し、TA エントリーを追加する
+  2. `GET /api/tournaments/[id]/tt/entries/[entryId]` を呼び出す
+  3. ステータスが 200 かつ `{ success: true, data: { id, player: {...}, tournament: {...}, version: number, ... } }` 形式であることを確認する
+  4. クリーンアップ
+- **期待結果**: 単一エントリが player・tournament・version フィールドを含む正しい形式で返される
+
+## TC-332: tt/entries 楽観的ロック競合 — stale version で PUT すると 409
+- **URL**: /api/tournaments/[id]/tt/entries/[entryId]
+- **authRequired**: true (admin)
+- **背景**: `tt/entries/[entryId]` の PUT は楽観的ロックを採用しており、クライアントが読み取ったバージョンと DB 上のバージョンが一致しない場合 HTTP 409 Conflict を返す。これにより複数ユーザーの並行編集が互いを無言で上書きするのを防ぐ
+- **手順**:
+  1. 一時トーナメントにプレイヤー1名を追加し、TA エントリーを作成する
+  2. `GET /api/tournaments/[id]/tt/entries/[entryId]` でエントリーと現在の `version` (例: 0) を取得する
+  3. `PUT /api/tournaments/[id]/tt/entries/[entryId]` に `{ version: -1, times: {} }` (stale) を送信する
+  4. HTTP 409 が返ることを確認する
+  5. クリーンアップ
+- **期待結果**: 古いバージョン番号での PUT が 409 Conflict で拒否される
+
+## TC-333: ポーリング統計モニタ API — 認証ユーザーのみアクセス可・レスポンス形式確認
+- **URL**: /api/monitor/polling-stats
+- **authRequired**: true (any role)
+- **背景**: `GET /api/monitor/polling-stats` は APIリクエスト量・応答時間・エラーレートなどの監視統計を返す。認証済みユーザーのみがアクセスできる（未認証は 401 で拒否）
+- **手順**:
+  1. 管理者セッションで `GET /api/monitor/polling-stats` を呼び出す
+  2. ステータスが 200 かつ `{ success: true, data: { totalRequests, averageResponseTime, activeConnections, errorRate, warnings, timePeriod } }` 形式であることを確認する
+  3. 未認証リクエストが 401 または 403 で拒否されることを確認する
+- **期待結果**: 管理者は監視統計を取得できる。未認証リクエストは拒否される
+
 ## TC-320: BM/MR/GP マッチリスト行レベルのスコア入力リンク非表示化 ✅ FIXED (PR #407)
 - **URL**: /tournaments/[temp-id]/bm, /mr, /gp → Matches タブ
 - **authRequired**: true (admin)

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -1804,6 +1804,138 @@ async function main() {
     log('TC-330', 'SKIP', 'TID not available');
   }
 
+  // TC-331: tt/entries single-entry GET — returns TTEntry with player and tournament data
+  // Verifies GET /api/tournaments/[id]/tt/entries/[entryId] returns a well-formed entry
+  // including related player and tournament objects (IDOR-protected by tournamentId).
+  if (pid) {
+    let tc331TournamentId = null;
+    try {
+      tc331TournamentId = await uiCreateTournament(page, `E2E TT Entry GET ${Date.now()}`);
+      await uiActivateTournament(page, tc331TournamentId);
+      await uiSetupTaPlayers(page, tc331TournamentId, [
+        { id: pid, name: playerName, nickname: nick },
+      ]);
+
+      const taResp = await apiFetchTa(page, tc331TournamentId);
+      const entry = (taResp.b?.data?.entries ?? [])[0] ?? null;
+      if (!entry) throw new Error('No TA entry created for TC-331');
+
+      const getResp = await page.evaluate(async ([tid, eid]) => {
+        const r = await fetch(`/api/tournaments/${tid}/tt/entries/${eid}`);
+        return { status: r.status, body: await r.json().catch(() => ({})) };
+      }, [tc331TournamentId, entry.id]);
+
+      const data = getResp.body?.data ?? {};
+      const hasShape =
+        getResp.status === 200 &&
+        getResp.body?.success === true &&
+        data.id === entry.id &&
+        typeof data.player === 'object' && data.player !== null &&
+        typeof data.tournament === 'object' && data.tournament !== null &&
+        typeof data.version === 'number';
+
+      log('TC-331', hasShape ? 'PASS' : 'FAIL',
+        getResp.status !== 200 ? `Got ${getResp.status}`
+        : !hasShape ? 'Response missing player, tournament, or version fields'
+        : '');
+    } catch (err) {
+      log('TC-331', 'FAIL', err instanceof Error ? err.message : 'TT entry GET test failed');
+    } finally {
+      if (tc331TournamentId) await deleteTournament(page, tc331TournamentId);
+    }
+  } else {
+    log('TC-331', 'SKIP', 'No player available');
+  }
+
+  // TC-332: tt/entries optimistic-locking conflict — stale version returns 409
+  // Verifies that PUT /api/tournaments/[id]/tt/entries/[entryId] with a version
+  // number that is one behind the current value returns HTTP 409 Conflict.
+  // This ensures concurrent edits cannot silently overwrite each other.
+  if (pid) {
+    let tc332TournamentId = null;
+    try {
+      tc332TournamentId = await uiCreateTournament(page, `E2E TT Lock ${Date.now()}`);
+      await uiActivateTournament(page, tc332TournamentId);
+      await uiSetupTaPlayers(page, tc332TournamentId, [
+        { id: pid, name: playerName, nickname: nick },
+      ]);
+
+      const taResp = await apiFetchTa(page, tc332TournamentId);
+      const entry = (taResp.b?.data?.entries ?? [])[0] ?? null;
+      if (!entry) throw new Error('No TA entry created for TC-332');
+
+      // Read the entry via tt/entries to obtain the current version number.
+      const readResp = await page.evaluate(async ([tid, eid]) => {
+        const r = await fetch(`/api/tournaments/${tid}/tt/entries/${eid}`);
+        return { status: r.status, body: await r.json().catch(() => ({})) };
+      }, [tc332TournamentId, entry.id]);
+
+      const currentVersion = readResp.body?.data?.version;
+      if (typeof currentVersion !== 'number') {
+        throw new Error(`No version in GET response: ${JSON.stringify(readResp.body).slice(0, 200)}`);
+      }
+
+      // Submit PUT with a stale version (currentVersion - 1) — must return 409.
+      const conflictResp = await page.evaluate(async ([tid, eid, staleVersion]) => {
+        const r = await fetch(`/api/tournaments/${tid}/tt/entries/${eid}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ version: staleVersion, times: {} }),
+        });
+        return { status: r.status };
+      }, [tc332TournamentId, entry.id, currentVersion - 1]);
+
+      log('TC-332', conflictResp.status === 409 ? 'PASS' : 'FAIL',
+        `Expected 409 for stale version, got ${conflictResp.status}`);
+    } catch (err) {
+      log('TC-332', 'FAIL', err instanceof Error ? err.message : 'TT optimistic lock conflict test failed');
+    } finally {
+      if (tc332TournamentId) await deleteTournament(page, tc332TournamentId);
+    }
+  } else {
+    log('TC-332', 'SKIP', 'No player available');
+  }
+
+  // TC-333: Polling-stats monitor API — authenticated gets 200 with stats shape, unauth gets 401
+  // Verifies GET /api/monitor/polling-stats requires authentication and returns the expected
+  // shape: { success, data: { totalRequests, averageResponseTime, activeConnections, errorRate,
+  // warnings, timePeriod } }.
+  try {
+    const adminResp = await page.evaluate(async () => {
+      const r = await fetch('/api/monitor/polling-stats');
+      return { status: r.status, body: await r.json().catch(() => ({})) };
+    });
+    const data = adminResp.body?.data ?? {};
+    const hasShape =
+      adminResp.status === 200 &&
+      adminResp.body?.success === true &&
+      typeof data.totalRequests === 'number' &&
+      typeof data.averageResponseTime === 'number' &&
+      typeof data.activeConnections === 'number' &&
+      typeof data.errorRate === 'number' &&
+      Array.isArray(data.warnings) &&
+      typeof data.timePeriod === 'object' && data.timePeriod !== null;
+
+    // Unauthenticated request via https module must be rejected with 401 or 403.
+    const anonStatus = await new Promise((resolve) => {
+      const req = https.get(`${BASE}/api/monitor/polling-stats`, (res) => {
+        res.resume();
+        resolve(res.statusCode);
+      });
+      req.on('error', () => resolve(0));
+      req.setTimeout(8000, () => { req.destroy(); resolve(0); });
+    });
+    const anonBlocked = anonStatus === 401 || anonStatus === 403;
+
+    log('TC-333',
+      hasShape && anonBlocked ? 'PASS' : 'FAIL',
+      adminResp.status !== 200 ? `Admin got ${adminResp.status}`
+        : !hasShape ? 'Response shape invalid'
+        : !anonBlocked ? `Anon got ${anonStatus} (expected 401/403)` : '');
+  } catch (err) {
+    log('TC-333', 'FAIL', err instanceof Error ? err.message : 'Polling stats test failed');
+  }
+
   // ===== Mode-specific suites (shared code with tc-bm/tc-mr/tc-gp/tc-ta) =====
   // Previously these were gated behind E2E_RUN_FOCUSED_SUITES and invoked
   // through spawnSync, which meant `node e2e/tc-all.js` silently skipped


### PR DESCRIPTION
## Summary

- **TC-331**: `GET /api/tournaments/[id]/tt/entries/[entryId]` — verifies single TTEntry response includes related `player`, `tournament`, and `version` fields (楽観的ロック用バージョン番号の存在確認)
- **TC-332**: `PUT` with stale `version` on `tt/entries/[entryId]` → **409 Conflict** — validates optimistic locking rejects concurrent overwrites (並行編集の上書き防止)
- **TC-333**: `GET /api/monitor/polling-stats` — admin authenticated gets 200 with stats shape (`totalRequests`, `averageResponseTime`, `activeConnections`, `errorRate`, `warnings`, `timePeriod`); unauthenticated blocked with 401/403

## Uncovered areas addressed

| Endpoint | Before | After |
|---|---|---|
| `GET /tt/entries/[entryId]` | 未カバー | TC-331 |
| `PUT /tt/entries/[entryId]` 楽観的ロック競合 | 未カバー | TC-332 |
| `GET /api/monitor/polling-stats` | 未カバー | TC-333 |

## Test plan

- [ ] All three TCs implement self-contained setup/teardown (isolated temp tournament per TC — no shared state pollution)
- [ ] TC-331/332 use existing `uiSetupTaPlayers` + `apiFetchTa` helpers, consistent with TC-317/318 pattern
- [ ] TC-333 uses `https` module for unauthenticated check (same pattern as TC-328/329)
- [ ] `E2E_TEST_CASES.md` updated with scenario documentation for TC-331/332/333

https://claude.ai/code/session_01PvffPPvriaxD4VHfQamC3F

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvffPPvriaxD4VHfQamC3F)_