### PR TITLE
Implement sequential publication of qualification modes

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1438,6 +1438,32 @@
   - `?phase=phase1`: `entries`/`rounds`/`availableCourses` が追加される
   - 不正 phase パラメータ: 400
 
+## TC-338: 予選モードの順次公開（TA → BM → MR → GP）
+- **URL**: /api/tournaments/:id (PUT)、各モード qualification ページ
+- **authRequired**: true (admin)
+- **背景**: admin が各 qualification ページの「公開」/「未公開」ボタンで予選モードを
+  段階的に公開する。`publicModes` は常に `[ta, bm, mr, gp]` の先頭からの連続した
+  プレフィックスでなければならず、`["ta", "mr"]` のようなギャップは 400 で拒否される。
+  公開は前方カスケード（BM を公開すると TA も公開される）、未公開は後方カスケード
+  （BM を未公開にすると MR/GP も未公開になる）。
+- **手順**:
+  1. 空の publicModes でトーナメント作成
+  2. BM qualification ページで admin として「公開」をクリック →
+     API に `publicModes: ["ta", "bm"]` が送られ、TA も自動で公開されることを確認
+  3. MR qualification ページで「公開」をクリック → `publicModes: ["ta", "bm", "mr"]`
+  4. GP qualification ページで「公開」をクリック → `publicModes: ["ta", "bm", "mr", "gp"]`
+  5. BM qualification ページで「未公開」をクリック →
+     `publicModes: ["ta"]` になり、MR/GP も自動で未公開になることを確認
+  6. 非 admin のタブバーでは `["ta"]` のみが表示され、BM/MR/GP は非表示であること
+  7. 直接 PUT で `publicModes: ["ta", "mr"]`（ギャップあり）を送信 → 400 VALIDATION_ERROR
+- **期待結果**:
+  - 「公開」ボタンは自モード以前の全モードを公開する
+  - 「未公開」ボタンは自モード以降の全モードを未公開にする
+  - サーバは非プレフィックスの publicModes を 400 で拒否する
+  - 非 admin の閲覧者には公開済みのモードだけがタブに出る
+
+---
+
 ## TC-337: トーナメント一覧 API ページネーション — GET /api/tournaments?limit&page
 - **URL**: /api/tournaments
 - **authRequired**: false (公開GETエンドポイント)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/route.test.ts
@@ -447,6 +447,70 @@ describe('PUT /api/tournaments/[id]', () => {
       });
     });
 
+    it.each([
+      [[]],
+      [['ta']],
+      [['ta', 'bm']],
+      [['ta', 'bm', 'mr']],
+      [['ta', 'bm', 'mr', 'gp']],
+    ])('should accept sequential prefix publicModes %p', async (publicModes) => {
+      (auth as jest.Mock).mockResolvedValue({
+        user: { id: 'admin-1', role: 'admin' },
+      });
+      (sanitizeMock.sanitizeInput as jest.Mock).mockReturnValue({ publicModes });
+      (prisma.tournament.update as jest.Mock).mockResolvedValue({ id: 't1', publicModes });
+      auditLogMock.createAuditLog.mockResolvedValue(undefined);
+
+      await tournamentRoute.PUT(
+        new NextRequest('http://localhost:3000/api/tournaments/t1', {
+          method: 'PUT',
+          body: JSON.stringify({ publicModes }),
+        }),
+        { params: Promise.resolve({ id: 't1' }) }
+      );
+
+      expect(prisma.tournament.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { publicModes } })
+      );
+    });
+
+    it.each([
+      // Out-of-order mode in the payload — publishing BM without TA is not allowed
+      [['bm']],
+      [['mr']],
+      [['gp']],
+      // Gaps
+      [['ta', 'mr']],
+      [['ta', 'gp']],
+      [['ta', 'bm', 'gp']],
+      // Wrong order
+      [['bm', 'ta']],
+      // Unknown mode
+      [['foo']],
+    ])('should reject non-sequential publicModes %p with 400', async (publicModes) => {
+      (auth as jest.Mock).mockResolvedValue({
+        user: { id: 'admin-1', role: 'admin' },
+      });
+      (sanitizeMock.sanitizeInput as jest.Mock).mockReturnValue({ publicModes });
+
+      await tournamentRoute.PUT(
+        new NextRequest('http://localhost:3000/api/tournaments/t1', {
+          method: 'PUT',
+          body: JSON.stringify({ publicModes }),
+        }),
+        { params: Promise.resolve({ id: 't1' }) }
+      );
+
+      expect(prisma.tournament.update).not.toHaveBeenCalled();
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          code: 'VALIDATION_ERROR',
+        }),
+        { status: 400 }
+      );
+    });
+
     it('should update tournament status successfully', async () => {
       const mockTournament = {
         id: 't1',

--- a/smkc-score-app/__tests__/lib/public-modes.test.ts
+++ b/smkc-score-app/__tests__/lib/public-modes.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @module __tests__/lib/public-modes.test.ts
+ * @description Tests for sequential publication logic used to reveal qualification
+ * modes (TA → BM → MR → GP) to non-admin viewers one stage at a time.
+ */
+import {
+  MODE_REVEAL_ORDER,
+  publishMode,
+  unpublishMode,
+  isSequentialPrefix,
+} from "@/lib/public-modes";
+
+describe("MODE_REVEAL_ORDER", () => {
+  it("enforces the canonical TA → BM → MR → GP order", () => {
+    expect(MODE_REVEAL_ORDER).toEqual(["ta", "bm", "mr", "gp"]);
+  });
+});
+
+describe("publishMode", () => {
+  it("publishing TA alone publishes only TA", () => {
+    expect(publishMode("ta")).toEqual(["ta"]);
+  });
+
+  it("publishing BM cascades to include TA", () => {
+    expect(publishMode("bm")).toEqual(["ta", "bm"]);
+  });
+
+  it("publishing MR cascades to include TA and BM", () => {
+    expect(publishMode("mr")).toEqual(["ta", "bm", "mr"]);
+  });
+
+  it("publishing GP publishes all prior modes", () => {
+    expect(publishMode("gp")).toEqual(["ta", "bm", "mr", "gp"]);
+  });
+});
+
+describe("unpublishMode", () => {
+  it("unpublishing TA cascades to unpublish everything", () => {
+    expect(unpublishMode("ta")).toEqual([]);
+  });
+
+  it("unpublishing BM keeps TA public but hides BM/MR/GP", () => {
+    expect(unpublishMode("bm")).toEqual(["ta"]);
+  });
+
+  it("unpublishing MR hides MR and GP, keeps TA and BM", () => {
+    expect(unpublishMode("mr")).toEqual(["ta", "bm"]);
+  });
+
+  it("unpublishing GP only hides GP", () => {
+    expect(unpublishMode("gp")).toEqual(["ta", "bm", "mr"]);
+  });
+});
+
+describe("isSequentialPrefix", () => {
+  it.each([
+    [[]],
+    [["ta"]],
+    [["ta", "bm"]],
+    [["ta", "bm", "mr"]],
+    [["ta", "bm", "mr", "gp"]],
+  ])("accepts valid prefix %p", (modes) => {
+    expect(isSequentialPrefix(modes)).toBe(true);
+  });
+
+  it.each([
+    // Gaps: BM without TA, MR without BM, etc.
+    [["bm"]],
+    [["mr"]],
+    [["gp"]],
+    [["ta", "mr"]],
+    [["ta", "gp"]],
+    // Wrong order
+    [["bm", "ta"]],
+    // Duplicates
+    [["ta", "ta"]],
+    // Unknown mode
+    [["foo"]],
+    // Too long
+    [["ta", "bm", "mr", "gp", "extra"]],
+  ])("rejects invalid sequence %p", (modes) => {
+    expect(isSequentialPrefix(modes)).toBe(false);
+  });
+});

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -124,8 +124,8 @@
     "generateFinalsBracket": "Generate Finals Bracket",
     "failedResetBracket": "Failed to reset bracket",
     "tbd": "TBD",
-    "showToPlayers": "Show to Players",
-    "hideFromPlayers": "Hide from Players"
+    "publishMode": "Publish",
+    "unpublishMode": "Unpublish"
   },
   "home": {
     "tagline": "SMKC Score Management",
@@ -275,14 +275,14 @@
     "public": "Public",
     "visibilityUpdated": "Visibility updated",
     "failedToUpdateVisibility": "Failed to update visibility",
-    "visibleModes": "Visible",
-    "hidden": "Hidden",
+    "visibleModes": "Published",
+    "hidden": "Unpublished",
     "timeTrial": "Time Trial",
     "battleMode": "Battle Mode",
     "matchRace": "Match Race",
     "grandPrix": "Grand Prix",
     "overall": "Overall",
-    "hiddenModes": "All Hidden"
+    "hiddenModes": "All Unpublished"
   },
   "ta": {
     "title": "Time Trial",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -124,8 +124,8 @@
     "failedResetBracket": "ブラケットのリセットに失敗しました",
     "generateFinalsBracket": "決勝ブラケットを生成",
     "tbd": "未定",
-    "showToPlayers": "プレイヤーに公開",
-    "hideFromPlayers": "プレイヤーに非表示"
+    "publishMode": "公開",
+    "unpublishMode": "未公開"
   },
   "home": {
     "tagline": "SMKC スコア管理",
@@ -281,8 +281,8 @@
     "grandPrix": "グランプリ",
     "overall": "総合",
     "visibleModes": "公開中",
-    "hidden": "非表示",
-    "hiddenModes": "全非表示"
+    "hidden": "未公開",
+    "hiddenModes": "全未公開"
   },
   "ta": {
     "title": "タイムアタック",

--- a/smkc-score-app/src/app/api/tournaments/[id]/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/route.ts
@@ -26,6 +26,7 @@ import {
   handleAuthzError,
   handleValidationError,
 } from "@/lib/error-handling";
+import { isSequentialPrefix } from "@/lib/public-modes";
 
 /**
  * GET /api/tournaments/:id
@@ -186,16 +187,20 @@ export async function PUT(
       }
     }
 
-    // Validate publicModes: must be an array of valid mode names.
-    const VALID_MODES = ["ta", "bm", "mr", "gp"];
+    // Validate publicModes: must be a sequential prefix of MODE_REVEAL_ORDER.
+    // Modes are revealed to non-admin viewers in order (TA → BM → MR → GP), so
+    // e.g. ["ta", "mr"] is rejected because publishing MR without BM is not
+    // meaningful in the tournament flow. See @/lib/public-modes for the rule.
     if (publicModes !== undefined) {
       if (
         !Array.isArray(publicModes) ||
-        !publicModes.every(
-          (m: unknown) => typeof m === "string" && VALID_MODES.includes(m)
-        )
+        !publicModes.every((m: unknown) => typeof m === "string") ||
+        !isSequentialPrefix(publicModes as string[])
       ) {
-        return handleValidationError("publicModes must be an array of valid mode names (ta, bm, mr, gp)", "publicModes");
+        return handleValidationError(
+          "publicModes must be a sequential prefix of [ta, bm, mr, gp]",
+          "publicModes"
+        );
       }
     }
 

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
@@ -75,6 +75,7 @@ import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
 import { parseManualScore } from "@/lib/parse-manual-score";
 import { canCreateFinalsFromQualification } from "@/lib/finals-action-availability";
+import { publishMode, unpublishMode, type RevealableMode } from "@/lib/public-modes";
 import type { Player } from "@/lib/types";
 
 /** Client-side logger for error tracking */
@@ -157,18 +158,19 @@ export default function BattleModePage({
   /* Whether a finals or playoff bracket already exists on the server */
   const [finalsExists, setFinalsExists] = useState<boolean | undefined>(undefined);
 
-  // Public modes visibility state (for admin toggle)
+  // Public modes visibility state (for admin toggle).
+  // publicModes is always a prefix of [ta, bm, mr, gp]: publishing a mode
+  // cascades to earlier modes, unpublishing cascades to later modes. See
+  // @/lib/public-modes for details.
   const [publicModes, setPublicModes] = useState<string[]>([]);
   const [visibilityUpdating, setVisibilityUpdating] = useState(false);
 
-  /** Toggle this mode's visibility for non-admin users */
-  const toggleModeVisibility = useCallback(async (mode: string) => {
+  /** Toggle this mode's publication state for non-admin viewers. */
+  const toggleModePublication = useCallback(async (mode: RevealableMode) => {
     setVisibilityUpdating(true);
     try {
       const isPublic = publicModes.includes(mode);
-      const newModes = isPublic
-        ? publicModes.filter((m) => m !== mode)
-        : [...publicModes, mode];
+      const newModes = isPublic ? unpublishMode(mode) : publishMode(mode);
       const res = await fetch(`/api/tournaments/${tournamentId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -493,14 +495,16 @@ export default function BattleModePage({
             </Button>
           )}
 
-          {/* Public/Private visibility toggle for BM mode (admin only) */}
+          {/* Publish/Unpublish toggle for BM mode (admin only).
+           * Publishing cascades to earlier modes; unpublishing cascades to
+           * later modes (see @/lib/public-modes). */}
           {isAdmin && (
             <Button
               variant={publicModes.includes("bm") ? "outline" : "default"}
-              onClick={() => toggleModeVisibility("bm")}
+              onClick={() => toggleModePublication("bm")}
               disabled={visibilityUpdating}
             >
-              {publicModes.includes("bm") ? tc('hideFromPlayers') : tc('showToPlayers')}
+              {publicModes.includes("bm") ? tc('unpublishMode') : tc('publishMode')}
             </Button>
           )}
 

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
@@ -79,6 +79,7 @@ import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
 import { parseManualScore } from "@/lib/parse-manual-score";
 import { canCreateFinalsFromQualification } from "@/lib/finals-action-availability";
+import { publishMode, unpublishMode, type RevealableMode } from "@/lib/public-modes";
 
 import type { Player } from "@/lib/types";
 
@@ -175,18 +176,19 @@ export default function GrandPrixPage({
   const [resettingBracket, setResettingBracket] = useState(false);
   const [finalsExists, setFinalsExists] = useState<boolean | undefined>(undefined);
 
-  // Public modes visibility state (for admin toggle)
+  // Public modes visibility state (for admin toggle).
+  // publicModes is always a prefix of [ta, bm, mr, gp]: publishing a mode
+  // cascades to earlier modes, unpublishing cascades to later modes. See
+  // @/lib/public-modes for details.
   const [publicModes, setPublicModes] = useState<string[]>([]);
   const [visibilityUpdating, setVisibilityUpdating] = useState(false);
 
-  /** Toggle this mode's visibility for non-admin users */
-  const toggleModeVisibility = useCallback(async (mode: string) => {
+  /** Toggle this mode's publication state for non-admin viewers. */
+  const toggleModePublication = useCallback(async (mode: RevealableMode) => {
     setVisibilityUpdating(true);
     try {
       const isPublic = publicModes.includes(mode);
-      const newModes = isPublic
-        ? publicModes.filter((m) => m !== mode)
-        : [...publicModes, mode];
+      const newModes = isPublic ? unpublishMode(mode) : publishMode(mode);
       const res = await fetch(`/api/tournaments/${tournamentId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -626,14 +628,16 @@ export default function GrandPrixPage({
             </Button>
           )}
 
-          {/* Public/Private visibility toggle for GP mode (admin only) */}
+          {/* Publish/Unpublish toggle for GP mode (admin only).
+           * Publishing cascades to earlier modes; unpublishing cascades to
+           * later modes (see @/lib/public-modes). */}
           {isAdmin && (
             <Button
               variant={publicModes.includes("gp") ? "outline" : "default"}
-              onClick={() => toggleModeVisibility("gp")}
+              onClick={() => toggleModePublication("gp")}
               disabled={visibilityUpdating}
             >
-              {publicModes.includes("gp") ? tc('hideFromPlayers') : tc('showToPlayers')}
+              {publicModes.includes("gp") ? tc('unpublishMode') : tc('publishMode')}
             </Button>
           )}
 

--- a/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
@@ -72,6 +72,7 @@ import { UpdateIndicator } from "@/components/ui/update-indicator";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
 import { canCreateFinalsFromQualification } from "@/lib/finals-action-availability";
+import { publishMode, unpublishMode, type RevealableMode } from "@/lib/public-modes";
 import type { Player } from "@/lib/types";
 
 /** Client-side logger for error tracking */
@@ -157,18 +158,19 @@ export default function MatchRacePage({
   const [resettingBracket, setResettingBracket] = useState(false);
   const [finalsExists, setFinalsExists] = useState<boolean | undefined>(undefined);
 
-  // Public modes visibility state (for admin toggle)
+  // Public modes visibility state (for admin toggle).
+  // publicModes is always a prefix of [ta, bm, mr, gp]: publishing a mode
+  // cascades to earlier modes, unpublishing cascades to later modes. See
+  // @/lib/public-modes for details.
   const [publicModes, setPublicModes] = useState<string[]>([]);
   const [visibilityUpdating, setVisibilityUpdating] = useState(false);
 
-  /** Toggle this mode's visibility for non-admin users */
-  const toggleModeVisibility = useCallback(async (mode: string) => {
+  /** Toggle this mode's publication state for non-admin viewers. */
+  const toggleModePublication = useCallback(async (mode: RevealableMode) => {
     setVisibilityUpdating(true);
     try {
       const isPublic = publicModes.includes(mode);
-      const newModes = isPublic
-        ? publicModes.filter((m) => m !== mode)
-        : [...publicModes, mode];
+      const newModes = isPublic ? unpublishMode(mode) : publishMode(mode);
       const res = await fetch(`/api/tournaments/${tournamentId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -599,14 +601,16 @@ export default function MatchRacePage({
             groupCount={groupCount}
             setGroupCount={setGroupCount}
           />}
-          {/* Public/Private visibility toggle for MR mode (admin only) */}
+          {/* Publish/Unpublish toggle for MR mode (admin only).
+           * Publishing cascades to earlier modes; unpublishing cascades to
+           * later modes (see @/lib/public-modes). */}
           {isAdmin && (
             <Button
               variant={publicModes.includes("mr") ? "outline" : "default"}
-              onClick={() => toggleModeVisibility("mr")}
+              onClick={() => toggleModePublication("mr")}
               disabled={visibilityUpdating}
             >
-              {publicModes.includes("mr") ? tc('hideFromPlayers') : tc('showToPlayers')}
+              {publicModes.includes("mr") ? tc('unpublishMode') : tc('publishMode')}
             </Button>
           )}
         </div>

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
@@ -70,6 +70,7 @@ import { Dice5, ChevronDown, ChevronRight, Eye, Lock, Unlock } from "lucide-reac
 import { toast } from "sonner";
 import { createLogger } from "@/lib/client-logger";
 import { parseManualScore } from "@/lib/parse-manual-score";
+import { publishMode, unpublishMode, type RevealableMode } from "@/lib/public-modes";
 
 const logger = createLogger({ serviceName: 'tournaments-ta' });
 
@@ -178,18 +179,19 @@ export default function TimeAttackPage({
   // Search query used inside the unified setup dialog
   const [playerSearchQuery, setPlayerSearchQuery] = useState("");
 
-  // Public modes visibility state (for admin toggle)
+  // Public modes visibility state (for admin toggle).
+  // publicModes is always a prefix of [ta, bm, mr, gp]: publishing a mode
+  // cascades to earlier modes, unpublishing cascades to later modes. See
+  // @/lib/public-modes for details.
   const [publicModes, setPublicModes] = useState<string[]>([]);
   const [visibilityUpdating, setVisibilityUpdating] = useState(false);
 
-  /** Toggle this mode's visibility for non-admin users */
-  const toggleModeVisibility = useCallback(async (mode: string) => {
+  /** Toggle this mode's publication state for non-admin viewers. */
+  const toggleModePublication = useCallback(async (mode: RevealableMode) => {
     setVisibilityUpdating(true);
     try {
       const isPublic = publicModes.includes(mode);
-      const newModes = isPublic
-        ? publicModes.filter((m) => m !== mode)
-        : [...publicModes, mode];
+      const newModes = isPublic ? unpublishMode(mode) : publishMode(mode);
       const res = await fetch(`/api/tournaments/${tournamentId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -787,15 +789,17 @@ export default function TimeAttackPage({
               )}
             </Button>
           )}
-          {/* Public/Private visibility toggle for TA mode (admin only) */}
+          {/* Publish/Unpublish toggle for TA mode (admin only).
+           * Publishing cascades to earlier modes; unpublishing cascades to
+           * later modes (see @/lib/public-modes). */}
           {isAdmin && (
             <Button
               variant={publicModes.includes("ta") ? "outline" : "default"}
-              onClick={() => toggleModeVisibility("ta")}
+              onClick={() => toggleModePublication("ta")}
               disabled={visibilityUpdating}
               size="sm"
             >
-              {publicModes.includes("ta") ? tc('hideFromPlayers') : tc('showToPlayers')}
+              {publicModes.includes("ta") ? tc('unpublishMode') : tc('publishMode')}
             </Button>
           )}
           {/* Legacy "Promote to Finals" button and dialog removed.

--- a/smkc-score-app/src/lib/public-modes.ts
+++ b/smkc-score-app/src/lib/public-modes.ts
@@ -1,0 +1,38 @@
+/**
+ * Sequential publication order for qualification modes.
+ *
+ * Admins publish modes to non-admin viewers one stage at a time, matching the
+ * tournament flow (TA → BM → MR → GP). A mode can only be public if every mode
+ * earlier in this list is also public, so `publicModes` stored on the
+ * Tournament must always be a prefix of this list.
+ *
+ * Publishing mode X ⇒ publish X and every earlier mode.
+ * Unpublishing mode X ⇒ unpublish X and every later mode (cascade).
+ */
+export const MODE_REVEAL_ORDER = ["ta", "bm", "mr", "gp"] as const;
+export type RevealableMode = (typeof MODE_REVEAL_ORDER)[number];
+
+/** Prefix of {@link MODE_REVEAL_ORDER} up to and including `mode`. */
+export function publishMode(mode: RevealableMode): RevealableMode[] {
+  const idx = MODE_REVEAL_ORDER.indexOf(mode);
+  return MODE_REVEAL_ORDER.slice(0, idx + 1);
+}
+
+/** Prefix of {@link MODE_REVEAL_ORDER} strictly before `mode` (cascades unpublish). */
+export function unpublishMode(mode: RevealableMode): RevealableMode[] {
+  const idx = MODE_REVEAL_ORDER.indexOf(mode);
+  return MODE_REVEAL_ORDER.slice(0, idx);
+}
+
+/**
+ * True iff `modes` is a valid prefix of {@link MODE_REVEAL_ORDER}: no gaps,
+ * canonical order, no duplicates. Used by the API to reject non-sequential
+ * `publicModes` payloads from clients.
+ */
+export function isSequentialPrefix(modes: readonly string[]): boolean {
+  if (modes.length > MODE_REVEAL_ORDER.length) return false;
+  for (let i = 0; i < modes.length; i++) {
+    if (modes[i] !== MODE_REVEAL_ORDER[i]) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
Adds sequential publication logic for qualification modes (TA → BM → MR → GP) to enforce a strict reveal order to non-admin viewers. Admins can now publish/unpublish modes with automatic cascading: publishing a mode also publishes all earlier modes, and unpublishing a mode also unpublishes all later modes.

## Key Changes

- **New library module** (`src/lib/public-modes.ts`):
  - `MODE_REVEAL_ORDER`: Canonical order of modes [ta, bm, mr, gp]
  - `publishMode()`: Returns all modes up to and including the target mode
  - `unpublishMode()`: Returns all modes before the target mode (cascades unpublish)
  - `isSequentialPrefix()`: Validates that a mode array is a valid prefix of the reveal order

- **API validation** (`src/app/api/tournaments/[id]/route.ts`):
  - Updated `publicModes` validation to use `isSequentialPrefix()` instead of simple array membership check
  - Rejects non-sequential payloads (e.g., `["ta", "mr"]` with gaps) with 400 VALIDATION_ERROR
  - Updated error message to clarify the sequential prefix requirement

- **UI updates** (ta/bm/mr/gp pages):
  - Replaced `toggleModeVisibility()` with `toggleModePublication()` using the new cascade logic
  - Updated button labels from "Show to Players"/"Hide from Players" to "Publish"/"Unpublish"
  - Added detailed comments explaining the cascading behavior

- **Comprehensive test coverage**:
  - New test file (`__tests__/lib/public-modes.test.ts`) with 84 lines covering all three utility functions
  - Extended API route tests with 70 lines validating both valid sequential prefixes and rejection of invalid sequences

- **Localization updates** (en.json, ja.json):
  - Updated button labels to "Publish"/"Unpublish" terminology
  - Updated status labels from "Visible"/"Hidden" to "Published"/"Unpublished"

- **Documentation** (E2E_TEST_CASES.md):
  - Added TC-338 test case documenting the sequential publication workflow and validation rules

## Implementation Details

The cascading behavior is enforced at the client level (using `publishMode()` and `unpublishMode()`) and validated at the server level (using `isSequentialPrefix()`). This ensures that `publicModes` stored on the Tournament is always a valid prefix of [ta, bm, mr, gp], matching the natural tournament progression.

https://claude.ai/code/session_01M1uCLgH31Z1nesXJarpYUS