### PR TITLE
Implement independent per-mode publish toggles (issue #618)

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/route.test.ts
@@ -447,13 +447,21 @@ describe('PUT /api/tournaments/[id]', () => {
       });
     });
 
+    // Independent per-mode toggling (issue #618): any subset of valid mode
+    // names is accepted, with no ordering or prefix constraint.
     it.each([
       [[]],
       [['ta']],
+      [['bm']],
+      [['mr']],
+      [['gp']],
       [['ta', 'bm']],
-      [['ta', 'bm', 'mr']],
+      [['bm', 'gp']],
+      [['ta', 'mr']],
       [['ta', 'bm', 'mr', 'gp']],
-    ])('should accept sequential prefix publicModes %p', async (publicModes) => {
+      // Order is irrelevant
+      [['gp', 'ta']],
+    ])('should accept any valid publicModes subset %p', async (publicModes) => {
       (auth as jest.Mock).mockResolvedValue({
         user: { id: 'admin-1', role: 'admin' },
       });
@@ -475,19 +483,13 @@ describe('PUT /api/tournaments/[id]', () => {
     });
 
     it.each([
-      // Out-of-order mode in the payload — publishing BM without TA is not allowed
-      [['bm']],
-      [['mr']],
-      [['gp']],
-      // Gaps
-      [['ta', 'mr']],
-      [['ta', 'gp']],
-      [['ta', 'bm', 'gp']],
-      // Wrong order
-      [['bm', 'ta']],
-      // Unknown mode
+      // Unknown mode names
       [['foo']],
-    ])('should reject non-sequential publicModes %p with 400', async (publicModes) => {
+      [['ta', 'foo']],
+      // Duplicates
+      [['ta', 'ta']],
+      [['bm', 'mr', 'bm']],
+    ])('should reject invalid publicModes %p with 400', async (publicModes) => {
       (auth as jest.Mock).mockResolvedValue({
         user: { id: 'admin-1', role: 'admin' },
       });

--- a/smkc-score-app/__tests__/lib/public-modes.test.ts
+++ b/smkc-score-app/__tests__/lib/public-modes.test.ts
@@ -1,84 +1,103 @@
 /**
  * @module __tests__/lib/public-modes.test.ts
- * @description Tests for sequential publication logic used to reveal qualification
- * modes (TA → BM → MR → GP) to non-admin viewers one stage at a time.
+ * @description Tests for the independent per-mode publish helpers used to reveal
+ * each qualification mode (TA, BM, MR, GP) to non-admin viewers (issue #618).
+ * Each mode toggles independently — there is no cascade or ordering constraint.
  */
 import {
   MODE_REVEAL_ORDER,
-  publishMode,
-  unpublishMode,
-  isSequentialPrefix,
+  addPublicMode,
+  removePublicMode,
+  isValidPublicModes,
 } from "@/lib/public-modes";
 
 describe("MODE_REVEAL_ORDER", () => {
-  it("enforces the canonical TA → BM → MR → GP order", () => {
+  it("enforces the canonical display order", () => {
     expect(MODE_REVEAL_ORDER).toEqual(["ta", "bm", "mr", "gp"]);
   });
 });
 
-describe("publishMode", () => {
-  it("publishing TA alone publishes only TA", () => {
-    expect(publishMode("ta")).toEqual(["ta"]);
+describe("addPublicMode", () => {
+  it("adds a mode to an empty set", () => {
+    expect(addPublicMode([], "bm")).toEqual(["bm"]);
   });
 
-  it("publishing BM cascades to include TA", () => {
-    expect(publishMode("bm")).toEqual(["ta", "bm"]);
+  it("adds a mode without affecting other modes (no cascade)", () => {
+    expect(addPublicMode([], "mr")).toEqual(["mr"]);
+    expect(addPublicMode(["gp"], "ta")).toEqual(["ta", "gp"]);
   });
 
-  it("publishing MR cascades to include TA and BM", () => {
-    expect(publishMode("mr")).toEqual(["ta", "bm", "mr"]);
+  it("is idempotent — adding the same mode twice does not duplicate", () => {
+    expect(addPublicMode(["bm"], "bm")).toEqual(["bm"]);
   });
 
-  it("publishing GP publishes all prior modes", () => {
-    expect(publishMode("gp")).toEqual(["ta", "bm", "mr", "gp"]);
-  });
-});
-
-describe("unpublishMode", () => {
-  it("unpublishing TA cascades to unpublish everything", () => {
-    expect(unpublishMode("ta")).toEqual([]);
+  it("normalizes output to MODE_REVEAL_ORDER for stable storage", () => {
+    expect(addPublicMode(["gp", "bm"], "ta")).toEqual(["ta", "bm", "gp"]);
   });
 
-  it("unpublishing BM keeps TA public but hides BM/MR/GP", () => {
-    expect(unpublishMode("bm")).toEqual(["ta"]);
-  });
-
-  it("unpublishing MR hides MR and GP, keeps TA and BM", () => {
-    expect(unpublishMode("mr")).toEqual(["ta", "bm"]);
-  });
-
-  it("unpublishing GP only hides GP", () => {
-    expect(unpublishMode("gp")).toEqual(["ta", "bm", "mr"]);
+  it("filters out invalid mode names from existing array", () => {
+    expect(addPublicMode(["foo", "bm"] as string[], "ta")).toEqual(["ta", "bm"]);
   });
 });
 
-describe("isSequentialPrefix", () => {
+describe("removePublicMode", () => {
+  it("removes only the named mode (no cascade to other modes)", () => {
+    expect(removePublicMode(["ta", "bm", "mr", "gp"], "bm")).toEqual([
+      "ta",
+      "mr",
+      "gp",
+    ]);
+  });
+
+  it("returns an unchanged set when the mode is not present", () => {
+    expect(removePublicMode(["ta"], "gp")).toEqual(["ta"]);
+  });
+
+  it("returns empty when removing the only public mode", () => {
+    expect(removePublicMode(["bm"], "bm")).toEqual([]);
+  });
+
+  it("normalizes output to MODE_REVEAL_ORDER and dedupes", () => {
+    expect(
+      removePublicMode(["gp", "bm", "ta", "bm"] as string[], "bm")
+    ).toEqual(["ta", "gp"]);
+  });
+
+  it("filters out invalid mode names", () => {
+    expect(removePublicMode(["foo", "ta"] as string[], "ta")).toEqual([]);
+  });
+});
+
+describe("isValidPublicModes", () => {
   it.each([
     [[]],
     [["ta"]],
-    [["ta", "bm"]],
-    [["ta", "bm", "mr"]],
-    [["ta", "bm", "mr", "gp"]],
-  ])("accepts valid prefix %p", (modes) => {
-    expect(isSequentialPrefix(modes)).toBe(true);
-  });
-
-  it.each([
-    // Gaps: BM without TA, MR without BM, etc.
     [["bm"]],
     [["mr"]],
     [["gp"]],
+    [["ta", "bm"]],
+    // Non-prefix subsets are now valid (independent toggling)
+    [["bm", "gp"]],
     [["ta", "mr"]],
-    [["ta", "gp"]],
-    // Wrong order
-    [["bm", "ta"]],
+    [["mr", "gp"]],
+    [["ta", "bm", "mr", "gp"]],
+    // Order is irrelevant — the API will store as-is
+    [["gp", "ta"]],
+  ])("accepts valid subset %p", (modes) => {
+    expect(isValidPublicModes(modes)).toBe(true);
+  });
+
+  it.each([
+    // Unknown mode names
+    [["foo"]],
+    [["ta", "foo"]],
     // Duplicates
     [["ta", "ta"]],
-    // Unknown mode
-    [["foo"]],
-    // Too long
-    [["ta", "bm", "mr", "gp", "extra"]],
-  ])("rejects invalid sequence %p", (modes) => {
-    expect(isSequentialPrefix(modes)).toBe(false);
+    [["bm", "mr", "bm"]],
+    // Non-string entries
+    [[1] as unknown[]],
+    [[null] as unknown[]],
+  ])("rejects invalid input %p", (modes) => {
+    expect(isValidPublicModes(modes)).toBe(false);
   });
 });

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -1983,7 +1983,7 @@ async function main() {
   try {
     if (!tc334TournamentId) throw new Error('TC-334 did not create a tournament; skipping');
 
-    // Admin publishes the TA mode (publicModes cascade: ['ta'])
+    // Admin publishes the TA mode (independent toggle; publicModes: ['ta'])
     const putResp = await page.evaluate(async (tid) => {
       const r = await fetch(`/api/tournaments/${tid}`, {
         method: 'PUT',
@@ -2197,9 +2197,11 @@ async function main() {
     }
   }
 
-  // TC-339: Mode publish/unpublish cascade — publishing TA publishes only TA;
-  // publishing BM cascades to also include TA. Unpublishing TA cascades to remove BM.
-  // Verifies the API enforces MODE_REVEAL_ORDER sequential prefix constraint.
+  // TC-339: Independent per-mode publish toggle (issue #618).
+  // Each mode publishes/unpublishes independently — toggling one mode must not
+  // affect the publish state of any other mode. Non-sequential subsets like
+  // ['bm'] alone or ['bm','gp'] are now valid; only invalid mode names and
+  // duplicates are rejected.
   let tc339TournamentId = null;
   try {
     const created = await page.evaluate(async () => {
@@ -2222,8 +2224,22 @@ async function main() {
       });
     }, tc339TournamentId);
 
-    // Publish BM — API should accept ['ta', 'bm'] as a valid sequential prefix
-    const bmPutResp = await page.evaluate(async (tid) => {
+    // Publish only BM — API must accept ['bm'] alone (no cascade to TA).
+    const bmOnlyResp = await page.evaluate(async (tid) => {
+      const r = await fetch(`/api/tournaments/${tid}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ publicModes: ['bm'] }),
+      });
+      return { status: r.status, body: await r.json().catch(() => ({})) };
+    }, tc339TournamentId);
+    const bmOnlyAccepted = bmOnlyResp.status === 200 &&
+      Array.isArray(bmOnlyResp.body?.data?.publicModes) &&
+      bmOnlyResp.body.data.publicModes.length === 1 &&
+      bmOnlyResp.body.data.publicModes.includes('bm');
+
+    // Toggle TA on without affecting BM — final state must be exactly {ta, bm}
+    const taAddResp = await page.evaluate(async (tid) => {
       const r = await fetch(`/api/tournaments/${tid}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -2231,23 +2247,45 @@ async function main() {
       });
       return { status: r.status, body: await r.json().catch(() => ({})) };
     }, tc339TournamentId);
-    const bmPublished = bmPutResp.status === 200 &&
-      Array.isArray(bmPutResp.body?.data?.publicModes) &&
-      bmPutResp.body.data.publicModes.includes('ta') &&
-      bmPutResp.body.data.publicModes.includes('bm');
+    const taAdded = taAddResp.status === 200 &&
+      Array.isArray(taAddResp.body?.data?.publicModes) &&
+      taAddResp.body.data.publicModes.includes('ta') &&
+      taAddResp.body.data.publicModes.includes('bm');
 
-    // Non-sequential publicModes (e.g., ['bm'] without 'ta') must be rejected with 400
+    // Toggle BM off — TA must remain, no cascade
+    const bmOffResp = await page.evaluate(async (tid) => {
+      const r = await fetch(`/api/tournaments/${tid}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ publicModes: ['ta'] }),
+      });
+      return { status: r.status, body: await r.json().catch(() => ({})) };
+    }, tc339TournamentId);
+    const bmOffNoCascade = bmOffResp.status === 200 &&
+      Array.isArray(bmOffResp.body?.data?.publicModes) &&
+      bmOffResp.body.data.publicModes.length === 1 &&
+      bmOffResp.body.data.publicModes.includes('ta');
+
+    // Invalid mode names and duplicates must still be rejected
     const invalidPut = await page.evaluate(async (tid) => {
       const r = await fetch(`/api/tournaments/${tid}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ publicModes: ['bm'] }),
+        body: JSON.stringify({ publicModes: ['foo'] }),
       });
       return { status: r.status };
     }, tc339TournamentId);
-    const invalidRejected = invalidPut.status === 400;
+    const dupePut = await page.evaluate(async (tid) => {
+      const r = await fetch(`/api/tournaments/${tid}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ publicModes: ['ta', 'ta'] }),
+      });
+      return { status: r.status };
+    }, tc339TournamentId);
+    const invalidRejected = invalidPut.status === 400 && dupePut.status === 400;
 
-    // After publishing BM, the tournament should appear in non-admin list
+    // After publishing modes, the tournament should appear in the non-admin list
     const appearsInList = await new Promise((resolve) => {
       const req = https.get(`${BASE}/api/tournaments?limit=100`, (res) => {
         let data = '';
@@ -2264,12 +2302,14 @@ async function main() {
     });
 
     log('TC-339',
-      bmPublished && invalidRejected && appearsInList ? 'PASS' : 'FAIL',
-      !bmPublished ? `BM publish failed (status=${bmPutResp.status}, modes=${JSON.stringify(bmPutResp.body?.data?.publicModes)})` :
-      !invalidRejected ? `Non-sequential modes accepted (status=${invalidPut.status}, expected 400)` :
+      bmOnlyAccepted && taAdded && bmOffNoCascade && invalidRejected && appearsInList ? 'PASS' : 'FAIL',
+      !bmOnlyAccepted ? `Independent BM publish failed (status=${bmOnlyResp.status}, modes=${JSON.stringify(bmOnlyResp.body?.data?.publicModes)})` :
+      !taAdded ? `TA add did not preserve BM (modes=${JSON.stringify(taAddResp.body?.data?.publicModes)})` :
+      !bmOffNoCascade ? `BM off cascaded into TA (modes=${JSON.stringify(bmOffResp.body?.data?.publicModes)})` :
+      !invalidRejected ? `Invalid modes accepted (foo=${invalidPut.status}, dupe=${dupePut.status}, expected 400)` :
       !appearsInList ? 'Published tournament not visible in non-admin list' : '');
   } catch (err) {
-    log('TC-339', 'FAIL', err instanceof Error ? err.message : 'Mode publish cascade test failed');
+    log('TC-339', 'FAIL', err instanceof Error ? err.message : 'Independent mode publish test failed');
   } finally {
     if (tc339TournamentId) {
       await page.evaluate(async (tid) => {

--- a/smkc-score-app/src/app/api/tournaments/[id]/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/route.ts
@@ -26,7 +26,7 @@ import {
   handleAuthzError,
   handleValidationError,
 } from "@/lib/error-handling";
-import { isSequentialPrefix } from "@/lib/public-modes";
+import { isValidPublicModes } from "@/lib/public-modes";
 
 /**
  * GET /api/tournaments/:id
@@ -189,18 +189,13 @@ export async function PUT(
       }
     }
 
-    // Validate publicModes: must be a sequential prefix of MODE_REVEAL_ORDER.
-    // Modes are revealed to non-admin viewers in order (TA → BM → MR → GP), so
-    // e.g. ["ta", "mr"] is rejected because publishing MR without BM is not
-    // meaningful in the tournament flow. See @/lib/public-modes for the rule.
+    // Validate publicModes: each entry must be a valid mode name, with no
+    // duplicates. Modes are independently publishable (issue #618), so any
+    // subset of [ta, bm, mr, gp] in any order is accepted.
     if (publicModes !== undefined) {
-      if (
-        !Array.isArray(publicModes) ||
-        !publicModes.every((m: unknown) => typeof m === "string") ||
-        !isSequentialPrefix(publicModes as string[])
-      ) {
+      if (!Array.isArray(publicModes) || !isValidPublicModes(publicModes)) {
         return handleValidationError(
-          "publicModes must be a sequential prefix of [ta, bm, mr, gp]",
+          "publicModes must be an array of valid modes (ta, bm, mr, gp) with no duplicates",
           "publicModes"
         );
       }

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
@@ -56,6 +56,7 @@ import {
 } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { GroupSetupDialog } from "@/components/tournament/group-setup-dialog";
+import { ModePublishSwitch } from "@/components/tournament/mode-publish-switch";
 import { QualificationPlayoffManager } from "@/components/tournament/qualification-playoff-manager";
 import { RankCell } from "@/components/tournament/rank-cell";
 import { TieWarningBanner } from "@/components/tournament/tie-warning-banner";
@@ -516,6 +517,15 @@ export default function BattleModePage({
               }))}
               groupCount={groupCount}
               setGroupCount={setGroupCount}
+            />
+          )}
+
+          {/* Per-mode independent publish toggle (issue #618) */}
+          {isAdmin && (
+            <ModePublishSwitch
+              tournamentId={tournamentId}
+              mode="bm"
+              modeLabelKey="battleMode"
             />
           )}
 

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
@@ -58,6 +58,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { GroupSetupDialog } from "@/components/tournament/group-setup-dialog";
+import { ModePublishSwitch } from "@/components/tournament/mode-publish-switch";
 import { QualificationPlayoffManager } from "@/components/tournament/qualification-playoff-manager";
 import { RankCell } from "@/components/tournament/rank-cell";
 import { TieWarningBanner } from "@/components/tournament/tie-warning-banner";
@@ -648,6 +649,15 @@ export default function GrandPrixPage({
             groupCount={groupCount}
             setGroupCount={setGroupCount}
           />}
+
+          {/* Per-mode independent publish toggle (issue #618) */}
+          {isAdmin && (
+            <ModePublishSwitch
+              tournamentId={tournamentId}
+              mode="gp"
+              modeLabelKey="grandPrix"
+            />
+          )}
         </div>
       </div>
 

--- a/smkc-score-app/src/app/tournaments/[id]/layout.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/layout.tsx
@@ -30,7 +30,6 @@ import { Badge } from "@/components/ui/badge";
 import { ExportButton } from "@/components/tournament/export-button";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { createLogger } from "@/lib/client-logger";
-import { publishMode, unpublishMode, type RevealableMode, MODE_REVEAL_ORDER } from "@/lib/public-modes";
 
 const logger = createLogger({ serviceName: "tournaments-layout" });
 
@@ -194,40 +193,6 @@ export default function TournamentLayout({
   };
 
   /**
-   * Toggles a mode's public visibility with cascade logic:
-   * publishing mode X also publishes all earlier modes (ta→bm→mr→gp order),
-   * unpublishing mode X also unpublishes all later modes.
-   * This ensures publicModes is always a sequential prefix of MODE_REVEAL_ORDER.
-   */
-  const [visibilityUpdating, setVisibilityUpdating] = useState(false);
-  const toggleMode = async (mode: RevealableMode) => {
-    setVisibilityUpdating(true);
-    try {
-      const currentModes = (tournament?.publicModes ?? []) as string[];
-      const isPublic = currentModes.includes(mode);
-      const newModes = isPublic ? unpublishMode(mode) : publishMode(mode);
-      const response = await fetch(`/api/tournaments/${id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ publicModes: newModes }),
-      });
-      if (response.ok) {
-        fetchTournament();
-      } else {
-        logger.error("Failed to update visibility", { status: response.status });
-      }
-    } catch (err) {
-      const metadata =
-        err instanceof Error
-          ? { message: err.message, stack: err.stack }
-          : { error: err };
-      logger.error("Failed to update visibility:", metadata);
-    } finally {
-      setVisibilityUpdating(false);
-    }
-  };
-
-  /**
    * Returns a styled Badge component based on tournament status.
    * - Draft: Secondary (gray) for setup phase
    * - Active: Default (primary) for in-progress
@@ -373,31 +338,11 @@ export default function TournamentLayout({
         </div>
 
         {/*
-         * Mode publish controls (admin only).
-         * Centralised here so the same UI appears regardless of which mode tab
-         * is active, and the "未公開" badge in the tab bar disappears instantly
-         * after toggling because the layout's own tournament state is updated.
-         * Publishing cascades to earlier modes; unpublishing cascades to later.
+         * Per-mode publish controls have moved next to each mode's player
+         * settings (issue #618). Each mode's publish state is now independent;
+         * the "未公開" badge below still reflects the per-mode state via
+         * tournament.publicModes.
          */}
-        {isAdmin && (
-          <div className="flex flex-wrap gap-2">
-            {MODE_REVEAL_ORDER.map((mode) => {
-              const labelKey = ({ ta: "timeTrial", bm: "battleMode", mr: "matchRace", gp: "grandPrix" } as const)[mode];
-              const isPublic = (tournament.publicModes ?? [] as string[]).includes(mode);
-              return (
-                <Button
-                  key={mode}
-                  variant={isPublic ? "outline" : "default"}
-                  size="sm"
-                  onClick={() => toggleMode(mode)}
-                  disabled={visibilityUpdating}
-                >
-                  {t(labelKey)}: {isPublic ? tc("unpublishMode") : tc("publishMode")}
-                </Button>
-              );
-            })}
-          </div>
-        )}
 
         {/* Child page content (TA, BM, MR, GP, or Overall sub-page) */}
         {children}

--- a/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
@@ -23,6 +23,7 @@ import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { GroupSetupDialog } from "@/components/tournament/group-setup-dialog";
+import { ModePublishSwitch } from "@/components/tournament/mode-publish-switch";
 import { QualificationPlayoffManager } from "@/components/tournament/qualification-playoff-manager";
 import { RankCell } from "@/components/tournament/rank-cell";
 import { TieWarningBanner } from "@/components/tournament/tie-warning-banner";
@@ -561,6 +562,15 @@ export default function MatchRacePage({
             groupCount={groupCount}
             setGroupCount={setGroupCount}
           />}
+
+          {/* Per-mode independent publish toggle (issue #618) */}
+          {isAdmin && (
+            <ModePublishSwitch
+              tournamentId={tournamentId}
+              mode="mr"
+              modeLabelKey="matchRace"
+            />
+          )}
         </div>
       </div>
 

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
@@ -59,6 +59,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Checkbox } from "@/components/ui/checkbox";
+import { ModePublishSwitch } from "@/components/tournament/mode-publish-switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { COURSE_INFO, POLLING_INTERVAL, TOTAL_COURSES } from "@/lib/constants";
 import { applyAutoPairsToSetup } from "@/lib/ta/pair-utils";
@@ -1017,6 +1018,15 @@ export default function TimeAttackPage({
                 </DialogFooter>
               </DialogContent>
             </Dialog>
+          )}
+
+          {/* Per-mode independent publish toggle (issue #618) */}
+          {isAdmin && (
+            <ModePublishSwitch
+              tournamentId={tournamentId}
+              mode="ta"
+              modeLabelKey="timeTrial"
+            />
           )}
         </div>
       </div>

--- a/smkc-score-app/src/components/tournament/mode-publish-switch.tsx
+++ b/smkc-score-app/src/components/tournament/mode-publish-switch.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { useModePublish } from "@/hooks/use-mode-publish";
+import type { RevealableMode } from "@/lib/public-modes";
+
+interface ModePublishSwitchProps {
+  tournamentId: string;
+  mode: RevealableMode;
+  /** i18n key inside the `common` namespace identifying the mode label (e.g. "battleMode"). */
+  modeLabelKey: string;
+}
+
+/**
+ * Per-mode publish/unpublish toggle (issue #618).
+ *
+ * Rendered next to the player-setup dialog on each mode page. Each mode
+ * publishes/unpublishes independently — toggling one mode does not affect
+ * any other mode.
+ */
+export function ModePublishSwitch({
+  tournamentId,
+  mode,
+  modeLabelKey,
+}: ModePublishSwitchProps) {
+  const tc = useTranslations("common");
+  const { isPublic, toggle, updating, loading } = useModePublish(
+    tournamentId,
+    mode
+  );
+
+  const stateLabel = isPublic ? tc("publishMode") : tc("unpublishMode");
+  const ariaLabel = `${tc(modeLabelKey)}: ${stateLabel}`;
+
+  return (
+    <div className="flex items-center gap-2">
+      <Switch
+        checked={isPublic}
+        onCheckedChange={toggle}
+        disabled={updating || loading}
+        aria-label={ariaLabel}
+      />
+      <Badge variant={isPublic ? "default" : "secondary"} className="text-xs">
+        {stateLabel}
+      </Badge>
+    </div>
+  );
+}

--- a/smkc-score-app/src/components/ui/switch.tsx
+++ b/smkc-score-app/src/components/ui/switch.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface SwitchProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+  /** Accessible label for assistive tech. Required because the switch has no visible label. */
+  "aria-label": string;
+  className?: string;
+  id?: string;
+}
+
+/**
+ * Accessible toggle switch.
+ *
+ * Built as a semantic <button role="switch"> rather than pulling in a Radix
+ * dependency for a single component (the codebase already follows this same
+ * pattern for the locale switcher in src/components/LocaleSwitcher.tsx).
+ */
+export function Switch({
+  checked,
+  onCheckedChange,
+  disabled = false,
+  className,
+  id,
+  "aria-label": ariaLabel,
+}: SwitchProps) {
+  const handleClick = () => {
+    if (disabled) return;
+    onCheckedChange(!checked);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      handleClick();
+    }
+  };
+
+  return (
+    <button
+      id={id}
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      disabled={disabled}
+      className={cn(
+        "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border border-transparent",
+        "transition-colors duration-200 ease-in-out",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        checked ? "bg-primary" : "bg-muted/60 hover:bg-muted",
+        className
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none inline-block size-5 rounded-full bg-white shadow-md ring-0",
+          "transition-transform duration-200 ease-in-out",
+          checked ? "translate-x-5" : "translate-x-0.5"
+        )}
+      />
+    </button>
+  );
+}

--- a/smkc-score-app/src/hooks/use-mode-publish.ts
+++ b/smkc-score-app/src/hooks/use-mode-publish.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { createLogger } from "@/lib/client-logger";
+import { fetchWithRetry } from "@/lib/fetch-with-retry";
+import {
+  addPublicMode,
+  removePublicMode,
+  type RevealableMode,
+} from "@/lib/public-modes";
+
+const logger = createLogger({ serviceName: "use-mode-publish" });
+
+export interface UseModePublishResult {
+  isPublic: boolean;
+  toggle: () => Promise<void>;
+  updating: boolean;
+  /** True until the initial publicModes fetch resolves. */
+  loading: boolean;
+}
+
+/**
+ * Hook for the per-mode publish toggle on each mode page (issue #618).
+ *
+ * Each mode publishes/unpublishes independently — toggling one mode does not
+ * affect the others. The hook fetches the tournament's current `publicModes`
+ * once on mount and then maintains local truth, updating it after each PUT.
+ */
+export function useModePublish(
+  tournamentId: string,
+  mode: RevealableMode
+): UseModePublishResult {
+  const [publicModes, setPublicModes] = useState<readonly string[]>([]);
+  const [updating, setUpdating] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await fetchWithRetry(
+          `/api/tournaments/${tournamentId}?fields=summary`
+        );
+        if (!response.ok) {
+          logger.error("Failed to fetch tournament for publish state", {
+            status: response.status,
+          });
+          return;
+        }
+        const json = await response.json();
+        const tournament = json.data ?? json;
+        if (!cancelled) {
+          setPublicModes(
+            Array.isArray(tournament?.publicModes)
+              ? (tournament.publicModes as string[])
+              : []
+          );
+        }
+      } catch (err) {
+        const metadata =
+          err instanceof Error
+            ? { message: err.message, stack: err.stack }
+            : { error: err };
+        logger.error("Failed to load publicModes", metadata);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tournamentId]);
+
+  const isPublic = publicModes.includes(mode);
+
+  const toggle = useCallback(async () => {
+    if (updating) return;
+    setUpdating(true);
+    try {
+      const next = isPublic
+        ? removePublicMode(publicModes, mode)
+        : addPublicMode(publicModes, mode);
+      const response = await fetch(`/api/tournaments/${tournamentId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ publicModes: next }),
+      });
+      if (response.ok) {
+        setPublicModes(next);
+      } else {
+        logger.error("Failed to update mode visibility", {
+          status: response.status,
+          mode,
+        });
+      }
+    } catch (err) {
+      const metadata =
+        err instanceof Error
+          ? { message: err.message, stack: err.stack }
+          : { error: err };
+      logger.error("Failed to update mode visibility:", metadata);
+    } finally {
+      setUpdating(false);
+    }
+  }, [isPublic, mode, publicModes, tournamentId, updating]);
+
+  return { isPublic, toggle, updating, loading };
+}

--- a/smkc-score-app/src/lib/public-modes.ts
+++ b/smkc-score-app/src/lib/public-modes.ts
@@ -1,38 +1,64 @@
 /**
- * Sequential publication order for qualification modes.
+ * Independent per-mode publish state for the four qualification modes.
  *
- * Admins publish modes to non-admin viewers one stage at a time, matching the
- * tournament flow (TA → BM → MR → GP). A mode can only be public if every mode
- * earlier in this list is also public, so `publicModes` stored on the
- * Tournament must always be a prefix of this list.
+ * `publicModes` on the Tournament is an unordered set serialized as a JSON
+ * array. Each mode's published state is independent of the others —
+ * publishing or unpublishing one mode does not affect any other mode.
  *
- * Publishing mode X ⇒ publish X and every earlier mode.
- * Unpublishing mode X ⇒ unpublish X and every later mode (cascade).
+ * MODE_REVEAL_ORDER is the canonical mode list and the display order; it is
+ * NOT a sequencing constraint on the stored value.
  */
 export const MODE_REVEAL_ORDER = ["ta", "bm", "mr", "gp"] as const;
 export type RevealableMode = (typeof MODE_REVEAL_ORDER)[number];
 
-/** Prefix of {@link MODE_REVEAL_ORDER} up to and including `mode`. */
-export function publishMode(mode: RevealableMode): RevealableMode[] {
-  const idx = MODE_REVEAL_ORDER.indexOf(mode);
-  return MODE_REVEAL_ORDER.slice(0, idx + 1);
-}
+const REVEALABLE_SET: ReadonlySet<string> = new Set(MODE_REVEAL_ORDER);
 
-/** Prefix of {@link MODE_REVEAL_ORDER} strictly before `mode` (cascades unpublish). */
-export function unpublishMode(mode: RevealableMode): RevealableMode[] {
-  const idx = MODE_REVEAL_ORDER.indexOf(mode);
-  return MODE_REVEAL_ORDER.slice(0, idx);
+function isRevealableMode(value: unknown): value is RevealableMode {
+  return typeof value === "string" && REVEALABLE_SET.has(value);
 }
 
 /**
- * True iff `modes` is a valid prefix of {@link MODE_REVEAL_ORDER}: no gaps,
- * canonical order, no duplicates. Used by the API to reject non-sequential
- * `publicModes` payloads from clients.
+ * Returns `modes ∪ {mode}`, normalized: only valid modes are kept,
+ * duplicates are removed, and the result is sorted by MODE_REVEAL_ORDER
+ * for stable storage and readable audit logs.
  */
-export function isSequentialPrefix(modes: readonly string[]): boolean {
-  if (modes.length > MODE_REVEAL_ORDER.length) return false;
-  for (let i = 0; i < modes.length; i++) {
-    if (modes[i] !== MODE_REVEAL_ORDER[i]) return false;
+export function addPublicMode(
+  modes: readonly string[],
+  mode: RevealableMode
+): RevealableMode[] {
+  const set = new Set<RevealableMode>();
+  for (const m of modes) {
+    if (isRevealableMode(m)) set.add(m);
+  }
+  set.add(mode);
+  return MODE_REVEAL_ORDER.filter((m) => set.has(m));
+}
+
+/**
+ * Returns `modes \ {mode}`, normalized: only valid modes are kept,
+ * duplicates are removed, sorted by MODE_REVEAL_ORDER.
+ */
+export function removePublicMode(
+  modes: readonly string[],
+  mode: RevealableMode
+): RevealableMode[] {
+  const set = new Set<RevealableMode>();
+  for (const m of modes) {
+    if (isRevealableMode(m) && m !== mode) set.add(m);
+  }
+  return MODE_REVEAL_ORDER.filter((m) => set.has(m));
+}
+
+/**
+ * True iff `modes` is an array of valid mode names with no duplicates.
+ * Order is irrelevant. Used by the API to validate `publicModes` payloads.
+ */
+export function isValidPublicModes(modes: readonly unknown[]): boolean {
+  const seen = new Set<string>();
+  for (const m of modes) {
+    if (!isRevealableMode(m)) return false;
+    if (seen.has(m)) return false;
+    seen.add(m);
   }
   return true;
 }


### PR DESCRIPTION
## Summary
Refactors the mode publication system from sequential cascading logic to independent per-mode toggles. Each qualification mode (TA, BM, MR, GP) can now be published or unpublished independently without affecting other modes.

## Key Changes

- **Mode publication logic**: Replaced `publishMode()` and `unpublishMode()` with `addPublicMode()` and `removePublicMode()` that operate on unordered sets. Renamed `isSequentialPrefix()` to `isValidPublicModes()` to accept any valid subset of modes rather than enforcing sequential prefixes.

- **New hook**: Added `useModePublish()` hook to manage per-mode publish state independently. Fetches initial `publicModes` on mount and maintains local truth, updating after each API call.

- **UI component**: Created `ModePublishSwitch` component with an accessible toggle switch and status badge, rendered on each mode page (TA, BM, MR, GP) next to player setup controls.

- **Switch component**: Added accessible `Switch` component built as semantic `<button role="switch">` with keyboard support (Enter/Space) and proper ARIA attributes.

- **API validation**: Updated `PUT /api/tournaments/[id]` to validate `publicModes` using the new `isValidPublicModes()` function, accepting any subset of valid mode names with no duplicates.

- **Layout cleanup**: Removed centralized mode publish controls from tournament layout; per-mode toggles now live on individual mode pages.

- **Tests**: Updated test suites to reflect independent toggling semantics—non-sequential subsets like `['bm']` alone or `['bm','gp']` are now valid; only invalid mode names and duplicates are rejected.

## Implementation Details

- `publicModes` is stored as an unordered JSON array but normalized to `MODE_REVEAL_ORDER` for stable storage and readable audit logs.
- The hook uses `fetchWithRetry()` for initial load and standard `fetch()` for updates, with proper error logging and cancellation support.
- Each mode page independently manages its own publish state; toggling one mode does not affect others.
- E2E tests (TC-339) verify independent toggling: publishing BM alone, adding TA without affecting BM, removing BM without affecting TA, and rejecting invalid mode names and duplicates.

https://claude.ai/code/session_01EgB9iMyKPjPcZiDDp6tPSG