### PR TITLE
fix(#619,#621): player name overflow + mode tab badge live update

### DIFF
--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -438,6 +438,54 @@ async function main() {
   t = await vis(page);
   log('TC-203', (t.includes('Overall') || t.includes('総合')) ? 'PASS' : 'FAIL');
 
+  // TC-823: Mode publish toggle updates layout tab badge in real time (issue #621)
+  // A new tournament has publicModes=[] so all mode tabs show a destructive "未公開" badge for admins.
+  // Toggling the per-mode switch dispatches a custom event that triggers a re-fetch of the layout's
+  // tournament data; the hidden badge should appear/disappear without a page reload.
+  {
+    let tc823TournamentId = null;
+    try {
+      tc823TournamentId = await uiCreateTournament(page, `E2E TC-823 ${Date.now()}`);
+
+      await nav(page, `/tournaments/${tc823TournamentId}/bm`);
+      await page.waitForTimeout(3000);
+
+      // BM tab link has exact href; the hidden badge lives inside it with `bg-destructive`
+      const bmTabBadge = page.locator(`a[href="/tournaments/${tc823TournamentId}/bm"] .bg-destructive`);
+      const hasBadgeBefore = await bmTabBadge.count() > 0;
+
+      // The ModePublishSwitch aria-label is "{mode}: {state}" (e.g. "バトルモード: 未公開")
+      const publishSwitch = page.getByRole('switch', { name: /バトルモード|Battle Mode/i }).first();
+      const switchExists = await publishSwitch.count() > 0;
+
+      let hasBadgeAfterPublish = true;
+      let hasBadgeAfterUnpublish = false;
+      if (switchExists) {
+        // Toggle to published
+        await publishSwitch.click();
+        await page.waitForTimeout(3000); // Wait for API call + publicModesChanged event + re-fetch
+        hasBadgeAfterPublish = await bmTabBadge.count() > 0;
+
+        // Toggle back to unpublished
+        await publishSwitch.click();
+        await page.waitForTimeout(3000);
+        hasBadgeAfterUnpublish = await bmTabBadge.count() > 0;
+      }
+
+      const pass = switchExists && hasBadgeBefore && !hasBadgeAfterPublish && hasBadgeAfterUnpublish;
+      log('TC-823', pass ? 'PASS' : 'FAIL',
+        !switchExists ? 'Publish switch not found on BM page'
+        : !hasBadgeBefore ? 'Hidden badge not shown before toggle'
+        : hasBadgeAfterPublish ? 'Hidden badge still shown after toggle to published (event/re-fetch missing)'
+        : !hasBadgeAfterUnpublish ? 'Hidden badge did not reappear after re-toggle to unpublished'
+        : '');
+    } catch (err) {
+      log('TC-823', 'FAIL', err instanceof Error ? err.message : 'TC-823 mode tab badge test failed');
+    } finally {
+      if (tc823TournamentId) await deleteTournament(page, tc823TournamentId);
+    }
+  }
+
   // TC-401: Shared all-mode tournament has completed qualification data in TA/BM/MR/GP
   if (setupAllModesError) {
     log('TC-401', 'FAIL', `setupAllModes failed: ${setupAllModesError.slice(0, 160)}`);

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -1276,6 +1276,79 @@ async function runTc520(adminPage) {
   }
 }
 
+/* ───────── TC-521: BM admin score dialog — long player names must not overflow ─────────
+ * Regression guard for issue #619: player names longer than the dialog pane width
+ * must be visually truncated (via CSS `truncate`) and not cause horizontal scroll.
+ *
+ * Approach: create 2 players with 50-char nicknames, open the score entry dialog,
+ * then evaluate whether the label elements overflow their containing div. */
+async function runTc521(adminPage) {
+  let tournamentId = null;
+  let player1Id = null;
+  let player2Id = null;
+
+  try {
+    const stamp = Date.now();
+    // 50-char name to guarantee overflow without truncation
+    const longName = `VeryLongPlayerNameForOverflowTest${stamp}`.slice(0, 50);
+    const player1 = await uiCreatePlayer(adminPage, longName, `e2e_bm_521_p1_${stamp}`);
+    const player2 = await uiCreatePlayer(adminPage, longName + 'X', `e2e_bm_521_p2_${stamp}`);
+    player1Id = player1.id;
+    player2Id = player2.id;
+
+    tournamentId = await uiCreateTournament(adminPage, `E2E BM521 ${stamp}`, {});
+    await uiActivateTournament(adminPage, tournamentId);
+
+    await setupModePlayersViaUi(adminPage, 'bm', tournamentId, [
+      { id: player1.id, name: longName, nickname: player1.nickname },
+      { id: player2.id, name: longName + 'X', nickname: player2.nickname },
+    ]);
+
+    await nav(adminPage, `/tournaments/${tournamentId}/bm`);
+    await adminPage.waitForTimeout(3000);
+
+    // Click the score entry button for the first non-BYE match
+    const scoreBtn = adminPage.getByRole('button', { name: /スコア入力|Enter Score/i }).first();
+    await scoreBtn.waitFor({ state: 'visible', timeout: 10000 });
+    await scoreBtn.click();
+    await adminPage.waitForTimeout(1500);
+
+    // Verify dialog is open and player names are visible (dialog should not be wider than viewport)
+    const dialogVisible = await adminPage.locator('[role="dialog"]').isVisible();
+
+    // Evaluate whether label text overflows its container — with `truncate`, scrollWidth should not
+    // exceed the viewport width (the label is capped by the max-w-[140px] parent).
+    const overflows = await adminPage.evaluate(() => {
+      const dialog = document.querySelector('[role="dialog"]');
+      if (!dialog) return { dialogWidth: 0, viewportWidth: window.innerWidth, labels: [] };
+      const labels = Array.from(dialog.querySelectorAll('label'));
+      return {
+        dialogWidth: dialog.getBoundingClientRect().width,
+        viewportWidth: window.innerWidth,
+        // scrollWidth > clientWidth means the element's content overflows its box
+        labels: labels.map(l => ({ scrollWidth: l.scrollWidth, clientWidth: l.clientWidth })),
+      };
+    });
+
+    const dialogFitsViewport = overflows.dialogWidth <= overflows.viewportWidth;
+    // Each label must not overflow its own bounding box (truncate keeps scrollWidth === clientWidth)
+    const labelsNoOverflow = overflows.labels.every(l => l.scrollWidth <= l.clientWidth);
+
+    const pass = dialogVisible && dialogFitsViewport && labelsNoOverflow;
+    log('TC-521', pass ? 'PASS' : 'FAIL',
+      !dialogVisible ? 'Score dialog did not open'
+      : !dialogFitsViewport ? `Dialog ${overflows.dialogWidth}px wider than viewport ${overflows.viewportWidth}px`
+      : !labelsNoOverflow ? `Label overflow detected: ${JSON.stringify(overflows.labels)}`
+      : '');
+  } catch (err) {
+    log('TC-521', 'FAIL', err instanceof Error ? err.message : 'TC-521 long name overflow test failed');
+  } finally {
+    if (tournamentId) await apiDeleteTournament(adminPage, tournamentId);
+    if (player1Id) await apiDeletePlayer(adminPage, player1Id);
+    if (player2Id) await apiDeletePlayer(adminPage, player2Id);
+  }
+}
+
 /**
  * Builds the BM suite spec for composition by tc-all. When `sharedFixture` is
  * provided (tc-all flow), we reuse it and skip cleanup — the orchestrator owns
@@ -1317,6 +1390,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-517', fn: runTc517 },
       { name: 'TC-519', fn: runTc519 },
       { name: 'TC-520', fn: runTc520 },
+      { name: 'TC-521', fn: runTc521 },
       { name: 'TC-505', fn: runTc505 },
       { name: 'TC-506', fn: runTc506 },
     ],
@@ -1325,7 +1399,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 
 module.exports = {
   runTc501, runTc502, runTc322, runTc503, runTc504, runTc505, runTc506, runTc511, runTc512, runTc513,
-  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520,
+  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521,
   getSuite,
   results,
   setSharedBmFinalsReady: (v) => { sharedBmFinalsReady = v; },

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
@@ -925,8 +925,8 @@ export default function BattleModePage({
             })()}
             <div className="flex items-center justify-center gap-4">
               {/* Player 1 score input */}
-              <div className="text-center">
-                <Label htmlFor={`bm-score1-${selectedMatch?.id}`}>{selectedMatch?.player1.nickname}</Label>
+              <div className="text-center min-w-0 max-w-[140px]">
+                <Label htmlFor={`bm-score1-${selectedMatch?.id}`} className="block truncate w-full">{selectedMatch?.player1.nickname}</Label>
                 <Input
                   id={`bm-score1-${selectedMatch?.id}`}
                   type="number"
@@ -948,8 +948,8 @@ export default function BattleModePage({
               </div>
               <span className="text-2xl" aria-hidden="true">-</span>
               {/* Player 2 score input */}
-              <div className="text-center">
-                <Label htmlFor={`bm-score2-${selectedMatch?.id}`}>{selectedMatch?.player2.nickname}</Label>
+              <div className="text-center min-w-0 max-w-[140px]">
+                <Label htmlFor={`bm-score2-${selectedMatch?.id}`} className="block truncate w-full">{selectedMatch?.player2.nickname}</Label>
                 <Input
                   id={`bm-score2-${selectedMatch?.id}`}
                   type="number"

--- a/smkc-score-app/src/app/tournaments/[id]/bm/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/participant/page.tsx
@@ -119,8 +119,8 @@ export default function BattleModeParticipantPage({
         {/* +/- button score input: [Player1 [-][score][+]] - [Player2 [-][score][+]] */}
         <div className="flex items-center justify-center gap-3 mb-4">
           {/* Player 1 score */}
-          <div className="text-center">
-            <p className="text-sm mb-2">{match.player1.nickname}</p>
+          <div className="text-center min-w-0 max-w-[120px]">
+            <p className="text-sm mb-2 truncate">{match.player1.nickname}</p>
             <div className="flex items-center gap-1">
               <Button
                 variant="outline"
@@ -147,8 +147,8 @@ export default function BattleModeParticipantPage({
           </div>
           <span className="text-xl mt-6">-</span>
           {/* Player 2 score */}
-          <div className="text-center">
-            <p className="text-sm mb-2">{match.player2.nickname}</p>
+          <div className="text-center min-w-0 max-w-[120px]">
+            <p className="text-sm mb-2 truncate">{match.player2.nickname}</p>
             <div className="flex items-center gap-1">
               <Button
                 variant="outline"

--- a/smkc-score-app/src/app/tournaments/[id]/layout.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/layout.tsx
@@ -167,6 +167,13 @@ export default function TournamentLayout({
     fetchTournament();
   }, [fetchTournament]);
 
+  // Re-fetch when a mode's publish state changes so tab badges update immediately (issue #621)
+  useEffect(() => {
+    const handler = () => { fetchTournament(); };
+    window.addEventListener('publicModesChanged', handler);
+    return () => window.removeEventListener('publicModesChanged', handler);
+  }, [fetchTournament]);
+
   /**
    * Updates the tournament status via PUT request.
    * Used for one-way status transitions:

--- a/smkc-score-app/src/components/tournament/participant-page-layout.tsx
+++ b/smkc-score-app/src/components/tournament/participant-page-layout.tsx
@@ -278,10 +278,10 @@ export function ParticipantPageLayout<TMatch extends BaseMatch>({
                               key={player.id}
                               className={`p-3 rounded-lg border ${isYou ? "bg-blue-50 border-blue-200" : "bg-gray-50 border-gray-200"}`}
                             >
-                              <div className="font-medium">
-                                {player.nickname}
+                              <div className="font-medium flex items-center gap-1 min-w-0">
+                                <span className="truncate min-w-0">{player.nickname}</span>
                                 {isYou && (
-                                  <Badge variant="default" className="ml-2 bg-blue-600">
+                                  <Badge variant="default" className="shrink-0 bg-blue-600">
                                     {tPart("you")}
                                   </Badge>
                                 )}

--- a/smkc-score-app/src/hooks/use-mode-publish.ts
+++ b/smkc-score-app/src/hooks/use-mode-publish.ts
@@ -88,6 +88,8 @@ export function useModePublish(
       });
       if (response.ok) {
         setPublicModes(next);
+        // Notify the tournament layout to refresh its publicModes so tab badges update without a page reload (issue #621)
+        window.dispatchEvent(new CustomEvent('publicModesChanged', { detail: { tournamentId } }));
       } else {
         logger.error("Failed to update mode visibility", {
           status: response.status,


### PR DESCRIPTION
## Summary

- **fix #619**: BM score entry screens (admin dialog, participant page, participant-page-layout player cards) now apply `truncate`/`max-w-*` CSS so long player nicknames don't overflow the pane
- **fix #621**: `useModePublish` dispatches a `publicModesChanged` CustomEvent after a successful toggle; the tournament layout listens for it and re-fetches tournament data, so the tab hidden/shown badge updates immediately without a page reload
- **E2E TC-521**: regression guard — opens the BM admin score dialog with a 50-char player name and asserts label elements don't overflow (`scrollWidth <= clientWidth`)
- **E2E TC-823**: verifies the tab badge live-update end-to-end (badge present before toggle → gone after publish → reappears after unpublish)

## Test plan

- [ ] TC-521 passes: BM score dialog with long name renders without overflow
- [ ] TC-823 passes: mode tab badge updates in real time after toggling ModePublishSwitch
- [ ] All existing BM E2E tests still pass (`node e2e/tc-bm.js`)
- [ ] No regression on other mode pages

https://claude.ai/code/session_017CdTu2LqkPRRu34vYgaYCY

---
_Generated by [Claude Code](https://claude.ai/code/session_017CdTu2LqkPRRu34vYgaYCY)_