### PR TITLE
fix(i18n): add missing common.{timeTrial,battleMode,matchRace,grandPrix} keys

### DIFF
--- a/smkc-score-app/__tests__/i18n/messages.test.ts
+++ b/smkc-score-app/__tests__/i18n/messages.test.ts
@@ -27,4 +27,21 @@ describe('translation messages', () => {
     expect(enMessages.common.viewTournament).toBe('View Tournament');
     expect(jaMessages.common.viewTournament).toBe('トーナメントを見る');
   });
+
+  /**
+   * ModePublishSwitch (src/components/tournament/mode-publish-switch.tsx) reads
+   * mode labels from the `common` namespace via `useTranslations('common')` and
+   * passes one of `timeTrial | battleMode | matchRace | grandPrix` as the key.
+   * If any of these are missing in `common`, the admin mode pages crash at
+   * render time with `MISSING_MESSAGE: common.<modeKey> (<locale>)` — which is
+   * exactly how the issue introduced by PR #620 (commit bb02f03) was found.
+   * This guards the contract between mode-publish-switch and the message files.
+   */
+  it.each(['timeTrial', 'battleMode', 'matchRace', 'grandPrix'] as const)(
+    'defines mode label "%s" in common for both locales (ModePublishSwitch contract)',
+    (modeKey) => {
+      expect(enMessages.common[modeKey]).toBeDefined();
+      expect(jaMessages.common[modeKey]).toBeDefined();
+    }
+  );
 });

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -125,7 +125,11 @@
     "failedResetBracket": "Failed to reset bracket",
     "tbd": "TBD",
     "publishMode": "Publish",
-    "unpublishMode": "Unpublish"
+    "unpublishMode": "Unpublish",
+    "timeTrial": "Time Trial",
+    "battleMode": "Battle Mode",
+    "matchRace": "Match Race",
+    "grandPrix": "Grand Prix"
   },
   "home": {
     "tagline": "SMKC Score Management",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -125,7 +125,11 @@
     "generateFinalsBracket": "決勝ブラケットを生成",
     "tbd": "未定",
     "publishMode": "公開",
-    "unpublishMode": "未公開"
+    "unpublishMode": "未公開",
+    "timeTrial": "タイムトライアル",
+    "battleMode": "バトルモード",
+    "matchRace": "マッチレース",
+    "grandPrix": "グランプリ"
   },
   "home": {
     "tagline": "SMKC スコア管理",


### PR DESCRIPTION
## Summary

- ModePublishSwitch (introduced in PR #620 / commit bb02f03) reads four mode label keys from the `common` namespace via `useTranslations('common')`, but those keys only exist in `home`/`tournaments`/`participant`. Admin mode pages crash at render with `MISSING_MESSAGE: common.<modeKey> (<locale>)`, which also crashes the E2E suite mid-`setupAllModes`.
- Add `timeTrial`, `battleMode`, `matchRace`, `grandPrix` to the `common` namespace in both `messages/en.json` and `messages/ja.json` (matching the existing translations used elsewhere).
- Extend `__tests__/i18n/messages.test.ts` with an `it.each` regression test that locks the ModePublishSwitch ↔ `common` namespace contract per locale.

## How discovered

Manual E2E verification with `agent-browser` on https://smkc.bluemoon.works/ (anonymous read-only) passed every TC-001..TC-008/TC-307/TC-320 scenario, but `node e2e/tc-all.js` crashed during admin setup with `[error] p: MISSING_MESSAGE: common.timeTrial (ja)` followed by `page.evaluate: Target page, context or browser has been closed`. The discrepancy: the ModePublishSwitch only renders for admins (`isAdmin && <ModePublishSwitch …/>`), so anonymous browsing never triggers it.

## Test plan

- [x] `npx jest __tests__/i18n/messages.test.ts` — 6/6 pass (was 2/2 before the regression test)
- [x] Lint: 0 errors
- [x] JSON validates in both locales
- [ ] Re-run `node e2e/tc-all.js` against production after deploy to confirm `setupAllModes` no longer crashes on the admin BM/MR/GP page

🤖 Generated with [Claude Code](https://claude.com/claude-code)