### PR TITLE
fix(client-logger): serialize Error meta with name/message/stack

### DIFF
--- a/smkc-score-app/__tests__/lib/client-logger.test.ts
+++ b/smkc-score-app/__tests__/lib/client-logger.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @module __tests__/lib/client-logger.test.ts
+ * Regression test for the client-side logger's Error serialization. Without
+ * the JSON.stringify replacer, an Error in meta serializes to `{}` because
+ * `name`/`message`/`stack` are non-enumerable — production logs end up showing
+ * `Failed to fetch data: {"error":{}}` instead of the actual cause. Found
+ * during a manual E2E pass against /tournaments/<id>/ta/phase1 in JA locale,
+ * where ta-elimination-phase.tsx emitted exactly that useless line.
+ */
+import { serializeMeta } from '@/lib/client-logger';
+
+describe('client-logger serializeMeta', () => {
+  it('serializes plain objects with JSON semantics', () => {
+    const out = serializeMeta({ tournamentId: 'abc', count: 3 });
+    expect(JSON.parse(out)).toEqual({ tournamentId: 'abc', count: 3 });
+  });
+
+  it('expands Error instances to { name, message, stack } instead of {}', () => {
+    const err = new Error('Failed to fetch phase1');
+    const out = serializeMeta({ error: err, tournamentId: 'tid_1' });
+    const parsed = JSON.parse(out);
+    expect(parsed.error.name).toBe('Error');
+    expect(parsed.error.message).toBe('Failed to fetch phase1');
+    expect(typeof parsed.error.stack).toBe('string');
+    expect(parsed.error.stack).toContain('Failed to fetch phase1');
+    expect(parsed.tournamentId).toBe('tid_1');
+  });
+
+  it('expands custom Error subclasses (e.g. TypeError) the same way', () => {
+    const err = new TypeError('not a function');
+    const parsed = JSON.parse(serializeMeta({ error: err }));
+    expect(parsed.error.name).toBe('TypeError');
+    expect(parsed.error.message).toBe('not a function');
+  });
+
+  it('handles nested Errors (e.g. inside an array)', () => {
+    const out = serializeMeta({ errors: [new Error('a'), new Error('b')] });
+    const parsed = JSON.parse(out);
+    expect(parsed.errors).toHaveLength(2);
+    expect(parsed.errors[0].message).toBe('a');
+    expect(parsed.errors[1].message).toBe('b');
+  });
+});

--- a/smkc-score-app/src/lib/client-logger.ts
+++ b/smkc-score-app/src/lib/client-logger.ts
@@ -21,6 +21,21 @@ interface LogMetadata extends Record<string, unknown> {
   service?: string;
 }
 
+/**
+ * Serialize meta for log output. Error instances need a JSON.stringify replacer
+ * because `name`/`message`/`stack` are non-enumerable and would otherwise
+ * disappear, leaving operators with `{"error":{}}` in production logs (mirrors
+ * the same handling in src/lib/logger.ts).
+ */
+export function serializeMeta(meta: LogMetadata): string {
+  return JSON.stringify(meta, (_key, value) => {
+    if (value instanceof Error) {
+      return { name: value.name, message: value.message, stack: value.stack };
+    }
+    return value;
+  });
+}
+
 // Silent test logger to avoid noise in test output
 const createTestLogger = (_serviceName: string) => {
   return {
@@ -52,7 +67,7 @@ export const createLogger = (options: LoggerOptions) => {
   // Format log message with timestamp, service name, and level
   const formatMessage = (level: string, message: string, meta?: LogMetadata): string => {
     const timestamp = new Date().toISOString();
-    const metaStr = meta ? ` ${JSON.stringify(meta)}` : '';
+    const metaStr = meta ? ` ${serializeMeta(meta)}` : '';
     return `[${timestamp}] [${serviceName}] [${level}] ${message}${metaStr}`;
   };
 


### PR DESCRIPTION
## Summary

- Browser-side `client-logger.ts` formatted meta with plain `JSON.stringify(meta)`. Because `Error.message`/`Error.stack` are non-enumerable, every `logger.error('...', { error: err })` (23 call sites) produced `{"error":{}}` in production browser consoles — zero diagnostic value for operators.
- The server-side logger (`src/lib/logger.ts:57-64`) already has the right Error-aware replacer. This PR ports the same replacer to `client-logger.ts` so both loggers behave consistently.
- Added a 4-case Jest test that locks down the contract: plain objects round-trip; an `Error` becomes `{name, message, stack}`; a `TypeError` subclass works; nested Errors inside arrays expand. All four would fail against the pre-fix code.

## How discovered

While running a manual anonymous E2E browser pass on https://smkc.bluemoon.works/ (JA locale, `/tournaments/<id>/ta/revival-1` → `/ta/phase1`), the console emitted:

```
[2026-04-25T07:38:46.476Z] [ta-elimination-phase] [ERROR] Failed to fetch data: {"error":{}}
```

Source: `src/components/tournament/ta-elimination-phase.tsx:228` — `logger.error("Failed to fetch data:", { error: err });`. The fetch error object was real, but the log line was useless.

## Why a logger-level fix instead of patching call sites

23 call sites use the `{ error: err }` pattern. Fixing the logger benefits all of them with no API change, and matches what the server logger already does. `sendToServer` is left untouched because no caller passes `enableServerAggregation: true` (YAGNI).

## Test plan

- [x] `npx jest __tests__/lib/client-logger.test.ts` — 4/4 pass
- [x] Existing `__tests__/lib/logger.test.ts` and `__tests__/i18n/messages.test.ts` still pass (21/21 with new + existing)
- [x] Lint clean for changed files
- [ ] After deploy, re-visit `/tournaments/<id>/ta/phase1` on production and confirm any future `Failed to fetch data` log line carries the actual `message` and `stack`

🤖 Generated with [Claude Code](https://claude.com/claude-code)