### PR TITLE
feat(#629): add noCamera flag to players + fix E2E failures (#616)

### DIFF
--- a/smkc-score-app/__tests__/app/api/players/[id]/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/players/[id]/route.test.ts
@@ -312,6 +312,7 @@ describe('PUT /api/players/[id]', () => {
             name: 'Updated Name',
             nickname: 'updated',
             country: 'US',
+            noCamera: false,
           },
         })
       );

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -717,6 +717,30 @@ async function apiUpdateTtEntry(page, tournamentId, entryId, payload) {
   { label: `TT entry PUT ${entryId}` });
 }
 
+/**
+ * Force-set the rank of a TT entry WITHOUT sending times in the payload.
+ *
+ * The PUT /tt/entries route calls recalculateRanks only when `times` is present.
+ * Sending only `rank` (no `times`) skips recalculation so tests that seed a
+ * single-player slot (e.g. rank 17 in a 1-player tournament) can preserve the
+ * desired rank even though recalculateRanks would otherwise derive rank=1 from
+ * actual time ordering.
+ *
+ * Must be called BEFORE freezing the stage (frozen entries block all PUTs).
+ */
+async function apiForceRankOnly(page, tournamentId, entryId, rank) {
+  const ge = await apiGetTtEntry(page, tournamentId, entryId);
+  const version = ge.b?.data?.version;
+  if (ge.s !== 200 || typeof version !== 'number') {
+    throw new Error(`Failed to fetch TT entry version for rank-only update (${entryId}, status=${ge.s})`);
+  }
+  const res = await apiUpdateTtEntry(page, tournamentId, entryId, { version, rank });
+  if (res.s !== 200) {
+    throw new Error(`Failed to force rank ${rank} for entry ${entryId} (${res.s}): ${JSON.stringify(res.b).slice(0, 120)}`);
+  }
+  return res;
+}
+
 /** Fetch current version, then PUT full times + totalTime + rank in one call.
  *  Callers pass already-formatted `times` (e.g. { MC1: '1:00.00' }) + totalTimeMs + rank. */
 async function apiSeedTtEntry(page, tournamentId, entryId, times, totalTimeMs, rank) {
@@ -2249,6 +2273,7 @@ module.exports = {
   apiGetTtEntry,
   apiUpdateTtEntry,
   apiSeedTtEntry,
+  apiForceRankOnly,
   apiPromoteTaPhase,
   apiSetTaPartner,
   apiUpdateTaSeeding,

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -18,6 +18,7 @@ const {
   apiUpdateTaSeeding,
   apiFetchTa,
   apiSeedTtEntry,
+  apiForceRankOnly,
   apiTaParticipantEditTime,
   installApiLogging,
   setupAllModes28PlayerQualification,
@@ -840,6 +841,10 @@ async function main() {
       const taEntry312 = (taData312.b?.data?.entries ?? []).find((e) => e.playerId === pid);
       if (!taEntry312) throw new Error(`No TA entry found for player ${pid}`);
       await apiSeedTtEntry(page, taTournamentId, taEntry312.id, rank17Times, rank17Total, 17);
+      /* recalculateRanks (called inside apiSeedTtEntry's PUT) assigns rank=1
+       * for a single-player tournament, overriding the requested rank=17.
+       * Force rank=17 with a times-free PUT so phase1HasPlayers becomes true. */
+      await apiForceRankOnly(page, taTournamentId, taEntry312.id, 17);
       await uiFreezeTaQualification(page, taTournamentId);
 
       /* uiPromoteTaPhase throws on non-200 so no explicit status check is
@@ -903,6 +908,8 @@ async function main() {
       const taEntry313 = (taData313.b?.data?.entries ?? []).find((e) => e.playerId === pid);
       if (!taEntry313) throw new Error(`No TA entry found for player ${pid}`);
       await apiSeedTtEntry(page, taTournamentId, taEntry313.id, rank17TimesTc313, rank17TotalTc313, 17);
+      /* Same rank-17 preservation needed as TC-312 — see comment there. */
+      await apiForceRankOnly(page, taTournamentId, taEntry313.id, 17);
       await uiFreezeTaQualification(page, taTournamentId);
 
       /* uiPromoteTaPhase throws on non-200 so no explicit status check is
@@ -1225,35 +1232,66 @@ async function main() {
   } else { log('TC-319', 'SKIP'); }
 
   // TC-518: TV Assignment up to 4
-  try {
-    await nav(page, `/tournaments/${TID}/bm`);
-    const tvSelect = page.locator('select.w-14').first();
-    const hasSelect = await tvSelect.count() > 0;
-    let options = [];
-    let optionsOk = false;
-    let assignOk = false;
-    if (hasSelect) {
-      options = await tvSelect.evaluateAll((sel) => Array.from(sel[0].options).map((o) => o.value));
-      optionsOk = ['1', '2', '3', '4'].every((v) => options.includes(v));
-      // Assign TV 4 to the first match
-      await tvSelect.selectOption('4');
-      await page.waitForTimeout(1000);
-      // Verify via API that the assignment persisted
-      const bmData = await page.evaluate(async (u) => {
-        const r = await fetch(u);
-        return r.json().catch(() => ({}));
-      }, `/api/tournaments/${TID}/bm`);
-      const matches = bmData.data?.matches || bmData.matches || [];
-      const firstMatchWithTv = matches.find((m) => m.tvNumber === 4);
-      assignOk = !!firstMatchWithTv;
+  // Uses an isolated 2-player BM tournament so this test is independent of
+  // setupAllModes28PlayerQualification (which can fail or time out). With 2
+  // players there is exactly 1 non-BYE match — enough to verify the TV select.
+  {
+    let tc518TournamentId = null;
+    let tc518P1Id = null;
+    let tc518P2Id = null;
+    try {
+      const ts518 = Date.now();
+      const p518a = await uiCreatePlayer(page, 'E2E BM TV A', `e2e_bmtv_a_${ts518}`);
+      tc518P1Id = p518a.id;
+      const p518b = await uiCreatePlayer(page, 'E2E BM TV B', `e2e_bmtv_b_${ts518}`);
+      tc518P2Id = p518b.id;
+      tc518TournamentId = await uiCreateTournament(page, `E2E TC-518 BM TV ${ts518}`);
+      await uiActivateTournament(page, tc518TournamentId);
+
+      // Set up BM with 2 players in group A — creates 1 non-BYE match
+      const bmSetup518 = await page.evaluate(async ([tid, p1, p2]) => {
+        const r = await fetch(`/api/tournaments/${tid}/bm`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ players: [{ playerId: p1, group: 'A' }, { playerId: p2, group: 'A' }] }),
+        });
+        return { s: r.status, b: await r.json().catch(() => ({})) };
+      }, [tc518TournamentId, tc518P1Id, tc518P2Id]);
+      if (bmSetup518.s !== 201) throw new Error(`BM setup failed (${bmSetup518.s})`);
+
+      await nav(page, `/tournaments/${tc518TournamentId}/bm`);
+      const tvSelect = page.locator('select.w-14').first();
+      const hasSelect = await tvSelect.count() > 0;
+      let options = [];
+      let optionsOk = false;
+      let assignOk = false;
+      if (hasSelect) {
+        options = await tvSelect.evaluateAll((sel) => Array.from(sel[0].options).map((o) => o.value));
+        optionsOk = ['1', '2', '3', '4'].every((v) => options.includes(v));
+        // Assign TV 4 to the first match
+        await tvSelect.selectOption('4');
+        await page.waitForTimeout(1000);
+        // Verify via API that the assignment persisted
+        const bmData518 = await page.evaluate(async (u) => {
+          const r = await fetch(u);
+          return r.json().catch(() => ({}));
+        }, `/api/tournaments/${tc518TournamentId}/bm`);
+        const matches518 = bmData518.data?.matches || bmData518.matches || [];
+        const matchWithTv = matches518.find((m) => m.tvNumber === 4);
+        assignOk = !!matchWithTv;
+      }
+      log('TC-518', hasSelect && optionsOk && assignOk ? 'PASS' : 'FAIL',
+        !hasSelect ? 'No TV select found on BM qualification page'
+        : !optionsOk ? `TV options missing 1-4 (got ${options.join(',')})`
+        : !assignOk ? 'TV 4 assignment did not persist'
+        : '');
+    } catch (err) {
+      log('TC-518', 'FAIL', err instanceof Error ? err.message : 'TV assignment test failed');
+    } finally {
+      if (tc518TournamentId) await deleteTournament(page, tc518TournamentId);
+      if (tc518P1Id) await deletePlayer(page, tc518P1Id);
+      if (tc518P2Id) await deletePlayer(page, tc518P2Id);
     }
-    log('TC-518', hasSelect && optionsOk && assignOk ? 'PASS' : 'FAIL',
-      !hasSelect ? 'No TV select found on BM qualification page'
-      : !optionsOk ? `TV options missing 1-4 (got ${options.join(',')})`
-      : !assignOk ? 'TV 4 assignment did not persist'
-      : '');
-  } catch (err) {
-    log('TC-518', 'FAIL', err instanceof Error ? err.message : 'TV assignment test failed');
   }
 
   // TC-104: Player delete
@@ -2510,7 +2548,9 @@ async function main() {
       await tc341PlayerPage.locator('#nickname').fill(nick);
       await tc341PlayerPage.locator('#password').fill(playerTempPassword);
       await tc341PlayerPage.getByRole('button', { name: /ログイン|Login/ }).click();
-      await tc341PlayerPage.waitForURL((url) => url.pathname === '/tournaments', { timeout: 15000 });
+      /* TC-341 runs late in the suite when the production server may be under
+       * more load; use a longer timeout than the default 15s to reduce flakiness. */
+      await tc341PlayerPage.waitForURL((url) => url.pathname === '/tournaments', { timeout: 30000 });
 
       const tc341PlayerResp = await tc341PlayerPage.evaluate(async (tid) => {
         const r = await fetch(`/api/tournaments/${tid}?fields=summary`);
@@ -2536,6 +2576,63 @@ async function main() {
     }
   } else {
     log('TC-341', 'SKIP', 'Player credentials not available');
+  }
+
+  // TC-344: noCamera flag — create player with noCamera=true, verify in API and UI, toggle via edit
+  {
+    let tc344PlayerId = null;
+    try {
+      const ts344 = Date.now();
+      const nick344 = `e2e_nocam_${ts344}`;
+
+      // Create player with noCamera=true via API
+      const createResp = await page.evaluate(async (d) => {
+        const r = await fetch('/api/players', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(d),
+        });
+        return { s: r.status, b: await r.json().catch(() => ({})) };
+      }, { name: 'E2E NoCamera Test', nickname: nick344, noCamera: true });
+
+      if (createResp.s !== 201) throw new Error(`Create failed (${createResp.s})`);
+      tc344PlayerId = createResp.b?.data?.player?.id;
+      if (!tc344PlayerId) throw new Error('No player id in create response');
+
+      // Verify noCamera=true in GET response
+      const getResp = await page.evaluate(async (id) => {
+        const r = await fetch(`/api/players/${id}`);
+        return { s: r.status, b: await r.json().catch(() => ({})) };
+      }, tc344PlayerId);
+      const noCameraTrue = getResp.b?.data?.noCamera === true;
+
+      // Update player to toggle noCamera=false
+      const putResp = await page.evaluate(async (d) => {
+        const r = await fetch(`/api/players/${d.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'E2E NoCamera Test', nickname: d.nick, noCamera: false }),
+        });
+        return { s: r.status, b: await r.json().catch(() => ({})) };
+      }, { id: tc344PlayerId, nick: nick344 });
+      const updateOk = putResp.s === 200 && putResp.b?.data?.noCamera === false;
+
+      // Verify updated value in GET
+      const getResp2 = await page.evaluate(async (id) => {
+        const r = await fetch(`/api/players/${id}`);
+        return { s: r.status, b: await r.json().catch(() => ({})) };
+      }, tc344PlayerId);
+      const noCameraFalse = getResp2.b?.data?.noCamera === false;
+
+      log('TC-344', noCameraTrue && updateOk && noCameraFalse ? 'PASS' : 'FAIL',
+        !noCameraTrue ? `noCamera should be true after create, got ${getResp.b?.data?.noCamera}` :
+        !updateOk ? `PUT noCamera=false failed (${putResp.s}), noCamera=${putResp.b?.data?.noCamera}` :
+        !noCameraFalse ? `noCamera should be false after update, got ${getResp2.b?.data?.noCamera}` : '');
+    } catch (err) {
+      log('TC-344', 'FAIL', err instanceof Error ? err.message : 'noCamera flag test failed');
+    } finally {
+      if (tc344PlayerId) await deletePlayer(page, tc344PlayerId);
+    }
   }
 
   // ===== Mode-specific suites (shared code with tc-bm/tc-mr/tc-gp/tc-ta) =====

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -35,7 +35,7 @@ const {
   uiPhaseStartRound, uiPhaseSubmitResults, uiPhaseCancelRound, uiPhaseUndoRound,
   uiCreateTournament, uiCreatePlayer,
   apiDeletePlayer,
-  apiDeleteTournament, apiGetTtEntry, apiSeedTtEntry, apiTaParticipantEditTime, loginPlayerBrowser,
+  apiDeleteTournament, apiGetTtEntry, apiSeedTtEntry, apiForceRankOnly, apiTaParticipantEditTime, loginPlayerBrowser,
   apiFetchTa, apiFetchTaPhase,
   makeTaTimesForRank,
   setupTaQualViaUi,
@@ -103,6 +103,13 @@ async function seedTaQualificationRanks(adminPage, tournamentId, entries, startR
     const rank = startRank + i;
     const { times, totalMs } = makeTaTimesForRank(rank);
     await apiSeedTtEntry(adminPage, tournamentId, entries[i].entryId, times, totalMs, rank);
+    /* recalculateRanks (triggered inside the PUT route when `times` is present)
+     * reorders by actual time values and may derive a different rank than the
+     * requested one when fewer than 24 players are in the tournament. Force the
+     * desired rank with a separate rank-only PUT (no `times` → no recalculate)
+     * so the Finals Phases card sees ranks in the 17–24 range and shows the
+     * "Start Phase 1" button. Must run before uiFreezeTaQualification. */
+    await apiForceRankOnly(adminPage, tournamentId, entries[i].entryId, rank);
     seeded.push({ ...entries[i], rank, times, totalMs });
   }
   return seeded;
@@ -298,10 +305,15 @@ async function runTc805(adminPage) {
     }).first();
     await removeDialog.waitFor({ state: 'visible', timeout: 10000 });
 
-    /* p1's entry appears in the right panel (staged entries). Click its Remove
-     * button to remove from the staged list, then save. */
-    const p1EntryRow = removeDialog.locator('div').filter({ hasText: new RegExp(`^.*${p1.nickname}.*$`) }).first();
-    await p1EntryRow.getByRole('button', { name: /^(Remove|削除)$/ }).click();
+    /* p1's entry appears in the right panel (staged entries). Each row has an
+     * input with aria-label `${nickname} seeding`; the Remove button is the
+     * only button sibling in that row div. Using the seeding input as an anchor
+     * avoids the strict-mode violation caused by `div.filter(hasText)` matching
+     * all ancestor divs (including the container with all 28 Remove buttons). */
+    await removeDialog
+      .locator(`input[aria-label="${p1.nickname} seeding"]`)
+      .locator('xpath=following-sibling::button')
+      .click();
     await removeDialog.getByRole('button', { name: /^(Save|保存)$/ }).click();
     await removeDialog.waitFor({ state: 'hidden', timeout: 30000 }).catch(() => {});
 

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -222,7 +222,8 @@
     "confirmResetPassword": "Are you sure you want to reset the password for this player?",
     "passwordResetSuccess": "Password Reset Successfully",
     "failedToResetPassword": "Failed to reset password",
-    "fetchError": "Failed to load players. Please try again."
+    "fetchError": "Failed to load players. Please try again.",
+    "noCamera": "No Camera"
   },
   "profile": {
     "title": "Profile",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -222,7 +222,8 @@
     "confirmResetPassword": "このプレイヤーのパスワードをリセットしますか？",
     "passwordResetSuccess": "パスワードのリセットに成功しました",
     "failedToResetPassword": "パスワードのリセットに失敗しました",
-    "fetchError": "プレイヤーの読み込みに失敗しました。再試行してください。"
+    "fetchError": "プレイヤーの読み込みに失敗しました。再試行してください。",
+    "noCamera": "カメラなし"
   },
   "profile": {
     "title": "プロフィール",

--- a/smkc-score-app/prisma/migrations/0005_player_no_camera/migration.sql
+++ b/smkc-score-app/prisma/migrations/0005_player_no_camera/migration.sql
@@ -1,0 +1,3 @@
+-- Add noCamera column to Player table.
+-- Existing players default to false (camera available).
+ALTER TABLE "Player" ADD COLUMN "noCamera" BOOLEAN NOT NULL DEFAULT false;

--- a/smkc-score-app/prisma/schema.prisma
+++ b/smkc-score-app/prisma/schema.prisma
@@ -79,6 +79,7 @@ model Player {
   name      String
   nickname  String   @unique
   country   String?
+  noCamera  Boolean  @default(false) // カメラなしフラグ（配信時のオーバーレイ制御用）
   password  String?  // bcrypt hashed password for player authentication
   deletedAt DateTime? // ソフトデリート用タイムスタンプ
   version   Int      @default(0) // 楽観的ロック用

--- a/smkc-score-app/src/app/api/players/[id]/route.ts
+++ b/smkc-score-app/src/app/api/players/[id]/route.ts
@@ -97,7 +97,7 @@ export async function PUT(
 
     // Sanitize input to prevent XSS and injection attacks
     const body = sanitizeInput(await request.json());
-    const { name, nickname, country } = body;
+    const { name, nickname, country, noCamera } = body;
 
     // Validate required fields
     if (!name || !nickname) {
@@ -112,6 +112,7 @@ export async function PUT(
         name,
         nickname,
         country: country || null,
+        noCamera: noCamera === true,
       },
     });
 

--- a/smkc-score-app/src/app/api/players/route.ts
+++ b/smkc-score-app/src/app/api/players/route.ts
@@ -161,7 +161,7 @@ export async function POST(request: NextRequest) {
 
     // Sanitize all input fields to prevent XSS and injection attacks
     const body = sanitizeInput(await request.json());
-    const { name, nickname, country } = body;
+    const { name, nickname, country, noCamera } = body;
 
     // Validate required fields before database operations
     if (!name || !nickname) {
@@ -182,6 +182,7 @@ export async function POST(request: NextRequest) {
         name,
         nickname,
         country: country || null,
+        noCamera: noCamera === true,
         password: hashedPassword,
       },
     });

--- a/smkc-score-app/src/app/players/page.tsx
+++ b/smkc-score-app/src/app/players/page.tsx
@@ -30,6 +30,7 @@ import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Card,
   CardContent,
@@ -81,6 +82,7 @@ interface Player {
   name: string;
   nickname: string;
   country: string | null;
+  noCamera: boolean;
   createdAt: string;
   /** Set by the API for admin users: true if the player is registered in any tournament. */
   hasTournamentData?: boolean;
@@ -132,6 +134,7 @@ export default function PlayersPage() {
     name: "",
     nickname: "",
     country: "",
+    noCamera: false,
   });
 
   /* Currently editing player ID (null when adding a new player) */
@@ -243,7 +246,7 @@ export default function PlayersPage() {
         };
         setPlayers(prev => [...prev, newPlayer]);
 
-        setFormData({ name: "", nickname: "", country: "" });
+        setFormData({ name: "", nickname: "", country: "", noCamera: false });
         setIsAddDialogOpen(false);
 
         if (!isLostResponse && data.temporaryPassword) {
@@ -299,12 +302,12 @@ export default function PlayersPage() {
         // Optimistic update: immediately reflect changes in the list
         setPlayers(prev => prev.map(p =>
           p.id === editingPlayerId
-            ? { ...p, name: formData.name, nickname: formData.nickname, country: formData.country || null }
+            ? { ...p, name: formData.name, nickname: formData.nickname, country: formData.country || null, noCamera: formData.noCamera }
             : p
         ));
         setIsEditDialogOpen(false);
         setEditingPlayerId(null);
-        setFormData({ name: "", nickname: "", country: "" });
+        setFormData({ name: "", nickname: "", country: "", noCamera: false });
       } else {
         const text = await response!.text();
         try {
@@ -418,6 +421,7 @@ export default function PlayersPage() {
       name: player.name,
       nickname: player.nickname,
       country: player.country || "",
+      noCamera: player.noCamera,
     });
     setEditingPlayerId(player.id);
     setError("");
@@ -432,7 +436,7 @@ export default function PlayersPage() {
     setIsEditDialogOpen(open);
     if (!open) {
       setEditingPlayerId(null);
-      setFormData({ name: "", nickname: "", country: "" });
+      setFormData({ name: "", nickname: "", country: "", noCamera: false });
     }
   };
 
@@ -483,7 +487,7 @@ export default function PlayersPage() {
         {isAdmin && (
           <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
             <DialogTrigger asChild>
-              <Button onClick={() => setFormData({ name: "", nickname: "", country: "" })}>
+              <Button onClick={() => setFormData({ name: "", nickname: "", country: "", noCamera: false })}>
                 {tc('addPlayer')}
               </Button>
             </DialogTrigger>
@@ -534,6 +538,16 @@ export default function PlayersPage() {
                     placeholder={t('countryPlaceholder')}
                   />
                 </div>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="noCamera"
+                    checked={formData.noCamera}
+                    onCheckedChange={(checked) =>
+                      setFormData({ ...formData, noCamera: checked === true })
+                    }
+                  />
+                  <Label htmlFor="noCamera">{t('noCamera')}</Label>
+                </div>
               </div>
               <DialogFooter>
                 <Button type="submit" disabled={submitting}>
@@ -578,6 +592,7 @@ export default function PlayersPage() {
                     <TableHead>{t('nickname')}</TableHead>
                     <TableHead>{t('fullName')}</TableHead>
                     <TableHead>{t('country')}</TableHead>
+                    <TableHead>{t('noCamera')}</TableHead>
                     {/* Actions column only visible to admins */}
                     {isAdmin && <TableHead className="text-right">{tc('actions')}</TableHead>}
                   </TableRow>
@@ -590,6 +605,7 @@ export default function PlayersPage() {
                       </TableCell>
                       <TableCell>{player.name}</TableCell>
                       <TableCell>{player.country || "-"}</TableCell>
+                      <TableCell>{player.noCamera ? "✗" : "-"}</TableCell>
                       {/* Admin-only action buttons: Edit and Delete */}
                       {isAdmin && (
                         <TableCell className="text-right space-x-2">
@@ -701,6 +717,16 @@ export default function PlayersPage() {
                     setFormData({ ...formData, country: e.target.value })
                   }
                 />
+              </div>
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="edit-noCamera"
+                  checked={formData.noCamera}
+                  onCheckedChange={(checked) =>
+                    setFormData({ ...formData, noCamera: checked === true })
+                  }
+                />
+                <Label htmlFor="edit-noCamera">{t('noCamera')}</Label>
               </div>
             </div>
             <DialogFooter>


### PR DESCRIPTION
## Summary

- **Issue #629**: Add `noCamera` boolean field to Player — schema, API, and UI
- **Issue #616**: Fix 12 E2E test failures (TC-312/313/518/341/805/809/810)

## Changes

### noCamera feature (#629)
- `prisma/schema.prisma`: Add `noCamera Boolean @default(false)` to Player model
- `prisma/migrations/0005_player_no_camera/migration.sql`: `ALTER TABLE Player ADD COLUMN noCamera`
- `src/app/api/players/route.ts`: POST persists `noCamera` from request body
- `src/app/api/players/[id]/route.ts`: PUT persists `noCamera` from request body
- `src/app/players/page.tsx`: Checkbox in Add/Edit dialogs; "No Camera" column in table
- `messages/en.json` / `messages/ja.json`: Add `noCamera` translation key
- `e2e/tc-all.js`: TC-344 — create/update noCamera via API and verify persistence

### E2E fixes (#616)
- **TC-312/313/809/810**: `recalculateRanks` overrides rank=17 for 1-player tournaments → add `apiForceRankOnly` helper (rank-only PUT skips `recalculateRanks`)
- **TC-805**: Playwright strict mode violation on Remove button (28 matches) → use XPath `following-sibling::button` from unique `input[aria-label]`
- **TC-518**: Was depending on 28-player shared setup (can fail) → isolated 2-player BM tournament
- **TC-341**: `waitForURL` timeout 15s → 30s for late-suite production latency

## Test plan

- [ ] `node e2e/tc-all.js` — TC-344 should PASS
- [ ] TC-312, TC-313, TC-518, TC-341, TC-805, TC-809, TC-810 — should PASS
- [ ] Admin can create a player with "No Camera" checked → checkbox persists
- [ ] Admin can edit a player to toggle noCamera → change reflected in table column

https://claude.ai/code/session_016M1PmGSedBdgfdVYU1UkQG

---
_Generated by [Claude Code](https://claude.ai/code/session_016M1PmGSedBdgfdVYU1UkQG)_