### PR TITLE
fix(#631): add D1 wrangler migration for Player.noCamera (P0 — production 500)

### DIFF
--- a/smkc-score-app/migrations/0019_add_player_no_camera.sql
+++ b/smkc-score-app/migrations/0019_add_player_no_camera.sql
@@ -1,0 +1,6 @@
+-- Migration: Add noCamera flag to Player
+-- Mirrors prisma/migrations/0005_player_no_camera (Prisma CLI is local-only;
+-- this wrangler-format file is the one D1 production actually applies).
+-- Boolean stored as INTEGER per SQLite convention; Prisma D1 adapter handles
+-- the 0/1 ↔ false/true conversion.
+ALTER TABLE "Player" ADD COLUMN "noCamera" INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary

- 本番障害 #631 を修正。`GET /api/players` が常時 500 → E2E 全停止 + 管理画面全機能停止。
- PR #630 が `prisma/migrations/` (Prisma CLI ローカル専用) にのみ migration を追加し、`migrations/` (wrangler 形式 D1) を入れ忘れていた。
- 本 PR は対応する `migrations/0019_add_player_no_camera.sql` を追加するだけ（コードロジック変更なし）。

## Post-merge: D1 適用必須

```bash
cd smkc-score-app
npx wrangler d1 migrations apply smkc-db --remote
# (再デプロイは不要 — コードは既にデプロイ済)
```

適用後の検証:
```bash
curl -i 'https://smkc.bluemoon.works/api/players?page=1&limit=5'
# 期待: HTTP 200, JSON で players[] が返る
npm run e2e:all   # fixture セットアップが通り全 TC 実行されること
```

## Test plan

- [ ] PR マージ → `wrangler d1 migrations apply smkc-db --remote` 実行
- [ ] `curl /api/players` が 200 を返すこと
- [ ] `/players` 管理画面で一覧表示できること
- [ ] noCamera チェックボックスを ON で player 作成 → 永続化されること
- [ ] `npm run e2e:all` が fixture フェーズを通過し TC を実行すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)