### PR TITLE
feat(#634, #635): TV numbers in finals + broadcast player name overlay

### DIFF
--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -15,6 +15,7 @@
  *   TC-506  28-player full + Grand Final Reset Match (M17)
  *   TC-510  BM Top-24 pre-bracket playoff → Top-16 finals flow
  *   TC-520  BM per-round target-wins API validation (issue #528: FT3/FT4/FT5/FT7)
+ *   TC-522  BM finals tvNumber PUT accepts 1–4, rejects 5, clears on null (issue #634)
  *
  * Setup:
  *   - Uses Playwright persistent profile at /tmp/playwright-smkc-profile.
@@ -1352,6 +1353,65 @@ async function runTc521(adminPage) {
   }
 }
 
+/* ───────── TC-522: BM finals tvNumber via PUT (Issue #634) ─────────
+ * Verifies that the finals route's putAdditionalFields now includes tvNumber:
+ *   - tvNumber=2 → 200, value persisted on the match
+ *   - tvNumber=5 → 422 (exceeds MAX_TV_NUMBER=4)
+ *   - tvNumber=null → 200 (clears TV assignment) */
+async function runTc522(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedBmFinalsSetup(adminPage);
+    const gen = await apiGenerateBmFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    const matches = await apiFetchBmFinalsMatches(adminPage, setup.tournamentId);
+    const m1 = matches.find((m) => m.matchNumber === 1);
+    if (!m1) throw new Error('Bracket missing match 1');
+
+    /* PUT tvNumber=2 — valid range is 1–4 */
+    const res2 = await adminPage.evaluate(async ([url, body]) => {
+      const r = await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [`/api/tournaments/${setup.tournamentId}/bm/finals`, { matchId: m1.id, tvNumber: 2 }]);
+
+    const after2 = await apiFetchBmFinalsMatches(adminPage, setup.tournamentId);
+    const tvSaved = after2.find((m) => m.id === m1.id)?.tvNumber === 2;
+
+    /* PUT tvNumber=5 — must be rejected (422) */
+    const res5 = await adminPage.evaluate(async ([url, body]) => {
+      const r = await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status };
+    }, [`/api/tournaments/${setup.tournamentId}/bm/finals`, { matchId: m1.id, tvNumber: 5 }]);
+
+    /* PUT tvNumber=null — must clear TV (200) */
+    const resNull = await adminPage.evaluate(async ([url, body]) => {
+      const r = await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status };
+    }, [`/api/tournaments/${setup.tournamentId}/bm/finals`, { matchId: m1.id, tvNumber: null }]);
+
+    const pass = res2.s === 200 && tvSaved && res5.s === 422 && resNull.s === 200;
+    log('TC-522', pass ? 'PASS' : 'FAIL',
+      !pass ? `tvNumber=2 → ${res2.s} (saved=${tvSaved}), tvNumber=5 → ${res5.s}, tvNumber=null → ${resNull.s}` : '');
+  } catch (err) {
+    log('TC-522', 'FAIL', err instanceof Error ? err.message : 'TC-522 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
 /**
  * Builds the BM suite spec for composition by tc-all. When `sharedFixture` is
  * provided (tc-all flow), we reuse it and skip cleanup — the orchestrator owns
@@ -1394,6 +1454,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-519', fn: runTc519 },
       { name: 'TC-520', fn: runTc520 },
       { name: 'TC-521', fn: runTc521 },
+      { name: 'TC-522', fn: runTc522 },
       { name: 'TC-505', fn: runTc505 },
       { name: 'TC-506', fn: runTc506 },
     ],
@@ -1402,7 +1463,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 
 module.exports = {
   runTc501, runTc502, runTc322, runTc503, runTc504, runTc505, runTc506, runTc511, runTc512, runTc513,
-  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521,
+  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522,
   getSuite,
   results,
   setSharedBmFinalsReady: (v) => { sharedBmFinalsReady = v; },

--- a/smkc-score-app/e2e/tc-overlay.js
+++ b/smkc-score-app/e2e/tc-overlay.js
@@ -24,6 +24,8 @@
  *   __tests__/lib/overlay/events.test.ts cover the aggregator path; manual
  *   QA on the shared 28-player fixture covers the route path.
  *   TC-915  GET /overlay-events?initial=1 returns currentPhase + event cap
+ *   TC-916  PUT /broadcast sets 1P/2P names; public GET reads them back
+ *   TC-917  overlay-events response includes overlayPlayer1Name / overlayPlayer2Name
  *
  * Setup is API-only: the suite owns a 2-player tournament with one match
  * per mode (BM/MR/GP) plus 2 TA entries, then tears everything down at the
@@ -621,6 +623,71 @@ async function runTc915(_adminPage) {
   }
 }
 
+/* ───────── TC-916: Broadcast API PUT/GET (Issue #635) ─────────
+ * Admin sets 1P/2P names via PUT /broadcast (needs auth → browser eval).
+ * Public GET /broadcast (unauthenticated, via httpsGet) must return them. */
+async function runTc916(adminPage) {
+  try {
+    const stamp = Date.now();
+    const name1 = `TC916_P1_${stamp}`;
+    const name2 = `TC916_P2_${stamp}`;
+
+    const putRes = await adminPage.evaluate(async ([url, body]) => {
+      const r = await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [
+      `/api/tournaments/${fixture.tournamentId}/broadcast`,
+      { player1Name: name1, player2Name: name2 },
+    ]);
+
+    const putOk = putRes.s === 200;
+
+    /* Unauthenticated GET must succeed (public endpoint) */
+    const getResp = await httpsGet(`/api/tournaments/${fixture.tournamentId}/broadcast`);
+    const getData = getResp.body?.data;
+    const namesMatch = getData?.player1Name === name1 && getData?.player2Name === name2;
+
+    log('TC-916',
+      putOk && getResp.status === 200 && namesMatch ? 'PASS' : 'FAIL',
+      !putOk ? `PUT status=${putRes.s} ${JSON.stringify(putRes.b).slice(0, 100)}` :
+      getResp.status !== 200 ? `GET status=${getResp.status}` :
+      !namesMatch ? `names mismatch got ${getData?.player1Name}/${getData?.player2Name}` : '');
+  } catch (err) {
+    log('TC-916', 'FAIL', err instanceof Error ? err.message : 'TC-916 threw');
+  }
+}
+
+/* ───────── TC-917: overlay-events exposes broadcast player names (Issue #635) ─────────
+ * After TC-916 sets names, /overlay-events?initial=1 must include
+ * overlayPlayer1Name and overlayPlayer2Name as non-empty strings. */
+async function runTc917(_adminPage) {
+  try {
+    const resp = await httpsGet(
+      `/api/tournaments/${fixture.tournamentId}/overlay-events?initial=1`,
+    );
+    const data = resp.body?.data;
+    const hasP1 = data && 'overlayPlayer1Name' in data && typeof data.overlayPlayer1Name === 'string';
+    const hasP2 = data && 'overlayPlayer2Name' in data && typeof data.overlayPlayer2Name === 'string';
+    /* TC-916 set both names, so they should be non-empty here */
+    const p1Set = hasP1 && data.overlayPlayer1Name.length > 0;
+    const p2Set = hasP2 && data.overlayPlayer2Name.length > 0;
+
+    log('TC-917',
+      resp.status === 200 && hasP1 && hasP2 && p1Set && p2Set ? 'PASS' : 'FAIL',
+      resp.status !== 200 ? `status=${resp.status}` :
+      !hasP1 ? 'overlayPlayer1Name missing from response' :
+      !hasP2 ? 'overlayPlayer2Name missing from response' :
+      !p1Set ? `overlayPlayer1Name is empty: "${data.overlayPlayer1Name}"` :
+      !p2Set ? `overlayPlayer2Name is empty: "${data.overlayPlayer2Name}"` : '');
+  } catch (err) {
+    log('TC-917', 'FAIL', err instanceof Error ? err.message : 'TC-917 threw');
+  }
+}
+
 /* ───────── TC-906: real-browser render of the overlay page ─────────
  * Navigates the admin page away to /overlay and writes a fresh score so the
  * running poll cycle picks it up. Must be the LAST test because it leaves
@@ -681,6 +748,8 @@ function getSuite() {
      *   - TC-911 (overall ranking) any time after qual data exists.
      *   - TC-909 (qualificationConfirmed) AFTER all score PUTs: the route
      *     blocks qualification edits once this flag is set.
+     *   - TC-916 / TC-917 (broadcast): TC-916 sets names, TC-917 reads them
+     *     back from overlay-events. Both after TC-909 to avoid races.
      *   - TC-906 (real-browser render) last: navigates the admin page
      *     away from anything cleanup might need. */
     tests: [
@@ -697,6 +766,8 @@ function getSuite() {
       { name: 'TC-911', fn: runTc911 },
       { name: 'TC-909', fn: runTc909 },
       { name: 'TC-915', fn: runTc915 },
+      { name: 'TC-916', fn: runTc916 },
+      { name: 'TC-917', fn: runTc917 },
       { name: 'TC-906', fn: runTc906 },
     ],
   };
@@ -705,6 +776,7 @@ function getSuite() {
 module.exports = {
   runTc901, runTc902, runTc903, runTc904, runTc905, runTc906,
   runTc907, runTc908, runTc909, runTc910, runTc911, runTc913, runTc914, runTc915,
+  runTc916, runTc917,
   getSuite,
   results,
 };

--- a/smkc-score-app/migrations/0020_add_broadcast_player_names.sql
+++ b/smkc-score-app/migrations/0020_add_broadcast_player_names.sql
@@ -1,0 +1,6 @@
+-- Migration: Add broadcast player name fields to Tournament
+-- Stores the current overlay player names (1P/2P) for the "配信に反映" feature.
+-- Admin sets these by clicking "配信に反映" on a match or via the 配信管理 page.
+-- Nullable so existing rows remain valid; empty string = no name displayed.
+ALTER TABLE "Tournament" ADD COLUMN "overlayPlayer1Name" TEXT;
+ALTER TABLE "Tournament" ADD COLUMN "overlayPlayer2Name" TEXT;

--- a/smkc-score-app/prisma/schema.prisma
+++ b/smkc-score-app/prisma/schema.prisma
@@ -128,6 +128,8 @@ model Tournament {
   dualReportEnabled Boolean @default(false) // When true, both players must report matching scores for auto-confirmation
   taPlayerSelfEdit  Boolean @default(true)  // §3.1: When false, players cannot edit their own TA times (only partner's)
   frozenStages  Json     @default("[]") // 凍結されたTAステージ名の配列 (例: ["qualification", "phase1"])
+  overlayPlayer1Name String? // 「配信に反映」で設定される1Pのオーバーレイ表示名
+  overlayPlayer2Name String? // 「配信に反映」で設定される2Pのオーバーレイ表示名
   qualificationConfirmed Boolean @default(false) // BM/MR/GP予選確定フラグ。trueの場合スコア編集不可
   qualificationConfirmedAt DateTime? // 予選確定日時（監査証跡）
   publicModes   Json     @default("[]") // 公開中のモード配列。空の場合全モード非表示（新建時は非公開）

--- a/smkc-score-app/src/app/api/tournaments/[id]/bm/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/bm/finals/route.ts
@@ -18,6 +18,7 @@ const { GET, POST, PUT } = createFinalsHandlers({
   qualificationOrderBy: [{ group: 'asc' }, { score: 'desc' }, { points: 'desc' }, { winRounds: 'desc' }],
   getStyle: 'grouped',
   putScoreFields: { dbField1: 'score1', dbField2: 'score2' },
+  putAdditionalFields: ['tvNumber'],
   getTargetWins: getBmFinalsTargetWins,
   getErrorMessage: 'Failed to fetch finals data',
   postErrorMessage: 'Failed to create finals bracket',

--- a/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
@@ -1,0 +1,141 @@
+/**
+ * Broadcast State API
+ *
+ * GET  /api/tournaments/[id]/broadcast  - Fetch current overlay player names (public)
+ * PUT  /api/tournaments/[id]/broadcast  - Set overlay player names (admin only)
+ *
+ * Stores the 1P/2P display names shown on the OBS overlay at fixed positions.
+ * Admin sets them by clicking "配信に反映" on a match row or via the 配信管理 page.
+ * The overlay dashboard polls this via overlay-events; we also expose it
+ * directly so the 配信管理 page can read/write without re-deriving the state
+ * from a wider events payload.
+ */
+
+import { NextRequest } from "next/server";
+import prisma from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+import { resolveTournamentId } from "@/lib/tournament-identifier";
+import {
+  createSuccessResponse,
+  createErrorResponse,
+  handleAuthzError,
+  handleValidationError,
+} from "@/lib/error-handling";
+import { sanitizeInput } from "@/lib/sanitize";
+import { createLogger } from "@/lib/logger";
+
+const MAX_NAME_LENGTH = 50;
+
+/**
+ * GET /api/tournaments/[id]/broadcast
+ *
+ * Returns the current overlay player names.
+ * Public — the overlay page reads this on each poll.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const logger = createLogger("broadcast-api");
+  const { id } = await params;
+  const tournamentId = await resolveTournamentId(id);
+
+  try {
+    const tournament = await prisma.tournament.findUnique({
+      where: { id: tournamentId },
+      select: { overlayPlayer1Name: true, overlayPlayer2Name: true },
+    });
+
+    if (!tournament) {
+      return createErrorResponse("Tournament not found", 404);
+    }
+
+    return createSuccessResponse({
+      player1Name: tournament.overlayPlayer1Name ?? "",
+      player2Name: tournament.overlayPlayer2Name ?? "",
+    });
+  } catch (error) {
+    logger.error("Failed to fetch broadcast state", { error, tournamentId });
+    return createErrorResponse("Failed to fetch broadcast state", 500);
+  }
+}
+
+/**
+ * PUT /api/tournaments/[id]/broadcast
+ *
+ * Updates the overlay player names.
+ * Requires admin authentication.
+ *
+ * Body: { player1Name?: string, player2Name?: string }
+ * Either field may be omitted to leave it unchanged.
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const logger = createLogger("broadcast-api");
+
+  const session = await auth();
+  if (!session?.user || session.user.role !== "admin") {
+    return handleAuthzError();
+  }
+
+  const { id } = await params;
+  const tournamentId = await resolveTournamentId(id);
+
+  try {
+    const body = sanitizeInput(await request.json()) as Record<string, unknown>;
+    const { player1Name, player2Name } = body;
+
+    /* Allow null/empty string to clear the field; reject only invalid types. */
+    if (player1Name !== undefined && player1Name !== null && typeof player1Name !== "string") {
+      return handleValidationError("player1Name must be a string", "player1Name");
+    }
+    if (player2Name !== undefined && player2Name !== null && typeof player2Name !== "string") {
+      return handleValidationError("player2Name must be a string", "player2Name");
+    }
+    if (typeof player1Name === "string" && player1Name.length > MAX_NAME_LENGTH) {
+      return handleValidationError(`player1Name must be at most ${MAX_NAME_LENGTH} characters`, "player1Name");
+    }
+    if (typeof player2Name === "string" && player2Name.length > MAX_NAME_LENGTH) {
+      return handleValidationError(`player2Name must be at most ${MAX_NAME_LENGTH} characters`, "player2Name");
+    }
+
+    const tournament = await prisma.tournament.findUnique({
+      where: { id: tournamentId },
+      select: { id: true },
+    });
+    if (!tournament) {
+      return createErrorResponse("Tournament not found", 404);
+    }
+
+    const updateData: Record<string, string | null> = {};
+    if (player1Name !== undefined) {
+      updateData.overlayPlayer1Name = player1Name === null ? null : (player1Name as string).trim() || null;
+    }
+    if (player2Name !== undefined) {
+      updateData.overlayPlayer2Name = player2Name === null ? null : (player2Name as string).trim() || null;
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      return handleValidationError("At least one of player1Name or player2Name is required", "body");
+    }
+
+    await prisma.tournament.update({
+      where: { id: tournamentId },
+      data: updateData,
+    });
+
+    return createSuccessResponse({
+      player1Name: updateData.overlayPlayer1Name !== undefined
+        ? (updateData.overlayPlayer1Name ?? "")
+        : undefined,
+      player2Name: updateData.overlayPlayer2Name !== undefined
+        ? (updateData.overlayPlayer2Name ?? "")
+        : undefined,
+    });
+  } catch (error) {
+    logger.error("Failed to update broadcast state", { error, tournamentId });
+    return createErrorResponse("Failed to update broadcast state", 500);
+  }
+}

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
@@ -18,7 +18,7 @@ const { GET, POST, PUT } = createFinalsHandlers({
   qualificationOrderBy: [{ group: 'asc' }, { points: 'desc' }, { score: 'desc' }],
   getStyle: 'paginated',
   putScoreFields: { dbField1: 'points1', dbField2: 'points2' },
-  putAdditionalFields: ['races', 'cup'],
+  putAdditionalFields: ['races', 'cup', 'tvNumber'],
   getTargetWins: getGpFinalsTargetWins,
   getErrorMessage: 'Failed to fetch grand prix finals data',
   postErrorMessage: 'Failed to create grand prix finals bracket',

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/finals/route.ts
@@ -18,7 +18,7 @@ const { GET, POST, PUT } = createFinalsHandlers({
   qualificationOrderBy: [{ group: 'asc' }, { score: 'desc' }, { points: 'desc' }, { winRounds: 'desc' }],
   getStyle: 'simple',
   putScoreFields: { dbField1: 'score1', dbField2: 'score2' },
-  putAdditionalFields: ['rounds'],
+  putAdditionalFields: ['rounds', 'tvNumber'],
   getTargetWins: getMrFinalsTargetWins,
   getErrorMessage: 'Failed to fetch finals data',
   postErrorMessage: 'Failed to create finals bracket',

--- a/smkc-score-app/src/app/api/tournaments/[id]/overlay-events/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/overlay-events/route.ts
@@ -79,6 +79,8 @@ export async function GET(
         id: true,
         qualificationConfirmed: true,
         qualificationConfirmedAt: true,
+        overlayPlayer1Name: true,
+        overlayPlayer2Name: true,
       },
     });
     if (!tournament) {
@@ -323,6 +325,9 @@ export async function GET(
       events: cappedEvents,
       currentPhase,
       currentPhaseFormat,
+      /* Broadcast player names for the overlay name display (配信に反映) */
+      overlayPlayer1Name: tournament.overlayPlayer1Name ?? "",
+      overlayPlayer2Name: tournament.overlayPlayer2Name ?? "",
     });
 
     /* Disable any intermediate caching: the response is time-sensitive and

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -62,7 +62,7 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
 import { PlayoffBracket } from "@/components/tournament/playoff-bracket";
-import { POLLING_INTERVAL } from "@/lib/constants";
+import { POLLING_INTERVAL, TV_NUMBER_OPTIONS } from "@/lib/constants";
 import { getBmFinalsTargetWins } from "@/lib/finals-target-wins";
 import { usePolling } from "@/lib/hooks/usePolling";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
@@ -86,6 +86,7 @@ interface BMMatch {
   matchNumber: number;
   round: string | null;
   stage?: string | null;
+  tvNumber?: number | null;
   player1Id: string;
   player2Id: string;
   score1: number;
@@ -193,7 +194,7 @@ export default function BattleModeFinals({
   /* Score entry dialog state */
   const [isScoreDialogOpen, setIsScoreDialogOpen] = useState(false);
   const [selectedMatch, setSelectedMatch] = useState<BMMatch | null>(null);
-  const [scoreForm, setScoreForm] = useState({ score1: 0, score2: 0 });
+  const [scoreForm, setScoreForm] = useState({ score1: 0, score2: 0, tvNumber: null as number | null });
   const selectedMatchTargetWins = selectedMatch ? getBmFinalsTargetWins(selectedMatch) : getBmFinalsTargetWins();
 
   /* Tournament completion state */
@@ -372,7 +373,7 @@ export default function BattleModeFinals({
   /** Open the score entry dialog pre-populated with existing scores */
   const openScoreDialog = (match: BMMatch) => {
     setSelectedMatch(match);
-    setScoreForm({ score1: match.score1, score2: match.score2 });
+    setScoreForm({ score1: match.score1, score2: match.score2, tvNumber: match.tvNumber ?? null });
     setIsScoreDialogOpen(true);
   };
 
@@ -392,6 +393,7 @@ export default function BattleModeFinals({
           matchId: selectedMatch.id,
           score1: scoreForm.score1,
           score2: scoreForm.score2,
+          tvNumber: scoreForm.tvNumber,
         }),
       });
 
@@ -404,7 +406,7 @@ export default function BattleModeFinals({
         }>(json);
         setIsScoreDialogOpen(false);
         setSelectedMatch(null);
-        setScoreForm({ score1: 0, score2: 0 });
+        setScoreForm({ score1: 0, score2: 0, tvNumber: null });
         if (data.playoffComplete !== undefined) {
           setPlayoffComplete(data.playoffComplete);
         }
@@ -776,6 +778,21 @@ export default function BattleModeFinals({
                 ))}
               </div>
             </div>
+            {/* TV number assignment for broadcast: admin selects TV 1–4 */}
+            <div className="flex items-center justify-center gap-3">
+              <Label htmlFor="bm-finals-tv" className="text-sm text-muted-foreground shrink-0">
+                TV#
+              </Label>
+              <select
+                id="bm-finals-tv"
+                className="w-20 h-8 text-center text-sm border rounded bg-background"
+                value={scoreForm.tvNumber ?? ""}
+                onChange={(e) => setScoreForm({ ...scoreForm, tvNumber: e.target.value ? parseInt(e.target.value) : null })}
+              >
+                <option value="">-</option>
+                {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>{n}</option>)}
+              </select>
+            </div>
             {/* Always rendered to reserve vertical space and prevent layout shift. */}
             <p className={`text-sm text-center ${
               scoreForm.score1 + scoreForm.score2 > 0 &&
@@ -786,7 +803,26 @@ export default function BattleModeFinals({
               {tFinals('matchNeedWinner', { targetWins: selectedMatchTargetWins })}
             </p>
           </div>
-          <DialogFooter>
+          <DialogFooter className="flex-wrap gap-2">
+            {selectedMatch && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={async () => {
+                  await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                      player1Name: selectedMatch.player1.nickname,
+                      player2Name: selectedMatch.player2.nickname,
+                    }),
+                  });
+                }}
+                title="配信に反映"
+              >
+                📺 配信に反映
+              </Button>
+            )}
             <Button
               onClick={handleScoreSubmit}
               disabled={scoreForm.score1 < selectedMatchTargetWins && scoreForm.score2 < selectedMatchTargetWins}

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
@@ -242,8 +242,8 @@ export default function BattleModePage({
     return () => { cancelled = true; };
   }, [tournamentId]);
 
-  /* Shared handlers for rank override and TV assignment */
-  const { handleRankOverrideSave, handleBulkRankOverrideSave, handleTvAssign } =
+  /* Shared handlers for rank override, TV assignment, and broadcast reflect */
+  const { handleRankOverrideSave, handleBulkRankOverrideSave, handleTvAssign, handleBroadcastReflect } =
     useQualificationActions({ tournamentId, mode: "bm", refetch });
 
   /**
@@ -860,6 +860,17 @@ export default function BattleModePage({
                                         <Link href={`/tournaments/${tournamentId}/bm/match/${match.id}`}>
                                           {tc('matchDetails')}
                                         </Link>
+                                      </Button>
+                                    )}
+                                    {/* 配信に反映: admin pushes this match's players to the overlay */}
+                                    {isAdmin && !match.isBye && (
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={() => handleBroadcastReflect(match.player1.nickname, match.player2.nickname)}
+                                        title="配信に反映"
+                                      >
+                                        📺
                                       </Button>
                                     )}
                                     {/* Admin-only score entry/edit button (not for BYE matches, locked when confirmed) */}

--- a/smkc-score-app/src/app/tournaments/[id]/broadcast/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/broadcast/page.tsx
@@ -1,0 +1,264 @@
+/**
+ * 配信管理 (Broadcast Management) Page
+ *
+ * Admin page for controlling the overlay player name display.
+ * Shows the 1P/2P names currently on the OBS overlay and lets the admin:
+ * - Pick player names from a searchable list
+ * - Type custom names directly
+ * - Preview the current overlay state
+ *
+ * Positions for the overlay are fixed in the scene:
+ *   1P: x:80, y:480, width:230px, height:48px
+ *   2P: x:80, y:870, width:230px, height:48px
+ */
+"use client";
+
+import { useState, useEffect, useCallback, use } from "react";
+import { useSession } from "next-auth/react";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface Player {
+  id: string;
+  name: string;
+  nickname: string;
+}
+
+interface BroadcastState {
+  player1Name: string;
+  player2Name: string;
+}
+
+export default function BroadcastPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id: tournamentId } = use(params);
+  const { data: session } = useSession();
+  const isAdmin = session?.user && session.user.role === "admin";
+  const t = useTranslations("common");
+
+  const [currentState, setCurrentState] = useState<BroadcastState>({ player1Name: "", player2Name: "" });
+  const [player1Input, setPlayer1Input] = useState("");
+  const [player2Input, setPlayer2Input] = useState("");
+  const [players, setPlayers] = useState<Player[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [savedFlash, setSavedFlash] = useState(false);
+
+  const fetchBroadcastState = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`);
+      if (res.ok) {
+        const json = await res.json();
+        const data = json.data ?? json;
+        setCurrentState({ player1Name: data.player1Name ?? "", player2Name: data.player2Name ?? "" });
+        setPlayer1Input(data.player1Name ?? "");
+        setPlayer2Input(data.player2Name ?? "");
+      }
+    } catch { /* silent */ }
+  }, [tournamentId]);
+
+  useEffect(() => {
+    fetchBroadcastState();
+    /* Fetch player list for the dropdown */
+    fetch("/api/players")
+      .then((r) => r.ok ? r.json() : null)
+      .then((json) => {
+        const data = json?.data ?? json;
+        if (Array.isArray(data)) {
+          setPlayers(data.filter((p: Player) => !("deletedAt" in p) || !p.deletedAt).map((p: Player) => ({
+            id: p.id,
+            name: p.name,
+            nickname: p.nickname,
+          })));
+        }
+      })
+      .catch(() => { /* silent */ });
+  }, [fetchBroadcastState]);
+
+  const handleSave = async () => {
+    if (!isAdmin) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ player1Name: player1Input.trim(), player2Name: player2Input.trim() }),
+      });
+      if (res.ok) {
+        await fetchBroadcastState();
+        setSavedFlash(true);
+        setTimeout(() => setSavedFlash(false), 2000);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClear = async () => {
+    if (!isAdmin) return;
+    setSaving(true);
+    try {
+      await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ player1Name: "", player2Name: "" }),
+      });
+      setPlayer1Input("");
+      setPlayer2Input("");
+      await fetchBroadcastState();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!isAdmin) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        {t("noPermission")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div>
+        <h2 className="text-2xl font-bold">📺 配信管理</h2>
+        <p className="text-muted-foreground text-sm mt-1">
+          オーバーレイに表示する1P/2Pの名前を設定します。
+        </p>
+      </div>
+
+      {/* Current overlay state preview */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">現在の配信表示</CardTitle>
+          <CardDescription>OBSオーバーレイに現在表示されている名前</CardDescription>
+        </CardHeader>
+        <CardContent className="flex gap-6">
+          <div className="space-y-1">
+            <p className="text-xs text-muted-foreground">1P (x:80, y:480)</p>
+            <p className={`font-bold text-lg ${currentState.player1Name ? "" : "text-muted-foreground"}`}>
+              {currentState.player1Name || "（未設定）"}
+            </p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-xs text-muted-foreground">2P (x:80, y:870)</p>
+            <p className={`font-bold text-lg ${currentState.player2Name ? "" : "text-muted-foreground"}`}>
+              {currentState.player2Name || "（未設定）"}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Name input form */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">名前を設定</CardTitle>
+          <CardDescription>
+            プレイヤーリストから選ぶか、直接入力してください。
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>1P 名前</Label>
+            {/* Player selector dropdown */}
+            {players.length > 0 && (
+              <Select
+                onValueChange={(val) => setPlayer1Input(val)}
+                value=""
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="プレイヤーリストから選択..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {players.map((p) => (
+                    <SelectItem key={p.id} value={p.nickname}>
+                      {p.nickname}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            <Input
+              value={player1Input}
+              onChange={(e) => setPlayer1Input(e.target.value)}
+              placeholder="1P の名前を入力..."
+              maxLength={50}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>2P 名前</Label>
+            {players.length > 0 && (
+              <Select
+                onValueChange={(val) => setPlayer2Input(val)}
+                value=""
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="プレイヤーリストから選択..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {players.map((p) => (
+                    <SelectItem key={p.id} value={p.nickname}>
+                      {p.nickname}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            <Input
+              value={player2Input}
+              onChange={(e) => setPlayer2Input(e.target.value)}
+              placeholder="2P の名前を入力..."
+              maxLength={50}
+            />
+          </div>
+          <div className="flex gap-2">
+            <Button
+              onClick={handleSave}
+              disabled={saving}
+              className={savedFlash ? "bg-green-600 hover:bg-green-600" : ""}
+            >
+              {savedFlash ? "✓ 反映しました" : "配信に反映"}
+            </Button>
+            <Button variant="outline" onClick={handleClear} disabled={saving}>
+              クリア
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="text-sm text-muted-foreground">
+        <p>
+          オーバーレイURL:{" "}
+          <Link
+            href={`/tournaments/${tournamentId}/overlay/dashboard`}
+            className="underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            /tournaments/{tournamentId}/overlay/dashboard
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -71,7 +71,7 @@ import {
 } from "@/components/ui/select";
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
 import { PlayoffBracket } from "@/components/tournament/playoff-bracket";
-import { COURSE_INFO, CUP_SUBSTITUTIONS, GP_POSITION_OPTIONS, POLLING_INTERVAL, TOTAL_GP_RACES, getDriverPoints, type CourseAbbr } from "@/lib/constants";
+import { COURSE_INFO, CUP_SUBSTITUTIONS, GP_POSITION_OPTIONS, POLLING_INTERVAL, TOTAL_GP_RACES, TV_NUMBER_OPTIONS, getDriverPoints, type CourseAbbr } from "@/lib/constants";
 import { formatGpPosition } from "@/lib/gp-utils";
 import { usePolling } from "@/lib/hooks/usePolling";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
@@ -100,6 +100,7 @@ interface GPMatch {
   points2: number;
   completed: boolean;
   cup?: string;
+  tvNumber?: number | null;
   player1: Player;
   player2: Player;
   races?: {
@@ -230,7 +231,8 @@ export default function GrandPrixFinals({
     suddenDeathWinnerId: string;
     cup: string;
     races: Race[];
-  }>({ suddenDeathWinnerId: "", cup: "", races: [] });
+    tvNumber: number | null;
+  }>({ suddenDeathWinnerId: "", cup: "", races: [], tvNumber: null });
   /* Admin override: skip race entry and write raw driver-points totals.
    * Mirrors the qualification page's manual-total form — used when the
    * cup total needs correcting but entering every race is overkill. */
@@ -428,6 +430,7 @@ export default function GrandPrixFinals({
       suddenDeathWinnerId: match.suddenDeathWinnerId ?? "",
       cup,
       races,
+      tvNumber: match.tvNumber ?? null,
     });
     /* Reset the manual-override form; pre-fill with the stored totals so the
      * admin can toggle into manual mode and tweak one side without retyping
@@ -492,6 +495,7 @@ export default function GrandPrixFinals({
     if (points1 === points2 && scoreForm.suddenDeathWinnerId) {
       body.suddenDeathWinnerId = scoreForm.suddenDeathWinnerId;
     }
+    body.tvNumber = scoreForm.tvNumber;
 
     try {
       const response = await fetch(`/api/tournaments/${tournamentId}/gp/finals`, {
@@ -505,7 +509,7 @@ export default function GrandPrixFinals({
         const data = unwrapApiData<{ isComplete?: boolean; champion?: string; playoffComplete?: boolean }>(json);
         setIsScoreDialogOpen(false);
         setSelectedMatch(null);
-        setScoreForm({ suddenDeathWinnerId: "", cup: "", races: [] });
+        setScoreForm({ suddenDeathWinnerId: "", cup: "", races: [], tvNumber: null });
         setManualScoreEnabled(false);
         setManualPoints1("");
         setManualPoints2("");
@@ -988,7 +992,39 @@ export default function GrandPrixFinals({
               {tFinals('gpTieNeedsWinner')}
             </p>
           </div>
-          <DialogFooter>
+          {/* TV number assignment for broadcast */}
+          <div className="flex items-center gap-3 px-1 pb-2">
+            <Label htmlFor="gp-finals-tv" className="text-sm text-muted-foreground shrink-0">TV#</Label>
+            <select
+              id="gp-finals-tv"
+              className="w-20 h-8 text-center text-sm border rounded bg-background"
+              value={scoreForm.tvNumber ?? ""}
+              onChange={(e) => setScoreForm({ ...scoreForm, tvNumber: e.target.value ? parseInt(e.target.value) : null })}
+            >
+              <option value="">-</option>
+              {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>{n}</option>)}
+            </select>
+          </div>
+          <DialogFooter className="flex-wrap gap-2">
+            {selectedMatch && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={async () => {
+                  await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                      player1Name: selectedMatch.player1.nickname,
+                      player2Name: selectedMatch.player2.nickname,
+                    }),
+                  });
+                }}
+                title="配信に反映"
+              >
+                📺 配信に反映
+              </Button>
+            )}
             <Button
               onClick={handleScoreSubmit}
               disabled={

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
@@ -266,7 +266,7 @@ export default function GrandPrixPage({
   }, [tournamentId]);
 
   /* Shared handlers for rank override and TV assignment */
-  const { handleRankOverrideSave, handleBulkRankOverrideSave, handleTvAssign } =
+  const { handleRankOverrideSave, handleBulkRankOverrideSave, handleTvAssign, handleBroadcastReflect } =
     useQualificationActions({ tournamentId, mode: "gp", refetch });
 
   /**
@@ -966,6 +966,16 @@ export default function GrandPrixPage({
                                     </TableCell>
                                   )}
                                   <TableCell className="text-right space-x-2">
+                                    {isAdmin && !match.isBye && (
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={() => handleBroadcastReflect(match.player1.nickname, match.player2.nickname)}
+                                        title="配信に反映"
+                                      >
+                                        📺
+                                      </Button>
+                                    )}
                                     {isAdmin && !match.isBye && (
                                       <Button
                                         variant={match.completed ? "outline" : "default"}

--- a/smkc-score-app/src/app/tournaments/[id]/layout.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/layout.tsx
@@ -58,6 +58,11 @@ const TABS = [
   { href: "overall-ranking", labelKey: "overall" },
 ] as const;
 
+/** Admin-only tabs shown after the main mode tabs */
+const ADMIN_TABS = [
+  { href: "broadcast", label: "📺 配信管理" },
+] as const;
+
 /**
  * Determines if the current page is a "minimal UI" page where the
  * tournament header and tab bar should be hidden.
@@ -91,6 +96,7 @@ function getActiveTab(pathname: string): string {
   /* Check "overall-ranking" first since it's the longest segment
      and won't conflict with shorter path segments */
   if (pathname.includes("/overall-ranking")) return "overall-ranking";
+  if (pathname.includes("/broadcast")) return "broadcast";
   for (const tab of TABS) {
     if (tab.href !== "overall-ranking" && pathname.includes(`/${tab.href}`)) {
       return tab.href;
@@ -347,6 +353,20 @@ export default function TournamentLayout({
               </Link>
             );
           })}
+          {/* Admin-only extra tabs */}
+          {isAdmin && ADMIN_TABS.map((tab) => (
+            <Link
+              key={tab.href}
+              href={`/tournaments/${id}/${tab.href}`}
+              className={`inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                activeTab === tab.href
+                  ? "bg-background text-foreground shadow-sm"
+                  : "hover:bg-background/50 hover:text-foreground"
+              }`}
+            >
+              {tab.label}
+            </Link>
+          ))}
         </div>
 
         {/*

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -71,7 +71,7 @@ import {
 } from "@/components/ui/select";
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
 import { PlayoffBracket } from "@/components/tournament/playoff-bracket";
-import { COURSE_INFO, POLLING_INTERVAL, type CourseAbbr } from "@/lib/constants";
+import { COURSE_INFO, POLLING_INTERVAL, TV_NUMBER_OPTIONS, type CourseAbbr } from "@/lib/constants";
 import { getMrFinalsMaxRounds, getMrFinalsTargetWins } from "@/lib/finals-target-wins";
 import { usePolling } from "@/lib/hooks/usePolling";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
@@ -89,6 +89,7 @@ interface MRMatch {
   matchNumber: number;
   round: string | null;
   stage?: string | null;
+  tvNumber?: number | null;
   player1Id: string;
   player2Id: string;
   score1: number;
@@ -232,6 +233,7 @@ export default function MatchRaceFinals({
   const [manualScoreEnabled, setManualScoreEnabled] = useState(false);
   const [manualScore1, setManualScore1] = useState<string>("");
   const [manualScore2, setManualScore2] = useState<string>("");
+  const [selectedTvNumber, setSelectedTvNumber] = useState<number | null>(null);
   const [champion, setChampion] = useState<Player | null>(null);
   const selectedMatchTargetWins = selectedMatch ? getMrFinalsTargetWins(selectedMatch) : getMrFinalsTargetWins();
 
@@ -409,6 +411,7 @@ export default function MatchRaceFinals({
     setManualScoreEnabled(false);
     setManualScore1(String(match.score1 ?? 0));
     setManualScore2(String(match.score2 ?? 0));
+    setSelectedTvNumber(match.tvNumber ?? null);
     setIsMatchDialogOpen(true);
   };
 
@@ -475,6 +478,7 @@ export default function MatchRaceFinals({
       body.score2 = loserCount;
       body.rounds = rounds;
     }
+    body.tvNumber = selectedTvNumber;
 
     try {
       const response = await fetch(`/api/tournaments/${tournamentId}/mr/finals`, {
@@ -873,7 +877,39 @@ export default function MatchRaceFinals({
               </TableBody>
             </Table>}
           </div>
-          <DialogFooter>
+          {/* TV number assignment for broadcast */}
+          <div className="flex items-center gap-3 px-1">
+            <Label htmlFor="mr-finals-tv" className="text-sm text-muted-foreground shrink-0">TV#</Label>
+            <select
+              id="mr-finals-tv"
+              className="w-20 h-8 text-center text-sm border rounded bg-background"
+              value={selectedTvNumber ?? ""}
+              onChange={(e) => setSelectedTvNumber(e.target.value ? parseInt(e.target.value) : null)}
+            >
+              <option value="">-</option>
+              {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>{n}</option>)}
+            </select>
+          </div>
+          <DialogFooter className="flex-wrap gap-2">
+            {selectedMatch && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={async () => {
+                  await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                      player1Name: selectedMatch.player1.nickname,
+                      player2Name: selectedMatch.player2.nickname,
+                    }),
+                  });
+                }}
+                title="配信に反映"
+              >
+                📺 配信に反映
+              </Button>
+            )}
             {/* i18n: Save result button */}
             <Button
               onClick={handleMatchSubmit}

--- a/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
@@ -240,7 +240,7 @@ export default function MatchRacePage({
   }, [tournamentId]);
 
   /* Shared handlers for rank override and TV assignment */
-  const { handleRankOverrideSave, handleBulkRankOverrideSave, handleTvAssign } =
+  const { handleRankOverrideSave, handleBulkRankOverrideSave, handleTvAssign, handleBroadcastReflect } =
     useQualificationActions({ tournamentId, mode: "mr", refetch });
 
   /**
@@ -873,6 +873,16 @@ export default function MatchRacePage({
                                     </TableCell>
                                   )}
                                   <TableCell className="text-right space-x-2">
+                                    {isAdmin && !match.isBye && (
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={() => handleBroadcastReflect(match.player1.nickname, match.player2.nickname)}
+                                        title="配信に反映"
+                                      >
+                                        📺
+                                      </Button>
+                                    )}
                                     {isAdmin && !match.isBye && (
                                       <Button
                                         variant={match.completed ? "outline" : "default"}

--- a/smkc-score-app/src/app/tournaments/[id]/overlay/dashboard/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/overlay/dashboard/page.tsx
@@ -44,6 +44,9 @@ export default function DashboardPage({
   const [events, setEvents] = useState<OverlayEvent[]>([]);
   const [currentPhase, setCurrentPhase] = useState<string>("");
   const [now, setNow] = useState<number>(() => Date.now());
+  /* Broadcast player names from "配信に反映" / 配信管理 page */
+  const [overlayPlayer1Name, setOverlayPlayer1Name] = useState<string>("");
+  const [overlayPlayer2Name, setOverlayPlayer2Name] = useState<string>("");
 
   /* `since` advances each poll. First call uses `?initial=1` (no since)
      to backfill recent history; subsequent calls echo back `serverTime`. */
@@ -81,6 +84,9 @@ export default function DashboardPage({
 
       sinceRef.current = payload.serverTime;
       if (payload.currentPhase) setCurrentPhase(payload.currentPhase);
+      /* Always update broadcast names (may change between polls even without new events) */
+      if (payload.overlayPlayer1Name !== undefined) setOverlayPlayer1Name(payload.overlayPlayer1Name);
+      if (payload.overlayPlayer2Name !== undefined) setOverlayPlayer2Name(payload.overlayPlayer2Name);
 
       const fresh = payload.events.filter((e) => {
         if (seenRef.current.has(e.id)) return false;
@@ -142,6 +148,36 @@ export default function DashboardPage({
       >
         <DashboardFooter currentPhase={currentPhase} />
       </div>
+
+      {/* 1P name display: x:80, y:480, w:230px, h:48px (「配信に反映」設定値) */}
+      {overlayPlayer1Name && (
+        <div
+          className="pointer-events-none fixed flex items-center"
+          style={{ left: 80, top: 480, width: 230, height: 48, overflow: "hidden" }}
+        >
+          <span
+            className="text-white font-bold text-xl leading-none truncate w-full"
+            style={{ textShadow: "0 1px 4px rgba(0,0,0,0.9), 0 0 8px rgba(0,0,0,0.8)" }}
+          >
+            {overlayPlayer1Name}
+          </span>
+        </div>
+      )}
+
+      {/* 2P name display: x:80, y:870, w:230px, h:48px (「配信に反映」設定値) */}
+      {overlayPlayer2Name && (
+        <div
+          className="pointer-events-none fixed flex items-center"
+          style={{ left: 80, top: 870, width: 230, height: 48, overflow: "hidden" }}
+        >
+          <span
+            className="text-white font-bold text-xl leading-none truncate w-full"
+            style={{ textShadow: "0 1px 4px rgba(0,0,0,0.9), 0 0 8px rgba(0,0,0,0.8)" }}
+          >
+            {overlayPlayer2Name}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -36,6 +36,7 @@ interface BMMatch {
   matchNumber: number;
   round: string | null;
   stage?: string | null;
+  tvNumber?: number | null;
   player1Id: string;
   player2Id: string;
   score1: number;
@@ -143,9 +144,10 @@ function MatchCard({
         }
       }}
     >
-      {/* Match number label */}
-      <div className="text-xs text-muted-foreground mb-1">
-        M{bracketMatch.matchNumber}
+      {/* Match number and TV number label */}
+      <div className="text-xs text-muted-foreground mb-1 flex justify-between">
+        <span>M{bracketMatch.matchNumber}</span>
+        {match?.tvNumber && <span className="text-blue-500">TV{match.tvNumber}</span>}
       </div>
 
       {/* Player 1 row with optional seed number and score */}

--- a/smkc-score-app/src/components/tournament/playoff-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/playoff-bracket.tsx
@@ -31,6 +31,7 @@ interface BMMatch {
   matchNumber: number;
   round: string | null;
   stage?: string | null;
+  tvNumber?: number | null;
   player1Id: string;
   player2Id: string;
   score1: number;
@@ -123,9 +124,10 @@ function PlayoffMatchCard({
         }
       }}
     >
-      {/* Match number label */}
-      <div className="text-xs text-muted-foreground mb-1">
-        M{bracketMatch.matchNumber}
+      {/* Match number and TV number label */}
+      <div className="text-xs text-muted-foreground mb-1 flex justify-between">
+        <span>M{bracketMatch.matchNumber}</span>
+        {match?.tvNumber && <span className="text-blue-500">TV{match.tvNumber}</span>}
       </div>
       {match?.cup && (
         <div className="mb-1 text-[11px] text-blue-600">

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -29,7 +29,7 @@ import { checkRateLimit } from '@/lib/rate-limit';
 import { getClientIdentifier } from '@/lib/request-utils';
 import { resolveTournamentId } from '@/lib/tournament-identifier';
 import { checkQualificationConfirmed } from '@/lib/qualification-confirmed-check';
-import { COURSES, CUPS } from '@/lib/constants';
+import { COURSES, CUPS, MAX_TV_NUMBER } from '@/lib/constants';
 
 /**
  * Bracket size inference thresholds.
@@ -1177,6 +1177,13 @@ export function createFinalsHandlers(config: FinalsConfig) {
       };
 
       if (config.putAdditionalFields) {
+        /* Validate tvNumber if present: must be an integer 1-MAX_TV_NUMBER or null/undefined to clear. */
+        if (body.tvNumber !== undefined && body.tvNumber !== null) {
+          const tv = body.tvNumber;
+          if (!Number.isInteger(tv) || tv < 1 || tv > MAX_TV_NUMBER) {
+            return handleValidationError(`tvNumber must be 1–${MAX_TV_NUMBER}`, 'tvNumber');
+          }
+        }
         for (const field of config.putAdditionalFields) {
           if (body[field] !== undefined) {
             updateData[field] = body[field] || null;

--- a/smkc-score-app/src/lib/hooks/useQualificationActions.ts
+++ b/smkc-score-app/src/lib/hooks/useQualificationActions.ts
@@ -96,5 +96,21 @@ export function useQualificationActions({ tournamentId, mode, refetch }: UseQual
     }
   }, [tournamentId, mode, refetch, logger]);
 
-  return { handleRankOverrideSave, handleBulkRankOverrideSave, handleTvAssign };
+  /**
+   * Push match players to the overlay as the current 1P/2P broadcast names.
+   * Used by the "配信に反映" button on each match row.
+   */
+  const handleBroadcastReflect = useCallback(async (player1Name: string, player2Name: string) => {
+    try {
+      await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ player1Name, player2Name }),
+      });
+    } catch (err) {
+      logger.error("Failed to reflect broadcast:", { error: err, tournamentId });
+    }
+  }, [tournamentId, logger]);
+
+  return { handleRankOverrideSave, handleBulkRankOverrideSave, handleTvAssign, handleBroadcastReflect };
 }

--- a/smkc-score-app/src/lib/overlay/types.ts
+++ b/smkc-score-app/src/lib/overlay/types.ts
@@ -177,4 +177,11 @@ export interface OverlayEventsResponse {
    * active phase has no meaningful FT value (TA, GP, qualification, barrage).
    */
   currentPhaseFormat?: string | null;
+  /**
+   * Broadcast player names set by the admin via "配信に反映" or 配信管理 page.
+   * Displayed on the OBS overlay canvas at the 1P/2P name positions.
+   * Empty string means no name is currently set.
+   */
+  overlayPlayer1Name?: string;
+  overlayPlayer2Name?: string;
 }


### PR DESCRIPTION
## Summary

- **Issue #634**: TV number (1–4) assignment for BM/MR/GP finals bracket matches — admins can set TV# via a dropdown in score dialogs; brackets display TV# badges on match cards
- **Issue #635**: 「配信に反映」broadcast player name overlay — admins can push 1P/2P names to the OBS dashboard overlay via 📺 buttons on match rows, finals dialogs, or the new 配信管理 page

## Changes

### Issue #634 — TV numbers in finals

- Add `tvNumber` to `putAdditionalFields` in BM/MR/GP finals API routes (`finals-route.ts`); validated as integer 1–4, null to clear
- `double-elimination-bracket` and `playoff-bracket` components show a `TV{n}` badge on match cards
- BM/MR/GP finals score dialogs include a TV number dropdown (alongside the score inputs)
- **E2E TC-522**: BM finals tvNumber accepts 1–4, rejects 5 (422), clears on null

### Issue #635 — Broadcast player name overlay

- **DB migration** `0020_add_broadcast_player_names.sql`: adds `overlayPlayer1Name`/`overlayPlayer2Name` columns to `Tournament`
- **New API** `GET/PUT /api/tournaments/[id]/broadcast`: public read, admin-only write; validates strings ≤50 chars
- **overlay-events route** now returns `overlayPlayer1Name`/`overlayPlayer2Name` in every response
- **📺 button** on BM/MR/GP qualification match rows (calls PUT /broadcast with the match's player nicknames)
- **配信に反映 button** in BM/MR/GP finals score dialogs
- **新ページ `配信管理`** at `/tournaments/[id]/broadcast`: player selector dropdown + free-text input + live preview of current OBS state
- **📺 配信管理 tab** in tournament layout (admin-only)
- **OBS dashboard overlay** displays 1P/2P names at the scene-fixed positions: 1P x:80 y:480 w:230px h:48px, 2P x:80 y:870 w:230px h:48px — white text with drop shadow, hidden when empty
- **E2E TC-916**: broadcast API PUT/GET round-trip (admin write + public read)
- **E2E TC-917**: overlay-events response includes `overlayPlayer1Name`/`overlayPlayer2Name`

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Unit tests pass (`npx jest`) — 2035 tests
- [ ] E2E TC-522 (BM finals tvNumber)
- [ ] E2E TC-916 (broadcast API)
- [ ] E2E TC-917 (overlay-events player names)
- [ ] Manual: open 配信管理 tab, set 1P/2P names, verify OBS dashboard updates within one poll cycle (3s)
- [ ] Manual: click 📺 on a qualification match row, verify dashboard updates
- [ ] Manual: open BM/MR/GP finals dialog, set TV#, verify badge appears on bracket card

https://claude.ai/code/session_01QUsTQBahpP2LF8CNnqsDA6

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUsTQBahpP2LF8CNnqsDA6)_