### PR TITLE
fix(#637-#643): broadcast UI, TV optimistic update, overlay CSS, bracket TV1 highlight, TA TV, i18n

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
@@ -623,12 +623,13 @@ describe('POST /api/tournaments/[id]/ta/phases', () => {
     await phasesRoute.POST(createPostRequest({ action: 'start_round', phase: 'phase1' }), { params: mockParams });
 
     expect(checkStageFrozen).toHaveBeenCalledWith(prisma, 'tournament-1', 'phase1');
-    // course is undefined (not provided in request), so the 4th arg is undefined = random selection
+    // course is undefined (not provided in request), tvNumber defaults to null
     expect(startPhaseRound).toHaveBeenCalledWith(
       prisma,
       expect.objectContaining({ tournamentId: 'tournament-1' }),
       'phase1',
-      undefined
+      undefined,
+      null
     );
     expect(NextResponse.json).toHaveBeenCalledWith({ success: true, data: { roundNumber: 1, course: 'MC1', manualOverride: false } });
   });
@@ -642,9 +643,24 @@ describe('POST /api/tournaments/[id]/ta/phases', () => {
       prisma,
       expect.objectContaining({ tournamentId: 'tournament-1' }),
       'phase1',
-      'DP1'
+      'DP1',
+      null
     );
     expect(NextResponse.json).toHaveBeenCalledWith({ success: true, data: { roundNumber: 2, course: 'DP1', manualOverride: true } });
+  });
+
+  it('should pass tvNumber to startPhaseRound when provided', async () => {
+    (startPhaseRound as jest.Mock).mockResolvedValue({ roundNumber: 1, course: 'MC1', manualOverride: false, tvNumber: 2 });
+
+    await phasesRoute.POST(createPostRequest({ action: 'start_round', phase: 'phase1', tvNumber: 2 }), { params: mockParams });
+
+    expect(startPhaseRound).toHaveBeenCalledWith(
+      prisma,
+      expect.objectContaining({ tournamentId: 'tournament-1' }),
+      'phase1',
+      undefined,
+      2
+    );
   });
 
   it('should return freeze error when phase is frozen for start_round', async () => {

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -129,7 +129,10 @@
     "timeTrial": "Time Trial",
     "battleMode": "Battle Mode",
     "matchRace": "Match Race",
-    "grandPrix": "Grand Prix"
+    "grandPrix": "Grand Prix",
+    "generatingBracket": "Generating bracket... Please wait.",
+    "broadcastReflect": "Broadcast",
+    "broadcastReflected": "Broadcast updated"
   },
   "home": {
     "tagline": "SMKC Score Management",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -129,7 +129,10 @@
     "timeTrial": "タイムトライアル",
     "battleMode": "バトルモード",
     "matchRace": "マッチレース",
-    "grandPrix": "グランプリ"
+    "grandPrix": "グランプリ",
+    "generatingBracket": "ブラケットを生成中...しばらくお待ちください。",
+    "broadcastReflect": "配信に反映",
+    "broadcastReflected": "配信に反映しました"
   },
   "home": {
     "tagline": "SMKC スコア管理",

--- a/smkc-score-app/prisma/migrations/0006_ta_phase_round_tv_number/migration.sql
+++ b/smkc-score-app/prisma/migrations/0006_ta_phase_round_tv_number/migration.sql
@@ -1,0 +1,3 @@
+-- Add tvNumber to TTPhaseRound for broadcast TV assignment.
+-- Existing rounds default to NULL (no TV assigned).
+ALTER TABLE "TTPhaseRound" ADD COLUMN "tvNumber" INTEGER;

--- a/smkc-score-app/prisma/schema.prisma
+++ b/smkc-score-app/prisma/schema.prisma
@@ -457,6 +457,7 @@ model TTPhaseRound {
   phase           String     // "phase1", "phase2", "phase3"
   roundNumber     Int        // Sequential round number within the phase
   course          String     // Course abbreviation (e.g., "MC1")
+  tvNumber        Int?       // Broadcast TV screen number (1-4), optional
   results         Json       // Array: [{playerId, timeMs, isRetry}]
   eliminatedIds   Json?      // Array of player IDs eliminated this round
   livesReset      Boolean    @default(false) // Whether lives were reset after this round

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
@@ -88,10 +88,12 @@ const PostRequestSchema = z.discriminatedUnion("action", [
   // Start a new round: selects a random course and creates a TTPhaseRound record.
   // Optional `course` allows admin to manually specify a course abbreviation (e.g. "MC1")
   // instead of using random selection. Must be a valid abbreviation in the current cycle.
+  // Optional `tvNumber` (1-4) assigns a broadcast TV screen to the round.
   z.object({
     action: z.literal("start_round"),
     phase: PhaseSchema,
-    course: z.string().optional(), // Admin manual course override; undefined = random
+    course: z.string().optional(),
+    tvNumber: z.number().int().min(1).max(4).nullable().optional(),
   }),
 
   // Cancel an unsubmitted round: deletes the TTPhaseRound record to free the course
@@ -290,12 +292,12 @@ export async function POST(
 
     // === Round Management Actions ===
     if (action === "start_round") {
-      const { phase, course } = parsed.data;
+      const { phase, course, tvNumber } = parsed.data;
       // Prevent starting rounds in a frozen phase (admin locked after completion)
       const freezeError = await checkStageFrozen(prisma, tournamentId, phase);
       if (freezeError) return freezeError;
       // Pass optional manual course; undefined = random selection (default behaviour)
-      const result = await startPhaseRound(prisma, context, phase, course);
+      const result = await startPhaseRound(prisma, context, phase, course, tvNumber ?? null);
       return createSuccessResponse(result);
     }
 

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -28,6 +28,7 @@
 import { useState, useEffect, useCallback, use } from "react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -199,6 +200,7 @@ export default function BattleModeFinals({
 
   /* Tournament completion state */
   const [champion, setChampion] = useState<Player | null>(null);
+  const [broadcasting, setBroadcasting] = useState(false);
 
   /**
    * Fetch finals data including matches, bracket structure, and round names.
@@ -808,19 +810,25 @@ export default function BattleModeFinals({
               <Button
                 variant="outline"
                 size="sm"
+                disabled={broadcasting}
                 onClick={async () => {
-                  await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
-                    method: "PUT",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({
-                      player1Name: selectedMatch.player1.nickname,
-                      player2Name: selectedMatch.player2.nickname,
-                    }),
-                  });
+                  setBroadcasting(true);
+                  try {
+                    await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
+                      method: "PUT",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({
+                        player1Name: selectedMatch.player1.nickname,
+                        player2Name: selectedMatch.player2.nickname,
+                      }),
+                    });
+                    toast.success("配信に反映しました");
+                  } finally {
+                    setBroadcasting(false);
+                  }
                 }}
-                title="配信に反映"
               >
-                📺 配信に反映
+                {broadcasting ? tCommon('saving') : tCommon('broadcastReflect')}
               </Button>
             )}
             <Button

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
@@ -157,6 +157,10 @@ export default function BattleModePage({
   const [resettingBracket, setResettingBracket] = useState(false);
   /* Whether a finals or playoff bracket already exists on the server */
   const [finalsExists, setFinalsExists] = useState<boolean | undefined>(undefined);
+  /* Track which match ID is currently being broadcast to prevent double-clicks */
+  const [broadcastingMatchId, setBroadcastingMatchId] = useState<string | null>(null);
+  /* Optimistic TV overrides: applied immediately on dropdown change, confirmed by next poll */
+  const [tvOverrides, setTvOverrides] = useState<Record<string, number | null>>({});
 
   /**
    * Fetch both BM qualification data and all players in parallel.
@@ -598,6 +602,7 @@ export default function BattleModePage({
                                 })),
                               )
                             }
+                            onBroadcast={handleBroadcastReflect}
                           />
                           <Table>
                             <TableHeader>
@@ -827,15 +832,18 @@ export default function BattleModePage({
                                   >
                                     {match.isBye ? tc('bye') : match.player2.nickname}
                                   </TableCell>
-                                  {/* TV# assignment: admin can select TV number, others see read-only */}
+                                  {/* TV# assignment: admin can select TV number, others see read-only.
+                                      Optimistic update: local state is updated immediately; API fires in background. */}
                                   <TableCell className="text-center">
                                     {isAdmin && !match.isBye ? (
                                       <select
                                         className="w-14 h-8 text-center text-sm border rounded bg-background"
-                                        value={match.tvNumber ?? ""}
+                                        value={(match.id in tvOverrides ? tvOverrides[match.id] : match.tvNumber) ?? ""}
                                         onChange={(e) => {
                                           const val = e.target.value;
-                                          handleTvAssign(match.id, val ? parseInt(val) : null);
+                                          const num = val ? parseInt(val) : null;
+                                          setTvOverrides((prev) => ({ ...prev, [match.id]: num }));
+                                          handleTvAssign(match.id, num);
                                         }}
                                       >
                                         <option value="">-</option>
@@ -865,12 +873,16 @@ export default function BattleModePage({
                                     {/* 配信に反映: admin pushes this match's players to the overlay */}
                                     {isAdmin && !match.isBye && (
                                       <Button
-                                        variant="ghost"
+                                        variant="outline"
                                         size="sm"
-                                        onClick={() => handleBroadcastReflect(match.player1.nickname, match.player2.nickname)}
-                                        title="配信に反映"
+                                        disabled={broadcastingMatchId === match.id}
+                                        onClick={async () => {
+                                          setBroadcastingMatchId(match.id);
+                                          await handleBroadcastReflect(match.player1.nickname, match.player2.nickname);
+                                          setBroadcastingMatchId(null);
+                                        }}
                                       >
-                                        📺
+                                        {broadcastingMatchId === match.id ? tc('saving') : tc('broadcastReflect')}
                                       </Button>
                                     )}
                                     {/* Admin-only score entry/edit button (not for BYE matches, locked when confirmed) */}

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -21,6 +21,7 @@
 import { useState, useEffect, useCallback, use } from "react";
 import { useSession } from "next-auth/react";
 import { useLocale, useTranslations } from "next-intl";
+import { toast } from "sonner";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -240,6 +241,7 @@ export default function GrandPrixFinals({
   const [manualPoints1, setManualPoints1] = useState<string>("");
   const [manualPoints2, setManualPoints2] = useState<string>("");
   const [champion, setChampion] = useState<Player | null>(null);
+  const [broadcasting, setBroadcasting] = useState(false);
 
   /** Fetch finals data including matches, bracket structure, and round names */
   const fetchFinalsData = useCallback(async () => {
@@ -1010,19 +1012,25 @@ export default function GrandPrixFinals({
               <Button
                 variant="outline"
                 size="sm"
+                disabled={broadcasting}
                 onClick={async () => {
-                  await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
-                    method: "PUT",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({
-                      player1Name: selectedMatch.player1.nickname,
-                      player2Name: selectedMatch.player2.nickname,
-                    }),
-                  });
+                  setBroadcasting(true);
+                  try {
+                    await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
+                      method: "PUT",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({
+                        player1Name: selectedMatch.player1.nickname,
+                        player2Name: selectedMatch.player2.nickname,
+                      }),
+                    });
+                    toast.success("配信に反映しました");
+                  } finally {
+                    setBroadcasting(false);
+                  }
                 }}
-                title="配信に反映"
               >
-                📺 配信に反映
+                {broadcasting ? tCommon('saving') : tCommon('broadcastReflect')}
               </Button>
             )}
             <Button

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
@@ -175,6 +175,8 @@ export default function GrandPrixPage({
   const [generatingBracket, setGeneratingBracket] = useState(false);
   const [resettingBracket, setResettingBracket] = useState(false);
   const [finalsExists, setFinalsExists] = useState<boolean | undefined>(undefined);
+  const [broadcastingMatchId, setBroadcastingMatchId] = useState<string | null>(null);
+  const [tvOverrides, setTvOverrides] = useState<Record<string, number | null>>({});
 
   /** Get courses belonging to a specific cup for the course selection dropdown */
   const getCupCourses = (cup: string): CourseAbbr[] => {
@@ -728,6 +730,7 @@ export default function GrandPrixPage({
                                 })),
                               )
                             }
+                            onBroadcast={handleBroadcastReflect}
                           />
                           <Table>
                             <TableHeader>
@@ -928,10 +931,12 @@ export default function GrandPrixPage({
                                     {isAdmin && !match.isBye ? (
                                       <select
                                         className="w-14 h-8 text-center text-sm border rounded bg-background"
-                                        value={match.tvNumber ?? ""}
+                                        value={(match.id in tvOverrides ? tvOverrides[match.id] : match.tvNumber) ?? ""}
                                         onChange={(e) => {
                                           const val = e.target.value;
-                                          handleTvAssign(match.id, val ? parseInt(val) : null);
+                                          const num = val ? parseInt(val) : null;
+                                          setTvOverrides((prev) => ({ ...prev, [match.id]: num }));
+                                          handleTvAssign(match.id, num);
                                         }}
                                       >
                                         <option value="">-</option>
@@ -968,12 +973,16 @@ export default function GrandPrixPage({
                                   <TableCell className="text-right space-x-2">
                                     {isAdmin && !match.isBye && (
                                       <Button
-                                        variant="ghost"
+                                        variant="outline"
                                         size="sm"
-                                        onClick={() => handleBroadcastReflect(match.player1.nickname, match.player2.nickname)}
-                                        title="配信に反映"
+                                        disabled={broadcastingMatchId === match.id}
+                                        onClick={async () => {
+                                          setBroadcastingMatchId(match.id);
+                                          await handleBroadcastReflect(match.player1.nickname, match.player2.nickname);
+                                          setBroadcastingMatchId(null);
+                                        }}
                                       >
-                                        📺
+                                        {broadcastingMatchId === match.id ? tc('saving') : tc('broadcastReflect')}
                                       </Button>
                                     )}
                                     {isAdmin && !match.isBye && (

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -21,6 +21,7 @@
 import { useState, useEffect, useCallback, use } from "react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import {
@@ -234,6 +235,7 @@ export default function MatchRaceFinals({
   const [manualScore1, setManualScore1] = useState<string>("");
   const [manualScore2, setManualScore2] = useState<string>("");
   const [selectedTvNumber, setSelectedTvNumber] = useState<number | null>(null);
+  const [broadcasting, setBroadcasting] = useState(false);
   const [champion, setChampion] = useState<Player | null>(null);
   const selectedMatchTargetWins = selectedMatch ? getMrFinalsTargetWins(selectedMatch) : getMrFinalsTargetWins();
 
@@ -895,19 +897,25 @@ export default function MatchRaceFinals({
               <Button
                 variant="outline"
                 size="sm"
+                disabled={broadcasting}
                 onClick={async () => {
-                  await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
-                    method: "PUT",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({
-                      player1Name: selectedMatch.player1.nickname,
-                      player2Name: selectedMatch.player2.nickname,
-                    }),
-                  });
+                  setBroadcasting(true);
+                  try {
+                    await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
+                      method: "PUT",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({
+                        player1Name: selectedMatch.player1.nickname,
+                        player2Name: selectedMatch.player2.nickname,
+                      }),
+                    });
+                    toast.success("配信に反映しました");
+                  } finally {
+                    setBroadcasting(false);
+                  }
                 }}
-                title="配信に反映"
               >
-                📺 配信に反映
+                {broadcasting ? tCommon('saving') : tCommon('broadcastReflect')}
               </Button>
             )}
             {/* i18n: Save result button */}

--- a/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
@@ -157,6 +157,8 @@ export default function MatchRacePage({
   const [generatingBracket, setGeneratingBracket] = useState(false);
   const [resettingBracket, setResettingBracket] = useState(false);
   const [finalsExists, setFinalsExists] = useState<boolean | undefined>(undefined);
+  const [broadcastingMatchId, setBroadcastingMatchId] = useState<string | null>(null);
+  const [tvOverrides, setTvOverrides] = useState<Record<string, number | null>>({});
 
   /**
    * Fetch MR data and player list concurrently.
@@ -641,6 +643,7 @@ export default function MatchRacePage({
                                 })),
                               )
                             }
+                            onBroadcast={handleBroadcastReflect}
                           />
                           <Table>
                             <TableHeader>
@@ -835,10 +838,12 @@ export default function MatchRacePage({
                                     {isAdmin && !match.isBye ? (
                                       <select
                                         className="w-14 h-8 text-center text-sm border rounded bg-background"
-                                        value={match.tvNumber ?? ""}
+                                        value={(match.id in tvOverrides ? tvOverrides[match.id] : match.tvNumber) ?? ""}
                                         onChange={(e) => {
                                           const val = e.target.value;
-                                          handleTvAssign(match.id, val ? parseInt(val) : null);
+                                          const num = val ? parseInt(val) : null;
+                                          setTvOverrides((prev) => ({ ...prev, [match.id]: num }));
+                                          handleTvAssign(match.id, num);
                                         }}
                                       >
                                         <option value="">-</option>
@@ -875,12 +880,16 @@ export default function MatchRacePage({
                                   <TableCell className="text-right space-x-2">
                                     {isAdmin && !match.isBye && (
                                       <Button
-                                        variant="ghost"
+                                        variant="outline"
                                         size="sm"
-                                        onClick={() => handleBroadcastReflect(match.player1.nickname, match.player2.nickname)}
-                                        title="配信に反映"
+                                        disabled={broadcastingMatchId === match.id}
+                                        onClick={async () => {
+                                          setBroadcastingMatchId(match.id);
+                                          await handleBroadcastReflect(match.player1.nickname, match.player2.nickname);
+                                          setBroadcastingMatchId(null);
+                                        }}
                                       >
-                                        📺
+                                        {broadcastingMatchId === match.id ? tc('saving') : tc('broadcastReflect')}
                                       </Button>
                                     )}
                                     {isAdmin && !match.isBye && (

--- a/smkc-score-app/src/app/tournaments/[id]/overlay/dashboard/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/overlay/dashboard/page.tsx
@@ -152,11 +152,11 @@ export default function DashboardPage({
       {/* 1P name display: x:80, y:480, w:230px, h:48px (「配信に反映」設定値) */}
       {overlayPlayer1Name && (
         <div
-          className="pointer-events-none fixed flex items-center"
+          className="pointer-events-none fixed flex items-center justify-center"
           style={{ left: 80, top: 480, width: 230, height: 48, overflow: "hidden" }}
         >
           <span
-            className="text-white font-bold text-xl leading-none truncate w-full"
+            className="text-white font-bold text-2xl leading-none truncate w-full text-center"
             style={{ textShadow: "0 1px 4px rgba(0,0,0,0.9), 0 0 8px rgba(0,0,0,0.8)" }}
           >
             {overlayPlayer1Name}
@@ -167,11 +167,11 @@ export default function DashboardPage({
       {/* 2P name display: x:80, y:870, w:230px, h:48px (「配信に反映」設定値) */}
       {overlayPlayer2Name && (
         <div
-          className="pointer-events-none fixed flex items-center"
+          className="pointer-events-none fixed flex items-center justify-center"
           style={{ left: 80, top: 870, width: 230, height: 48, overflow: "hidden" }}
         >
           <span
-            className="text-white font-bold text-xl leading-none truncate w-full"
+            className="text-white font-bold text-2xl leading-none truncate w-full text-center"
             style={{ textShadow: "0 1px 4px rgba(0,0,0,0.9), 0 0 8px rgba(0,0,0,0.8)" }}
           >
             {overlayPlayer2Name}

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -75,7 +75,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { COURSE_INFO, RETRY_PENALTY_DISPLAY, RETRY_PENALTY_MS } from "@/lib/constants";
+import { COURSE_INFO, RETRY_PENALTY_DISPLAY, RETRY_PENALTY_MS, TV_NUMBER_OPTIONS } from "@/lib/constants";
 import { generateRandomTimeString, msToDisplayTime, timeToMs } from "@/lib/ta/time-utils";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { Dice5 } from "lucide-react";
@@ -103,6 +103,7 @@ interface PhaseRound {
   phase: string;
   roundNumber: number;
   course: string;
+  tvNumber?: number | null;
   results: Array<{ playerId: string; timeMs: number; isRetry: boolean }>;
   eliminatedIds: string[] | null;
   livesReset: boolean;
@@ -161,6 +162,7 @@ export default function TimeAttackFinals({
   // Admin-selected course override. "__random__" = use random selection (default).
   // Cannot use "" because Radix UI Select reserves empty string for "no selection" (placeholder).
   const [selectedCourse, setSelectedCourse] = useState<string>("__random__");
+  const [selectedTvNumber, setSelectedTvNumber] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -297,6 +299,7 @@ export default function TimeAttackFinals({
             // Only include course when admin has manually selected one;
             // omitting it lets the server choose randomly (default behaviour).
             ...(selectedCourse && selectedCourse !== "__random__" ? { course: selectedCourse } : {}),
+            ...(selectedTvNumber !== null ? { tvNumber: selectedTvNumber } : {}),
           }),
         }
       );
@@ -324,6 +327,7 @@ export default function TimeAttackFinals({
       setCourseTimes(initialTimes);
       setRetryFlags(initialRetry);
       setSelectedCourse("__random__"); // Reset manual selection after round is started
+      setSelectedTvNumber(null); // Reset TV selection after round is started
       fetchData();
     } catch (err) {
       const errorMessage =
@@ -881,6 +885,19 @@ export default function TimeAttackFinals({
                     </SelectContent>
                   </Select>
                 </div>
+                {/* TV number selector for the next round */}
+                <div className="flex items-center gap-3">
+                  <Label className="text-sm text-muted-foreground shrink-0">{tCommon('tvNumber')}</Label>
+                  <select
+                    className="w-20 h-8 text-center text-sm border rounded bg-background"
+                    value={selectedTvNumber ?? ""}
+                    disabled={startingRound || hasOpenRound}
+                    onChange={(e) => setSelectedTvNumber(e.target.value ? parseInt(e.target.value) : null)}
+                  >
+                    <option value="">-</option>
+                    {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>{n}</option>)}
+                  </select>
+                </div>
                 <Button
                   className="w-full"
                   size="lg"
@@ -1059,6 +1076,11 @@ export default function TimeAttackFinals({
                             })}
                           </h4>
                           <div className="flex gap-2">
+                            {round.tvNumber && (
+                              <Badge variant="outline" className="text-blue-600 border-blue-400 text-xs">
+                                TV{round.tvNumber}
+                              </Badge>
+                            )}
                             {round.livesReset && (
                               <Badge className="bg-yellow-500 text-black">
                                 {tTaFinals('livesReset')}

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -126,11 +126,15 @@ function MatchCard({
     bracketMatch.round === "winners_r1" || bracketMatch.round === "winners_qf";
   const showTBD = !isFirstRound && isTBD;
 
+  /* TV1 gets a subtle amber highlight so broadcast crew can spot it instantly. */
+  const isTV1 = match?.tvNumber === 1;
+
   return (
     <div
       className={cn(
         "border rounded-lg p-2 bg-card min-w-[180px] cursor-pointer hover:border-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary",
-        match?.completed && "border-green-500/50"
+        match?.completed && "border-green-500/50",
+        isTV1 && "bg-amber-50 border-amber-300 dark:bg-amber-950/30 dark:border-amber-700"
       )}
       onClick={onClick}
       role="button"

--- a/smkc-score-app/src/components/tournament/playoff-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/playoff-bracket.tsx
@@ -107,11 +107,14 @@ function PlayoffMatchCard({
   const isWinner1 = !!match?.completed && match.score1 >= targetWins && match.score1 > match.score2;
   const isWinner2 = !!match?.completed && match.score2 >= targetWins && match.score2 > match.score1;
 
+  const isTV1 = match?.tvNumber === 1;
+
   return (
     <div
       className={cn(
         "border rounded-lg p-2 bg-card min-w-[180px] cursor-pointer hover:border-primary transition-colors focus:outline-none focus:ring-2 focus:ring-primary",
-        match?.completed && "border-green-500/50"
+        match?.completed && "border-green-500/50",
+        isTV1 && "bg-amber-50 border-amber-300 dark:bg-amber-950/30 dark:border-amber-700"
       )}
       onClick={onClick}
       role="button"

--- a/smkc-score-app/src/components/tournament/qualification-playoff-manager.tsx
+++ b/smkc-score-app/src/components/tournament/qualification-playoff-manager.tsx
@@ -30,6 +30,8 @@ interface QualificationPlayoffManagerProps {
   groups: PlayoffGroup[];
   isAdmin: boolean;
   onSave: (entries: PlayoffEntry[]) => Promise<boolean>;
+  /** Broadcast first two players in the group to the overlay. */
+  onBroadcast?: (player1Name: string, player2Name: string) => Promise<boolean>;
 }
 
 function moveEntry<T>(entries: T[], from: number, to: number): T[] {
@@ -43,11 +45,13 @@ export function QualificationPlayoffManager({
   groups,
   isAdmin,
   onSave,
+  onBroadcast,
 }: QualificationPlayoffManagerProps) {
   const tc = useTranslations("common");
   const [openGroupId, setOpenGroupId] = useState<string | null>(null);
   const [draftOrder, setDraftOrder] = useState<PlayoffEntry[]>([]);
   const [saving, setSaving] = useState(false);
+  const [broadcastingGroupId, setBroadcastingGroupId] = useState<string | null>(null);
 
   const activeGroup = useMemo(
     () => groups.find((group) => group.id === openGroupId) ?? null,
@@ -88,15 +92,31 @@ export function QualificationPlayoffManager({
                   {group.players.map((player) => player.nickname).join(" / ")}
                 </div>
               </div>
-              {isAdmin ? (
-                <Button size="sm" variant="outline" onClick={() => openDialog(group)}>
-                  {tc("recordPlayoffResult")}
-                </Button>
-              ) : (
-                <div className="text-sm text-yellow-900">
-                  {tc("playoffPending")}
-                </div>
-              )}
+              <div className="flex gap-2 flex-wrap">
+                {isAdmin && onBroadcast && group.players.length >= 2 && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={broadcastingGroupId === group.id}
+                    onClick={async () => {
+                      setBroadcastingGroupId(group.id);
+                      await onBroadcast(group.players[0].nickname, group.players[1].nickname);
+                      setBroadcastingGroupId(null);
+                    }}
+                  >
+                    {broadcastingGroupId === group.id ? tc("saving") : tc("broadcastReflect")}
+                  </Button>
+                )}
+                {isAdmin ? (
+                  <Button size="sm" variant="outline" onClick={() => openDialog(group)}>
+                    {tc("recordPlayoffResult")}
+                  </Button>
+                ) : (
+                  <div className="text-sm text-yellow-900">
+                    {tc("playoffPending")}
+                  </div>
+                )}
+              </div>
             </CardContent>
           </Card>
         ))}

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -58,7 +58,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { COURSE_INFO, RETRY_PENALTY_DISPLAY, RETRY_PENALTY_MS } from "@/lib/constants";
+import { COURSE_INFO, RETRY_PENALTY_DISPLAY, RETRY_PENALTY_MS, TV_NUMBER_OPTIONS } from "@/lib/constants";
 import { generateRandomTimeString, msToDisplayTime, timeToMs } from "@/lib/ta/time-utils";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { Dice5 } from "lucide-react";
@@ -96,6 +96,7 @@ interface PhaseRound {
   phase: string;
   roundNumber: number;
   course: string;
+  tvNumber?: number | null;
   results: Array<{ playerId: string; timeMs: number; isRetry: boolean }>;
   eliminatedIds: string[] | null;
   livesReset: boolean;
@@ -131,6 +132,8 @@ export default function TAEliminationPhase({
   // Admin-selected course override. "__random__" = use random selection (default).
   // Cannot use "" because Radix UI Select reserves empty string for "no selection" (placeholder).
   const [selectedCourse, setSelectedCourse] = useState<string>("__random__");
+  // Admin-selected TV number for the next round (null = no TV assigned).
+  const [selectedTvNumber, setSelectedTvNumber] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -269,6 +272,7 @@ export default function TAEliminationPhase({
             // Only include course when admin has manually selected one;
             // omitting it lets the server choose randomly (default behaviour).
             ...(selectedCourse && selectedCourse !== "__random__" ? { course: selectedCourse } : {}),
+            ...(selectedTvNumber !== null ? { tvNumber: selectedTvNumber } : {}),
           }),
         }
       );
@@ -296,6 +300,7 @@ export default function TAEliminationPhase({
       setCourseTimes(initialTimes);
       setRetryFlags(initialRetry);
       setSelectedCourse("__random__"); // Reset manual selection after round is started
+      setSelectedTvNumber(null); // Reset TV selection after round is started
       fetchData();
     } catch (err) {
       const errorMessage =
@@ -803,6 +808,19 @@ export default function TAEliminationPhase({
                     </SelectContent>
                   </Select>
                 </div>
+                {/* TV number selector for the next round */}
+                <div className="flex items-center gap-3">
+                  <Label className="text-sm text-muted-foreground shrink-0">{tCommon('tvNumber')}</Label>
+                  <select
+                    className="w-20 h-8 text-center text-sm border rounded bg-background"
+                    value={selectedTvNumber ?? ""}
+                    disabled={startingRound || hasOpenRound}
+                    onChange={(e) => setSelectedTvNumber(e.target.value ? parseInt(e.target.value) : null)}
+                  >
+                    <option value="">-</option>
+                    {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>{n}</option>)}
+                  </select>
+                </div>
                 <Button
                   className="w-full"
                   size="lg"
@@ -955,6 +973,11 @@ export default function TAEliminationPhase({
                             {tElim('roundTitle', { number: round.roundNumber, course: courseInfo?.name || round.course })}
                           </h4>
                           <div className="flex items-center gap-1">
+                            {round.tvNumber && (
+                              <Badge variant="outline" className="text-blue-600 border-blue-400 text-xs">
+                                TV{round.tvNumber}
+                              </Badge>
+                            )}
                             {/* Show "手動選択" badge when admin manually specified the course */}
                             {round.manualOverride && (
                               <Badge variant="outline" className="text-amber-600 border-amber-400 text-xs">

--- a/smkc-score-app/src/lib/hooks/useQualificationActions.ts
+++ b/smkc-score-app/src/lib/hooks/useQualificationActions.ts
@@ -6,6 +6,7 @@
  */
 
 import { useCallback, useMemo } from "react";
+import { toast } from "sonner";
 import { createLogger } from "@/lib/client-logger";
 
 type Mode = "bm" | "mr" | "gp";
@@ -81,34 +82,40 @@ export function useQualificationActions({ tournamentId, mode, refetch }: UseQual
 
   /**
    * Handle TV number assignment for a match.
-   * Calls the PATCH endpoint to update the match's broadcast TV assignment.
+   * Fires the PATCH in the background without waiting; the caller should apply
+   * optimistic UI updates before calling this. No refetch is triggered so the
+   * dropdown feels instant — the next polling cycle will confirm the value.
    */
-  const handleTvAssign = useCallback(async (matchId: string, tvNumber: number | null) => {
-    try {
-      await fetch(`/api/tournaments/${tournamentId}/${mode}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ matchId, tvNumber }),
-      });
-      refetch();
-    } catch (err) {
+  const handleTvAssign = useCallback((matchId: string, tvNumber: number | null) => {
+    fetch(`/api/tournaments/${tournamentId}/${mode}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ matchId, tvNumber }),
+    }).catch((err) => {
       logger.error("Failed to assign TV:", { error: err, tournamentId, matchId });
-    }
-  }, [tournamentId, mode, refetch, logger]);
+    });
+  }, [tournamentId, mode, logger]);
 
   /**
    * Push match players to the overlay as the current 1P/2P broadcast names.
    * Used by the "配信に反映" button on each match row.
+   * Returns true on success so callers can show per-button feedback.
    */
-  const handleBroadcastReflect = useCallback(async (player1Name: string, player2Name: string) => {
+  const handleBroadcastReflect = useCallback(async (player1Name: string, player2Name: string): Promise<boolean> => {
     try {
-      await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
+      const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ player1Name, player2Name }),
       });
+      if (res.ok) {
+        toast.success("配信に反映しました");
+        return true;
+      }
+      return false;
     } catch (err) {
       logger.error("Failed to reflect broadcast:", { error: err, tournamentId });
+      return false;
     }
   }, [tournamentId, logger]);
 

--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -882,8 +882,9 @@ export async function startPhaseRound(
   prisma: PrismaClient,
   context: PhaseContext,
   phase: "phase1" | "phase2" | "phase3",
-  manualCourse?: string
-): Promise<{ roundNumber: number; course: string; manualOverride: boolean }> {
+  manualCourse?: string,
+  tvNumber?: number | null
+): Promise<{ roundNumber: number; course: string; manualOverride: boolean; tvNumber: number | null }> {
   const logger = createLogger("ta-phase-manager");
   const { tournamentId, userId, ipAddress, userAgent } = context;
 
@@ -950,6 +951,7 @@ export async function startPhaseRound(
           roundNumber,
           course,
           manualOverride,
+          tvNumber: tvNumber ?? null,
           results: [], // Will be populated by submitRoundResults
         },
       });
@@ -1000,7 +1002,7 @@ export async function startPhaseRound(
     });
   }
 
-  return { roundNumber, course, manualOverride };
+  return { roundNumber, course, manualOverride, tvNumber: tvNumber ?? null };
 }
 
 /**


### PR DESCRIPTION
## Summary

- **#637** Broadcast button now shows a text label (`配信に反映`) and loading state instead of an emoji-only button; `toast.success` feedback on success
- **#638** OBS overlay dashboard: 1P/2P player name is now `text-2xl` + `justify-center text-center` (was small and left-aligned)
- **#639** TV number assignment uses optimistic local state (`tvOverrides`) — UI updates instantly without waiting for API response or refetch
- **#640** Added missing `common.generatingBracket`, `common.broadcastReflect`, `common.broadcastReflected` i18n keys to both `en.json` and `ja.json`
- **#641** TV1 match is highlighted with amber background in double-elimination and playoff bracket components
- **#642** Broadcast button added to `QualificationPlayoffManager` yellow card panel via new optional `onBroadcast` callback prop
- **#643** `TTPhaseRound.tvNumber` DB column added (migration `0006_ta_phase_round_tv_number`); TV selector + badge wired up in TA Phase 1/2 (`ta-elimination-phase.tsx`) and Phase 3 (`ta/finals/page.tsx`)

## Test plan

- [ ] Broadcast button displays text and shows loading state while request is in flight
- [ ] `toast.success` notification appears after broadcast
- [ ] OBS overlay dashboard shows large, centered player names
- [ ] Selecting a TV number in a qualification match updates immediately without UI flicker
- [ ] `ブラケットを生成中...` message appears correctly (no missing i18n key error)
- [ ] TV1 match is visually highlighted in bracket views
- [ ] Broadcast button appears in sudden-death playoff group panels with ≥2 players
- [ ] TA Phase 1/2/3 round start UI includes TV number dropdown; submitted rounds show TV badge

https://claude.ai/code/session_013An3Pa8ouoFH5qQ7qAKDih

---
_Generated by [Claude Code](https://claude.ai/code/session_013An3Pa8ouoFH5qQ7qAKDih)_