### PR TITLE
fix: broadcast UX polish — i18n toast, error feedback, tvOverrides cleanup

### DIFF
--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -132,7 +132,8 @@
     "grandPrix": "Grand Prix",
     "generatingBracket": "Generating bracket... Please wait.",
     "broadcastReflect": "Broadcast",
-    "broadcastReflected": "Broadcast updated"
+    "broadcastReflected": "Broadcast updated",
+    "broadcastError": "Broadcast failed"
   },
   "home": {
     "tagline": "SMKC Score Management",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -132,7 +132,8 @@
     "grandPrix": "グランプリ",
     "generatingBracket": "ブラケットを生成中...しばらくお待ちください。",
     "broadcastReflect": "配信に反映",
-    "broadcastReflected": "配信に反映しました"
+    "broadcastReflected": "配信に反映しました",
+    "broadcastError": "配信に失敗しました"
   },
   "home": {
     "tagline": "SMKC スコア管理",

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -814,7 +814,7 @@ export default function BattleModeFinals({
                 onClick={async () => {
                   setBroadcasting(true);
                   try {
-                    await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
+                    const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
                       method: "PUT",
                       headers: { "Content-Type": "application/json" },
                       body: JSON.stringify({
@@ -822,7 +822,13 @@ export default function BattleModeFinals({
                         player2Name: selectedMatch.player2.nickname,
                       }),
                     });
-                    toast.success("配信に反映しました");
+                    if (res.ok) {
+                      toast.success(tCommon("broadcastReflected"));
+                    } else {
+                      toast.error(tCommon("broadcastError"));
+                    }
+                  } catch {
+                    toast.error(tCommon("broadcastError"));
                   } finally {
                     setBroadcasting(false);
                   }

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
@@ -246,6 +246,22 @@ export default function BattleModePage({
     return () => { cancelled = true; };
   }, [tournamentId]);
 
+  /* Clear tvOverrides for matches where the API has caught up to the optimistic value */
+  useEffect(() => {
+    if (!pollData) return;
+    setTvOverrides((prev) => {
+      const next = { ...prev };
+      let changed = false;
+      for (const match of (pollData.matches ?? [])) {
+        if (match.id in next && next[match.id] === match.tvNumber) {
+          delete next[match.id];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [pollData]);
+
   /* Shared handlers for rank override, TV assignment, and broadcast reflect */
   const { handleRankOverrideSave, handleBulkRankOverrideSave, handleTvAssign, handleBroadcastReflect } =
     useQualificationActions({ tournamentId, mode: "bm", refetch });

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -1016,7 +1016,7 @@ export default function GrandPrixFinals({
                 onClick={async () => {
                   setBroadcasting(true);
                   try {
-                    await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
+                    const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
                       method: "PUT",
                       headers: { "Content-Type": "application/json" },
                       body: JSON.stringify({
@@ -1024,7 +1024,13 @@ export default function GrandPrixFinals({
                         player2Name: selectedMatch.player2.nickname,
                       }),
                     });
-                    toast.success("配信に反映しました");
+                    if (res.ok) {
+                      toast.success(tCommon("broadcastReflected"));
+                    } else {
+                      toast.error(tCommon("broadcastError"));
+                    }
+                  } catch {
+                    toast.error(tCommon("broadcastError"));
                   } finally {
                     setBroadcasting(false);
                   }

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
@@ -267,6 +267,22 @@ export default function GrandPrixPage({
     return () => { cancelled = true; };
   }, [tournamentId]);
 
+  /* Clear tvOverrides for matches where the API has caught up to the optimistic value */
+  useEffect(() => {
+    if (!pollData) return;
+    setTvOverrides((prev) => {
+      const next = { ...prev };
+      let changed = false;
+      for (const match of (pollData.matches ?? [])) {
+        if (match.id in next && next[match.id] === match.tvNumber) {
+          delete next[match.id];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [pollData]);
+
   /* Shared handlers for rank override and TV assignment */
   const { handleRankOverrideSave, handleBulkRankOverrideSave, handleTvAssign, handleBroadcastReflect } =
     useQualificationActions({ tournamentId, mode: "gp", refetch });

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -901,7 +901,7 @@ export default function MatchRaceFinals({
                 onClick={async () => {
                   setBroadcasting(true);
                   try {
-                    await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
+                    const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
                       method: "PUT",
                       headers: { "Content-Type": "application/json" },
                       body: JSON.stringify({
@@ -909,7 +909,13 @@ export default function MatchRaceFinals({
                         player2Name: selectedMatch.player2.nickname,
                       }),
                     });
-                    toast.success("配信に反映しました");
+                    if (res.ok) {
+                      toast.success(tCommon("broadcastReflected"));
+                    } else {
+                      toast.error(tCommon("broadcastError"));
+                    }
+                  } catch {
+                    toast.error(tCommon("broadcastError"));
                   } finally {
                     setBroadcasting(false);
                   }

--- a/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
@@ -241,6 +241,22 @@ export default function MatchRacePage({
     return () => { cancelled = true; };
   }, [tournamentId]);
 
+  /* Clear tvOverrides for matches where the API has caught up to the optimistic value */
+  useEffect(() => {
+    if (!pollData) return;
+    setTvOverrides((prev) => {
+      const next = { ...prev };
+      let changed = false;
+      for (const match of (pollData.matches ?? [])) {
+        if (match.id in next && next[match.id] === match.tvNumber) {
+          delete next[match.id];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [pollData]);
+
   /* Shared handlers for rank override and TV assignment */
   const { handleRankOverrideSave, handleBulkRankOverrideSave, handleTvAssign, handleBroadcastReflect } =
     useQualificationActions({ tournamentId, mode: "mr", refetch });

--- a/smkc-score-app/src/lib/hooks/useQualificationActions.ts
+++ b/smkc-score-app/src/lib/hooks/useQualificationActions.ts
@@ -6,6 +6,7 @@
  */
 
 import { useCallback, useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { createLogger } from "@/lib/client-logger";
 
@@ -28,6 +29,7 @@ interface RankOverrideUpdate {
  * These functions are identical across BM/MR/GP qualification pages.
  */
 export function useQualificationActions({ tournamentId, mode, refetch }: UseQualificationActionsOptions) {
+  const tc = useTranslations("common");
   // Memoize logger so useCallback deps stay referentially stable
   const logger = useMemo(() => createLogger({ serviceName: `tournaments-${mode}` }), [mode]);
 
@@ -109,15 +111,17 @@ export function useQualificationActions({ tournamentId, mode, refetch }: UseQual
         body: JSON.stringify({ player1Name, player2Name }),
       });
       if (res.ok) {
-        toast.success("配信に反映しました");
+        toast.success(tc("broadcastReflected"));
         return true;
       }
+      toast.error(tc("broadcastError"));
       return false;
     } catch (err) {
       logger.error("Failed to reflect broadcast:", { error: err, tournamentId });
+      toast.error(tc("broadcastError"));
       return false;
     }
-  }, [tournamentId, logger]);
+  }, [tournamentId, tc, logger]);
 
   return { handleRankOverrideSave, handleBulkRankOverrideSave, handleTvAssign, handleBroadcastReflect };
 }


### PR DESCRIPTION
## Summary

Addresses the three minor review comments from #647:

- **i18n**: Replace hardcoded `"配信に反映しました"` strings with `tCommon('broadcastReflected')` in `useQualificationActions`, `bm/finals`, `mr/finals`, `gp/finals`
- **Error feedback**: Add `toast.error(tCommon('broadcastError'))` when broadcast API returns `!res.ok` or throws — previously the button just silently re-enabled
- **tvOverrides cleanup**: Add `useEffect` in bm/mr/gp pages that removes confirmed entries from the `tvOverrides` map each time polling data arrives (prevents unbounded accumulation)

Also adds `broadcastError` i18n key to both `en.json` and `ja.json`.

## Test plan

- [ ] Broadcast button shows `"Broadcast updated"` / `"配信に反映しました"` toast on success
- [ ] Broadcast button shows `"Broadcast failed"` / `"配信に失敗しました"` toast on API error
- [ ] TV override map shrinks after polling confirms the change

https://claude.ai/code/session_013An3Pa8ouoFH5qQ7qAKDih

---
_Generated by [Claude Code](https://claude.ai/code/session_013An3Pa8ouoFH5qQ7qAKDih)_