### PR TITLE
feat: overlay/dashboard broadcast enhancements (#644, #645, #646, #649, #651)

### DIFF
--- a/smkc-score-app/e2e/tc-overlay.js
+++ b/smkc-score-app/e2e/tc-overlay.js
@@ -26,6 +26,8 @@
  *   TC-915  GET /overlay-events?initial=1 returns currentPhase + event cap
  *   TC-916  PUT /broadcast sets 1P/2P names; public GET reads them back
  *   TC-917  overlay-events response includes overlayPlayer1Name / overlayPlayer2Name
+ *   TC-918  PUT /broadcast with matchLabel/wins/ft → GET returns new fields (#644/#645/#649)
+ *   TC-919  overlay-events includes overlayMatchLabel / overlayPlayer1Wins / overlayPlayer2Wins / overlayMatchFt
  *
  * Setup is API-only: the suite owns a 2-player tournament with one match
  * per mode (BM/MR/GP) plus 2 TA entries, then tears everything down at the
@@ -688,6 +690,87 @@ async function runTc917(_adminPage) {
   }
 }
 
+/* ───────── TC-918: Broadcast PUT with match info fields (#644/#645/#649) ─────────
+ * Verifies that the new overlayMatchLabel, overlayPlayer1Wins, overlayPlayer2Wins,
+ * and overlayMatchFt fields can be set via PUT /broadcast and read back via
+ * public GET /broadcast. Extends TC-916's coverage of the broadcast API. */
+async function runTc918(adminPage) {
+  try {
+    const stamp = Date.now();
+    const name1 = `TC918_P1_${stamp}`;
+    const name2 = `TC918_P2_${stamp}`;
+    const matchLabel = '決勝 QF';
+    const player1Wins = 3;
+    const player2Wins = 1;
+    const matchFt = 5;
+
+    const putRes = await adminPage.evaluate(async ([url, body]) => {
+      const r = await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [
+      `/api/tournaments/${fixture.tournamentId}/broadcast`,
+      { player1Name: name1, player2Name: name2, matchLabel, player1Wins, player2Wins, matchFt },
+    ]);
+    if (putRes.s !== 200) {
+      log('TC-918', 'FAIL', `PUT status=${putRes.s} ${JSON.stringify(putRes.b).slice(0, 100)}`);
+      return;
+    }
+
+    const getResp = await httpsGet(`/api/tournaments/${fixture.tournamentId}/broadcast`);
+    const d = getResp.body?.data;
+    const hasLabel = d?.matchLabel === matchLabel;
+    const hasWins = d?.player1Wins === player1Wins && d?.player2Wins === player2Wins;
+    const hasFt = d?.matchFt === matchFt;
+
+    log('TC-918',
+      getResp.status === 200 && hasLabel && hasWins && hasFt ? 'PASS' : 'FAIL',
+      getResp.status !== 200 ? `GET status=${getResp.status}` :
+      !hasLabel ? `matchLabel mismatch: got "${d?.matchLabel}"` :
+      !hasWins ? `wins mismatch: got ${d?.player1Wins}/${d?.player2Wins}` :
+      !hasFt ? `matchFt mismatch: got ${d?.matchFt}` : '');
+  } catch (err) {
+    log('TC-918', 'FAIL', err instanceof Error ? err.message : 'TC-918 threw');
+  }
+}
+
+/* ───────── TC-919: overlay-events includes new broadcast match info fields ─────────
+ * After TC-918 sets matchLabel/wins/ft, the overlay-events endpoint must
+ * expose them so the dashboard page can render them without a separate fetch.
+ * Verifies overlayMatchLabel, overlayPlayer1Wins, overlayPlayer2Wins,
+ * overlayMatchFt all appear in the overlay-events response (#645, #649). */
+async function runTc919(_adminPage) {
+  try {
+    const resp = await httpsGet(
+      `/api/tournaments/${fixture.tournamentId}/overlay-events?initial=1`,
+    );
+    const d = resp.body?.data;
+    const hasLabel = d && 'overlayMatchLabel' in d;
+    const hasWins = d && 'overlayPlayer1Wins' in d && 'overlayPlayer2Wins' in d;
+    const hasFt = d && 'overlayMatchFt' in d;
+    /* TC-918 set matchLabel = "決勝 QF", wins = 3/1, ft = 5 */
+    const labelCorrect = hasLabel && d.overlayMatchLabel === '決勝 QF';
+    const winsCorrect = hasWins && d.overlayPlayer1Wins === 3 && d.overlayPlayer2Wins === 1;
+    const ftCorrect = hasFt && d.overlayMatchFt === 5;
+
+    log('TC-919',
+      resp.status === 200 && hasLabel && hasWins && hasFt && labelCorrect && winsCorrect && ftCorrect
+        ? 'PASS' : 'FAIL',
+      resp.status !== 200 ? `status=${resp.status}` :
+      !hasLabel ? 'overlayMatchLabel missing from overlay-events' :
+      !hasWins ? 'overlayPlayer1Wins/overlayPlayer2Wins missing' :
+      !hasFt ? 'overlayMatchFt missing' :
+      !labelCorrect ? `label mismatch: "${d.overlayMatchLabel}"` :
+      !winsCorrect ? `wins mismatch: ${d.overlayPlayer1Wins}/${d.overlayPlayer2Wins}` :
+      !ftCorrect ? `ft mismatch: ${d.overlayMatchFt}` : '');
+  } catch (err) {
+    log('TC-919', 'FAIL', err instanceof Error ? err.message : 'TC-919 threw');
+  }
+}
+
 /* ───────── TC-906: real-browser render of the overlay page ─────────
  * Navigates the admin page away to /overlay and writes a fresh score so the
  * running poll cycle picks it up. Must be the LAST test because it leaves
@@ -768,6 +851,11 @@ function getSuite() {
       { name: 'TC-915', fn: runTc915 },
       { name: 'TC-916', fn: runTc916 },
       { name: 'TC-917', fn: runTc917 },
+      /* TC-918/919 run after TC-916/917 so broadcast names are already set
+         and the PUT extends them with new match-info fields. TC-919 must
+         follow TC-918 so the fields exist in the DB to read back. */
+      { name: 'TC-918', fn: runTc918 },
+      { name: 'TC-919', fn: runTc919 },
       { name: 'TC-906', fn: runTc906 },
     ],
   };
@@ -776,7 +864,7 @@ function getSuite() {
 module.exports = {
   runTc901, runTc902, runTc903, runTc904, runTc905, runTc906,
   runTc907, runTc908, runTc909, runTc910, runTc911, runTc913, runTc914, runTc915,
-  runTc916, runTc917,
+  runTc916, runTc917, runTc918, runTc919,
   getSuite,
   results,
 };

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -500,6 +500,7 @@
     "tvAssigned": "TV{n} assigned to M{matchNumber}",
     "tvCleared": "TV cleared from M{matchNumber}",
     "failedAssignTv": "Failed to assign TV",
+    "saveTvNumber": "Save TV#",
     "fiveRaces": "5 Races:",
     "fiveRacesDesc": "Each match consists of 5 unique courses",
     "mrEnteredRacesDesc": "Select courses only for the races you actually played.",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -500,6 +500,7 @@
     "tvAssigned": "M{matchNumber} に TV{n} を割り当てました",
     "tvCleared": "M{matchNumber} の TV 割り当てを解除しました",
     "failedAssignTv": "TV の割り当てに失敗しました",
+    "saveTvNumber": "TV# 保存",
     "fiveRaces": "5レース：",
     "fiveRacesDesc": "各試合は5つの異なるコースで構成",
     "mrEnteredRacesDesc": "実際に行ったレース分だけコースを入力してください。",

--- a/smkc-score-app/prisma/migrations/0007_overlay_broadcast_match_info/migration.sql
+++ b/smkc-score-app/prisma/migrations/0007_overlay_broadcast_match_info/migration.sql
@@ -1,0 +1,8 @@
+-- Add broadcast match info fields to Tournament for overlay display.
+-- overlayMatchLabel: round label shown in dashboard footer when "配信に反映" is pressed (e.g., "決勝 QF")
+-- overlayPlayer1Wins / overlayPlayer2Wins: current wins in the broadcast match
+-- overlayMatchFt: First-To target wins for the broadcast match (BM/MR finals: 5)
+ALTER TABLE "Tournament" ADD COLUMN "overlayMatchLabel" TEXT;
+ALTER TABLE "Tournament" ADD COLUMN "overlayPlayer1Wins" INTEGER;
+ALTER TABLE "Tournament" ADD COLUMN "overlayPlayer2Wins" INTEGER;
+ALTER TABLE "Tournament" ADD COLUMN "overlayMatchFt" INTEGER;

--- a/smkc-score-app/prisma/schema.prisma
+++ b/smkc-score-app/prisma/schema.prisma
@@ -128,8 +128,12 @@ model Tournament {
   dualReportEnabled Boolean @default(false) // When true, both players must report matching scores for auto-confirmation
   taPlayerSelfEdit  Boolean @default(true)  // §3.1: When false, players cannot edit their own TA times (only partner's)
   frozenStages  Json     @default("[]") // 凍結されたTAステージ名の配列 (例: ["qualification", "phase1"])
-  overlayPlayer1Name String? // 「配信に反映」で設定される1Pのオーバーレイ表示名
-  overlayPlayer2Name String? // 「配信に反映」で設定される2Pのオーバーレイ表示名
+  overlayPlayer1Name  String? // 「配信に反映」で設定される1Pのオーバーレイ表示名
+  overlayPlayer2Name  String? // 「配信に反映」で設定される2Pのオーバーレイ表示名
+  overlayMatchLabel   String? // 「配信に反映」時に設定される試合ラウンド表示名 (例: "決勝 QF")
+  overlayPlayer1Wins  Int?    // 配信中試合の1P勝利数
+  overlayPlayer2Wins  Int?    // 配信中試合の2P勝利数
+  overlayMatchFt      Int?    // 配信中試合のFirst-To目標勝利数 (BM/MR決勝: 5)
   qualificationConfirmed Boolean @default(false) // BM/MR/GP予選確定フラグ。trueの場合スコア編集不可
   qualificationConfirmedAt DateTime? // 予選確定日時（監査証跡）
   publicModes   Json     @default("[]") // 公開中のモード配列。空の場合全モード非表示（新建時は非公開）

--- a/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
@@ -29,7 +29,7 @@ const MAX_NAME_LENGTH = 50;
 /**
  * GET /api/tournaments/[id]/broadcast
  *
- * Returns the current overlay player names.
+ * Returns the current overlay player names and match info.
  * Public — the overlay page reads this on each poll.
  */
 export async function GET(
@@ -43,7 +43,14 @@ export async function GET(
   try {
     const tournament = await prisma.tournament.findUnique({
       where: { id: tournamentId },
-      select: { overlayPlayer1Name: true, overlayPlayer2Name: true },
+      select: {
+        overlayPlayer1Name: true,
+        overlayPlayer2Name: true,
+        overlayMatchLabel: true,
+        overlayPlayer1Wins: true,
+        overlayPlayer2Wins: true,
+        overlayMatchFt: true,
+      },
     });
 
     if (!tournament) {
@@ -53,6 +60,10 @@ export async function GET(
     return createSuccessResponse({
       player1Name: tournament.overlayPlayer1Name ?? "",
       player2Name: tournament.overlayPlayer2Name ?? "",
+      matchLabel: tournament.overlayMatchLabel ?? null,
+      player1Wins: tournament.overlayPlayer1Wins ?? null,
+      player2Wins: tournament.overlayPlayer2Wins ?? null,
+      matchFt: tournament.overlayMatchFt ?? null,
     });
   } catch (error) {
     logger.error("Failed to fetch broadcast state", { error, tournamentId });
@@ -60,14 +71,16 @@ export async function GET(
   }
 }
 
+const MAX_LABEL_LENGTH = 50;
+
 /**
  * PUT /api/tournaments/[id]/broadcast
  *
- * Updates the overlay player names.
+ * Updates the overlay player names and optional match info.
  * Requires admin authentication.
  *
- * Body: { player1Name?: string, player2Name?: string }
- * Either field may be omitted to leave it unchanged.
+ * Body: { player1Name?, player2Name?, matchLabel?, player1Wins?, player2Wins?, matchFt? }
+ * Any field may be omitted to leave it unchanged.
  */
 export async function PUT(
   request: NextRequest,
@@ -85,7 +98,7 @@ export async function PUT(
 
   try {
     const body = sanitizeInput(await request.json()) as Record<string, unknown>;
-    const { player1Name, player2Name } = body;
+    const { player1Name, player2Name, matchLabel, player1Wins, player2Wins, matchFt } = body;
 
     /* Allow null/empty string to clear the field; reject only invalid types. */
     if (player1Name !== undefined && player1Name !== null && typeof player1Name !== "string") {
@@ -100,6 +113,21 @@ export async function PUT(
     if (typeof player2Name === "string" && player2Name.length > MAX_NAME_LENGTH) {
       return handleValidationError(`player2Name must be at most ${MAX_NAME_LENGTH} characters`, "player2Name");
     }
+    if (matchLabel !== undefined && matchLabel !== null && typeof matchLabel !== "string") {
+      return handleValidationError("matchLabel must be a string", "matchLabel");
+    }
+    if (typeof matchLabel === "string" && matchLabel.length > MAX_LABEL_LENGTH) {
+      return handleValidationError(`matchLabel must be at most ${MAX_LABEL_LENGTH} characters`, "matchLabel");
+    }
+    if (player1Wins !== undefined && player1Wins !== null && typeof player1Wins !== "number") {
+      return handleValidationError("player1Wins must be a number", "player1Wins");
+    }
+    if (player2Wins !== undefined && player2Wins !== null && typeof player2Wins !== "number") {
+      return handleValidationError("player2Wins must be a number", "player2Wins");
+    }
+    if (matchFt !== undefined && matchFt !== null && typeof matchFt !== "number") {
+      return handleValidationError("matchFt must be a number", "matchFt");
+    }
 
     const tournament = await prisma.tournament.findUnique({
       where: { id: tournamentId },
@@ -109,16 +137,28 @@ export async function PUT(
       return createErrorResponse("Tournament not found", 404);
     }
 
-    const updateData: Record<string, string | null> = {};
+    const updateData: Record<string, string | number | null> = {};
     if (player1Name !== undefined) {
       updateData.overlayPlayer1Name = player1Name === null ? null : (player1Name as string).trim() || null;
     }
     if (player2Name !== undefined) {
       updateData.overlayPlayer2Name = player2Name === null ? null : (player2Name as string).trim() || null;
     }
+    if (matchLabel !== undefined) {
+      updateData.overlayMatchLabel = matchLabel === null ? null : (matchLabel as string).trim() || null;
+    }
+    if (player1Wins !== undefined) {
+      updateData.overlayPlayer1Wins = player1Wins === null ? null : (player1Wins as number);
+    }
+    if (player2Wins !== undefined) {
+      updateData.overlayPlayer2Wins = player2Wins === null ? null : (player2Wins as number);
+    }
+    if (matchFt !== undefined) {
+      updateData.overlayMatchFt = matchFt === null ? null : (matchFt as number);
+    }
 
     if (Object.keys(updateData).length === 0) {
-      return handleValidationError("At least one of player1Name or player2Name is required", "body");
+      return handleValidationError("At least one field is required", "body");
     }
 
     await prisma.tournament.update({
@@ -132,6 +172,18 @@ export async function PUT(
         : undefined,
       player2Name: updateData.overlayPlayer2Name !== undefined
         ? (updateData.overlayPlayer2Name ?? "")
+        : undefined,
+      matchLabel: updateData.overlayMatchLabel !== undefined
+        ? (updateData.overlayMatchLabel ?? null)
+        : undefined,
+      player1Wins: updateData.overlayPlayer1Wins !== undefined
+        ? (updateData.overlayPlayer1Wins ?? null)
+        : undefined,
+      player2Wins: updateData.overlayPlayer2Wins !== undefined
+        ? (updateData.overlayPlayer2Wins ?? null)
+        : undefined,
+      matchFt: updateData.overlayMatchFt !== undefined
+        ? (updateData.overlayMatchFt ?? null)
         : undefined,
     });
   } catch (error) {

--- a/smkc-score-app/src/app/api/tournaments/[id]/overlay-events/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/overlay-events/route.ts
@@ -81,6 +81,10 @@ export async function GET(
         qualificationConfirmedAt: true,
         overlayPlayer1Name: true,
         overlayPlayer2Name: true,
+        overlayMatchLabel: true,
+        overlayPlayer1Wins: true,
+        overlayPlayer2Wins: true,
+        overlayMatchFt: true,
       },
     });
     if (!tournament) {
@@ -328,6 +332,11 @@ export async function GET(
       /* Broadcast player names for the overlay name display (配信に反映) */
       overlayPlayer1Name: tournament.overlayPlayer1Name ?? "",
       overlayPlayer2Name: tournament.overlayPlayer2Name ?? "",
+      /* Match info set by "配信に反映" for footer label and score display */
+      overlayMatchLabel: tournament.overlayMatchLabel ?? null,
+      overlayPlayer1Wins: tournament.overlayPlayer1Wins ?? null,
+      overlayPlayer2Wins: tournament.overlayPlayer2Wins ?? null,
+      overlayMatchFt: tournament.overlayMatchFt ?? null,
     });
 
     /* Disable any intermediate caching: the response is time-sensitive and

--- a/smkc-score-app/src/app/globals.css
+++ b/smkc-score-app/src/app/globals.css
@@ -223,6 +223,31 @@
     }
   }
 
+  /**
+   * Overlay timeline slide-in animation (#646).
+   *
+   * New event cards in the dashboard timeline slide in from the right edge
+   * so the broadcaster can immediately spot fresh activity. The animation
+   * completes in 400ms so it never obscures the content for long.
+   *
+   * Applied via the `timeline-slide-in` class, which React attaches to newly
+   * added entries for one animation cycle, then removes via `onAnimationEnd`.
+   */
+  .timeline-slide-in {
+    animation: timeline-slide-in 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+  }
+
+  @keyframes timeline-slide-in {
+    from {
+      opacity: 0;
+      transform: translateX(60px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
   /*
    * OBS browser-source overlay mode.
    *

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -201,6 +201,8 @@ export default function BattleModeFinals({
   /* Tournament completion state */
   const [champion, setChampion] = useState<Player | null>(null);
   const [broadcasting, setBroadcasting] = useState(false);
+  /* Loading state for the explicit TV# save button in the score dialog (#651) */
+  const [tvSaving, setTvSaving] = useState(false);
 
   /**
    * Fetch finals data including matches, bracket structure, and round names.
@@ -819,7 +821,9 @@ export default function BattleModeFinals({
                 ))}
               </div>
             </div>
-            {/* TV number assignment for broadcast: admin selects TV 1–4 */}
+            {/* TV number assignment for broadcast: admin selects TV 1–4.
+                The explicit save button (#651) lets admins assign TV# before
+                scores are ready, without having to submit the full score form. */}
             <div className="flex items-center justify-center gap-3">
               <Label htmlFor="bm-finals-tv" className="text-sm text-muted-foreground shrink-0">
                 TV#
@@ -833,6 +837,20 @@ export default function BattleModeFinals({
                 <option value="">-</option>
                 {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>{n}</option>)}
               </select>
+              {selectedMatch && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={tvSaving}
+                  onClick={async () => {
+                    setTvSaving(true);
+                    await handleBracketTvNumberChange(selectedMatch, scoreForm.tvNumber);
+                    setTvSaving(false);
+                  }}
+                >
+                  {tvSaving ? tCommon("saving") : tFinals("saveTvNumber")}
+                </Button>
+              )}
             </div>
             {/* Always rendered to reserve vertical space and prevent layout shift. */}
             <p className={`text-sm text-center ${
@@ -853,12 +871,21 @@ export default function BattleModeFinals({
                 onClick={async () => {
                   setBroadcasting(true);
                   try {
+                    /* Build round label "決勝 QF" etc. from the match's round key */
+                    const roundKey = selectedMatch.round ?? "";
+                    const roundName = roundNames[roundKey] || roundKey;
+                    const matchLabel = roundName ? `決勝 ${roundName}` : "決勝";
                     const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
                       method: "PUT",
                       headers: { "Content-Type": "application/json" },
                       body: JSON.stringify({
                         player1Name: selectedMatch.player1.nickname,
                         player2Name: selectedMatch.player2.nickname,
+                        /* Include score and round info (#645, #649) */
+                        matchLabel,
+                        player1Wins: selectedMatch.score1,
+                        player2Wins: selectedMatch.score2,
+                        matchFt: selectedMatchTargetWins,
                       }),
                     });
                     if (res.ok) {

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -78,6 +78,7 @@ import { parseManualScore } from "@/lib/parse-manual-score";
  * Note: Client logger is created at module level (unlike server API loggers).
  */
 import type { Player } from "@/lib/types";
+import { buildMatchLabel } from "@/lib/overlay/phase";
 
 const logger = createLogger({ serviceName: 'tournaments-bm-finals' });
 
@@ -871,10 +872,7 @@ export default function BattleModeFinals({
                 onClick={async () => {
                   setBroadcasting(true);
                   try {
-                    /* Build round label "決勝 QF" etc. from the match's round key */
-                    const roundKey = selectedMatch.round ?? "";
-                    const roundName = roundNames[roundKey] || roundKey;
-                    const matchLabel = roundName ? `決勝 ${roundName}` : "決勝";
+                    const matchLabel = buildMatchLabel(selectedMatch.round, roundNames);
                     const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
                       method: "PUT",
                       headers: { "Content-Type": "application/json" },

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -80,6 +80,7 @@ import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
 import { parseManualScore } from "@/lib/parse-manual-score";
 import type { Player } from "@/lib/types";
+import { buildMatchLabel } from "@/lib/overlay/phase";
 
 /** Client-side logger for error tracking */
 const logger = createLogger({ serviceName: 'tournaments-gp-finals' });
@@ -1069,11 +1070,9 @@ export default function GrandPrixFinals({
                 onClick={async () => {
                   setBroadcasting(true);
                   try {
-                    const roundKey = selectedMatch.round ?? "";
-                    const roundName = roundNames[roundKey] || roundKey;
-                    const matchLabel = roundName ? `決勝 ${roundName}` : "決勝";
-                    const score1 = selectedMatch.score1 ?? (selectedMatch as { points1?: number }).points1 ?? 0;
-                    const score2 = selectedMatch.score2 ?? (selectedMatch as { points2?: number }).points2 ?? 0;
+                    const matchLabel = buildMatchLabel(selectedMatch.round, roundNames);
+                    /* Finals matches expose driver points as score1/score2 (per GPMatch type).
+                       No FT threshold applies to GP — points are accumulated across races. */
                     const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
                       method: "PUT",
                       headers: { "Content-Type": "application/json" },
@@ -1081,9 +1080,8 @@ export default function GrandPrixFinals({
                         player1Name: selectedMatch.player1.nickname,
                         player2Name: selectedMatch.player2.nickname,
                         matchLabel,
-                        player1Wins: score1,
-                        player2Wins: score2,
-                        /* GP uses accumulated points, no FT threshold */
+                        player1Wins: selectedMatch.score1,
+                        player2Wins: selectedMatch.score2,
                         matchFt: null,
                       }),
                     });

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -242,6 +242,7 @@ export default function GrandPrixFinals({
   const [manualPoints2, setManualPoints2] = useState<string>("");
   const [champion, setChampion] = useState<Player | null>(null);
   const [broadcasting, setBroadcasting] = useState(false);
+  const [tvSaving, setTvSaving] = useState(false);
 
   /** Fetch finals data including matches, bracket structure, and round names */
   const fetchFinalsData = useCallback(async () => {
@@ -1031,7 +1032,8 @@ export default function GrandPrixFinals({
               {tFinals('gpTieNeedsWinner')}
             </p>
           </div>
-          {/* TV number assignment for broadcast */}
+          {/* TV number assignment for broadcast: explicit save button (#651)
+              lets admins assign TV# before scores are entered. */}
           <div className="flex items-center gap-3 px-1 pb-2">
             <Label htmlFor="gp-finals-tv" className="text-sm text-muted-foreground shrink-0">TV#</Label>
             <select
@@ -1043,6 +1045,20 @@ export default function GrandPrixFinals({
               <option value="">-</option>
               {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>{n}</option>)}
             </select>
+            {selectedMatch && (
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={tvSaving}
+                onClick={async () => {
+                  setTvSaving(true);
+                  await handleBracketTvNumberChange(selectedMatch, scoreForm.tvNumber);
+                  setTvSaving(false);
+                }}
+              >
+                {tvSaving ? tCommon("saving") : tFinals("saveTvNumber")}
+              </Button>
+            )}
           </div>
           <DialogFooter className="flex-wrap gap-2">
             {selectedMatch && (
@@ -1053,12 +1069,22 @@ export default function GrandPrixFinals({
                 onClick={async () => {
                   setBroadcasting(true);
                   try {
+                    const roundKey = selectedMatch.round ?? "";
+                    const roundName = roundNames[roundKey] || roundKey;
+                    const matchLabel = roundName ? `決勝 ${roundName}` : "決勝";
+                    const score1 = selectedMatch.score1 ?? (selectedMatch as { points1?: number }).points1 ?? 0;
+                    const score2 = selectedMatch.score2 ?? (selectedMatch as { points2?: number }).points2 ?? 0;
                     const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
                       method: "PUT",
                       headers: { "Content-Type": "application/json" },
                       body: JSON.stringify({
                         player1Name: selectedMatch.player1.nickname,
                         player2Name: selectedMatch.player2.nickname,
+                        matchLabel,
+                        player1Wins: score1,
+                        player2Wins: score2,
+                        /* GP uses accumulated points, no FT threshold */
+                        matchFt: null,
                       }),
                     });
                     if (res.ok) {

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -80,6 +80,7 @@ import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
 import { parseManualScore } from "@/lib/parse-manual-score";
 import type { Player } from "@/lib/types";
+import { buildMatchLabel } from "@/lib/overlay/phase";
 
 /** Client-side logger for error tracking */
 const logger = createLogger({ serviceName: 'tournaments-mr-finals' });
@@ -954,9 +955,7 @@ export default function MatchRaceFinals({
                 onClick={async () => {
                   setBroadcasting(true);
                   try {
-                    const roundKey = selectedMatch.round ?? "";
-                    const roundName = roundNames[roundKey] || roundKey;
-                    const matchLabel = roundName ? `決勝 ${roundName}` : "決勝";
+                    const matchLabel = buildMatchLabel(selectedMatch.round, roundNames);
                     const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
                       method: "PUT",
                       headers: { "Content-Type": "application/json" },

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -236,6 +236,7 @@ export default function MatchRaceFinals({
   const [manualScore2, setManualScore2] = useState<string>("");
   const [selectedTvNumber, setSelectedTvNumber] = useState<number | null>(null);
   const [broadcasting, setBroadcasting] = useState(false);
+  const [tvSaving, setTvSaving] = useState(false);
   const [champion, setChampion] = useState<Player | null>(null);
   const selectedMatchTargetWins = selectedMatch ? getMrFinalsTargetWins(selectedMatch) : getMrFinalsTargetWins();
 
@@ -916,7 +917,8 @@ export default function MatchRaceFinals({
               </TableBody>
             </Table>}
           </div>
-          {/* TV number assignment for broadcast */}
+          {/* TV number assignment for broadcast: explicit save button (#651)
+              lets admins assign TV# before scores are entered. */}
           <div className="flex items-center gap-3 px-1">
             <Label htmlFor="mr-finals-tv" className="text-sm text-muted-foreground shrink-0">TV#</Label>
             <select
@@ -928,6 +930,20 @@ export default function MatchRaceFinals({
               <option value="">-</option>
               {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>{n}</option>)}
             </select>
+            {selectedMatch && (
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={tvSaving}
+                onClick={async () => {
+                  setTvSaving(true);
+                  await handleBracketTvNumberChange(selectedMatch, selectedTvNumber);
+                  setTvSaving(false);
+                }}
+              >
+                {tvSaving ? tCommon("saving") : tFinals("saveTvNumber")}
+              </Button>
+            )}
           </div>
           <DialogFooter className="flex-wrap gap-2">
             {selectedMatch && (
@@ -938,12 +954,19 @@ export default function MatchRaceFinals({
                 onClick={async () => {
                   setBroadcasting(true);
                   try {
+                    const roundKey = selectedMatch.round ?? "";
+                    const roundName = roundNames[roundKey] || roundKey;
+                    const matchLabel = roundName ? `決勝 ${roundName}` : "決勝";
                     const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
                       method: "PUT",
                       headers: { "Content-Type": "application/json" },
                       body: JSON.stringify({
                         player1Name: selectedMatch.player1.nickname,
                         player2Name: selectedMatch.player2.nickname,
+                        matchLabel,
+                        player1Wins: selectedMatch.score1,
+                        player2Wins: selectedMatch.score2,
+                        matchFt: selectedMatchTargetWins,
                       }),
                     });
                     if (res.ok) {

--- a/smkc-score-app/src/app/tournaments/[id]/overlay/dashboard/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/overlay/dashboard/page.tsx
@@ -62,6 +62,9 @@ export default function DashboardPage({
   const sinceRef = useRef<string | null>(null);
   /* Dedupe overlapping `since` windows the same way the toast page does. */
   const seenRef = useRef<Set<string>>(new Set());
+  /* Timer ref for the slide-in animation clearance — cleaned up on unmount
+     so we never call setState after the component unmounts (#646). */
+  const animationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   /* Tick a wall-clock state every second so relative-time labels update
      without re-fetching. The poll loop runs every 3s for new data. */
@@ -111,10 +114,12 @@ export default function DashboardPage({
       if (fresh.length === 0) return;
 
       /* Mark new events for the slide-in animation. Clear after 500ms
-         (longer than the 400ms animation) so the class doesn't linger. */
+         (longer than the 400ms animation) so the class doesn't linger.
+         Cancel any previous pending clear so rapid polls don't fight. */
       const freshIds = new Set(fresh.map((e) => e.id));
       setNewEventIds(freshIds);
-      setTimeout(() => setNewEventIds(new Set()), 500);
+      if (animationTimerRef.current) clearTimeout(animationTimerRef.current);
+      animationTimerRef.current = setTimeout(() => setNewEventIds(new Set()), 500);
 
       setEvents((prev) => {
         /* Append new events and trim from the BOTTOM (oldest) so the
@@ -131,15 +136,12 @@ export default function DashboardPage({
     // eslint-disable-next-line react-hooks/set-state-in-effect
     void poll();
     const interval = setInterval(poll, POLLING_INTERVAL);
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+      /* Prevent setState-after-unmount from the slide-in animation timer. */
+      if (animationTimerRef.current) clearTimeout(animationTimerRef.current);
+    };
   }, [poll]);
-
-  /* Score display: "wins / FT" for BM/MR, raw score for GP (no FT).
-     Returns null when there is no score info at all. */
-  function scoreLabel(wins: number | null): string | null {
-    if (wins === null) return null;
-    return `${wins}`;
-  }
 
   return (
     <div
@@ -200,10 +202,9 @@ export default function DashboardPage({
               style={{ textShadow: "0 1px 4px rgba(0,0,0,0.9)" }}
               data-testid="overlay-p1-score"
             >
-              {/* Show "wins / FT" for BM/MR, or just the score for GP */}
               {overlayMatchFt !== null
-                ? `${scoreLabel(overlayPlayer1Wins)} / ${overlayMatchFt}`
-                : scoreLabel(overlayPlayer1Wins)}
+                ? `${overlayPlayer1Wins} / ${overlayMatchFt}`
+                : `${overlayPlayer1Wins}`}
             </span>
           )}
         </div>
@@ -229,8 +230,8 @@ export default function DashboardPage({
               data-testid="overlay-p2-score"
             >
               {overlayMatchFt !== null
-                ? `${scoreLabel(overlayPlayer2Wins)} / ${overlayMatchFt}`
-                : scoreLabel(overlayPlayer2Wins)}
+                ? `${overlayPlayer2Wins} / ${overlayMatchFt}`
+                : `${overlayPlayer2Wins}`}
             </span>
           )}
         </div>

--- a/smkc-score-app/src/app/tournaments/[id]/overlay/dashboard/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/overlay/dashboard/page.tsx
@@ -42,11 +42,20 @@ export default function DashboardPage({
   const { id } = use(params);
 
   const [events, setEvents] = useState<OverlayEvent[]>([]);
+  /* IDs of events that arrived in the latest poll — used for slide-in animation (#646).
+     Cleared after 500ms so the animation CSS class is no longer needed. */
+  const [newEventIds, setNewEventIds] = useState<ReadonlySet<string>>(new Set());
   const [currentPhase, setCurrentPhase] = useState<string>("");
+  const [currentPhaseFormat, setCurrentPhaseFormat] = useState<string | null>(null);
   const [now, setNow] = useState<number>(() => Date.now());
   /* Broadcast player names from "配信に反映" / 配信管理 page */
   const [overlayPlayer1Name, setOverlayPlayer1Name] = useState<string>("");
   const [overlayPlayer2Name, setOverlayPlayer2Name] = useState<string>("");
+  /* Match info set by "配信に反映" for footer label and score display (#644/#645/#649) */
+  const [overlayMatchLabel, setOverlayMatchLabel] = useState<string | null>(null);
+  const [overlayPlayer1Wins, setOverlayPlayer1Wins] = useState<number | null>(null);
+  const [overlayPlayer2Wins, setOverlayPlayer2Wins] = useState<number | null>(null);
+  const [overlayMatchFt, setOverlayMatchFt] = useState<number | null>(null);
 
   /* `since` advances each poll. First call uses `?initial=1` (no since)
      to backfill recent history; subsequent calls echo back `serverTime`. */
@@ -84,9 +93,15 @@ export default function DashboardPage({
 
       sinceRef.current = payload.serverTime;
       if (payload.currentPhase) setCurrentPhase(payload.currentPhase);
-      /* Always update broadcast names (may change between polls even without new events) */
+      /* currentPhaseFormat may be null (no FT for this phase) — always update */
+      if ("currentPhaseFormat" in payload) setCurrentPhaseFormat(payload.currentPhaseFormat ?? null);
+      /* Broadcast names and match info — always update (may change between polls) */
       if (payload.overlayPlayer1Name !== undefined) setOverlayPlayer1Name(payload.overlayPlayer1Name);
       if (payload.overlayPlayer2Name !== undefined) setOverlayPlayer2Name(payload.overlayPlayer2Name);
+      if ("overlayMatchLabel" in payload) setOverlayMatchLabel(payload.overlayMatchLabel ?? null);
+      if ("overlayPlayer1Wins" in payload) setOverlayPlayer1Wins(payload.overlayPlayer1Wins ?? null);
+      if ("overlayPlayer2Wins" in payload) setOverlayPlayer2Wins(payload.overlayPlayer2Wins ?? null);
+      if ("overlayMatchFt" in payload) setOverlayMatchFt(payload.overlayMatchFt ?? null);
 
       const fresh = payload.events.filter((e) => {
         if (seenRef.current.has(e.id)) return false;
@@ -94,6 +109,12 @@ export default function DashboardPage({
         return true;
       });
       if (fresh.length === 0) return;
+
+      /* Mark new events for the slide-in animation. Clear after 500ms
+         (longer than the 400ms animation) so the class doesn't linger. */
+      const freshIds = new Set(fresh.map((e) => e.id));
+      setNewEventIds(freshIds);
+      setTimeout(() => setNewEventIds(new Set()), 500);
 
       setEvents((prev) => {
         /* Append new events and trim from the BOTTOM (oldest) so the
@@ -112,6 +133,13 @@ export default function DashboardPage({
     const interval = setInterval(poll, POLLING_INTERVAL);
     return () => clearInterval(interval);
   }, [poll]);
+
+  /* Score display: "wins / FT" for BM/MR, raw score for GP (no FT).
+     Returns null when there is no score info at all. */
+  function scoreLabel(wins: number | null): string | null {
+    if (wins === null) return null;
+    return `${wins}`;
+  }
 
   return (
     <div
@@ -136,7 +164,7 @@ export default function DashboardPage({
         {/* min-h-0 lets the inner scroll container shrink to fit; without
             it flex children inflate to content height and overflow the box. */}
         <div className="min-h-0 flex-1">
-          <DashboardTimeline events={events} now={now} />
+          <DashboardTimeline events={events} now={now} newEventIds={newEventIds} />
         </div>
       </div>
 
@@ -146,13 +174,18 @@ export default function DashboardPage({
         className="pointer-events-none fixed"
         style={{ bottom: 0, left: 170, width: 1050, height: 82 }}
       >
-        <DashboardFooter currentPhase={currentPhase} />
+        <DashboardFooter
+          currentPhase={currentPhase}
+          currentPhaseFormat={currentPhaseFormat}
+          overlayMatchLabel={overlayMatchLabel}
+        />
       </div>
 
-      {/* 1P name display: x:80, y:480, w:230px, h:48px (「配信に反映」設定値) */}
+      {/* 1P name display: x:80, y:480, w:230px, h:48px (「配信に反映」設定値)
+          Shows player name + current wins when match score is available (#645) */}
       {overlayPlayer1Name && (
         <div
-          className="pointer-events-none fixed flex items-center justify-center"
+          className="pointer-events-none fixed flex flex-col items-center justify-center"
           style={{ left: 80, top: 480, width: 230, height: 48, overflow: "hidden" }}
         >
           <span
@@ -161,13 +194,26 @@ export default function DashboardPage({
           >
             {overlayPlayer1Name}
           </span>
+          {overlayPlayer1Wins !== null && (
+            <span
+              className="text-yellow-300 font-bold text-lg leading-none tabular-nums"
+              style={{ textShadow: "0 1px 4px rgba(0,0,0,0.9)" }}
+              data-testid="overlay-p1-score"
+            >
+              {/* Show "wins / FT" for BM/MR, or just the score for GP */}
+              {overlayMatchFt !== null
+                ? `${scoreLabel(overlayPlayer1Wins)} / ${overlayMatchFt}`
+                : scoreLabel(overlayPlayer1Wins)}
+            </span>
+          )}
         </div>
       )}
 
-      {/* 2P name display: x:80, y:870, w:230px, h:48px (「配信に反映」設定値) */}
+      {/* 2P name display: x:80, y:870, w:230px, h:48px (「配信に反映」設定値)
+          Shows player name + current wins when match score is available (#645) */}
       {overlayPlayer2Name && (
         <div
-          className="pointer-events-none fixed flex items-center justify-center"
+          className="pointer-events-none fixed flex flex-col items-center justify-center"
           style={{ left: 80, top: 870, width: 230, height: 48, overflow: "hidden" }}
         >
           <span
@@ -176,6 +222,17 @@ export default function DashboardPage({
           >
             {overlayPlayer2Name}
           </span>
+          {overlayPlayer2Wins !== null && (
+            <span
+              className="text-yellow-300 font-bold text-lg leading-none tabular-nums"
+              style={{ textShadow: "0 1px 4px rgba(0,0,0,0.9)" }}
+              data-testid="overlay-p2-score"
+            >
+              {overlayMatchFt !== null
+                ? `${scoreLabel(overlayPlayer2Wins)} / ${overlayMatchFt}`
+                : scoreLabel(overlayPlayer2Wins)}
+            </span>
+          )}
         </div>
       )}
     </div>

--- a/smkc-score-app/src/components/overlay/dashboard-footer.tsx
+++ b/smkc-score-app/src/components/overlay/dashboard-footer.tsx
@@ -1,11 +1,16 @@
 /**
  * Bottom-strip phase footer for the OBS dashboard browser source.
  *
+ * Shows the current tournament phase label and, when available, the FT format
+ * badge (e.g., "FT5"). When an admin has pressed "配信に反映" for a specific
+ * match, `overlayMatchLabel` overrides the auto-computed `currentPhase` so the
+ * footer reflects exactly what's on-air (issue #649). FT format is always shown
+ * for BM/MR bracket finals (issue #644).
+ *
  * Slot dimensions and screen position are owned by the parent page — this
  * component only paints text into the rectangle it's given. The right side
  * of the canvas is reserved for the broadcaster's 解説 / Discord overlay,
- * so the footer container is intentionally width-bounded by its parent
- * (no full-width assumptions baked in here).
+ * so the footer container is intentionally width-bounded by its parent.
  */
 
 "use client";
@@ -13,20 +18,44 @@
 interface DashboardFooterProps {
   /** Pre-computed Japanese phase label from the overlay-events API. */
   currentPhase: string;
+  /** FT format string (e.g., "FT5") — null/undefined when not applicable. */
+  currentPhaseFormat?: string | null;
+  /**
+   * Round label set by the last "配信に反映" click (e.g., "決勝 QF").
+   * When non-empty, overrides `currentPhase` so the footer shows exactly
+   * which match is on-air rather than the auto-computed phase.
+   */
+  overlayMatchLabel?: string | null;
 }
 
-export function DashboardFooter({ currentPhase }: DashboardFooterProps) {
+export function DashboardFooter({
+  currentPhase,
+  currentPhaseFormat,
+  overlayMatchLabel,
+}: DashboardFooterProps) {
+  /* Prefer the admin-set label from "配信に反映" when available. */
+  const label = overlayMatchLabel || currentPhase;
+
   return (
     <div
-      className="flex h-full w-full items-center px-6 text-blue-900"
+      className="flex h-full w-full items-center gap-3 px-6 text-blue-900"
       data-testid="dashboard-footer"
     >
       {/* Lift the label 30px above the strip's vertical center so it sits
-          flush with the broadcast scene's text baseline (the underlying OBS
-          chrome puts its title text higher than this footer's mid-line). */}
+          flush with the broadcast scene's text baseline. */}
       <span className="-translate-y-[30px] text-5xl font-bold tracking-tight">
-        {currentPhase}
+        {label}
       </span>
+      {currentPhaseFormat && (
+        /* FT badge — same vertical offset as the phase label so they
+           form a single visual unit on the broadcast canvas. */
+        <span
+          className="-translate-y-[30px] rounded-md bg-blue-900 px-3 py-1 text-2xl font-bold tracking-tight text-white"
+          data-testid="dashboard-footer-ft"
+        >
+          {currentPhaseFormat}
+        </span>
+      )}
     </div>
   );
 }

--- a/smkc-score-app/src/components/overlay/dashboard-timeline.tsx
+++ b/smkc-score-app/src/components/overlay/dashboard-timeline.tsx
@@ -43,9 +43,15 @@ interface DashboardTimelineProps {
   events: OverlayEvent[];
   /** Current wall clock for relative-time labels. */
   now: number;
+  /**
+   * IDs of events that were just added this poll cycle.
+   * These entries receive a slide-in animation (#646) on their first render.
+   * The parent is responsible for clearing this set once the animation is done.
+   */
+  newEventIds?: ReadonlySet<string>;
 }
 
-export function DashboardTimeline({ events, now }: DashboardTimelineProps) {
+export function DashboardTimeline({ events, now, newEventIds }: DashboardTimelineProps) {
   /* Reverse so newest renders at the top. Don't mutate the prop — callers
      reuse the same array reference across renders for diffing. */
   const ordered = [...events].reverse();
@@ -56,18 +62,21 @@ export function DashboardTimeline({ events, now }: DashboardTimelineProps) {
       style={{ scrollbarWidth: "none" }}
       data-testid="dashboard-timeline"
     >
-      {/* gap-4 (was mb-3 ≈ 12px between cards) gives ~16px breathing room
-          between cards so the new bordered look reads as separated blocks
-          rather than a continuous list. */}
+      {/* gap-4 gives ~16px breathing room between cards so the bordered look
+          reads as separated blocks rather than a continuous list. */}
       <div className="flex flex-col gap-4">
         {ordered.map((event) => {
           const isMatch =
             event.type === "match_completed" && !!event.matchResult;
           const isTaTime =
             event.type === "ta_time_recorded" && !!event.taTimeRecord;
+          /* New entries slide in from the right (#646). The class is removed
+             after the animation completes to keep the DOM clean. */
+          const isNew = newEventIds?.has(event.id) ?? false;
           return (
             <div
               key={event.id}
+              className={isNew ? "timeline-slide-in" : undefined}
               data-testid="dashboard-timeline-entry"
               data-event-id={event.id}
             >

--- a/smkc-score-app/src/lib/hooks/useQualificationActions.ts
+++ b/smkc-score-app/src/lib/hooks/useQualificationActions.ts
@@ -99,16 +99,31 @@ export function useQualificationActions({ tournamentId, mode, refetch }: UseQual
   }, [tournamentId, mode, logger]);
 
   /**
-   * Push match players to the overlay as the current 1P/2P broadcast names.
+   * Push match players (and optional score/round info) to the overlay.
    * Used by the "配信に反映" button on each match row.
+   *
+   * When `matchInfo` is supplied the broadcast API also updates:
+   *   - `matchLabel`   → footer phase label (issue #649)
+   *   - `player1Wins` / `player2Wins` → score display next to names (issue #645)
+   *   - `matchFt`     → First-To target for the score label
+   *
    * Returns true on success so callers can show per-button feedback.
    */
-  const handleBroadcastReflect = useCallback(async (player1Name: string, player2Name: string): Promise<boolean> => {
+  const handleBroadcastReflect = useCallback(async (
+    player1Name: string,
+    player2Name: string,
+    matchInfo?: {
+      matchLabel?: string;
+      player1Wins?: number;
+      player2Wins?: number;
+      matchFt?: number;
+    },
+  ): Promise<boolean> => {
     try {
       const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ player1Name, player2Name }),
+        body: JSON.stringify({ player1Name, player2Name, ...matchInfo }),
       });
       if (res.ok) {
         toast.success(tc("broadcastReflected"));

--- a/smkc-score-app/src/lib/overlay/phase.ts
+++ b/smkc-score-app/src/lib/overlay/phase.ts
@@ -116,6 +116,26 @@ export function computeCurrentPhase(input: ComputeCurrentPhaseInput): string {
 }
 
 /**
+ * Build a human-readable match label for the overlay footer (issue #649).
+ *
+ * Called by the "配信に反映" handler in BM/MR/GP finals pages to construct
+ * the `overlayMatchLabel` stored in the DB. The label mirrors the format
+ * used by `computeCurrentPhase` so the footer stays visually consistent
+ * whether it shows the auto-computed phase or an admin-pinned one.
+ *
+ * @param roundKey   - The raw `round` value from the DB (e.g. "winners_qf")
+ * @param roundNames - Locale map from the API (e.g. { winners_qf: "QF" })
+ */
+export function buildMatchLabel(
+  roundKey: string | null | undefined,
+  roundNames: Record<string, string>,
+): string {
+  if (!roundKey) return "決勝";
+  const roundName = roundNames[roundKey] ?? roundKey;
+  return roundName ? `決勝 ${roundName}` : "決勝";
+}
+
+/**
  * Format ("First To" / equivalent) string shown next to the phase label —
  * for example, BM bracket finals are best-of-9 / FT5. Returns `null` when
  * the active phase has no meaningful FT value (e.g. TA tournaments are

--- a/smkc-score-app/src/lib/overlay/types.ts
+++ b/smkc-score-app/src/lib/overlay/types.ts
@@ -184,4 +184,16 @@ export interface OverlayEventsResponse {
    */
   overlayPlayer1Name?: string;
   overlayPlayer2Name?: string;
+  /**
+   * Round label of the match selected by "配信に反映" (e.g. "決勝 QF").
+   * When set, the dashboard footer uses this instead of the auto-computed phase.
+   * Null/undefined means fall back to computeCurrentPhase.
+   */
+  overlayMatchLabel?: string | null;
+  /** Current wins for 1P in the broadcast match. Null when not set. */
+  overlayPlayer1Wins?: number | null;
+  /** Current wins for 2P in the broadcast match. Null when not set. */
+  overlayPlayer2Wins?: number | null;
+  /** First-To target wins for the broadcast match (BM/MR finals: 5). Null for modes without FT. */
+  overlayMatchFt?: number | null;
 }


### PR DESCRIPTION
## Summary

- **#644**: DashboardFooterにFTバッジ（"FT5"等）を追加。`currentPhaseFormat`がAPIから返されていたが未表示だった
- **#645**: 「配信に反映」押下時にプレイヤーの勝利数とFT目標をoverlay/dashboardの名前横に表示（BM/MR: "wins / FT"、GP: ドライバーポイント表示）
- **#646**: タイムラインの新着エントリが右端からスライドインするアニメーションを追加（400ms CSS animation）
- **#649**: 「配信に反映」押下時に試合のラウンドラベル（"決勝 QF"等）もDBに保存し、dashboardフッターに即時反映
- **#651**: BM/MR/GP決勝スコアダイアログにTV# 保存ボタンを追加。スコア入力前でも独立してTV番号を保存可能に

## Schema Changes

Migration `0007_overlay_broadcast_match_info` で `Tournament` テーブルに4フィールドを追加:

| フィールド | 型 | 用途 |
|---|---|---|
| `overlayMatchLabel` | String? | 「配信に反映」で設定するラウンド表示名 |
| `overlayPlayer1Wins` | Int? | 配信中試合の1P勝利数 |
| `overlayPlayer2Wins` | Int? | 配信中試合の2P勝利数 |
| `overlayMatchFt` | Int? | First-To目標勝利数（BM/MR決勝: 5） |

## Test plan

- [ ] BM/MR決勝で「配信に反映」→ overlay/dashboard フッターに "決勝 QF FT5" 等が表示される
- [ ] 「配信に反映」後、名前の下に "wins / FT" (例: "2 / 5") が表示される
- [ ] GP決勝で「配信に反映」→ ドライバーポイントが表示される (FT非表示)
- [ ] タイムラインに新着エントリが追加されると右からスライドインする
- [ ] スコアダイアログの「TV# 保存」ボタンでスコアなしでもTV番号が保存される
- [ ] ビルド: `npm run build` 成功

https://claude.ai/code/session_01D8ZYL39SzEzutSERNGccPo

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8ZYL39SzEzutSERNGccPo)_