### PR TITLE
fix(ui): issue #654 review items + E2E coverage for overlay/dashboard and bracket TV#

### DIFF
--- a/smkc-score-app/__tests__/components/ui/badge.test.tsx
+++ b/smkc-score-app/__tests__/components/ui/badge.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * @module Badge Component Tests
+ *
+ * Smoke tests for the Badge component variants.
+ * Covers:
+ * - default, secondary, destructive, outline: standard shadcn variants
+ * - flag-active, flag-draft, flag-completed: JSMKC status variants
+ * - asChild: renders the Slot child instead of a <span>
+ * - custom className passthrough
+ */
+import { render, screen } from '@testing-library/react';
+import { Badge } from '@/components/ui/badge';
+
+describe('Badge', () => {
+  it('renders children', () => {
+    render(<Badge>Hello</Badge>);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('renders with default variant classes', () => {
+    render(<Badge data-testid="badge">Default</Badge>);
+    const el = screen.getByTestId('badge');
+    expect(el).toHaveClass('bg-primary', 'text-primary-foreground');
+  });
+
+  it('renders secondary variant', () => {
+    render(<Badge variant="secondary" data-testid="badge">Secondary</Badge>);
+    const el = screen.getByTestId('badge');
+    expect(el).toHaveClass('bg-secondary', 'text-secondary-foreground');
+  });
+
+  it('renders destructive variant', () => {
+    render(<Badge variant="destructive" data-testid="badge">Error</Badge>);
+    const el = screen.getByTestId('badge');
+    expect(el).toHaveClass('bg-destructive', 'text-white');
+  });
+
+  it('renders outline variant', () => {
+    render(<Badge variant="outline" data-testid="badge">Outline</Badge>);
+    const el = screen.getByTestId('badge');
+    expect(el).toHaveClass('border-foreground/70', 'bg-transparent');
+  });
+
+  it('renders flag-active variant', () => {
+    render(<Badge variant="flag-active" data-testid="badge">Active</Badge>);
+    const el = screen.getByTestId('badge');
+    expect(el).toHaveClass('flag-active');
+  });
+
+  it('renders flag-draft variant', () => {
+    render(<Badge variant="flag-draft" data-testid="badge">Draft</Badge>);
+    const el = screen.getByTestId('badge');
+    expect(el).toHaveClass('flag-draft');
+  });
+
+  it('renders flag-completed variant', () => {
+    render(<Badge variant="flag-completed" data-testid="badge">Done</Badge>);
+    const el = screen.getByTestId('badge');
+    expect(el).toHaveClass('flag-completed');
+  });
+
+  it('accepts custom className', () => {
+    render(<Badge className="custom-class" data-testid="badge">Custom</Badge>);
+    expect(screen.getByTestId('badge')).toHaveClass('custom-class');
+  });
+
+  it('renders as child element with asChild', () => {
+    render(
+      <Badge asChild>
+        <a href="/test" data-testid="link-badge">Link</a>
+      </Badge>
+    );
+    const el = screen.getByTestId('link-badge');
+    expect(el.tagName).toBe('A');
+    expect(el).toHaveAttribute('href', '/test');
+  });
+});

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -16,6 +16,7 @@
  *   TC-510  BM Top-24 pre-bracket playoff → Top-16 finals flow
  *   TC-520  BM per-round target-wins API validation (issue #528: FT3/FT4/FT5/FT7)
  *   TC-522  BM finals tvNumber PUT accepts 1–4, rejects 5, clears on null (issue #634)
+ *   TC-523  BM finals score dialog — TV# save button persists without score submit (issue #651)
  *
  * Setup:
  *   - Uses Playwright persistent profile at /tmp/playwright-smkc-profile.
@@ -1412,6 +1413,75 @@ async function runTc522(adminPage) {
   }
 }
 
+/* ───────── TC-523: BM finals score dialog — TV# save button (issue #651) ─────────
+ * Verifies that the explicit "TV# 保存" button in the score dialog saves the
+ * TV# assignment immediately without submitting the full match score.
+ *
+ * Flow:
+ *   1. Generate an 8-player BM finals bracket.
+ *   2. Navigate to the BM finals page and open the score dialog for match 1.
+ *   3. Select TV#3 in the dialog's TV# dropdown and click "TV# 保存".
+ *   4. Confirm the dialog stays open (no score submitted → scores unchanged).
+ *   5. Verify TV#3 was persisted on the match via the finals API.
+ */
+async function runTc523(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedBmFinalsSetup(adminPage);
+    const gen = await apiGenerateBmFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    /* Navigate to finals page — wait for bracket cards to appear. */
+    await nav(adminPage, `/tournaments/${setup.tournamentId}/bm/finals`);
+    await adminPage.waitForTimeout(3000);
+
+    /* Click the first match card to open the score dialog. */
+    const matchCards = adminPage.locator('[data-testid="bracket-match-card"]');
+    const cardCount = await matchCards.count();
+    if (cardCount === 0) throw new Error('No bracket match cards found');
+    await matchCards.first().click();
+    await adminPage.waitForTimeout(1000);
+
+    /* Dialog must be visible before we interact with the TV# selector. */
+    const dialog = adminPage.locator('[role="dialog"]');
+    const dialogVisible = await dialog.isVisible();
+    if (!dialogVisible) throw new Error('Score dialog did not open');
+
+    /* Select TV#3 from the dropdown (id="bm-finals-tv"). */
+    await adminPage.locator('#bm-finals-tv').selectOption('3');
+    await adminPage.waitForTimeout(300);
+
+    /* Click the save button (text: "TV# 保存" / "Save TV#"). */
+    const saveBtn = dialog.getByRole('button', { name: /TV#\s*保存|Save TV#/i });
+    await saveBtn.waitFor({ state: 'visible', timeout: 5000 });
+    await saveBtn.click();
+    await adminPage.waitForTimeout(1500);
+
+    /* Dialog must still be open — TV# save must not close it. */
+    const stillOpen = await dialog.isVisible();
+
+    /* Verify TV#3 was persisted on match 1 via the API. */
+    const matches = await apiFetchBmFinalsMatches(adminPage, setup.tournamentId);
+    const m1 = matches.find((m) => m.matchNumber === 1);
+    const tvSaved = m1?.tvNumber === 3;
+
+    const pass = dialogVisible && stillOpen && tvSaved;
+    log('TC-523', pass ? 'PASS' : 'FAIL',
+      !dialogVisible ? 'Score dialog did not open' :
+      !stillOpen ? 'Dialog closed unexpectedly after TV# save' :
+      !tvSaved ? `tvNumber not saved: got ${m1?.tvNumber}` : '');
+  } catch (err) {
+    log('TC-523', 'FAIL', err instanceof Error ? err.message : 'TC-523 failed');
+  } finally {
+    /* Always reset the bracket so later tests get a clean state. */
+    if (setup) {
+      await adminPage.evaluate(async (url) => {
+        await fetch(url, { method: 'DELETE' }).catch(() => {});
+      }, `/api/tournaments/${setup?.tournamentId}/bm/finals`);
+    }
+  }
+}
+
 /**
  * Builds the BM suite spec for composition by tc-all. When `sharedFixture` is
  * provided (tc-all flow), we reuse it and skip cleanup — the orchestrator owns
@@ -1455,6 +1525,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-520', fn: runTc520 },
       { name: 'TC-521', fn: runTc521 },
       { name: 'TC-522', fn: runTc522 },
+      { name: 'TC-523', fn: runTc523 },
       { name: 'TC-505', fn: runTc505 },
       { name: 'TC-506', fn: runTc506 },
     ],
@@ -1463,7 +1534,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 
 module.exports = {
   runTc501, runTc502, runTc322, runTc503, runTc504, runTc505, runTc506, runTc511, runTc512, runTc513,
-  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522,
+  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522, runTc523,
   getSuite,
   results,
   setSharedBmFinalsReady: (v) => { sharedBmFinalsReady = v; },

--- a/smkc-score-app/e2e/tc-overlay.js
+++ b/smkc-score-app/e2e/tc-overlay.js
@@ -28,6 +28,7 @@
  *   TC-917  overlay-events response includes overlayPlayer1Name / overlayPlayer2Name
  *   TC-918  PUT /broadcast with matchLabel/wins/ft → GET returns new fields (#644/#645/#649)
  *   TC-919  overlay-events includes overlayMatchLabel / overlayPlayer1Wins / overlayPlayer2Wins / overlayMatchFt
+ *   TC-920  Dashboard page renders matchLabel and score display in real browser (#644/#645/#649)
  *
  * Setup is API-only: the suite owns a 2-player tournament with one match
  * per mode (BM/MR/GP) plus 2 TA entries, then tears everything down at the
@@ -771,6 +772,48 @@ async function runTc919(_adminPage) {
   }
 }
 
+/* ───────── TC-920: Dashboard page renders match score data in real browser ─────────
+ * After TC-918/919 have set matchLabel/wins/ft via PUT /broadcast, the
+ * /overlay/dashboard page must reflect that data when polled:
+ *   - DashboardFooter shows the matchLabel in the footer strip (#649)
+ *   - DashboardFooter shows the FT badge (#644)
+ *   - Player name slots show win counts (#645)
+ *
+ * Must run after TC-918 (so matchLabel, wins, ft are set in the DB) and
+ * after TC-906 is done with the overlay page navigation. We navigate the
+ * admin browser to /overlay/dashboard so we can read rendered content.
+ */
+async function runTc920(adminPage) {
+  try {
+    await adminPage.goto(
+      `${BASE}/tournaments/${fixture.tournamentId}/overlay/dashboard`,
+      { waitUntil: 'domcontentloaded', timeout: 30_000 },
+    );
+    /* Wait for the root element then allow the poll cycle (3s) + render. */
+    await adminPage.waitForSelector('[data-testid="dashboard-root"]', { timeout: 10_000 });
+    await adminPage.waitForTimeout(8000);
+
+    const footerText = await adminPage.locator('[data-testid="dashboard-footer"]').innerText().catch(() => '');
+    /* TC-918 set matchLabel="決勝 QF", so footer must contain it. */
+    const hasLabel = footerText.includes('決勝 QF');
+    /* TC-918 also set matchFt=5, so the FT badge must show "FT5". */
+    const ftBadgeText = await adminPage.locator('[data-testid="dashboard-footer-ft"]').innerText().catch(() => '');
+    const hasFt = ftBadgeText.includes('FT5');
+    /* TC-918/916 set player names + wins. At least one score element must exist. */
+    const scoreEl = adminPage.locator('[data-testid="overlay-p1-score"],[data-testid="overlay-p2-score"]');
+    const scoreCount = await scoreEl.count();
+    const hasScore = scoreCount > 0;
+
+    const pass = hasLabel && hasFt && hasScore;
+    log('TC-920', pass ? 'PASS' : 'FAIL',
+      !hasLabel ? `matchLabel missing from footer: "${footerText}"` :
+      !hasFt ? `FT badge missing or wrong: "${ftBadgeText}"` :
+      !hasScore ? 'score elements not rendered on dashboard' : '');
+  } catch (err) {
+    log('TC-920', 'FAIL', err instanceof Error ? err.message : 'TC-920 threw');
+  }
+}
+
 /* ───────── TC-906: real-browser render of the overlay page ─────────
  * Navigates the admin page away to /overlay and writes a fresh score so the
  * running poll cycle picks it up. Must be the LAST test because it leaves
@@ -856,6 +899,9 @@ function getSuite() {
          follow TC-918 so the fields exist in the DB to read back. */
       { name: 'TC-918', fn: runTc918 },
       { name: 'TC-919', fn: runTc919 },
+      /* TC-920 must run after TC-918/919 set matchLabel/wins/ft,
+         and before TC-906 navigates away. */
+      { name: 'TC-920', fn: runTc920 },
       { name: 'TC-906', fn: runTc906 },
     ],
   };
@@ -864,7 +910,7 @@ function getSuite() {
 module.exports = {
   runTc901, runTc902, runTc903, runTc904, runTc905, runTc906,
   runTc907, runTc908, runTc909, runTc910, runTc911, runTc913, runTc914, runTc915,
-  runTc916, runTc917, runTc918, runTc919,
+  runTc916, runTc917, runTc918, runTc919, runTc920,
   getSuite,
   results,
 };

--- a/smkc-score-app/package.json
+++ b/smkc-score-app/package.json
@@ -21,6 +21,7 @@
     "finals:reapply-ranks": "node scripts/reapply-rank-overrides.js",
     "build:cf": "opennextjs-cloudflare build",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
+    "preview:fast": "opennextjs-cloudflare dev",
     "deploy": "npm run build:cf && wrangler deploy"
   },
   "dependencies": {

--- a/smkc-score-app/src/components/tournament/tie-warning-banner.tsx
+++ b/smkc-score-app/src/components/tournament/tie-warning-banner.tsx
@@ -25,7 +25,7 @@ export function TieWarningBanner({ hasTies, isAdmin }: TieWarningBannerProps) {
   if (!hasTies) return null;
 
   return (
-    <div className="mb-2 flex items-center gap-2 rounded-sm border border-y border-r border-l-[3px] border-l-accent border-foreground/15 bg-accent/15 px-3 py-2 text-sm text-foreground">
+    <div className="mb-2 flex items-center gap-2 rounded-sm border border-l-[3px] border-l-accent border-foreground/15 bg-accent/15 px-3 py-2 text-sm text-foreground">
       {/* Warning icon */}
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/smkc-score-app/src/components/ui/card.tsx
+++ b/smkc-score-app/src/components/ui/card.tsx
@@ -2,10 +2,7 @@
  * Card — Paddock Editorial.
  *
  * Pit-board surface: 1px charcoal border, no drop shadow, slightly tighter
- * vertical rhythm than stock shadcn. The optional `data-flag` attribute on
- * the root surfaces a 4px decorative checker strip across the top edge —
- * use it for hero/leader cards (e.g., podium, primary tournament cards) by
- * passing `data-flag="checker"` on the Card.
+ * vertical rhythm than stock shadcn.
  */
 import * as React from "react"
 
@@ -16,9 +13,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        // Decorative checker strip is opt-in via data-flag="checker".
-        "relative bg-card text-card-foreground flex flex-col gap-5 rounded-sm border border-foreground/15 py-7 shadow-none",
-        "data-[flag=checker]:before:content-[''] data-[flag=checker]:before:absolute data-[flag=checker]:before:left-0 data-[flag=checker]:before:right-0 data-[flag=checker]:before:top-0 data-[flag=checker]:before:h-1 data-[flag=checker]:before:checker-strip",
+        "bg-card text-card-foreground flex flex-col gap-5 rounded-sm border border-foreground/15 py-7 shadow-none",
         className
       )}
       {...props}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **card.tsx**: `data-flag="checker"` の未使用実装を削除（YAGNI）
- **tie-warning-banner.tsx**: `border border-y border-r border-l-[3px]` → `border border-l-[3px]`（border が全辺をカバーするため border-y/border-r は冗長）
- **badge.test.tsx**: `flag-active` / `flag-draft` / `flag-completed` バリアントのスモークテストを追加
- **package.json**: `preview:fast` スクリプトを追加（`opennextjs-cloudflare dev`）— フルビルド不要の高速確認用
- **TC-523**: BM決勝スコアダイアログ内 TV# 保存ボタンが、スコア未入力でも TV# を永続化することを検証（issue #651）
- **TC-920**: Dashboard ページが `overlayMatchLabel` / 勝利数 / FT バッジをブラウザで正しくレンダリングすることを検証（#644/#645/#649）

## Closes

Closes #654

## Test plan

- [ ] `npm test` がパスすること（badge.test.tsx 含む全 2080 件）
- [ ] TC-523: BM 決勝ページの score dialog で TV# 3 を選択 → "TV# 保存" → dialog が閉じないこと + API で tvNumber=3 が永続化されていること
- [ ] TC-920: `/overlay/dashboard` で dashboard-footer に "決勝 QF" と "FT5" バッジが表示され、overlay-p1-score 要素が存在すること

https://claude.ai/code/session_01MdCyECv4cmDbn6524MEqNE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdCyECv4cmDbn6524MEqNE)_