### PR TITLE
fix(e2e): MR/GP setup qualificationConfirmed reset + TC-340 badge toggle test (#656)

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -521,6 +521,42 @@
   2. ステータスが 200 かつ `{ success: true, data: { totalRequests, averageResponseTime, activeConnections, errorRate, warnings, timePeriod } }` 形式であることを確認する
   3. 未認証リクエストが 401 または 403 で拒否されることを確認する
 - **期待結果**: 管理者は監視統計を取得できる。未認証リクエストは拒否される
+- **スクリプト**: tc-all.js TC-333
+
+## TC-334: トーナメント可視性 — 未公開トーナメントは未認証ユーザーにブロックされる
+- **URL**: /api/tournaments/:id
+- **authRequired**: false (unauthenticated access test)
+- **背景**: `publicModes: []` のプライベートトーナメントは未認証ユーザーからは 403 で保護される。管理者は引き続きアクセスできる。
+- **手順**:
+  1. 管理者 API で新しいプライベートトーナメントを作成（publicModes デフォルト=[]）
+  2. `https` モジュールで未認証 GET `/api/tournaments/:id` → 403 であることを確認
+  3. 管理者セッションで同エンドポイントを GET → 200 であることを確認
+- **期待結果**: 未認証: 403。管理者セッション: 200
+- **スクリプト**: tc-all.js TC-334
+
+## TC-335: トーナメント可視性切り替え — 管理者が最初のモードを公開すると未認証アクセスが許可される
+- **URL**: /api/tournaments/:id, /api/tournaments (list)
+- **authRequired**: true (admin PUT), then false (anon GET)
+- **背景**: TC-334 の続き。`publicModes: ['ta']` に PUT して公開すると、未認証ユーザーが詳細 API と一覧 API で参照できるようになる。
+- **手順**:
+  1. TC-334 で作成したトーナメントに PUT `{ publicModes: ['ta'] }` を送信
+  2. `https` モジュールで未認証 GET `/api/tournaments/:id?fields=summary` → 200 かつ `publicModes` に `'ta'` が含まれることを確認
+  3. 未認証で GET `/api/tournaments` (一覧) → レスポンスにトーナメントが出現することを確認
+- **期待結果**: 公開後は未認証ユーザーも詳細・一覧で参照可能
+- **スクリプト**: tc-all.js TC-335
+
+## TC-344: noCamera フラグ — 作成・取得・編集で正しく永続化される
+- **URL**: /api/players (POST, GET, PUT)
+- **authRequired**: true (admin)
+- **背景**: プレイヤーの `noCamera` フラグはカメラ不参加プレイヤーを示す。作成時に `true` を設定し、GET で確認、PUT で `false` に更新・再確認するフルライフサイクルテスト。
+- **手順**:
+  1. POST `/api/players` `{ noCamera: true }` でプレイヤーを作成
+  2. GET `/api/players/:id` → `data.noCamera === true` を確認
+  3. PUT `/api/players/:id` `{ noCamera: false }` で更新 → レスポンスの `data.noCamera === false` を確認
+  4. 再度 GET → `data.noCamera === false` を確認
+  5. クリーンアップ（プレイヤー削除）
+- **期待結果**: 作成・更新・取得の全段階で noCamera フラグが正しく反映される
+- **スクリプト**: tc-all.js TC-344
 
 ## TC-320: BM/MR/GP マッチリスト行レベルのスコア入力リンク非表示化 ✅ FIXED (PR #407)
 - **URL**: /tournaments/[temp-id]/bm, /mr, /gp → Matches タブ
@@ -1494,7 +1530,7 @@
   - 公開ボタンはタブバー直下のコントロール行に常に表示される
   - 公開/未公開切替後に「未公開」バッジがリロードなしで更新される
   - 操作後のページに「未公開」の古い表示が残らない
-- **スクリプト**: 未スクリプト化（UI インタラクションのため手動確認）
+- **スクリプト**: `e2e/tc-all.js` TC-340
 
 ---
 

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -1964,6 +1964,9 @@ async function setupMrQualViaUi(
   { score1 = 3, score2 = 1, randomize = true, resolveTies = true } = {},
 ) {
   await uiActivateTournament(adminPage, tournamentId);
+  /* BM suite leaves qualificationConfirmed=true on the shared tournament,
+   * which disables the MR score-entry button. Reset before re-seeding. */
+  await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: false });
   await setupModePlayersViaUi(adminPage, 'mr', tournamentId, players);
   await uiPutAllMrQualScores(adminPage, tournamentId, { score1, score2, randomize });
   if (resolveTies) {
@@ -1981,6 +1984,9 @@ async function setupGpQualViaUi(
   { points1 = 45, points2 = 0, randomize = true, resolveTies = true } = {},
 ) {
   await uiActivateTournament(adminPage, tournamentId);
+  /* BM suite leaves qualificationConfirmed=true on the shared tournament,
+   * which disables the GP score-entry button. Reset before re-seeding. */
+  await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: false });
   await setupModePlayersViaUi(adminPage, 'gp', tournamentId, players);
   await uiPutAllGpQualScores(adminPage, tournamentId, { points1, points2, randomize });
   if (resolveTies) {

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -2507,6 +2507,71 @@ async function main() {
     }
   }
 
+  // TC-340: Layout publish button — "Unpublished" badge disappears from tab after publishing TA
+  // Verifies that the publicModesChanged event emitted by ModePublishSwitch causes the layout
+  // to re-fetch tournament state and remove the "Unpublished" tab badge without a page reload.
+  // Then toggles back to confirm the badge reappears (issue #614 / issue #621).
+  let tc340TournamentId = null;
+  try {
+    // Create a private tournament (publicModes defaults to [])
+    const tc340Created = await page.evaluate(async () => {
+      const r = await fetch('/api/tournaments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: `E2E TC-340 Badge ${Date.now()}`, date: new Date().toISOString() }),
+      });
+      return { status: r.status, body: await r.json().catch(() => ({})) };
+    });
+    tc340TournamentId = tc340Created.body?.data?.id ?? null;
+    if (!tc340TournamentId) throw new Error(`Tournament creation failed (${tc340Created.status})`);
+
+    // Activate so the TA page renders content (score pages require status='active')
+    await page.evaluate(async (tid) => {
+      await fetch(`/api/tournaments/${tid}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'active' }),
+      });
+    }, tc340TournamentId);
+
+    // Navigate to the TA page — layout renders the tab nav with "Unpublished" badge for TA
+    await nav(page, `/tournaments/${tc340TournamentId}/ta`);
+
+    // Step 1: TA tab must show the "Unpublished"/"未公開" badge since publicModes=[]
+    const tabNav = page.locator('nav[aria-label="Tournament sections"]');
+    const hiddenBadge = () => tabNav.getByText(/^(Unpublished|未公開)$/).first();
+    const badgeBeforePublish = await hiddenBadge().isVisible().catch(() => false);
+
+    // Step 2: Click the ModePublishSwitch for TA to publish it
+    // aria-label pattern: "Time Trial: Publish" / "タイムトライアル: 公開"
+    const publishSwitch = page.getByRole('switch', { name: /Time Trial|タイムトライアル/ });
+    await publishSwitch.click();
+    // Allow the publicModesChanged event handler + re-fetch to resolve
+    await page.waitForTimeout(3000);
+
+    // Step 3: Badge must be gone from the tab without a reload
+    const badgeAfterPublish = await hiddenBadge().isVisible().catch(() => false);
+
+    // Step 4: Toggle back to unpublish — badge must reappear
+    await publishSwitch.click();
+    await page.waitForTimeout(3000);
+    const badgeAfterUnpublish = await hiddenBadge().isVisible().catch(() => false);
+
+    log('TC-340',
+      badgeBeforePublish && !badgeAfterPublish && badgeAfterUnpublish ? 'PASS' : 'FAIL',
+      !badgeBeforePublish ? 'Unpublished badge not visible in tab before publish' :
+      badgeAfterPublish ? 'Unpublished badge still visible after publish (re-render failed?)' :
+      !badgeAfterUnpublish ? 'Unpublished badge did not reappear after unpublish' : '');
+  } catch (err) {
+    log('TC-340', 'FAIL', err instanceof Error ? err.message : 'Layout badge toggle test failed');
+  } finally {
+    if (tc340TournamentId) {
+      await page.evaluate(async (tid) => {
+        await fetch(`/api/tournaments/${tid}`, { method: 'DELETE' }).catch(() => {});
+      }, tc340TournamentId).catch(() => {});
+    }
+  }
+
   // TC-341: Authenticated player can access private tournament detail API (publicModes: [])
   // Regression test for the #615 fix regression: the visibility check was too strict,
   // blocking authenticated non-admin users (players) when publicModes was empty.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **fix(e2e/common)**: `setupMrQualViaUi` と `setupGpQualViaUi` に `qualificationConfirmed: false` リセットを追加。`setupBmQualViaUi` には既存の同リセットがあったが MR/GP には欠落しており、BM suite が `qualificationConfirmed=true` のまま次のスイートに渡ることで MR/GP の結果入力ボタンが永続的に disabled になり 28 件がカスケード FAIL していた（closes #656）
- **feat(e2e)**: TC-340 をスクリプト化。TA モードの ModePublishSwitch クリック後に、レイアウトの `publicModesChanged` イベント再フェッチで「未公開」タブバッジがリロードなしに消えること・再押下で再表示されることを検証
- **docs(E2E_TEST_CASES)**: TC-334/335/344（スクリプト済みだが未文書）を追記、TC-333/340 のスクリプト欄を更新

## Test plan

- [ ] `e2e/lib/common.js` の `setupMrQualViaUi` / `setupGpQualViaUi` に `apiUpdateTournament(..., { qualificationConfirmed: false })` が追加されていることを確認
- [ ] `e2e/tc-all.js` に TC-340 ブロックが追加され、正しい順序（TC-339 の後、TC-341 の前）に配置されていることを確認
- [ ] `E2E_TEST_CASES.md` に TC-334/335/340/344 が文書化されていることを確認
- [ ] CI が green になること

https://claude.ai/code/session_012rFRN9ApAqYMpn8wyNpWfS
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012rFRN9ApAqYMpn8wyNpWfS)_