### PR TITLE
fix: resolve TC-523/TC-906/TC-920 E2E regressions (issue #658)

### DIFF
--- a/smkc-score-app/e2e/tc-overlay.js
+++ b/smkc-score-app/e2e/tc-overlay.js
@@ -821,18 +821,22 @@ async function runTc920(adminPage) {
  * cleanup still works). */
 async function runTc906(adminPage) {
   try {
+    /* Inject a fresh overall_ranking_updated event immediately before
+     * navigating. TC-909/TC-911 run many steps earlier; with TC-920's 8s
+     * wait and other intervening tests the elapsed time can exceed the
+     * overlay page's 30-second no-`since` initial window, leaving the first
+     * poll with zero events and no toast to show. Recalculating here
+     * guarantees at least one event is younger than 5s. */
+    await apiRecalculateOverallRanking(adminPage, fixture.tournamentId);
+
     await adminPage.goto(
       `${BASE}/tournaments/${fixture.tournamentId}/overlay`,
       { waitUntil: 'domcontentloaded', timeout: 30_000 },
     );
     await adminPage.waitForSelector('[data-testid="overlay-root"]', { timeout: 10_000 });
-    /* Wait for any toast — by the time TC-906 runs, recent events from TC-909
-       (qualification_confirmed) and TC-911 (overall_ranking_updated) will
-       still be inside the server's 30-second initial-poll window, so the
-       page's first poll surfaces at least one toast. We deliberately accept
-       any event type (mode-specific or neutral) because each individual
-       event type already has its own dedicated TC; this test is purely
-       about proving the SSR → hydrate → poll → animate pipeline works. */
+    /* Wait for any toast. We deliberately accept any event type because each
+     * individual event type already has its own dedicated TC; this test is
+     * purely about proving the SSR → hydrate → poll → animate pipeline. */
     await adminPage.waitForSelector('[data-testid="overlay-toast"]', { timeout: 15_000 });
 
     const stackText = await adminPage.locator('[data-testid="overlay-toast-stack"]').innerText();

--- a/smkc-score-app/src/app/tournaments/[id]/overlay/dashboard/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/overlay/dashboard/page.tsx
@@ -178,7 +178,7 @@ export default function DashboardPage({
       >
         <DashboardFooter
           currentPhase={currentPhase}
-          currentPhaseFormat={currentPhaseFormat}
+          currentPhaseFormat={overlayMatchFt !== null ? `FT${overlayMatchFt}` : currentPhaseFormat}
           overlayMatchLabel={overlayMatchLabel}
         />
       </div>

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -149,6 +149,7 @@ function MatchCard({
       onClick={onClick}
       role="button"
       tabIndex={0}
+      data-testid="bracket-match-card"
       aria-label={`Match ${bracketMatch.matchNumber}: ${player1?.nickname || tc('tbd')} vs ${player2?.nickname || tc('tbd')}${showTBD ? ' (Pending)' : ''}`}
       onKeyDown={(e) => {
         /* Support keyboard activation for accessibility */


### PR DESCRIPTION
## Summary

- **TC-523**: `data-testid="bracket-match-card"` を `MatchCard` コンポーネントに追加。BM finals ページでブラケットカードをクリックするテストが対象要素を発見できなかった
- **TC-920**: `DashboardFooter` が `overlayMatchFt` を受け取っておらず、管理者が `matchFt=5` を設定しても FT バッジが空白になっていた。`overlayMatchFt` が設定されている場合は `FT${overlayMatchFt}` を優先して渡すよう修正
- **TC-906**: TC-909/TC-911 のイベントが overlay ページの 30 秒初期ウィンドウを超えてしまうケースを修正。overlay に遷移する直前に `apiRecalculateOverallRanking` を呼び出し、確実に新鮮なイベントを作成する

Issue #656 (MR/GP qualificationConfirmed リセット欠落) はコードベースで既に修正済みのため close 済み。

## Test plan

- [ ] TC-523: BM finals ページで `[data-testid="bracket-match-card"]` が存在し、クリックでダイアログが開くこと
- [ ] TC-920: PUT /broadcast で `matchFt=5` 設定後、dashboard の `[data-testid="dashboard-footer-ft"]` が `FT5` を表示すること
- [ ] TC-906: `/overlay` ページに遷移後 15 秒以内に `[data-testid="overlay-toast"]` が visible になること
- [ ] `npm run e2e:all` で OVERLAY/BM スイートの FAIL 数が減少すること

https://claude.ai/code/session_01BkeQjbda1dgovrwGzvYCto

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkeQjbda1dgovrwGzvYCto)_