### PR TITLE
fix: API bulk MR/GP qual scoring + TC-340 badge re-render (#661/#662)

### DIFF
--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -1931,6 +1931,71 @@ async function apiPutAllBmQualScores(page, tournamentId, opts = {}) {
   }
 }
 
+/** API-driven MR qualification score entry for EVERY open match.
+ *  Mirrors apiPutAllBmQualScores (issue #517/#661): bypasses the UI dialog loop
+ *  that requires a full browser click per race winner, which takes 35 min for
+ *  182 matches in a 28-player two-group tournament.
+ *  Submits { matchId, score1, score2 } to the bulk PUT endpoint.
+ *  score1 + score2 must equal TOTAL_MR_RACES (4). */
+async function apiPutAllMrQualScores(page, tournamentId, opts = {}) {
+  const { score1: fixedS1, score2: fixedS2, randomize = true } = opts;
+  const data = await apiFetchMr(page, tournamentId);
+  const matches = (data.matches || []).filter((m) => !m.isBye && !m.completed);
+
+  for (const match of matches) {
+    const profile = randomize ? pickRandomMrScoreProfile() : { score1: fixedS1 ?? 3, score2: fixedS2 ?? 1 };
+    const result = await withRetry(() => page.evaluate(async ([url, body]) => {
+      const r = await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status, id: body.matchId };
+    }, [`/api/tournaments/${tournamentId}/mr`, {
+      matchId: match.id,
+      score1: profile.score1,
+      score2: profile.score2,
+    }]), { label: `MR qual API PUT ${match.id}` });
+
+    if (result.s !== 200) {
+      throw new Error(`apiPutAllMrQualScores failed for match ${match.id} (${result.s})`);
+    }
+  }
+}
+
+/** API-driven GP qualification score entry for EVERY open match.
+ *  Mirrors apiPutAllBmQualScores (issue #517/#661): bypasses the UI dialog loop
+ *  that takes 35 min for 182 matches in a 28-player setup.
+ *  Uses the per-match manual-score endpoint (/gp/match/[id]) with points1/points2
+ *  so we don't need to construct per-race position arrays. */
+async function apiPutAllGpQualScores(page, tournamentId, opts = {}) {
+  const { points1: fixedP1, points2: fixedP2, randomize = true } = opts;
+  const data = await apiFetchGp(page, tournamentId);
+  const matches = (data.matches || []).filter((m) => !m.isBye && !m.completed);
+
+  for (const match of matches) {
+    const pts = randomize ? pickRandomGpPoints() : { points1: fixedP1 ?? 45, points2: fixedP2 ?? 0 };
+
+    const result = await withRetry(() => page.evaluate(async ([url, body]) => {
+      const r = await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status };
+    }, [`/api/tournaments/${tournamentId}/gp/match/${match.id}`, {
+      points1: pts.points1,
+      points2: pts.points2,
+      completed: true,
+      version: match.version,
+    }]), { label: `GP qual API PUT ${match.id}` });
+
+    if (result.s !== 200) {
+      throw new Error(`apiPutAllGpQualScores failed for match ${match.id} (${result.s})`);
+    }
+  }
+}
+
 /** UI-driven BM qualification: group assignment + all match scores.
  *  `players` must be `{ id, name, nickname }[]`. Idempotent — safe to re-run
  *  because setupModePlayersViaUi clears selected players before re-adding. */
@@ -1955,8 +2020,10 @@ async function setupBmQualViaUi(adminPage, tournamentId, players, { score1 = 3, 
   }
 }
 
-/** UI-driven MR qualification: group assignment + all match scores (3-1
- *  via per-race winner buttons). */
+/** MR qualification: group assignment + all match scores via API bulk PUT.
+ *  Uses apiPutAllMrQualScores (mirrors the BM API approach from issue #517)
+ *  to avoid the 35-min UI click loop for 182 matches in a 28-player setup
+ *  (issue #661). The UI dialog flow is still covered by TC-601/602. */
 async function setupMrQualViaUi(
   adminPage,
   tournamentId,
@@ -1968,15 +2035,18 @@ async function setupMrQualViaUi(
    * which disables the MR score-entry button. Reset before re-seeding. */
   await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: false });
   await setupModePlayersViaUi(adminPage, 'mr', tournamentId, players);
-  await uiPutAllMrQualScores(adminPage, tournamentId, { score1, score2, randomize });
+  /* Use API bulk scoring to avoid renderer OOM and suite timeout on 182-match
+   * 28-player tournaments (issue #661). Individual UI flow covered by TC-601/602. */
+  await apiPutAllMrQualScores(adminPage, tournamentId, { score1, score2, randomize });
   if (resolveTies) {
     await resolveAllTies(adminPage, tournamentId, 'mr');
   }
 }
 
-/** UI-driven GP qualification: group assignment + all match scores via the
- *  dialog's Manual Total Score toggle (45-0 by default, matching the
- *  player1-wins-all-5-races outcome of makeRacesP1Wins). */
+/** GP qualification: group assignment + all match scores via API bulk PUT.
+ *  Uses apiPutAllGpQualScores (mirrors the BM API approach from issue #517)
+ *  to avoid the 35-min UI click loop for 182 matches in a 28-player setup
+ *  (issue #661). The UI dialog flow is still covered by TC-701/702. */
 async function setupGpQualViaUi(
   adminPage,
   tournamentId,
@@ -1988,7 +2058,10 @@ async function setupGpQualViaUi(
    * which disables the GP score-entry button. Reset before re-seeding. */
   await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: false });
   await setupModePlayersViaUi(adminPage, 'gp', tournamentId, players);
-  await uiPutAllGpQualScores(adminPage, tournamentId, { points1, points2, randomize });
+  /* Use API bulk scoring (manual-score endpoint) to avoid renderer OOM and
+   * suite timeout on 182-match 28-player tournaments (issue #661). Individual
+   * UI flow covered by TC-701/702. */
+  await apiPutAllGpQualScores(adminPage, tournamentId, { points1, points2, randomize });
   if (resolveTies) {
     await resolveAllTies(adminPage, tournamentId, 'gp');
   }
@@ -2275,6 +2348,7 @@ module.exports = {
   apiSetupBmGroup,
   apiFetchBm,
   apiPutBmQualScore,
+  apiPutAllBmQualScores,
   apiSetBmFinalsScore,
   apiGenerateBmFinals,
   apiFetchBmFinalsMatches,
@@ -2284,6 +2358,7 @@ module.exports = {
   apiSetupMrGroup,
   apiFetchMr,
   apiPutMrQualScore,
+  apiPutAllMrQualScores,
   apiGenerateMrFinals,
   apiSetMrFinalsScore,
   apiFetchMrFinalsMatches,
@@ -2295,6 +2370,7 @@ module.exports = {
   apiSetupGpGroup,
   apiFetchGp,
   apiPutGpQualScore,
+  apiPutAllGpQualScores,
   apiSetGpFinalsScore,
   apiGenerateGpFinals,
   apiFetchGpFinalsMatches,

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -2543,18 +2543,27 @@ async function main() {
     const badgeBeforePublish = await hiddenBadge().isVisible().catch(() => false);
 
     // Step 2: Click the ModePublishSwitch for TA to publish it
-    // aria-label pattern: "Time Trial: Publish" / "タイムトライアル: 公開"
+    // aria-label: "Time Trial: Unpublish" (en) / "タイムトライアル: 未公開" (ja)
     const publishSwitch = page.getByRole('switch', { name: /Time Trial|タイムトライアル/ });
     await publishSwitch.click();
-    // Allow the publicModesChanged event handler + re-fetch to resolve
-    await page.waitForTimeout(3000);
+    // Wait for publicModesChanged event → layout re-fetch → badge disappears.
+    // Use polling instead of fixed timeout: D1 PUT + GET can take >3s on cold start.
+    await page.waitForFunction(
+      () => !document.querySelector('nav[aria-label="Tournament sections"]')
+        ?.textContent?.match(/Unpublished|未公開/),
+      { timeout: 10000 },
+    ).catch(() => {});
 
     // Step 3: Badge must be gone from the tab without a reload
     const badgeAfterPublish = await hiddenBadge().isVisible().catch(() => false);
 
     // Step 4: Toggle back to unpublish — badge must reappear
     await publishSwitch.click();
-    await page.waitForTimeout(3000);
+    await page.waitForFunction(
+      () => document.querySelector('nav[aria-label="Tournament sections"]')
+        ?.textContent?.match(/Unpublished|未公開/),
+      { timeout: 10000 },
+    ).catch(() => {});
     const badgeAfterUnpublish = await hiddenBadge().isVisible().catch(() => false);
 
     log('TC-340',

--- a/smkc-score-app/src/app/tournaments/[id]/layout.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/layout.tsx
@@ -141,7 +141,8 @@ export default function TournamentLayout({
   const fetchTournament = useCallback(async () => {
     try {
       // ?fields=summary skips BM relations — layout only needs name/date/status
-      const response = await fetchWithRetry(`/api/tournaments/${id}?fields=summary`);
+      // cache:'no-store' prevents stale publicModes after publicModesChanged re-fetch (issue #662)
+      const response = await fetchWithRetry(`/api/tournaments/${id}?fields=summary`, { cache: 'no-store' });
       if (response.ok) {
         const json = await response.json();
         // API uses createSuccessResponse: { success, data: {...} }


### PR DESCRIPTION
## Summary

### fix(e2e/#661): API bulk scoring for MR/GP qualification (TC-601/TC-701 suite timeout)

- Add `apiPutAllMrQualScores`: fetches all MR qualification matches, then sequentially PUTs `{ matchId, score1, score2 }` to the bulk endpoint — same pattern as `apiPutAllBmQualScores` (issue #517)
- Add `apiPutAllGpQualScores`: fetches all GP qualification matches, then sequentially PUTs `{ points1, points2, completed, version }` to the per-match manual-score endpoint (`/gp/match/[id]`), same path as the UI manual-score dialog
- Update `setupMrQualViaUi` and `setupGpQualViaUi` to use the new API functions instead of the 35-min UI click loops
- Export both new functions from `common.js`
- Individual UI dialog flow still covered by TC-601/602 (MR) and TC-701/702 (GP)

### fix(#662): TC-340 layout badge not disappearing after publish

- Add `cache: 'no-store'` to `fetchTournament` in `layout.tsx` so the `publicModesChanged` event re-fetch always gets a fresh API response (prevents any edge-cached stale `publicModes`)
- TC-340: replace fixed `waitForTimeout(3000)` with `waitForFunction` polling — handles Cloudflare Workers D1 cold-start latency where PUT + GET can exceed 3s

## Test plan

- [ ] TC-601 (MR 28-player qual) should complete in < 5 min instead of 35+ min
- [ ] TC-701 (GP 28-player qual) should complete in < 5 min instead of 35+ min  
- [ ] TC-604~621 and TC-703~719 should run (no longer skipped due to suite timeout)
- [ ] TC-340 should PASS (layout "Unpublished" badge disappears after publish switch click)
- [ ] All pre-existing passing tests remain passing

https://claude.ai/code/session_01QkWwUabh9o23wTZ5nbtfjz

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkWwUabh9o23wTZ5nbtfjz)_