### PR TITLE
fix: per-slot TBD detection, TV# uniqueness, E2E cleanup, homepage redundancy

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1649,7 +1649,10 @@ describe('Finals Route Factory', () => {
     it('updates tvNumber on a finals match without touching scores', async () => {
       mockAuth.mockResolvedValue({ user: { id: 'admin-1', role: 'admin' } } as any);
       const existing = createMockMatch({ id: 'match-1', stage: 'finals', tvNumber: null });
-      (prisma.bMMatch as any).findFirst.mockResolvedValue(existing);
+      /* Two findFirst calls: IDOR check (returns match) + uniqueness check (null = no conflict) */
+      (prisma.bMMatch as any).findFirst
+        .mockResolvedValueOnce(existing)
+        .mockResolvedValueOnce(null);
       (prisma.bMMatch as any).update.mockResolvedValue({ ...existing, tvNumber: 2 });
 
       const { PATCH } = createFinalsHandlers(createMockConfig());

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -1208,8 +1208,11 @@ describe('Qualification Route Factory', () => {
       };
       /* PATCH now short-circuits with 404 when the match doesn't belong to
        * the tournament (IDOR prevention via findFirst). Provide a stub so
-       * the update path runs. */
-      (prisma.bMMatch as any).findFirst.mockResolvedValue(mockMatch);
+       * the update path runs. The second findFirst is the TV# uniqueness check;
+       * null means no conflict. */
+      (prisma.bMMatch as any).findFirst
+        .mockResolvedValueOnce(mockMatch)  // IDOR check: match found
+        .mockResolvedValueOnce(null);       // uniqueness check: no conflict
       (prisma.bMMatch as any).update.mockResolvedValue(mockMatch);
 
       const config = createMockConfig();
@@ -1244,7 +1247,10 @@ describe('Qualification Route Factory', () => {
         player1: { id: 'p1', nickname: 'Alice' },
         player2: { id: 'p2', nickname: 'Bob' },
       };
-      (prisma.bMMatch as any).findFirst.mockResolvedValue(mockMatch);
+      /* Two findFirst calls: IDOR check (returns match) + uniqueness check (null = no conflict) */
+      (prisma.bMMatch as any).findFirst
+        .mockResolvedValueOnce(mockMatch)
+        .mockResolvedValueOnce(null);
       (prisma.bMMatch as any).update.mockResolvedValue(mockMatch);
 
       const config = createMockConfig();
@@ -1431,6 +1437,10 @@ describe('Qualification Route Factory', () => {
 
     it('should return 500 on database error', async () => {
       mockAuth.mockResolvedValue({ user: { id: 'user-1', role: 'admin' } });
+      /* IDOR check passes, uniqueness check finds no conflict, then update throws. */
+      (prisma.bMMatch as any).findFirst
+        .mockResolvedValueOnce({ id: 'match-1', round: 'round-1', tournamentId: 'tournament-123' })
+        .mockResolvedValueOnce(null);
       (prisma.bMMatch as any).update.mockRejectedValue(new Error('DB error'));
 
       const config = createMockConfig();

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -2500,11 +2500,8 @@ async function main() {
   } catch (err) {
     log('TC-339', 'FAIL', err instanceof Error ? err.message : 'Independent mode publish test failed');
   } finally {
-    if (tc339TournamentId) {
-      await page.evaluate(async (tid) => {
-        await fetch(`/api/tournaments/${tid}`, { method: 'DELETE' }).catch(() => {});
-      }, tc339TournamentId).catch(() => {});
-    }
+    /* Must set status→draft first; DELETE rejects non-draft tournaments (issue #667). */
+    if (tc339TournamentId) await deleteTournament(page, tc339TournamentId);
   }
 
   // TC-340: Layout publish button — "Unpublished" badge disappears from tab after publishing TA
@@ -2574,11 +2571,8 @@ async function main() {
   } catch (err) {
     log('TC-340', 'FAIL', err instanceof Error ? err.message : 'Layout badge toggle test failed');
   } finally {
-    if (tc340TournamentId) {
-      await page.evaluate(async (tid) => {
-        await fetch(`/api/tournaments/${tid}`, { method: 'DELETE' }).catch(() => {});
-      }, tc340TournamentId).catch(() => {});
-    }
+    /* Must set status→draft first; DELETE rejects non-draft tournaments (issue #667). */
+    if (tc340TournamentId) await deleteTournament(page, tc340TournamentId);
   }
 
   // TC-341: Authenticated player can access private tournament detail API (publicModes: [])
@@ -2706,6 +2700,217 @@ async function main() {
       log('TC-344', 'FAIL', err instanceof Error ? err.message : 'noCamera flag test failed');
     } finally {
       if (tc344PlayerId) await deletePlayer(page, tc344PlayerId);
+    }
+  }
+
+  // TC-345: Duplicate TV number rejected in qualification round (issue #668)
+  // Verifies that assigning the same TV number to two different matches in the
+  // same round returns 400. Uses an isolated 2-player BM tournament so this
+  // test is independent of the shared 28-player setup.
+  {
+    let tc345TournamentId = null;
+    let tc345P1Id = null;
+    let tc345P2Id = null;
+    let tc345P3Id = null;
+    let tc345P4Id = null;
+    try {
+      const ts345 = Date.now();
+      const p345a = await uiCreatePlayer(page, 'E2E TV Dup A', `e2e_tvdup_a_${ts345}`);
+      tc345P1Id = p345a.id;
+      const p345b = await uiCreatePlayer(page, 'E2E TV Dup B', `e2e_tvdup_b_${ts345}`);
+      tc345P2Id = p345b.id;
+      const p345c = await uiCreatePlayer(page, 'E2E TV Dup C', `e2e_tvdup_c_${ts345}`);
+      tc345P3Id = p345c.id;
+      const p345d = await uiCreatePlayer(page, 'E2E TV Dup D', `e2e_tvdup_d_${ts345}`);
+      tc345P4Id = p345d.id;
+
+      tc345TournamentId = await uiCreateTournament(page, `E2E TC-345 TV Dup ${ts345}`);
+      await uiActivateTournament(page, tc345TournamentId);
+
+      // Set up BM with 4 players in group A — creates 2 non-BYE matches in the same round
+      const bmSetup345 = await page.evaluate(async ([tid, p1, p2, p3, p4]) => {
+        const r = await fetch(`/api/tournaments/${tid}/bm`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ players: [
+            { playerId: p1, group: 'A' },
+            { playerId: p2, group: 'A' },
+            { playerId: p3, group: 'A' },
+            { playerId: p4, group: 'A' },
+          ] }),
+        });
+        return { s: r.status, b: await r.json().catch(() => ({})) };
+      }, [tc345TournamentId, tc345P1Id, tc345P2Id, tc345P3Id, tc345P4Id]);
+      if (bmSetup345.s !== 201) throw new Error(`BM setup failed (${bmSetup345.s})`);
+
+      // Fetch matches to find two matches in the same round
+      const bmData345 = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/bm`);
+        return r.json().catch(() => ({}));
+      }, tc345TournamentId);
+      const matches345 = bmData345.data?.matches ?? bmData345.matches ?? [];
+      if (matches345.length < 2) throw new Error(`Expected ≥2 matches, got ${matches345.length}`);
+
+      // Assign TV1 to first match — should succeed
+      const patch1 = await page.evaluate(async ([tid, mid]) => {
+        const r = await fetch(`/api/tournaments/${tid}/bm`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ matchId: mid, tvNumber: 1 }),
+        });
+        return { s: r.status, b: await r.json().catch(() => ({})) };
+      }, [tc345TournamentId, matches345[0].id]);
+      const firstOk = patch1.s === 200;
+
+      // Assign TV1 to second match in same round — must be rejected (409/400)
+      const sameRound345 = matches345.filter((m) => m.round === matches345[0].round);
+      const secondMatchId = sameRound345.length > 1 ? sameRound345[1].id : matches345[1]?.id;
+      const patch2 = await page.evaluate(async ([tid, mid]) => {
+        const r = await fetch(`/api/tournaments/${tid}/bm`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ matchId: mid, tvNumber: 1 }),
+        });
+        return { s: r.status, b: await r.json().catch(() => ({})) };
+      }, [tc345TournamentId, secondMatchId]);
+      const dupRejected = patch2.s === 400 || patch2.s === 409;
+
+      log('TC-345', firstOk && dupRejected ? 'PASS' : 'FAIL',
+        !firstOk ? `First TV1 assignment failed (${patch1.s})`
+        : !dupRejected ? `Duplicate TV1 was accepted (${patch2.s}) — uniqueness guard missing`
+        : '');
+    } catch (err) {
+      log('TC-345', 'FAIL', err instanceof Error ? err.message : 'TV duplicate test failed');
+    } finally {
+      if (tc345TournamentId) await deleteTournament(page, tc345TournamentId);
+      if (tc345P1Id) await deletePlayer(page, tc345P1Id);
+      if (tc345P2Id) await deletePlayer(page, tc345P2Id);
+      if (tc345P3Id) await deletePlayer(page, tc345P3Id);
+      if (tc345P4Id) await deletePlayer(page, tc345P4Id);
+    }
+  }
+
+  // TC-346: Loser bracket slot TBD detection after partial QF completion (issue #669)
+  // After bracket creation, all losers_r1 match player IDs are identical placeholders
+  // (player1Id === player2Id). After one QF match completes and its loser is routed,
+  // the losers_r1 match should have player1Id ≠ player2Id (one real, one placeholder).
+  // The UI must show the real player name for the filled slot and "TBD" for the unfilled.
+  // This test covers the API-level invariant; the component fix is covered by the type check.
+  {
+    let tc346TournamentId = null;
+    let tc346Players = [];
+    try {
+      const ts346 = Date.now();
+      const playerNames = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'].map((l) => `e2e_lb_${l}_${ts346}`);
+      for (const nick of playerNames) {
+        const p = await uiCreatePlayer(page, `E2E LB ${nick}`, nick);
+        tc346Players.push(p.id);
+      }
+      tc346TournamentId = await uiCreateTournament(page, `E2E TC-346 LB TBD ${ts346}`);
+      await uiActivateTournament(page, tc346TournamentId);
+
+      // Enroll all 8 players in BM qualification (4 per group)
+      const bmSetup346 = await page.evaluate(async ([tid, pids]) => {
+        const r = await fetch(`/api/tournaments/${tid}/bm`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ players: [
+            { playerId: pids[0], group: 'A' }, { playerId: pids[1], group: 'A' },
+            { playerId: pids[2], group: 'A' }, { playerId: pids[3], group: 'A' },
+            { playerId: pids[4], group: 'B' }, { playerId: pids[5], group: 'B' },
+            { playerId: pids[6], group: 'B' }, { playerId: pids[7], group: 'B' },
+          ] }),
+        });
+        return { s: r.status, b: await r.json().catch(() => ({})) };
+      }, [tc346TournamentId, tc346Players]);
+      if (bmSetup346.s !== 201) throw new Error(`BM setup failed (${bmSetup346.s})`);
+
+      // Give each player a score so they can be ranked for finals seeding
+      const bmMatches346 = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/bm`);
+        const j = await r.json().catch(() => ({}));
+        return j.data?.matches ?? j.matches ?? [];
+      }, tc346TournamentId);
+
+      // Complete all qualification matches with distinct scores (score1 > score2 always)
+      for (const m of bmMatches346) {
+        if (!m.completed && m.player1?.id && m.player2?.id) {
+          await page.evaluate(async ([tid, mid]) => {
+            await fetch(`/api/tournaments/${tid}/bm`, {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ matchId: mid, score1: 4, score2: 1 }),
+            });
+          }, [tc346TournamentId, m.id]);
+        }
+      }
+
+      // Confirm qualification so finals can be created
+      await page.evaluate(async (tid) => {
+        await fetch(`/api/tournaments/${tid}`, {
+          method: 'PUT', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ qualificationConfirmed: true }),
+        });
+      }, tc346TournamentId);
+
+      // Create the 8-player finals bracket
+      const finalsCreate346 = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/bm/finals`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        });
+        return { s: r.status, b: await r.json().catch(() => ({})) };
+      }, tc346TournamentId);
+      if (finalsCreate346.s !== 200 && finalsCreate346.s !== 201) {
+        throw new Error(`Finals bracket creation failed (${finalsCreate346.s})`);
+      }
+
+      // Fetch the bracket
+      const finalsData346 = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/bm/finals`);
+        return r.json().catch(() => ({}));
+      }, tc346TournamentId);
+      const allMatches346 = finalsData346.data?.matches ?? finalsData346.matches ?? [];
+
+      // Verify: all losers_r1 matches initially have player1Id === player2Id (placeholder state)
+      const losersR1 = allMatches346.filter((m) => m.round === 'losers_r1');
+      const allPlaceholder = losersR1.length > 0 && losersR1.every((m) => m.player1Id === m.player2Id);
+
+      // Complete one WB QF match so its loser is routed into losers_r1
+      const qfMatches346 = allMatches346.filter((m) => m.round === 'winners_qf');
+      let partiallyFilled = false;
+      if (qfMatches346.length > 0) {
+        const firstQf = qfMatches346[0];
+        await page.evaluate(async ([tid, mid]) => {
+          await fetch(`/api/tournaments/${tid}/bm/finals`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ matchId: mid, score1: 5, score2: 0 }),
+          });
+        }, [tc346TournamentId, firstQf.id]);
+
+        // Re-fetch bracket; the losers_r1 match fed by this QF should now have player1Id ≠ player2Id
+        const finalsAfter346 = await page.evaluate(async (tid) => {
+          const r = await fetch(`/api/tournaments/${tid}/bm/finals`);
+          return r.json().catch(() => ({}));
+        }, tc346TournamentId);
+        const matchesAfter = finalsAfter346.data?.matches ?? finalsAfter346.matches ?? [];
+        const losersR1After = matchesAfter.filter((m) => m.round === 'losers_r1');
+        // At least one losers_r1 match should now have player1Id ≠ player2Id (one slot filled by QF loser)
+        partiallyFilled = losersR1After.some((m) => m.player1Id !== m.player2Id);
+      }
+
+      log('TC-346',
+        allPlaceholder && partiallyFilled ? 'PASS' : 'FAIL',
+        !allPlaceholder ? `losers_r1 initial placeholder check failed (${losersR1.length} matches, allSame=${allPlaceholder})`
+        : !partiallyFilled ? 'After QF completion, no losers_r1 match was partially filled (routing failed?)'
+        : '');
+    } catch (err) {
+      log('TC-346', 'FAIL', err instanceof Error ? err.message : 'Loser bracket TBD test failed');
+    } finally {
+      if (tc346TournamentId) await deleteTournament(page, tc346TournamentId);
+      for (const pid of tc346Players) await deletePlayer(page, pid);
     }
   }
 

--- a/smkc-score-app/src/app/page.tsx
+++ b/smkc-score-app/src/app/page.tsx
@@ -47,16 +47,6 @@ export default function Home() {
         <p className="mt-5 max-w-xl text-base sm:text-lg text-muted-foreground">
           {t('tagline')}
         </p>
-        <div className="mt-7 flex flex-wrap gap-3">
-          <Button asChild size="lg">
-            <Link href="/tournaments">{t('viewTournamentsButton')}</Link>
-          </Button>
-          <Button asChild size="lg" variant="outline">
-            <Link href="/players">
-              {isAdmin ? t('managePlayers') : t('viewPlayers')}
-            </Link>
-          </Button>
-        </div>
       </section>
 
       {/* Entry panels */}

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -54,6 +54,10 @@ interface BracketMatch {
   bracket: "winners" | "losers" | "grand_final";
   player1Seed?: number;
   player2Seed?: number;
+  winnerGoesTo?: number;
+  loserGoesTo?: number;
+  /** Position in the receiving match (1 or 2), used for winner routing */
+  position?: 1 | 2;
 }
 
 /** Props for the main DoubleEliminationBracket component */
@@ -88,7 +92,7 @@ interface DoubleEliminationBracketProps {
  * @param bracketMatch - Bracket structure definition for this position
  * @param seededPlayers - Seeded player data for seed number display
  * @param onClick - Click handler for score entry
- * @param isTBD - Whether this match has undetermined players
+ * @param isTBD - Per-slot TBD flags: whether player1/player2 slots are undetermined
  */
 function MatchCard({
   match,
@@ -103,7 +107,7 @@ function MatchCard({
   bracketMatch: BracketMatch;
   seededPlayers?: { seed: number; playerId: string; player: Player }[];
   onClick?: () => void;
-  isTBD: boolean;
+  isTBD: { player1: boolean; player2: boolean };
   getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
   onTvNumberChange?: (match: BMMatch, tvNumber: number | null) => void;
 }) {
@@ -125,16 +129,14 @@ function MatchCard({
   const isWinner2 = !!match?.completed && match.score2 >= targetWins && match.score2 > match.score1;
 
   /*
-   * Determine if this match should show "TBD" for players.
-   * Winners first-round matches (winners_qf, winners_r1) always have real
-   * players from direct seeding. losers_r1 is populated from winners-side
-   * losers so its players are unknown until those matches complete — issue
-   * #574: immediately after bracket generation both slots were filled with
-   * seed 1 as a placeholder and it needs to render as TBD.
+   * Per-slot TBD display. First-round matches (seeded) always show real names.
+   * For later rounds, show "TBD" only for the specific slot that hasn't been
+   * filled yet by a routing event from a completed prior match (issue #669).
    */
   const isFirstRound =
     bracketMatch.round === "winners_r1" || bracketMatch.round === "winners_qf";
-  const showTBD = !isFirstRound && isTBD;
+  const showTBD1 = !isFirstRound && isTBD.player1;
+  const showTBD2 = !isFirstRound && isTBD.player2;
 
   /* TV1 gets a subtle amber highlight so broadcast crew can spot it instantly. */
   const isTV1 = match?.tvNumber === 1;
@@ -150,7 +152,7 @@ function MatchCard({
       role="button"
       tabIndex={0}
       data-testid="bracket-match-card"
-      aria-label={`Match ${bracketMatch.matchNumber}: ${player1?.nickname || tc('tbd')} vs ${player2?.nickname || tc('tbd')}${showTBD ? ' (Pending)' : ''}`}
+      aria-label={`Match ${bracketMatch.matchNumber}: ${showTBD1 ? tc('tbd') : player1?.nickname || tc('tbd')} vs ${showTBD2 ? tc('tbd') : player2?.nickname || tc('tbd')}${(showTBD1 || showTBD2) ? ' (Pending)' : ''}`}
       onKeyDown={(e) => {
         /* Support keyboard activation for accessibility */
         if (e.key === 'Enter' || e.key === ' ') {
@@ -203,8 +205,8 @@ function MatchCard({
               [{bracketMatch.player1Seed}]
             </span>
           )}
-          <span className={showTBD ? "text-muted-foreground" : ""}>
-            {showTBD ? tc("tbd") : player1?.nickname || tc("tbd")}
+          <span className={showTBD1 ? "text-muted-foreground" : ""}>
+            {showTBD1 ? tc("tbd") : player1?.nickname || tc("tbd")}
           </span>
         </span>
         <span className="font-mono">
@@ -225,8 +227,8 @@ function MatchCard({
               [{bracketMatch.player2Seed}]
             </span>
           )}
-          <span className={showTBD ? "text-muted-foreground" : ""}>
-            {showTBD ? tc("tbd") : player2?.nickname || tc("tbd")}
+          <span className={showTBD2 ? "text-muted-foreground" : ""}>
+            {showTBD2 ? tc("tbd") : player2?.nickname || tc("tbd")}
           </span>
         </span>
         <span className="font-mono">
@@ -314,20 +316,72 @@ export function DoubleEliminationBracket({
     bracketStructure.find((b) => b.matchNumber === matchNumber);
 
   /**
-   * Determine if a match should display "TBD" for its players.
-   * A match is TBD when:
-   * - No match data exists for this position
-   * - It's not a first-round match AND both player IDs are the same
-   *   (indicating placeholder players that haven't been filled in yet)
+   * Reverse routing map: `${matchNumber}-${slot}` → source match number.
+   *
+   * When a source match completes, its winner/loser is routed into a specific
+   * slot of a later match. A slot is "filled" only after its source match has
+   * been completed. This mirrors the getNextMatchInfo server-side logic for
+   * computing loser positions (issue #669).
+   *
+   * Loser position rules (same as getNextMatchInfo in double-elimination.ts):
+   *   winners_r1:  (matchNumber - 1) % 2 + 1
+   *   winners_qf:  position 2 for 16-player; (matchNumber - 1) % 2 + 1 for 8-player
+   *   winners_sf:  always 1
+   *   winners_final: always 2
    */
-  const isTBD = (matchNumber: number) => {
+  const slotSourceMap = (() => {
+    const map = new Map<string, number>();
+    const is16Player = bracketStructure.length > 17;
+    for (const bm of bracketStructure) {
+      if (bm.winnerGoesTo) {
+        const pos = bm.position ?? 1;
+        map.set(`${bm.winnerGoesTo}-${pos}`, bm.matchNumber);
+      }
+      if (bm.loserGoesTo) {
+        let loserPos: 1 | 2;
+        if (bm.round === 'winners_r1') {
+          loserPos = ((bm.matchNumber - 1) % 2 + 1) as 1 | 2;
+        } else if (bm.round === 'winners_qf') {
+          loserPos = is16Player ? 2 : ((bm.matchNumber - 1) % 2 + 1) as 1 | 2;
+        } else if (bm.round === 'winners_sf') {
+          loserPos = 1;
+        } else if (bm.round === 'winners_final') {
+          loserPos = 2;
+        } else {
+          continue;
+        }
+        map.set(`${bm.loserGoesTo}-${loserPos}`, bm.matchNumber);
+      }
+    }
+    return map;
+  })();
+
+  /**
+   * Per-slot TBD detection. A slot is TBD when no completed source match
+   * has routed a real player into it yet. Returns per-slot flags so the
+   * bracket can show "Player vs TBD" when only one slot has been filled,
+   * rather than hiding both names (issue #669).
+   */
+  const isTBD = (matchNumber: number): { player1: boolean; player2: boolean } => {
     const match = getMatch(matchNumber);
-    if (!match) return true;
+    if (!match) return { player1: true, player2: true };
     const bracket = getBracketMatch(matchNumber);
-    /* First round matches always have real players from seeding */
-    if (bracket?.round === "winners_qf" || bracket?.round === "winners_r1") return false;
-    /* Later rounds: check if both player IDs are the same (placeholder state) */
-    return !match.completed && match.player1Id === match.player2Id;
+    /* First-round seeded matches always have real players */
+    if (bracket?.round === "winners_qf" || bracket?.round === "winners_r1") {
+      return { player1: false, player2: false };
+    }
+    if (match.completed) return { player1: false, player2: false };
+
+    const isSlotTBD = (slot: 1 | 2): boolean => {
+      /* Seeded slots (playoff_r2 BYE seeds) are always filled */
+      if (slot === 1 && bracket?.player1Seed != null) return false;
+      if (slot === 2 && bracket?.player2Seed != null) return false;
+      const sourceMatchNumber = slotSourceMap.get(`${matchNumber}-${slot}`);
+      if (sourceMatchNumber == null) return true;
+      return !getMatch(sourceMatchNumber)?.completed;
+    };
+
+    return { player1: isSlotTBD(1), player2: isSlotTBD(2) };
   };
 
   /* Group bracket positions by round for organized display */

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -318,10 +318,10 @@ export function DoubleEliminationBracket({
   /**
    * Reverse routing map: `${matchNumber}-${slot}` → source match number.
    *
-   * When a source match completes, its winner/loser is routed into a specific
-   * slot of a later match. A slot is "filled" only after its source match has
-   * been completed. This mirrors the getNextMatchInfo server-side logic for
-   * computing loser positions (issue #669).
+   * `bracketStructure` is always produced by `generateBracketStructure()` on the
+   * server, which guarantees `winnerGoesTo`, `loserGoesTo`, and `position` are
+   * populated for every non-terminal match. The map will therefore contain an
+   * entry for every non-seeded slot under normal circumstances.
    *
    * Loser position rules (same as getNextMatchInfo in double-elimination.ts):
    *   winners_r1:  (matchNumber - 1) % 2 + 1
@@ -331,6 +331,7 @@ export function DoubleEliminationBracket({
    */
   const slotSourceMap = (() => {
     const map = new Map<string, number>();
+    /* 8-player bracket = 17 matches; 16-player = 31 matches. */
     const is16Player = bracketStructure.length > 17;
     for (const bm of bracketStructure) {
       if (bm.winnerGoesTo) {
@@ -377,7 +378,13 @@ export function DoubleEliminationBracket({
       if (slot === 1 && bracket?.player1Seed != null) return false;
       if (slot === 2 && bracket?.player2Seed != null) return false;
       const sourceMatchNumber = slotSourceMap.get(`${matchNumber}-${slot}`);
-      if (sourceMatchNumber == null) return true;
+      if (sourceMatchNumber == null) {
+        /* Routing fields absent (should not happen with generateBracketStructure,
+         * but degrade gracefully using the placeholder heuristic: bracket creation
+         * initialises unfilled slots to seededPlayers[0].playerId for both players,
+         * so equal IDs means both slots are still placeholders. */
+        return !match.completed && match.player1Id === match.player2Id;
+      }
       return !getMatch(sourceMatchNumber)?.completed;
     };
 

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -1183,6 +1183,22 @@ export function createFinalsHandlers(config: FinalsConfig) {
           if (!Number.isInteger(tv) || tv < 1 || tv > MAX_TV_NUMBER) {
             return handleValidationError(`tvNumber must be 1–${MAX_TV_NUMBER}`, 'tvNumber');
           }
+          /* Uniqueness guard: prevent the same TV number in the same round (issue #668). */
+          const tvConflict = await model(prisma).findFirst({
+            where: {
+              tournamentId,
+              stage: match.stage,
+              round: match.round,
+              tvNumber: tv,
+              id: { not: matchId },
+            },
+          });
+          if (tvConflict) {
+            return handleValidationError(
+              `TV${tv} is already assigned to match ${tvConflict.matchNumber} in this round`,
+              'tvNumber',
+            );
+          }
         }
         for (const field of config.putAdditionalFields) {
           if (body[field] !== undefined) {
@@ -1476,6 +1492,26 @@ export function createFinalsHandlers(config: FinalsConfig) {
       }
       if (existing.stage !== 'finals' && existing.stage !== 'playoff') {
         return createErrorResponse('Finals match not found', 404, 'NOT_FOUND');
+      }
+
+      /* Uniqueness guard: prevent the same TV number being assigned to two
+       * different matches in the same round (issue #668). */
+      if (tvNumber !== null && tvNumber !== undefined) {
+        const conflict = await model(prisma).findFirst({
+          where: {
+            tournamentId,
+            stage: existing.stage,
+            round: existing.round,
+            tvNumber,
+            id: { not: matchId },
+          },
+        });
+        if (conflict) {
+          return handleValidationError(
+            `TV${tvNumber} is already assigned to match ${conflict.matchNumber} in this round`,
+            'tvNumber',
+          );
+        }
       }
 
       const match = await model(prisma).update({

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -618,6 +618,24 @@ export function createQualificationHandlers(config: EventTypeConfig) {
         return createErrorResponse('Match not found', 404, 'NOT_FOUND');
       }
 
+      /* Uniqueness guard: prevent the same TV number in the same round (issue #668). */
+      if (tvNumber !== null && tvNumber !== undefined) {
+        const tvConflict = await matchModel(prisma).findFirst({
+          where: {
+            tournamentId,
+            round: existingMatch.round,
+            tvNumber,
+            id: { not: matchId },
+          },
+        });
+        if (tvConflict) {
+          return handleValidationError(
+            `TV${tvNumber} is already assigned to match ${tvConflict.matchNumber} in this round`,
+            'tvNumber',
+          );
+        }
+      }
+
       const match = await matchModel(prisma).update({
         where: { id: matchId, tournamentId },
         data: { tvNumber: tvNumber ?? null },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **#669** Loser bracket shows wrong player name (e.g. "e2e_shared_11" in all opponent slots): replaced the whole-match `isTBD` check (`player1Id === player2Id`) with **per-slot detection** using the bracket's reverse routing map. After one QF completes, the unfilled slot now shows "TBD" while the filled slot shows the real player name. Adds `winnerGoesTo`/`loserGoesTo`/`position` to the component's `BracketMatch` interface so slot sources can be resolved without extra API calls.
- **#668** Same TV number assignable to multiple matches in the same round: added a **uniqueness guard** in the qualification PATCH handler (`qualification-route.ts`) and the finals PATCH/PUT handlers (`finals-route.ts`). Returns 400 with a descriptive message when the TV number is already taken in that round.
- **#667** E2E cleanup leaking tournaments (publish/badge tests): TC-339 and TC-340 were calling `DELETE` directly on `active`-status tournaments, which the API rejects. Fixed by using the `deleteTournament()` helper that first sets `status → draft` then deletes.
- **#665** Top page has three redundant paths to tournaments/players: removed the two hero-section CTA buttons. The header nav links and entry panels below already provide the same navigation.

## New E2E test cases

- **TC-345** — TV number duplicate rejected in qualification round (covers #668)
- **TC-346** — Loser bracket placeholder routing + per-slot TBD invariant (covers #669)

## Test plan

- [ ] Navigate to BM finals bracket mid-tournament (some QF done, some pending) — partially filled losers_r1 slots show the real player for the filled side and "TBD" for the pending side
- [ ] Try assigning the same TV number to two matches in the same round — second PATCH returns 400
- [ ] Run E2E suite (`npm run e2e:all`) — TC-339/TC-340 cleanup no longer leaks tournaments; TC-345/TC-346 pass
- [ ] Home page hero section shows only the tagline with no buttons; entry panels below still navigate correctly

https://claude.ai/code/session_01E8RN9Tu8eWa2zdqVUC7U4J
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8RN9Tu8eWa2zdqVUC7U4J)_