### PR TITLE
fix: E2E test failures and GP champion banner SD winner (#678)

### DIFF
--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -1152,7 +1152,8 @@ async function uiPhaseStartRound(page, tournamentId, phase) {
     await page.waitForTimeout(300);
   }
   const startBtn = page.getByRole('button', { name: /^(Start Round \d+|ラウンド\s*\d+\s*開始)$/ }).first();
-  await startBtn.waitFor({ state: 'visible', timeout: 15000 });
+  /* 25s to absorb D1 cold-start + fetchWithRetry delays (issue #678) */
+  await startBtn.waitFor({ state: 'visible', timeout: 25000 });
 
   const responsePromise = page.waitForResponse((res) =>
     res.url().includes(`/api/tournaments/${tournamentId}/ta/phases`) &&

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -1269,10 +1269,11 @@ async function main() {
        * the session-driven `isAdmin` flag flips true. Wait until the table
        * row + admin TV select are mounted (15 s for D1 cold start), then
        * assert. */
+      /* 25s to absorb D1 cold-start + fetchWithRetry delays (issue #678) */
       await page.waitForFunction(
         () => document.querySelectorAll('select.w-14').length > 0,
         null,
-        { timeout: 15000 },
+        { timeout: 25000 },
       ).catch(() => {});
       const tvSelect = page.locator('select.w-14').first();
       const hasSelect = await tvSelect.count() > 0;
@@ -3025,6 +3026,120 @@ async function main() {
       }
     } else {
       log('TC-349', 'SKIP', 'No tournament ID available');
+    }
+  }
+
+  // TC-350: BM finals bracket UI — TBD slots render correctly before/after QF completion
+  // Issue #673: TC-346 only verified the API invariant (player1Id/player2Id diverge after
+  // routing); this test verifies the UI actually renders the real player nickname and
+  // the "TBD" placeholder text for unfilled loser-bracket slots.
+  {
+    let tc350TournamentId = null;
+    let tc350Players = [];
+    try {
+      const ts350 = Date.now();
+      const nicknames350 = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'].map((l) => `e2e_lb350_${l}_${ts350}`);
+      for (const nick of nicknames350) {
+        const p = await uiCreatePlayer(page, `E2E LB350 ${nick}`, nick);
+        tc350Players.push({ id: p.id, nickname: nick });
+      }
+      tc350TournamentId = await uiCreateTournament(page, `E2E TC-350 LB UI ${ts350}`);
+      await uiActivateTournament(page, tc350TournamentId);
+
+      /* Enroll all 8 in BM qualification and give them distinct scores */
+      await page.evaluate(async ([tid, pids]) => {
+        await fetch(`/api/tournaments/${tid}/bm`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ players: [
+            { playerId: pids[0], group: 'A' }, { playerId: pids[1], group: 'A' },
+            { playerId: pids[2], group: 'A' }, { playerId: pids[3], group: 'A' },
+            { playerId: pids[4], group: 'B' }, { playerId: pids[5], group: 'B' },
+            { playerId: pids[6], group: 'B' }, { playerId: pids[7], group: 'B' },
+          ] }),
+        });
+      }, [tc350TournamentId, tc350Players.map((p) => p.id)]);
+
+      /* Score and finish all qual matches */
+      const qualMatches350 = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/bm`);
+        const j = await r.json().catch(() => ({}));
+        return j.data?.matches ?? j.matches ?? [];
+      }, tc350TournamentId);
+      for (const m of qualMatches350) {
+        if (!m.completed && m.player1Id && m.player2Id && m.player1Id !== m.player2Id) {
+          await page.evaluate(async ([tid, mid]) => {
+            await fetch(`/api/tournaments/${tid}/bm`, {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ matchId: mid, score1: 4, score2: 1 }),
+            });
+          }, [tc350TournamentId, m.id]);
+        }
+      }
+
+      /* Confirm and generate finals */
+      await page.evaluate(async (tid) => {
+        await fetch(`/api/tournaments/${tid}`, {
+          method: 'PUT', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ qualificationConfirmed: true }),
+        });
+        await fetch(`/api/tournaments/${tid}/bm/finals`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        });
+      }, tc350TournamentId);
+
+      /* Open bracket page and wait for it to render */
+      await nav(page, `/tournaments/${tc350TournamentId}/bm/finals`);
+      /* 25s to absorb D1 cold-start + fetchWithRetry delays */
+      await page.waitForFunction(
+        () => document.querySelector('[data-testid="bracket-match-card"]') !== null,
+        null,
+        { timeout: 25000 },
+      ).catch(() => {});
+
+      const pageText350 = await page.locator('body').innerText();
+      /* Before any QF is played, losers bracket slots should show TBD (either literal
+       * "TBD" or the Japanese equivalent "未定"). */
+      const hasTbd = pageText350.includes('TBD') || pageText350.includes('未定');
+
+      /* Complete one QF match via API so its loser is routed */
+      const finalsMatches350 = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/bm/finals`);
+        const j = await r.json().catch(() => ({}));
+        return j.data?.matches ?? j.matches ?? [];
+      }, tc350TournamentId);
+      const firstQf350 = finalsMatches350.find((m) => m.round === 'winners_qf' && m.player1Id && m.player2Id);
+      let routed350 = false;
+      if (firstQf350) {
+        await page.evaluate(async ([tid, mid]) => {
+          await fetch(`/api/tournaments/${tid}/bm/finals`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ matchId: mid, score1: 5, score2: 0 }),
+          });
+        }, [tc350TournamentId, firstQf350.id]);
+
+        /* Re-fetch bracket page and wait for update */
+        await nav(page, `/tournaments/${tc350TournamentId}/bm/finals`);
+        await page.waitForTimeout(8000);
+        const pageAfter350 = await page.locator('body').innerText();
+        /* After routing, at least one loser bracket match should show a real player nickname */
+        routed350 = tc350Players.some((p) => pageAfter350.includes(p.nickname));
+      }
+
+      log('TC-350',
+        hasTbd && routed350 ? 'PASS' : 'FAIL',
+        !hasTbd ? 'Bracket page did not show TBD for empty loser slots'
+        : !routed350 ? 'Routed player nickname not visible in bracket UI after QF completion'
+        : '');
+    } catch (err) {
+      log('TC-350', 'FAIL', err instanceof Error ? err.message : 'BM bracket TBD UI test failed');
+    } finally {
+      if (tc350TournamentId) await deleteTournament(page, tc350TournamentId);
+      for (const p of tc350Players) await deletePlayer(page, p.id);
     }
   }
 

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -676,8 +676,9 @@ async function runTc516(adminPage) {
     /* The qualification page renders "View Tournament" as a <Link> inside
      * <Button asChild>, so the DOM element is an <a> tag (role=link).
      * Use getByText so we match regardless of the underlying element. */
+    /* 25s to absorb D1 cold-start + fetchWithRetry delays (issue #678) */
     await adminPage.getByText(/View Tournament|トーナメントを見る/).first()
-      .waitFor({ state: 'visible', timeout: 15000 });
+      .waitFor({ state: 'visible', timeout: 25000 });
 
     const qualText = await adminPage.locator('body').innerText();
     const hasViewTournament = qualText.includes('View Tournament') || qualText.includes('トーナメントを見る');
@@ -1335,7 +1336,8 @@ async function runTc521(adminPage) {
 
     // Click the score entry button for the first non-BYE match
     const scoreBtn = adminPage.getByRole('button', { name: /スコア入力|Enter Score/i }).first();
-    await scoreBtn.waitFor({ state: 'visible', timeout: 10000 });
+    /* 25s to absorb D1 cold-start + fetchWithRetry delays (issue #678) */
+    await scoreBtn.waitFor({ state: 'visible', timeout: 25000 });
     await scoreBtn.click();
     await adminPage.waitForTimeout(1500);
 
@@ -1489,6 +1491,54 @@ async function runTc523(adminPage) {
   }
 }
 
+/* ───────── TC-524: BM bracket startingCourseNumber randomisation (issue #671) ─────────
+ * After bracket creation each match should carry a startingCourseNumber in [1,4].
+ * All matches within the same round must share the same value (issue #671 requirement).
+ * Different rounds are allowed to differ — the per-round random assignment means
+ * uniqueness is not guaranteed across rounds. */
+async function runTc524(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedBmFinalsSetup(adminPage);
+    const gen = await apiGenerateBmFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    const matches = await apiFetchBmFinalsMatches(adminPage, setup.tournamentId);
+    const finalsMatches = matches.filter((m) => m.stage === 'finals' || !m.stage);
+    if (finalsMatches.length === 0) throw new Error('No finals matches returned');
+
+    /* All matches must have a valid startingCourseNumber */
+    const allHaveValidCourse = finalsMatches.every(
+      (m) => Number.isInteger(m.startingCourseNumber) && m.startingCourseNumber >= 1 && m.startingCourseNumber <= 4,
+    );
+
+    /* All matches in the same round must share the same startingCourseNumber */
+    const byRound = new Map();
+    for (const m of finalsMatches) {
+      if (!m.round) continue;
+      if (!byRound.has(m.round)) byRound.set(m.round, new Set());
+      byRound.get(m.round).add(m.startingCourseNumber);
+    }
+    const roundsUniform = [...byRound.values()].every((vals) => vals.size === 1);
+
+    const pass = allHaveValidCourse && roundsUniform;
+    log('TC-524', pass ? 'PASS' : 'FAIL',
+      !allHaveValidCourse
+        ? `Some matches have invalid startingCourseNumber: ${JSON.stringify(finalsMatches.map((m) => ({ mn: m.matchNumber, sn: m.startingCourseNumber })))}`
+        : !roundsUniform
+        ? `Matches in the same round have different startingCourseNumbers: ${JSON.stringify([...byRound.entries()].map(([r, s]) => ({ round: r, values: [...s] })))}`
+        : '');
+  } catch (err) {
+    log('TC-524', 'FAIL', err instanceof Error ? err.message : 'TC-524 failed');
+  } finally {
+    if (setup) {
+      await adminPage.evaluate(async (url) => {
+        await fetch(url, { method: 'DELETE' }).catch(() => {});
+      }, `/api/tournaments/${setup?.tournamentId}/bm/finals`);
+    }
+  }
+}
+
 /**
  * Builds the BM suite spec for composition by tc-all. When `sharedFixture` is
  * provided (tc-all flow), we reuse it and skip cleanup — the orchestrator owns
@@ -1533,6 +1583,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-521', fn: runTc521 },
       { name: 'TC-522', fn: runTc522 },
       { name: 'TC-523', fn: runTc523 },
+      { name: 'TC-524', fn: runTc524 },
       { name: 'TC-505', fn: runTc505 },
       { name: 'TC-506', fn: runTc506 },
     ],

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -1109,19 +1109,28 @@ async function runTc719(adminPage) {
     const sdRes = await apiSetGpFinalsScore(adminPage, tournamentId, qfMatch.id, 5, 5, qfMatch.player1Id);
     const sdAccepted = sdRes.s === 200;
 
-    /* Winner must be recorded as the sudden-death winner. */
+    /* Winner must be recorded as the sudden-death winner.
+     * GPMatch schema has no dedicated winnerId column; routing is verified
+     * by checking that the SD winner appears in the next bracket match. */
     const after = await apiFetchGpFinalsMatches(adminPage, tournamentId);
     const qfAfter = after.find((m) => m.id === qfMatch.id);
-    const winnerRouted = qfAfter?.completed === true &&
-      qfAfter?.suddenDeathWinnerId === qfMatch.player1Id &&
-      qfAfter?.winnerId === qfMatch.player1Id;
+    const sdPersisted = qfAfter?.completed === true &&
+      qfAfter?.suddenDeathWinnerId === qfMatch.player1Id;
+
+    /* Verify bracket advancement: winners_qf winner must appear in a winners_sf slot. */
+    const nextMatch = after.find(
+      (m) => m.round === 'winners_sf' &&
+        (m.player1Id === qfMatch.player1Id || m.player2Id === qfMatch.player1Id),
+    );
+    const winnerRouted = sdPersisted && !!nextMatch;
 
     const ok = noSdRejected && badSdRejected && sdAccepted && winnerRouted;
     log('TC-719', ok ? 'PASS' : 'FAIL',
       !noSdRejected ? `Tied score without suddenDeathWinnerId not rejected (${noSd.s})`
       : !badSdRejected ? `Tied score with invalid suddenDeathWinnerId not rejected (${badSd.s})`
       : !sdAccepted ? `Tied score with valid suddenDeathWinnerId not accepted (${sdRes.s})`
-      : !winnerRouted ? `Match not completed with correct winner (completed=${qfAfter?.completed}, sdWinner=${qfAfter?.suddenDeathWinnerId})`
+      : !sdPersisted ? `SD not persisted (completed=${qfAfter?.completed}, sdWinner=${qfAfter?.suddenDeathWinnerId})`
+      : !winnerRouted ? `SD winner not routed to winners_sf`
       : '');
   } catch (err) {
     log('TC-719', 'FAIL', err instanceof Error ? err.message : 'GP 719 failed');

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -385,7 +385,8 @@ async function runTc604(adminPage) {
       }
     }
 
-    await adminPage.getByRole('button', { name: /Save|保存/ }).click();
+    /* Use anchored pattern to avoid matching the "TV# 保存" button added in #671 */
+    await adminPage.getByRole('button', { name: /^(Save|結果保存)$/ }).click();
     await adminPage.waitForTimeout(3000);
 
     // Poll for bracket update

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -188,7 +188,8 @@ async function runTc802(adminPage) {
      * in document order. When no partner is set the partner card is absent
      * and both `.first()` and `.last()` refer to the single self widgets. */
     const submitBtn = ctx.page.getByRole('button', { name: /タイム送信|Submit Times/ }).last();
-    await submitBtn.waitFor({ timeout: 15000 });
+    /* 25s to absorb D1 cold-start + fetchWithRetry delays (issue #678) */
+    await submitBtn.waitFor({ timeout: 25000 });
 
     const allTimeInputs = ctx.page.locator('input[placeholder="M:SS.mm"]');
     const inputCount = await allTimeInputs.count();

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -161,6 +161,10 @@ function getMatchWinner(match: GPMatch): Player | null {
   const score2 = getGpScore(match, 2);
   if (score1 > score2) return match.player1;
   if (score2 > score1) return match.player2;
+  /* Tied scores resolved by sudden-death: winner is whichever player's id matches */
+  if (match.suddenDeathWinnerId) {
+    return match.player1?.id === match.suddenDeathWinnerId ? match.player1 : match.player2;
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary

Issue #678 で報告された E2E 失敗の修正と E2E テストカバレッジ追加。

### App 修正
- **[TC-712]** `gp/finals/page.tsx` — `getMatchWinner` が suddenDeathWinnerId を考慮していなかったため、タイ決着の GP グランドファイナルでチャンピオンバナーにニックネームが表示されなかったのを修正

### E2E テスト修正
- **[TC-604]** `tc-mr.js:388` — `/Save|保存/` セレクタが「TV# 保存」にも一致して strict-mode violation → `/^(Save|結果保存)$/` に絞る (#671 UI 追加の影響)
- **[TC-719]** `tc-gp.js` — GPMatch スキーマに `winnerId` カラムが存在しないため、`winnerId` チェックを削除し `suddenDeathWinnerId` の保存と `winners_sf` へのルーティング確認に変更
- **[TC-516/518/521/809/810]** D1 コールドスタート + fetchWithRetry による遅延を吸収するため waitFor タイムアウトを 10〜15s → 25s に統一

### E2E カバレッジ追加
- **TC-524** (tc-bm.js): BM ブラケット作成時に全マッチへ `startingCourseNumber` (1–4) が割り当てられ、同ラウンドの全マッチが同じ値を持つことを検証 (#671 修正の回帰テスト)
- **TC-350** (tc-all.js): BM 決勝ブラケット UI が未確定スロットに「TBD」を表示し、QF 完了後にルーティングされたプレイヤーのニックネームが表示されることを検証 (#673 で指摘された UI カバレッジ不足の解消)

### クローズ
- #666, #671, #672 — PR #675 で修正済みのためクローズ

## Test plan

- [ ] TC-604 (MR finals save button selector) passes without strict-mode violation
- [ ] TC-712 (GP grand final SD champion banner) passes with correct nickname
- [ ] TC-719 (GP non-GF SD winner routing) passes without `winnerId` assertion failure
- [ ] TC-516/518/521/809/810 pass without timeout failures on production
- [ ] TC-524 NEW: BM bracket `startingCourseNumber` per-round uniformity verified
- [ ] TC-350 NEW: BM finals bracket UI TBD slot rendering verified

https://claude.ai/code/session_014hgpg6uyjQu3VMAMzjbco3

---
_Generated by [Claude Code](https://claude.ai/code/session_014hgpg6uyjQu3VMAMzjbco3)_