### PR TITLE
feat: NoCamera player warning when TV# assigned to finals match (#674)

### DIFF
--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -19,6 +19,7 @@
  *   TC-523  BM finals score dialog — TV# autosaves on select (no explicit save button)
  *   TC-524  BM bracket startingCourseNumber randomisation per round (#671)
  *   TC-525  BM finals score dialog — startingCourseNumber autosaves on select
+ *   TC-526  NoCamera player warning toast when TV# assigned to their match (#674)
  *
  * Setup:
  *   - Uses Playwright persistent profile at /tmp/playwright-smkc-profile.
@@ -1612,6 +1613,120 @@ async function runTc525(adminPage) {
   }
 }
 
+/* ───────── TC-526: NoCamera player warning when TV# assigned (issue #674) ─────────
+ * When an admin assigns a TV number to a BM finals match that contains a
+ * NoCamera player, the API must still succeed (the restriction is advisory)
+ * AND the match data returned by GET must expose `player1.noCamera` so the
+ * frontend can surface a toast warning.
+ *
+ * Flow:
+ *   1. Generate an 8-player BM finals bracket.
+ *   2. Fetch M1 and identify player1.
+ *   3. Update player1 to noCamera=true via PUT /api/players/:id.
+ *   4. Re-fetch M1 and verify player1.noCamera === true in the response.
+ *   5. PATCH M1 with tvNumber=1 — must return 200 (noCamera is advisory only).
+ *   6. Navigate to BM finals page and open the score dialog for M1.
+ *   7. Select TV# 1 in the dialog and confirm a warning toast appears.
+ *   8. Restore player1 noCamera=false, clean up bracket.
+ */
+async function runTc526(adminPage) {
+  let setup = null;
+  let p1Id = null;
+  let p1Name = null;
+  let p1Nickname = null;
+  try {
+    setup = await prepareSharedBmFinalsSetup(adminPage);
+    const gen = await apiGenerateBmFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    const matches = await apiFetchBmFinalsMatches(adminPage, setup.tournamentId);
+    const m1 = matches.find((m) => m.matchNumber === 1 && m.player1Id && m.player2Id);
+    if (!m1) throw new Error('M1 not ready');
+    p1Id = m1.player1Id;
+
+    /* Fetch current player data so the PUT can include required name/nickname. */
+    const playerRes = await adminPage.evaluate(async (url) => {
+      const r = await fetch(url);
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, `/api/players/${p1Id}`);
+    const playerData = playerRes.b?.data ?? playerRes.b;
+    p1Name = playerData?.name ?? 'unknown';
+    p1Nickname = playerData?.nickname ?? 'unknown';
+
+    /* Set noCamera=true on player1. */
+    const setNoCamera = await adminPage.evaluate(async ([url, body]) => {
+      const r = await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status };
+    }, [`/api/players/${p1Id}`, { name: p1Name, nickname: p1Nickname, noCamera: true }]);
+    if (setNoCamera.s !== 200) throw new Error(`Failed to set noCamera on player (${setNoCamera.s})`);
+
+    /* Confirm GET response exposes noCamera for the match. */
+    const after = await apiFetchBmFinalsMatches(adminPage, setup.tournamentId);
+    const m1After = after.find((m) => m.matchNumber === 1);
+    const noCameraVisible = m1After?.player1?.noCamera === true;
+
+    /* PATCH TV#1 — must succeed even with a noCamera player (advisory only). */
+    const patchRes = await adminPage.evaluate(async ([url, body]) => {
+      const r = await fetch(url, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status };
+    }, [`/api/tournaments/${setup.tournamentId}/bm/finals`, { matchId: m1.id, tvNumber: 1 }]);
+    const tvPatchOk = patchRes.s === 200;
+
+    /* UI: navigate to finals page, open score dialog for M1, change TV# to 2,
+     * then verify a warning toast appears (data-type="warning"). */
+    await nav(adminPage, `/tournaments/${setup.tournamentId}/bm/finals`);
+    await adminPage.waitForTimeout(3000);
+
+    const matchCards = adminPage.locator('[data-testid="bracket-match-card"]');
+    if (await matchCards.count() === 0) throw new Error('No bracket match cards found');
+    await matchCards.first().click();
+    await adminPage.waitForTimeout(800);
+
+    const dialogVisible = await adminPage.locator('[role="dialog"]').isVisible();
+    /* Change the TV# inside the dialog — triggers handleBracketTvNumberChange. */
+    await adminPage.locator('#bm-finals-tv').selectOption('2');
+    await adminPage.waitForTimeout(2000);
+
+    /* Sonner renders warnings as <li data-type="warning"> inside the toaster. */
+    const warningToast = adminPage.locator('[data-sonner-toast][data-type="warning"]');
+    const warningShown = await warningToast.count() > 0;
+
+    const pass = noCameraVisible && tvPatchOk && dialogVisible && warningShown;
+    log('TC-526', pass ? 'PASS' : 'FAIL',
+      !noCameraVisible ? `player1.noCamera not visible in GET response (got ${m1After?.player1?.noCamera})`
+      : !tvPatchOk ? `TV# PATCH failed for noCamera match (${patchRes.s})`
+      : !dialogVisible ? 'Score dialog did not open'
+      : !warningShown ? 'No warning toast shown for noCamera player TV# assignment'
+      : '');
+  } catch (err) {
+    log('TC-526', 'FAIL', err instanceof Error ? err.message : 'TC-526 failed');
+  } finally {
+    /* Restore player noCamera flag before bracket cleanup. */
+    if (p1Id && p1Name && p1Nickname) {
+      await adminPage.evaluate(async ([url, body]) => {
+        await fetch(url, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }).catch(() => {});
+      }, [`/api/players/${p1Id}`, { name: p1Name, nickname: p1Nickname, noCamera: false }]);
+    }
+    if (setup) {
+      await adminPage.evaluate(async (url) => {
+        await fetch(url, { method: 'DELETE' }).catch(() => {});
+      }, `/api/tournaments/${setup.tournamentId}/bm/finals`);
+    }
+  }
+}
+
 /**
  * Builds the BM suite spec for composition by tc-all. When `sharedFixture` is
  * provided (tc-all flow), we reuse it and skip cleanup — the orchestrator owns
@@ -1658,6 +1773,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-523', fn: runTc523 },
       { name: 'TC-524', fn: runTc524 },
       { name: 'TC-525', fn: runTc525 },
+      { name: 'TC-526', fn: runTc526 },
       { name: 'TC-505', fn: runTc505 },
       { name: 'TC-506', fn: runTc506 },
     ],
@@ -1666,7 +1782,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 
 module.exports = {
   runTc501, runTc502, runTc322, runTc503, runTc504, runTc505, runTc506, runTc511, runTc512, runTc513,
-  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522, runTc523, runTc524, runTc525,
+  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522, runTc523, runTc524, runTc525, runTc526,
   getSuite,
   results,
   setSharedBmFinalsReady: (v) => { sharedBmFinalsReady = v; },

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -500,6 +500,7 @@
     "tvAssigned": "TV{n} assigned to M{matchNumber}",
     "tvCleared": "TV cleared from M{matchNumber}",
     "failedAssignTv": "Failed to assign TV",
+    "noCameraWarning": "No Camera player in this match — check broadcast setup",
     "saveTvNumber": "Save TV#",
     "courseAssigned": "Start course set to BC{n} for M{matchNumber}",
     "courseCleared": "Start course cleared for M{matchNumber}",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -500,6 +500,7 @@
     "tvAssigned": "M{matchNumber} に TV{n} を割り当てました",
     "tvCleared": "M{matchNumber} の TV 割り当てを解除しました",
     "failedAssignTv": "TV の割り当てに失敗しました",
+    "noCameraWarning": "このマッチにカメラなしのプレイヤーがいます — 配信設定を確認してください",
     "saveTvNumber": "TV# 保存",
     "courseAssigned": "M{matchNumber} の開始コースをBC{n}に設定しました",
     "courseCleared": "M{matchNumber} の開始コースをクリアしました",

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -415,6 +415,11 @@ export default function BattleModeFinals({
         toast.success(tFinals('tvCleared', { matchNumber: match.matchNumber }));
       } else {
         toast.success(tFinals('tvAssigned', { n: tvNumber, matchNumber: match.matchNumber }));
+        /* Warn when assigning a TV slot to a match containing a NoCamera player
+         * so the admin can reconsider the broadcast layout (issue #674). */
+        if (match.player1?.noCamera || match.player2?.noCamera) {
+          toast.warning(tFinals('noCameraWarning'));
+        }
       }
       refetch();
     } catch (err) {

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -208,8 +208,8 @@ export default function BattleModeFinals({
    * `onChange`, so an admin scrubbing through a dropdown can race multiple
    * PATCH responses; whichever resolves last wins on the server. We abort the
    * pending request when a new selection arrives so the latest pick is the
-   * authoritative write. Keyed by match-id+field to avoid cross-talk between
-   * dialogs reopened on different matches. */
+   * authoritative write. Only one score dialog is open at a time, so a single
+   * ref per field is sufficient — no per-match keying is needed. */
   const tvAbortRef = useRef<AbortController | null>(null);
   const courseAbortRef = useRef<AbortController | null>(null);
 

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -418,7 +418,7 @@ export default function GrandPrixFinals({
    * don't have to enter the score dialog just to assign a broadcast slot.
    */
   const handleBracketTvNumberChange = async (
-    match: { id: string; matchNumber: number },
+    match: { id: string; matchNumber: number; player1?: { noCamera?: boolean } | null; player2?: { noCamera?: boolean } | null },
     tvNumber: number | null,
   ) => {
     try {
@@ -436,6 +436,10 @@ export default function GrandPrixFinals({
         toast.success(tFinals('tvCleared', { matchNumber: match.matchNumber }));
       } else {
         toast.success(tFinals('tvAssigned', { n: tvNumber, matchNumber: match.matchNumber }));
+        /* Warn when assigning a TV slot to a match containing a NoCamera player (issue #674). */
+        if (match.player1?.noCamera || match.player2?.noCamera) {
+          toast.warning(tFinals('noCameraWarning'));
+        }
       }
       refetch();
     } catch (err) {

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -428,6 +428,10 @@ export default function MatchRaceFinals({
         toast.success(tFinals('tvCleared', { matchNumber: match.matchNumber }));
       } else {
         toast.success(tFinals('tvAssigned', { n: tvNumber, matchNumber: match.matchNumber }));
+        /* Warn when assigning a TV slot to a match containing a NoCamera player (issue #674). */
+        if (match.player1?.noCamera || match.player2?.noCamera) {
+          toast.warning(tFinals('noCameraWarning'));
+        }
       }
       refetch();
     } catch (err) {

--- a/smkc-score-app/src/components/overlay/dashboard-timeline.tsx
+++ b/smkc-score-app/src/components/overlay/dashboard-timeline.tsx
@@ -168,7 +168,7 @@ function MatchScoreboardCard({
           cup name as a single chip. Source-of-truth is the aggregator — we
           render whichever field is populated and skip the row entirely when
           neither is, so legacy rows without context don't get a stray gap. */}
-      {(r.courses?.length || r.cup) && (
+      {((r.courses && r.courses.length > 0) || r.cup) && (
         <div
           className="mt-2 flex flex-wrap items-center gap-1.5"
           data-testid="dashboard-timeline-context"

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -618,11 +618,14 @@ export function createQualificationHandlers(config: EventTypeConfig) {
         return createErrorResponse('Match not found', 404, 'NOT_FOUND');
       }
 
-      /* Uniqueness guard: prevent the same TV number in the same round (issue #668). */
+      /* Uniqueness guard: prevent the same TV number in the same round (issue #668).
+       * Scope to `stage` so a finals match in a same-named round cannot create
+       * a false conflict with a qualification match (issue #673). */
       if (tvNumber !== null && tvNumber !== undefined) {
         const tvConflict = await matchModel(prisma).findFirst({
           where: {
             tournamentId,
+            stage: existingMatch.stage,
             round: existingMatch.round,
             tvNumber,
             id: { not: matchId },

--- a/smkc-score-app/src/lib/overlay/events.ts
+++ b/smkc-score-app/src/lib/overlay/events.ts
@@ -142,7 +142,6 @@ export function buildOverlayEvents(input: BuildOverlayEventsInput): OverlayEvent
   for (const e of ttEntries) {
     if (e.updatedAt.getTime() <= sinceMs) continue;
     const stageLabel = TA_STAGE_LABEL[e.stage] ?? "";
-    const rankSuffix = e.rank ? `（現在 ${e.rank} 位）` : "";
     const prefix = stageLabel ? `[${stageLabel}] ` : "";
     const playerName = nick(e.player);
 
@@ -180,6 +179,7 @@ export function buildOverlayEvents(input: BuildOverlayEventsInput): OverlayEvent
       // Phase rounds (phase1/2/3) are single-course; per-course notification
       // remains the right granularity. Skip until lastRecorded* is populated.
       if (!e.lastRecordedCourse || !e.lastRecordedTime) continue;
+      const rankSuffix = e.rank ? `（現在 ${e.rank} 位）` : "";
       title = `${prefix}${playerName} が ${e.lastRecordedCourse} で ${e.lastRecordedTime} を記録しました${rankSuffix}`;
       taTimeRecord = {
         player: playerName,

--- a/smkc-score-app/src/lib/types.ts
+++ b/smkc-score-app/src/lib/types.ts
@@ -7,4 +7,6 @@ export interface Player {
   id: string;
   name: string;
   nickname: string;
+  /** True when the player has no streaming camera; used to warn admins before TV# assignment. */
+  noCamera?: boolean;
 }


### PR DESCRIPTION
## Summary

複数のオープンIssueに対応した修正・機能実装をまとめたPR。

### Issue #674: NoCameraプレイヤーへのTV# 割り当て警告（メイン機能）
- BM / MR / GP の finals ページの `handleBracketTvNumberChange` に警告トーストを追加
- 共有 `Player` 型に `noCamera?: boolean` を追加（APIレスポンスには既存フィールド）
- EN/JA の `finals.noCameraWarning` i18nキーを追加
- TC-526 E2Eテスト追加

### Issue #681: コメントの齟齬修正
- `tvAbortRef` / `courseAbortRef` のコメント「Keyed by match-id+field」が実装と不一致だったため修正（実際は単純なコンポーネントレベルref）

### Issue #683: dashboard-timeline 条件式の明示化
- `r.courses?.length || r.cup` → `(r.courses && r.courses.length > 0) || r.cup` に変更（空配列混入リスクを明示的に排除）

### Issue #685: overlay events.ts の rankSuffix スコープ修正
- `rankSuffix` を定義場所（ループ先頭）から実際に使用する `else` ブランチ内に移動

### Issue #673: qualification-route.ts の TV# 重複チェックに stage フィルター追加
- BM は qualification と finals で同一テーブルを共有するため、stage フィルターなしでは理論上クロスステージの誤衝突が起きうる

## 変更ファイル

| ファイル | 変更 |
|---------|------|
| `src/lib/types.ts` | `Player.noCamera?: boolean` 追加 |
| `messages/en.json` / `ja.json` | `finals.noCameraWarning` 追加 |
| `src/app/tournaments/[id]/bm/finals/page.tsx` | noCamera 警告 + コメント修正 (#681) |
| `src/app/tournaments/[id]/mr/finals/page.tsx` | noCamera 警告 |
| `src/app/tournaments/[id]/gp/finals/page.tsx` | noCamera 警告（型拡張含む） |
| `src/lib/overlay/events.ts` | rankSuffix スコープ修正 (#685) |
| `src/components/overlay/dashboard-timeline.tsx` | 条件式明示化 (#683) |
| `src/lib/api-factories/qualification-route.ts` | stage フィルター追加 (#673) |
| `e2e/tc-bm.js` | TC-526 追加 |

## 設計判断

- noCamera 警告は **advisory のみ** — TV# 割り当てをブロックしない
- 資格画面の `handleTvAssign`（matchId のみ受け取る汎用 hook）は対象外
- **Issue #676** (BM開始コースランダム化) は既存コード (`createBmRoundStartingCourses` + autosave PATCH, TC-524) でカバー済み

## Test plan

- [ ] TC-526 が `node e2e/tc-bm.js` でパスする
- [ ] noCamera プレイヤーがいる試合に TV# 割り当て → 警告トーストが表示される
- [ ] 通常プレイヤーの試合では警告が出ない
- [ ] CI passes

https://claude.ai/code/session_01VqWM3nBVHzNS8XSF615thN