### PR TITLE
fix(#696): 予選確定をモード別（BM/MR/GP）に独立化

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -624,6 +624,17 @@
 - **期待結果**: 片スロットが実名、もう片方が TBD
 - **スクリプト**: tc-all.js TC-350
 
+## TC-351: モード別予選確定 — BM 確定が MR/GP スコアをロックしないこと (issue #696)
+- **authRequired**: true (admin)
+- **背景**: issue #696「一つのモードで予選を確定させると他のモードの予選も確定されてしまう」のリグレッションテスト。BM/MR/GP はそれぞれ独立した `bmQualificationConfirmed`/`mrQualificationConfirmed`/`gpQualificationConfirmed` フラグを持つ。
+- **手順**:
+  1. 新規トーナメントを作成し BM・MR 予選をセットアップ
+  2. `PUT /api/tournaments/{id}` に `{ bmQualificationConfirmed: true }` を送信
+  3. BM GET レスポンスの `qualificationConfirmed` が `true` であることを確認
+  4. MR マッチにスコアを PUT → 200 が返ること（MR はロックされていない）
+- **期待結果**: BM のみロック、MR は編集可能
+- **スクリプト**: tc-all.js TC-351
+
 ## TC-401: 全モードトーナメント — TA/BM/MR/GP の予選データが正しく存在する
 - **authRequired**: true (admin)
 - **背景**: `setupAllModes28PlayerQualification` で28名 × 4モードの予選を完了させた後、各モード API が有効なデータを返すことを確認する統合テスト。

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/route.test.ts
@@ -78,7 +78,7 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', qualificationConfirmed: false }));
+    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', bmQualificationConfirmed: false }));
     (auth as jest.Mock).mockResolvedValue({ user: { id: 'admin1', role: 'admin' } });
     (createLogger as jest.Mock).mockReturnValue(loggerMock);
     configureNextResponseMock(jest.requireMock('next/server').NextResponse);

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
@@ -72,7 +72,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', qualificationConfirmed: false }));
+    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', bmQualificationConfirmed: false }));
     (auth as jest.Mock).mockResolvedValue({ user: { id: 'admin1', role: 'admin' } });
     (createLogger as jest.Mock).mockReturnValue(loggerMock);
     configureNextResponseMock(jest.requireMock('next/server').NextResponse);

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -83,7 +83,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', qualificationConfirmed: false }));
+    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', gpQualificationConfirmed: false }));
     (auth as jest.Mock).mockResolvedValue({ user: { id: 'admin1', role: 'admin' } });
     configureNextResponseMock(jest.requireMock('next/server').NextResponse);
     (createLogger as jest.Mock).mockReturnValue(logger);

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/route.test.ts
@@ -62,7 +62,7 @@ describe('GP API Route - /api/tournaments/[id]/gp', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', qualificationConfirmed: false }));
+    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', gpQualificationConfirmed: false }));
     (auth as jest.Mock).mockResolvedValue({ user: { id: 'admin1', role: 'admin' } });
     /* Reset all prisma model mocks to ensure no queued mockResolvedValueOnce values leak between tests */
     (prisma.gPQualification.findMany as jest.Mock).mockReset();

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
@@ -74,7 +74,7 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', qualificationConfirmed: false }));
+    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', mrQualificationConfirmed: false }));
     (auth as jest.Mock).mockResolvedValue({ user: { id: 'admin1', role: 'admin' } });
     (createLogger as jest.Mock).mockReturnValue(loggerMock);
     configureNextResponseMock(jest.requireMock('next/server').NextResponse);

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
@@ -67,7 +67,7 @@ describe('MR API Route - /api/tournaments/[id]/mr', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', qualificationConfirmed: false }));
+    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', mrQualificationConfirmed: false }));
     (auth as jest.Mock).mockResolvedValue({ user: { id: 'admin1', role: 'admin' } });
     (createLogger as jest.Mock).mockReturnValue(loggerMock);
     configureNextResponseMock(jest.requireMock('next/server').NextResponse);

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -59,6 +59,7 @@ describe('Finals Route Factory', () => {
   let mockLogger: ReturnType<typeof createLogger>;
 
   const createMockConfig = (overrides = {}) => ({
+    eventTypeCode: 'bm' as const,
     matchModel: 'bMMatch',
     qualificationModel: 'bMQualification',
     loggerName: 'bm-finals',
@@ -103,7 +104,7 @@ describe('Finals Route Factory', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', qualificationConfirmed: false }));
+    (prisma.tournament.findFirst as jest.Mock).mockImplementation((args: any) => Promise.resolve({ id: args?.where?.OR?.[0]?.id ?? 't1', bmQualificationConfirmed: false, mrQualificationConfirmed: false, gpQualificationConfirmed: false }));
 
     // Setup mocks
     mockAuth = auth as jest.MockedFunction<typeof auth>;
@@ -658,7 +659,7 @@ describe('Finals Route Factory', () => {
       (prisma.tournament as any).findUnique.mockResolvedValue({
         id: 'tournament-123',
         name: 'Test Tournament',
-        qualificationConfirmed: true,
+        bmQualificationConfirmed: true,
       });
       (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(8));
       (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -113,10 +113,12 @@ describe('Qualification Route Factory', () => {
 
     // Default tournament for resolveTournament(); individual tests override
     // this when they need a specific qualificationConfirmed flag or to
-    // simulate a missing tournament.
+    // simulate a missing tournament. Uses per-mode flags (issue #696).
     (prisma.tournament.findFirst as jest.Mock).mockResolvedValue({
       id: 'tournament-123',
-      qualificationConfirmed: false,
+      bmQualificationConfirmed: false,
+      mrQualificationConfirmed: false,
+      gpQualificationConfirmed: false,
     });
   });
 

--- a/smkc-score-app/__tests__/lib/qualification-confirmed-check.test.ts
+++ b/smkc-score-app/__tests__/lib/qualification-confirmed-check.test.ts
@@ -2,9 +2,10 @@
  * Tests for checkQualificationConfirmed.
  *
  * Covers:
- * - Returns null when qualification is not confirmed (edits allowed)
- * - Returns 403 NextResponse when qualification is confirmed (edits locked)
+ * - Returns null when the specific mode's qualification is not confirmed (edits allowed)
+ * - Returns 403 NextResponse when the specific mode's qualification is confirmed (edits locked)
  * - Returns 404 NextResponse when tournament is not found
+ * - Checks only the requested mode's flag, not other modes (issue #696)
  */
 
 jest.mock('next/server', () => ({
@@ -15,7 +16,11 @@ jest.mock('next/server', () => ({
 
 import { checkQualificationConfirmed } from '@/lib/qualification-confirmed-check';
 
-function makePrisma(tournament: { qualificationConfirmed: boolean } | null) {
+function makePrisma(tournament: {
+  bmQualificationConfirmed?: boolean;
+  mrQualificationConfirmed?: boolean;
+  gpQualificationConfirmed?: boolean;
+} | null) {
   return {
     tournament: {
       findUnique: jest.fn().mockResolvedValue(tournament),
@@ -28,32 +33,75 @@ describe('checkQualificationConfirmed', () => {
     jest.clearAllMocks();
   });
 
-  it('returns null when qualification is not confirmed (edits allowed)', async () => {
-    const prisma = makePrisma({ qualificationConfirmed: false });
-    const result = await checkQualificationConfirmed(prisma, 'tournament-1');
+  it('returns null when bm qualification is not confirmed (edits allowed)', async () => {
+    const prisma = makePrisma({ bmQualificationConfirmed: false });
+    const result = await checkQualificationConfirmed(prisma, 'tournament-1', 'bm');
     expect(result).toBeNull();
   });
 
-  it('returns 403 response when qualification is confirmed (edits locked)', async () => {
-    const prisma = makePrisma({ qualificationConfirmed: true });
-    const result = await checkQualificationConfirmed(prisma, 'tournament-1') as { status: number; body: unknown };
+  it('returns 403 when bm qualification is confirmed (edits locked)', async () => {
+    const prisma = makePrisma({ bmQualificationConfirmed: true });
+    const result = await checkQualificationConfirmed(prisma, 'tournament-1', 'bm') as { status: number; body: unknown };
     expect(result).not.toBeNull();
     expect(result.status).toBe(403);
   });
 
-  it('returns 404 response when tournament is not found', async () => {
+  it('returns null when mr qualification is not confirmed', async () => {
+    const prisma = makePrisma({ mrQualificationConfirmed: false });
+    const result = await checkQualificationConfirmed(prisma, 'tournament-1', 'mr');
+    expect(result).toBeNull();
+  });
+
+  it('returns 403 when mr qualification is confirmed', async () => {
+    const prisma = makePrisma({ mrQualificationConfirmed: true });
+    const result = await checkQualificationConfirmed(prisma, 'tournament-1', 'mr') as { status: number };
+    expect(result).not.toBeNull();
+    expect(result.status).toBe(403);
+  });
+
+  it('returns null when gp qualification is not confirmed', async () => {
+    const prisma = makePrisma({ gpQualificationConfirmed: false });
+    const result = await checkQualificationConfirmed(prisma, 'tournament-1', 'gp');
+    expect(result).toBeNull();
+  });
+
+  it('returns 403 when gp qualification is confirmed', async () => {
+    const prisma = makePrisma({ gpQualificationConfirmed: true });
+    const result = await checkQualificationConfirmed(prisma, 'tournament-1', 'gp') as { status: number };
+    expect(result).not.toBeNull();
+    expect(result.status).toBe(403);
+  });
+
+  it('returns 404 when tournament is not found', async () => {
     const prisma = makePrisma(null);
-    const result = await checkQualificationConfirmed(prisma, 'nonexistent-id') as { status: number };
+    const result = await checkQualificationConfirmed(prisma, 'nonexistent-id', 'bm') as { status: number };
     expect(result).not.toBeNull();
     expect(result.status).toBe(404);
   });
 
-  it('queries the correct tournament by id', async () => {
-    const prisma = makePrisma({ qualificationConfirmed: false });
-    await checkQualificationConfirmed(prisma, 'my-tournament');
+  it('checks only the requested mode — bm confirmed does not affect mr check (issue #696)', async () => {
+    // bm is confirmed but mr is not
+    const prisma = makePrisma({ mrQualificationConfirmed: false });
+    const result = await checkQualificationConfirmed(prisma, 'tournament-1', 'mr');
+    // MR should NOT be locked even though bm would be confirmed in a real tournament
+    expect(result).toBeNull();
+  });
+
+  it('queries the correct tournament by id with the mode-specific field', async () => {
+    const prisma = makePrisma({ bmQualificationConfirmed: false });
+    await checkQualificationConfirmed(prisma, 'my-tournament', 'bm');
     expect(prisma.tournament.findUnique).toHaveBeenCalledWith({
       where: { id: 'my-tournament' },
-      select: { qualificationConfirmed: true },
+      select: { bmQualificationConfirmed: true },
+    });
+  });
+
+  it('queries mr-specific field when mode is mr', async () => {
+    const prisma = makePrisma({ mrQualificationConfirmed: false });
+    await checkQualificationConfirmed(prisma, 'my-tournament', 'mr');
+    expect(prisma.tournament.findUnique).toHaveBeenCalledWith({
+      where: { id: 'my-tournament' },
+      select: { mrQualificationConfirmed: true },
     });
   });
 });

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -2872,7 +2872,7 @@ async function main() {
       await page.evaluate(async (tid) => {
         await fetch(`/api/tournaments/${tid}`, {
           method: 'PUT', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ qualificationConfirmed: true }),
+          body: JSON.stringify({ bmQualificationConfirmed: true }),
         });
       }, tc346TournamentId);
 
@@ -3082,7 +3082,7 @@ async function main() {
       await page.evaluate(async (tid) => {
         await fetch(`/api/tournaments/${tid}`, {
           method: 'PUT', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ qualificationConfirmed: true }),
+          body: JSON.stringify({ bmQualificationConfirmed: true }),
         });
         await fetch(`/api/tournaments/${tid}/bm/finals`, {
           method: 'POST',
@@ -3140,6 +3140,91 @@ async function main() {
     } finally {
       if (tc350TournamentId) await deleteTournament(page, tc350TournamentId);
       for (const p of tc350Players) await deletePlayer(page, p.id);
+    }
+  }
+
+  // TC-351: Per-mode qualification confirmed independence (issue #696)
+  // Confirming BM qual must NOT lock MR/GP scores; each mode has its own flag.
+  {
+    let tc351TournamentId = null;
+    const tc351Players = [];
+    const ts351 = Date.now();
+    try {
+      // Create minimal tournament and 2 players
+      tc351TournamentId = await uiCreateTournament(page, `E2E TC-351 QualConf ${ts351}`);
+      for (let i = 0; i < 2; i++) {
+        const p = await createPlayer(page, `tc351p${i}_${ts351}`, `351p${i}`);
+        tc351Players.push(p);
+      }
+
+      // Setup BM qualification (2 players, 1 group)
+      await page.evaluate(async ({ tid, pids }) => {
+        await fetch(`/api/tournaments/${tid}/bm`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ players: [{ playerId: pids[0], group: 'A' }, { playerId: pids[1], group: 'A' }], groupCount: 1 }),
+        });
+      }, { tid: tc351TournamentId, pids: tc351Players.map(p => p.id) });
+
+      // Setup MR qualification too
+      await page.evaluate(async ({ tid, pids }) => {
+        await fetch(`/api/tournaments/${tid}/mr`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ players: [{ playerId: pids[0], group: 'A' }, { playerId: pids[1], group: 'A' }], groupCount: 1 }),
+        });
+      }, { tid: tc351TournamentId, pids: tc351Players.map(p => p.id) });
+
+      // Confirm BM qualification only
+      const confirmBm = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ bmQualificationConfirmed: true }),
+        });
+        return r.status;
+      }, tc351TournamentId);
+
+      // Get a MR match ID
+      const mrData = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/mr`);
+        const j = await r.json().catch(() => ({}));
+        return j.data ?? j;
+      }, tc351TournamentId);
+      const mrMatchId = (mrData.matches ?? [])[0]?.id;
+
+      // Try to enter MR score — should succeed because MR is NOT confirmed
+      let mrScoreStatus = 0;
+      if (mrMatchId) {
+        mrScoreStatus = await page.evaluate(async ({ tid, mid }) => {
+          const r = await fetch(`/api/tournaments/${tid}/mr`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ matchId: mid, score1: 2, score2: 2 }),
+          });
+          return r.status;
+        }, { tid: tc351TournamentId, mid: mrMatchId });
+      }
+
+      // Verify BM GET returns bmQualificationConfirmed=true
+      const bmData = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/bm`);
+        const j = await r.json().catch(() => ({}));
+        return j.data ?? j;
+      }, tc351TournamentId);
+
+      const bmConfirmed = bmData.qualificationConfirmed === true;
+      const mrUnlocked = !mrMatchId || mrScoreStatus === 200;
+
+      log('TC-351',
+        bmConfirmed && mrUnlocked ? 'PASS' : 'FAIL',
+        `bm_confirmed=${bmConfirmed} mr_unlocked=${mrUnlocked} mr_status=${mrScoreStatus}`,
+      );
+    } catch (err) {
+      log('TC-351', 'FAIL', err instanceof Error ? err.message : 'Per-mode qual confirm test failed');
+    } finally {
+      if (tc351TournamentId) await deleteTournament(page, tc351TournamentId);
+      for (const p of tc351Players) await deletePlayer(page, p.id);
     }
   }
 

--- a/smkc-score-app/migrations/0026_per_mode_qualification_confirmed.sql
+++ b/smkc-score-app/migrations/0026_per_mode_qualification_confirmed.sql
@@ -1,0 +1,14 @@
+-- Add per-mode qualification confirmed flags to Tournament.
+-- Previously a single qualificationConfirmed flag covered all modes (BM/MR/GP),
+-- causing one mode's confirmation to lock all other modes' scores (issue #696).
+-- Each mode now has its own flag so confirmations are independent.
+-- Existing qualificationConfirmed=1 rows have all three per-mode flags set to 1
+-- since we cannot retroactively know which mode was originally confirmed.
+ALTER TABLE "Tournament" ADD COLUMN "bmQualificationConfirmed" BOOLEAN NOT NULL DEFAULT 0;
+ALTER TABLE "Tournament" ADD COLUMN "mrQualificationConfirmed" BOOLEAN NOT NULL DEFAULT 0;
+ALTER TABLE "Tournament" ADD COLUMN "gpQualificationConfirmed" BOOLEAN NOT NULL DEFAULT 0;
+UPDATE "Tournament" SET
+  "bmQualificationConfirmed" = "qualificationConfirmed",
+  "mrQualificationConfirmed" = "qualificationConfirmed",
+  "gpQualificationConfirmed" = "qualificationConfirmed"
+WHERE "qualificationConfirmed" = 1;

--- a/smkc-score-app/prisma/migrations/0009_per_mode_qualification_confirmed/migration.sql
+++ b/smkc-score-app/prisma/migrations/0009_per_mode_qualification_confirmed/migration.sql
@@ -1,0 +1,14 @@
+-- Add per-mode qualification confirmed flags to Tournament.
+-- Previously a single qualificationConfirmed flag covered all modes (BM/MR/GP),
+-- causing one mode's confirmation to lock all other modes' scores (issue #696).
+-- Each mode now has its own flag so confirmations are independent.
+-- Existing qualificationConfirmed=1 rows have all three per-mode flags set to 1
+-- since we cannot retroactively know which mode was originally confirmed.
+ALTER TABLE "Tournament" ADD COLUMN "bmQualificationConfirmed" BOOLEAN NOT NULL DEFAULT 0;
+ALTER TABLE "Tournament" ADD COLUMN "mrQualificationConfirmed" BOOLEAN NOT NULL DEFAULT 0;
+ALTER TABLE "Tournament" ADD COLUMN "gpQualificationConfirmed" BOOLEAN NOT NULL DEFAULT 0;
+UPDATE "Tournament" SET
+  "bmQualificationConfirmed" = "qualificationConfirmed",
+  "mrQualificationConfirmed" = "qualificationConfirmed",
+  "gpQualificationConfirmed" = "qualificationConfirmed"
+WHERE "qualificationConfirmed" = 1;

--- a/smkc-score-app/prisma/schema.prisma
+++ b/smkc-score-app/prisma/schema.prisma
@@ -134,8 +134,11 @@ model Tournament {
   overlayPlayer1Wins  Int?    // 配信中試合の1P勝利数
   overlayPlayer2Wins  Int?    // 配信中試合の2P勝利数
   overlayMatchFt      Int?    // 配信中試合のFirst-To目標勝利数 (BM/MR決勝: 5)
-  qualificationConfirmed Boolean @default(false) // BM/MR/GP予選確定フラグ。trueの場合スコア編集不可
-  qualificationConfirmedAt DateTime? // 予選確定日時（監査証跡）
+  qualificationConfirmed Boolean @default(false) // 後方互換レガシーフィールド（オーバーレイ参照のみ）
+  qualificationConfirmedAt DateTime? // 最後に予選が確定された日時（監査証跡・オーバーレイイベント用）
+  bmQualificationConfirmed Boolean @default(false) // BMモード予選確定フラグ。trueの場合BMスコア編集不可
+  mrQualificationConfirmed Boolean @default(false) // MRモード予選確定フラグ。trueの場合MRスコア編集不可
+  gpQualificationConfirmed Boolean @default(false) // GPモード予選確定フラグ。trueの場合GPスコア編集不可
   publicModes   Json     @default("[]") // 公開中のモード配列。空の場合全モード非表示（新建時は非公開）
   deletedAt     DateTime? // ソフトデリート用タイムスタンプ
   version       Int      @default(0) // 楽観的ロック用

--- a/smkc-score-app/src/app/api/tournaments/[id]/bm/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/bm/finals/route.ts
@@ -10,6 +10,7 @@ import { createFinalsHandlers } from '@/lib/api-factories/finals-route';
 import { getBmFinalsTargetWins } from '@/lib/finals-target-wins';
 
 const { GET, POST, PUT, PATCH } = createFinalsHandlers({
+  eventTypeCode: 'bm',
   matchModel: 'bMMatch',
   qualificationModel: 'bMQualification',
   loggerName: 'bm-finals-api',

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
@@ -9,6 +9,7 @@ import { createFinalsHandlers } from '@/lib/api-factories/finals-route';
 import { getGpFinalsTargetWins } from '@/lib/finals-target-wins';
 
 const { GET, POST, PUT, PATCH } = createFinalsHandlers({
+  eventTypeCode: 'gp',
   matchModel: 'gPMatch',
   qualificationModel: 'gPQualification',
   loggerName: 'gp-finals-api',

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/finals/route.ts
@@ -10,6 +10,7 @@ import { createFinalsHandlers } from '@/lib/api-factories/finals-route';
 import { getMrFinalsTargetWins } from '@/lib/finals-target-wins';
 
 const { GET, POST, PUT, PATCH } = createFinalsHandlers({
+  eventTypeCode: 'mr',
   matchModel: 'mRMatch',
   qualificationModel: 'mRQualification',
   loggerName: 'mr-finals-api',

--- a/smkc-score-app/src/app/api/tournaments/[id]/overlay-events/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/overlay-events/route.ts
@@ -130,7 +130,10 @@ export async function GET(
       where: { id: tournamentId },
       select: {
         id: true,
-        qualificationConfirmed: true,
+        // Per-mode flags (issue #696); OR of all three = "any qual confirmed" for phase display
+        bmQualificationConfirmed: true,
+        mrQualificationConfirmed: true,
+        gpQualificationConfirmed: true,
         qualificationConfirmedAt: true,
         overlayPlayer1Name: true,
         overlayPlayer2Name: true,
@@ -199,7 +202,8 @@ export async function GET(
         // labels). We keep `events: []` so the merge-on-client step is a
         // no-op. Skipping the 17 detail queries is the whole point.
         const minimalPhaseInput = {
-          qualificationConfirmed: tournament.qualificationConfirmed,
+          // Any mode being confirmed = "qualification confirmed" for overlay phase display (#696)
+          qualificationConfirmed: tournament.bmQualificationConfirmed || tournament.mrQualificationConfirmed || tournament.gpQualificationConfirmed,
           taCurrentPhase: "qualification" as const,
           taLatestPhaseRoundNumber: null as number | null,
           latestFinalsRound: null as string | null,
@@ -458,7 +462,8 @@ export async function GET(
     }
 
     const phaseInput = {
-      qualificationConfirmed: tournament.qualificationConfirmed,
+      // Any mode being confirmed = "qualification confirmed" for overlay phase display (#696)
+      qualificationConfirmed: tournament.bmQualificationConfirmed || tournament.mrQualificationConfirmed || tournament.gpQualificationConfirmed,
       taCurrentPhase,
       taLatestPhaseRoundNumber,
       latestFinalsRound: latestFinals?.round ?? null,

--- a/smkc-score-app/src/app/api/tournaments/[id]/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/route.ts
@@ -169,7 +169,14 @@ export async function PUT(
   try {
     // Sanitize input to prevent XSS/injection attacks
     const body = sanitizeInput(await request.json());
-    const { name, date, status, frozenStages, taPlayerSelfEdit, qualificationConfirmed, publicModes } = body;
+    const {
+      name, date, status, frozenStages, taPlayerSelfEdit, publicModes,
+      // Per-mode qualification confirmed flags (issue #696).
+      // Legacy qualificationConfirmed is no longer accepted; use the mode-specific fields.
+      bmQualificationConfirmed,
+      mrQualificationConfirmed,
+      gpQualificationConfirmed,
+    } = body;
     const slug = normalizeTournamentSlug(body.slug);
 
     if (slug !== undefined && slug !== null && !isValidTournamentSlug(slug)) {
@@ -214,9 +221,20 @@ export async function PUT(
         ...(status && { status }),
         ...(frozenStages !== undefined && { frozenStages }),
         ...(taPlayerSelfEdit !== undefined && { taPlayerSelfEdit: taPlayerSelfEdit === true }),
-        ...(qualificationConfirmed !== undefined && {
-          qualificationConfirmed: qualificationConfirmed === true,
-          qualificationConfirmedAt: qualificationConfirmed ? new Date() : null,
+        // Per-mode qualification confirmed flags (issue #696).
+        // qualificationConfirmedAt is updated whenever any mode is confirmed so the
+        // overlay event system (overlay-events/route.ts) continues to fire correctly.
+        ...(bmQualificationConfirmed !== undefined && {
+          bmQualificationConfirmed: bmQualificationConfirmed === true,
+          ...(bmQualificationConfirmed === true && { qualificationConfirmedAt: new Date() }),
+        }),
+        ...(mrQualificationConfirmed !== undefined && {
+          mrQualificationConfirmed: mrQualificationConfirmed === true,
+          ...(mrQualificationConfirmed === true && { qualificationConfirmedAt: new Date() }),
+        }),
+        ...(gpQualificationConfirmed !== undefined && {
+          gpQualificationConfirmed: gpQualificationConfirmed === true,
+          ...(gpQualificationConfirmed === true && { qualificationConfirmedAt: new Date() }),
         }),
         ...(publicModes !== undefined && { publicModes }),
       },
@@ -239,7 +257,9 @@ export async function PUT(
           date,
           status,
           frozenStages,
-          qualificationConfirmed,
+          bmQualificationConfirmed,
+          mrQualificationConfirmed,
+          gpQualificationConfirmed,
           publicModes,
         },
       });

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page.tsx
@@ -320,7 +320,8 @@ export default function BattleModePage({
       const response = await fetch(`/api/tournaments/${tournamentId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ qualificationConfirmed: newValue }),
+        // Use per-mode field so only BM scores are locked/unlocked (#696)
+        body: JSON.stringify({ bmQualificationConfirmed: newValue }),
       });
       if (response.ok) {
         refetch();

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page.tsx
@@ -299,7 +299,8 @@ export default function GrandPrixPage({
       const response = await fetch(`/api/tournaments/${tournamentId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ qualificationConfirmed: newValue }),
+        // Use per-mode field so only GP scores are locked/unlocked (#696)
+        body: JSON.stringify({ gpQualificationConfirmed: newValue }),
       });
       if (response.ok) {
         refetch();

--- a/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/page.tsx
@@ -273,7 +273,8 @@ export default function MatchRacePage({
       const response = await fetch(`/api/tournaments/${tournamentId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ qualificationConfirmed: newValue }),
+        // Use per-mode field so only MR scores are locked/unlocked (#696)
+        body: JSON.stringify({ mrQualificationConfirmed: newValue }),
       });
       if (response.ok) {
         refetch();

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -350,6 +350,8 @@ async function normalizeRoundCoursesToSingleSet(
  * handlers with the correct Prisma model, score fields, and response shape.
  */
 export interface FinalsConfig {
+  /** Event type code used to select the per-mode qualification confirmed flag (#696). */
+  eventTypeCode: 'bm' | 'mr' | 'gp';
   /** Prisma model name for match records (e.g. 'bMMatch') */
   matchModel: string;
   /** Prisma model name for qualification records (e.g. 'bMQualification') */
@@ -427,14 +429,17 @@ export function createFinalsHandlers(config: FinalsConfig) {
     const logger = createLogger(config.loggerName);
     const { id } = await params;
 
-    // Resolve and verify in one D1 round-trip. The previous flow did a
-    // findFirst inside resolveTournamentId followed by a findUnique here,
-    // both reading the same row. The handler only consumes
-    // `qualificationConfirmed` from the response, so the projection stays
-    // tight to keep the payload small.
+    // Resolve and verify in one D1 round-trip. The handler only consumes
+    // the mode-specific qualificationConfirmed flag, so the projection stays
+    // tight. Using per-mode flags (issue #696) prevents BM confirmation from
+    // locking MR/GP bracket creation.
+    const modeField = `${config.eventTypeCode}QualificationConfirmed` as
+      | 'bmQualificationConfirmed'
+      | 'mrQualificationConfirmed'
+      | 'gpQualificationConfirmed';
     const tournament = await resolveTournament(id, {
       id: true,
-      qualificationConfirmed: true,
+      [modeField]: true,
     });
     if (!tournament) {
       return createErrorResponse('Tournament not found', 404, 'NOT_FOUND');
@@ -626,7 +631,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
           bracketStructure,
           bracketSize,
           roundNames,
-          qualificationConfirmed: tournament.qualificationConfirmed ?? false,
+          qualificationConfirmed: (tournament as Record<string, unknown>)[modeField] as boolean ?? false,
           phase,
           playoffMatches,
           playoffStructure,
@@ -668,7 +673,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
           bracketStructure,
           bracketSize,
           roundNames,
-          qualificationConfirmed: tournament.qualificationConfirmed ?? false,
+          qualificationConfirmed: (tournament as Record<string, unknown>)[modeField] as boolean ?? false,
           playoffStructure,
           playoffSeededPlayers,
           playoffComplete,

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -105,13 +105,16 @@ export function createQualificationHandlers(config: EventTypeConfig) {
     let tournamentId: string = id;
 
     try {
-      // Resolve identifier (id or slug) AND read qualificationConfirmed in
-      // a single findFirst. The previous flow ran resolveTournamentId →
-      // findFirst, then fanned out into a parallel findUnique to grab
-      // qualificationConfirmed; merging them collapses one D1 round-trip.
+      // Resolve identifier (id or slug) AND read the mode-specific
+      // qualificationConfirmed flag in a single findFirst. Each mode has
+      // its own flag so confirming one mode does not lock the others (#696).
+      const modeField = `${config.eventTypeCode}QualificationConfirmed` as
+        | 'bmQualificationConfirmed'
+        | 'mrQualificationConfirmed'
+        | 'gpQualificationConfirmed';
       const tournament = await resolveTournament(id, {
         id: true,
-        qualificationConfirmed: true,
+        [modeField]: true,
       });
       if (!tournament) {
         return createErrorResponse(`${config.eventDisplayName} tournament not found`, 404, 'NOT_FOUND');
@@ -147,7 +150,9 @@ export function createQualificationHandlers(config: EventTypeConfig) {
       const responseBody = {
         qualifications: rankedQualifications,
         matches,
-        qualificationConfirmed: tournament.qualificationConfirmed,
+        // Return the mode-specific flag under the generic key so the frontend
+        // polling hook (useParticipantMatches / page state) needs no changes.
+        qualificationConfirmed: (tournament as Record<string, unknown>)[modeField] as boolean ?? false,
       };
       const etag = generateETag([responseBody]);
       const ifNoneMatch = request.headers.get('if-none-match');
@@ -505,8 +510,8 @@ export function createQualificationHandlers(config: EventTypeConfig) {
     const tournamentId = await resolveTournamentId(id);
 
     try {
-      /* Block score edits when qualification is confirmed (admin locked results) */
-      const lockError = await checkQualificationConfirmed(prisma, tournamentId);
+      /* Block score edits when this mode's qualification is confirmed (admin locked results) */
+      const lockError = await checkQualificationConfirmed(prisma, tournamentId, config.eventTypeCode);
       if (lockError) return lockError;
 
       /* Defense-in-depth: always sanitize user input */

--- a/smkc-score-app/src/lib/qualification-confirmed-check.ts
+++ b/smkc-score-app/src/lib/qualification-confirmed-check.ts
@@ -1,15 +1,16 @@
 /**
  * Qualification Confirmed Check Utility
  *
- * Validates whether a tournament's BM/MR/GP qualification is confirmed (locked).
- * When qualificationConfirmed is true, all score-update and score-report
- * API endpoints reject modifications for qualification-stage matches.
+ * Validates whether a specific mode's qualification is confirmed (locked).
+ * When a mode's qualificationConfirmed flag is true, all score-update and
+ * score-report API endpoints for that mode reject modifications.
  * This prevents accidental or unauthorized changes after admin confirmation.
  *
- * Follows the same pattern as freeze-check.ts (TA stage freeze).
+ * Each mode (bm/mr/gp) has its own independent flag so confirming one mode
+ * does not lock the others (issue #696).
  *
  * Usage:
- *   const lockError = await checkQualificationConfirmed(prisma, tournamentId);
+ *   const lockError = await checkQualificationConfirmed(prisma, tournamentId, 'bm');
  *   if (lockError) return lockError;
  */
 
@@ -17,30 +18,42 @@ import type { NextResponse } from "next/server";
 import type { PrismaClient } from "@prisma/client";
 import { createErrorResponse } from "@/lib/error-handling";
 
+type QualMode = 'bm' | 'mr' | 'gp';
+
+/** Maps event type code to the corresponding per-mode DB column name. */
+const MODE_FIELD: Record<QualMode, 'bmQualificationConfirmed' | 'mrQualificationConfirmed' | 'gpQualificationConfirmed'> = {
+  bm: 'bmQualificationConfirmed',
+  mr: 'mrQualificationConfirmed',
+  gp: 'gpQualificationConfirmed',
+};
+
 /**
- * Check if the tournament's qualification is confirmed (locked from edits).
+ * Check if a specific mode's qualification is confirmed (locked from edits).
  * Returns a 403 NextResponse if confirmed, or null if edits are allowed.
  *
  * @param prisma - Prisma client instance
  * @param tournamentId - Tournament ID to check
+ * @param mode - Which mode to check ('bm' | 'mr' | 'gp')
  * @returns NextResponse with 403 error if confirmed, null if not confirmed
  */
 export async function checkQualificationConfirmed(
   prisma: PrismaClient,
-  tournamentId: string
+  tournamentId: string,
+  mode: QualMode,
 ): Promise<NextResponse | null> {
+  const field = MODE_FIELD[mode];
   const tournament = await prisma.tournament.findUnique({
     where: { id: tournamentId },
-    select: { qualificationConfirmed: true },
+    select: { [field]: true },
   });
 
   if (!tournament) {
     return createErrorResponse("Tournament not found", 404);
   }
 
-  if (tournament.qualificationConfirmed) {
+  if (tournament[field]) {
     return createErrorResponse(
-      'Qualification is confirmed. Score edits are locked.',
+      `${mode.toUpperCase()} qualification is confirmed. Score edits are locked.`,
       403,
       'QUALIFICATION_CONFIRMED',
     );


### PR DESCRIPTION
## 概要

Issue #696 の修正。`qualificationConfirmed` を共有フラグとして持っていたため、1つのモードを確定すると全モードがロックされるバグを修正した。

## 変更内容

### スキーマ変更
- `Tournament` モデルに `bmQualificationConfirmed`、`mrQualificationConfirmed`、`gpQualificationConfirmed` の3フラグを追加
- 既存の `qualificationConfirmed` はオーバーレイ後方互換のため保持（ただし書き込みは廃止）

### D1マイグレーション
- `migrations/0026_per_mode_qualification_confirmed.sql` を追加
- 既存データのバックフィル処理（`qualificationConfirmed=1` なら全モードを1に設定）

### API変更
- `PUT /api/tournaments/:id` のリクエストボディ: `qualificationConfirmed` → `bmQualificationConfirmed` / `mrQualificationConfirmed` / `gpQualificationConfirmed`
- 各モードの `GET` レスポンスキーは引き続き `qualificationConfirmed` として返す（フロントエンド後方互換）
- `checkQualificationConfirmed()` にモード引数 `'bm' | 'mr' | 'gp'` を追加

### フロントエンド変更
- BM/MR/GP ページのトグルハンドラーがモード別フィールド名を使用するよう更新

### オーバーレイ互換
- `overlay-events` は3フラグの OR を使用: `bmQualificationConfirmed || mrQualificationConfirmed || gpQualificationConfirmed`

## テスト

- 単体テスト: 全2077件パス (107スイート)
- E2Eテスト: TC-351 追加（BM確定後もMRスコア編集が可能なことを確認）

## 関連 Issue

Closes #696

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3a7saqLMV43pbdaWAi5kb)_