### PR TITLE
fix(e2e): TC-351 createPlayer → uiCreatePlayer typo (#704)

### DIFF
--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3153,7 +3153,7 @@ async function main() {
       // Create minimal tournament and 2 players
       tc351TournamentId = await uiCreateTournament(page, `E2E TC-351 QualConf ${ts351}`);
       for (let i = 0; i < 2; i++) {
-        const p = await createPlayer(page, `tc351p${i}_${ts351}`, `351p${i}`);
+        const p = await uiCreatePlayer(page, `tc351p${i}_${ts351}`, `351p${i}`);
         tc351Players.push(p);
       }
 


### PR DESCRIPTION
## Summary

- Fixes a `ReferenceError: createPlayer is not defined` in TC-351 (introduced by PR #698)
- The actual helper imported in `tc-all.js:25` is `uiCreatePlayer`; this 1-line rename restores the test

## Test plan

- [ ] `npm run e2e:all` → TC-351 advances past the player-creation step
- [ ] No other call sites use the bare `createPlayer` symbol

Fixes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)