### PR TITLE
fix(e2e): use per-mode qualificationConfirmed flags after PR #698 (#708)

### DIFF
--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -2029,9 +2029,9 @@ async function setupBmQualViaUi(adminPage, tournamentId, players, { score1 = 3, 
    * hangs on waitForResponse. Idempotent for already-active tournaments. */
   await uiActivateTournament(adminPage, tournamentId);
   /* The shared fixture tournament persists across suite invocations.
-   * If a previous run left qualificationConfirmed=true, score PUTs are
+   * If a previous run left bmQualificationConfirmed=true, score PUTs are
    * blocked with 403. Reset the lock before re-seeding qualification. */
-  await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: false });
+  await apiUpdateTournament(adminPage, tournamentId, { bmQualificationConfirmed: false });
   await setupModePlayersViaUi(adminPage, 'bm', tournamentId, players);
   /* Use API-based bulk scoring to avoid persistent-context renderer OOM
    * crashes during the 182-match 28-player qualification loop (issue #517).
@@ -2054,9 +2054,9 @@ async function setupMrQualViaUi(
   { score1 = 3, score2 = 1, randomize = true, resolveTies = true } = {},
 ) {
   await uiActivateTournament(adminPage, tournamentId);
-  /* BM suite leaves qualificationConfirmed=true on the shared tournament,
-   * which disables the MR score-entry button. Reset before re-seeding. */
-  await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: false });
+  /* Reset the MR per-mode confirmation flag so score PUTs are unblocked
+   * when re-running the shared tournament. */
+  await apiUpdateTournament(adminPage, tournamentId, { mrQualificationConfirmed: false });
   await setupModePlayersViaUi(adminPage, 'mr', tournamentId, players);
   /* Use API bulk scoring to avoid renderer OOM and suite timeout on 182-match
    * 28-player tournaments (issue #661). Individual UI flow covered by TC-601/602. */
@@ -2077,9 +2077,9 @@ async function setupGpQualViaUi(
   { points1 = 45, points2 = 0, randomize = true, resolveTies = true } = {},
 ) {
   await uiActivateTournament(adminPage, tournamentId);
-  /* BM suite leaves qualificationConfirmed=true on the shared tournament,
-   * which disables the GP score-entry button. Reset before re-seeding. */
-  await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: false });
+  /* Reset the GP per-mode confirmation flag so score PUTs are unblocked
+   * when re-running the shared tournament. */
+  await apiUpdateTournament(adminPage, tournamentId, { gpQualificationConfirmed: false });
   await setupModePlayersViaUi(adminPage, 'gp', tournamentId, players);
   /* Use API bulk scoring (manual-score endpoint) to avoid renderer OOM and
    * suite timeout on 182-match 28-player tournaments (issue #661). Individual

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -77,7 +77,7 @@ async function prepareSharedBmPair(adminPage, { dualReport = false } = {}) {
   /* The shared fixture tournament persists across suite invocations.
    * If a previous run left qualificationConfirmed=true, score PUTs are
    * blocked with 403 and the participant page hides score buttons. */
-  await apiUpdateTournament(adminPage, tournament.id, { qualificationConfirmed: false });
+  await apiUpdateTournament(adminPage, tournament.id, { bmQualificationConfirmed: false });
   await setupModePlayersViaUi(adminPage, 'bm', tournament.id, players);
 
   const data = await apiFetchBm(adminPage, tournament.id);
@@ -339,7 +339,7 @@ async function runTc512(adminPage) {
   const tournamentId = normalTournament.id;
 
   try {
-    await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: false });
+    await apiUpdateTournament(adminPage, tournamentId, { bmQualificationConfirmed: false });
     await setupModePlayersViaUi(adminPage, 'bm', tournamentId, players.slice(0, 2));
 
     const bmData = await apiFetchBm(adminPage, tournamentId);
@@ -585,7 +585,7 @@ async function runTc515(adminPage) {
     /* The "Generate Bracket" / "Start Playoff" button is gated by
      * canCreateFinalsFromQualification which requires qualificationConfirmed.
      * Confirm qualification first so the button appears. */
-    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: true });
+    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { bmQualificationConfirmed: true });
     if (confirmRes.s !== 200) throw new Error(`Failed to confirm qualification (${confirmRes.s})`);
 
     /* Previous tests (TC-510) may have left a bracket behind. Reset it so
@@ -681,7 +681,7 @@ async function runTc516(adminPage) {
     /* Confirm qualification so the bracket action button is visible.
      * Without this, canCreateFinalsFromQualification returns false and
      * the button is hidden both before and after reset. */
-    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: true });
+    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { bmQualificationConfirmed: true });
     if (confirmRes.s !== 200) throw new Error(`Failed to confirm qualification (${confirmRes.s})`);
 
     const gen = await apiGenerateBmFinals(adminPage, tournamentId, 8);

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -65,7 +65,7 @@ async function prepareSharedGpPair(adminPage, { dualReport = false } = {}) {
 
   /* Reset qualificationConfirmed before re-seeding so score PUTs aren't 403'd
    * by state left over from the BM/MR suites. Mirrors prepareSharedBmPair. */
-  await apiUpdateTournament(adminPage, tournament.id, { qualificationConfirmed: false });
+  await apiUpdateTournament(adminPage, tournament.id, { gpQualificationConfirmed: false });
   await setupModePlayersViaUi(adminPage, 'gp', tournament.id, players);
 
   const data = await apiFetchGp(adminPage, tournament.id);
@@ -691,7 +691,7 @@ async function runTc715(adminPage) {
     const { tournamentId } = setup;
 
     /* The bracket action button requires qualificationConfirmed. */
-    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: true });
+    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { gpQualificationConfirmed: true });
     if (confirmRes.s !== 200) throw new Error(`Failed to confirm qualification (${confirmRes.s})`);
 
     /* Previous tests may have left a bracket behind. Reset it so
@@ -802,7 +802,7 @@ async function runTc716(adminPage) {
     const { tournamentId } = setup;
 
     /* Confirm qualification so the bracket action button is visible. */
-    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: true });
+    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { gpQualificationConfirmed: true });
     if (confirmRes.s !== 200) throw new Error(`Failed to confirm qualification (${confirmRes.s})`);
 
     const gen = await apiGenerateGpFinals(adminPage, tournamentId, 8);

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -111,7 +111,7 @@ async function prepareSharedMrPair(adminPage, { dualReport = false } = {}) {
    * (TC-603) and the participant page winner buttons (TC-602) are both gated
    * on this flag, so reset it before re-seeding. Mirrors prepareSharedBmPair
    * in tc-bm.js. */
-  await apiUpdateTournament(adminPage, tournament.id, { qualificationConfirmed: false });
+  await apiUpdateTournament(adminPage, tournament.id, { mrQualificationConfirmed: false });
   await setupModePlayersViaUi(adminPage, 'mr', tournament.id, players);
 
   const data = await apiFetchMr(adminPage, tournament.id);
@@ -153,7 +153,7 @@ async function prepareSharedMrFinalsSetup(adminPage) {
   /* The UI "Generate Bracket" button is gated on qualificationConfirmed=true
    * (mr/finals/page.tsx). TC-604 clicks that button, so confirm here.
    * Idempotent — safe even when finals are already in progress. */
-  await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: true });
+  await apiUpdateTournament(adminPage, tournamentId, { mrQualificationConfirmed: true });
 
   return {
     tournamentId,
@@ -817,7 +817,7 @@ async function runTc611(adminPage) {
         body: JSON.stringify(body),
       });
       return { s: r.status };
-    }, [`/api/tournaments/${tournamentId}`, { qualificationConfirmed: true }]);
+    }, [`/api/tournaments/${tournamentId}`, { mrQualificationConfirmed: true }]);
     const confirmOk = confirmRes.s === 200;
 
     // Step 3: Score edit should be blocked (403)
@@ -844,7 +844,7 @@ async function runTc611(adminPage) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       });
-    }, [`/api/tournaments/${tournamentId}`, { qualificationConfirmed: false }]);
+    }, [`/api/tournaments/${tournamentId}`, { mrQualificationConfirmed: false }]);
 
     // Step 6: Score edit should work again
     const postUnlock = await apiPutMrQualScore(adminPage, tournamentId, match.id, 2, 2);
@@ -865,7 +865,7 @@ async function runTc611(adminPage) {
     if (tournamentId) {
       await adminPage.evaluate(async ([url, body]) => {
         await fetch(url, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
-      }, [`/api/tournaments/${tournamentId}`, { qualificationConfirmed: false }]).catch(() => {});
+      }, [`/api/tournaments/${tournamentId}`, { mrQualificationConfirmed: false }]).catch(() => {});
       await deleteTournament(adminPage, tournamentId);
     }
     if (player1) await deletePlayer(adminPage, player1.id);
@@ -892,7 +892,7 @@ async function runTc612(adminPage) {
 
     /* Reset qualificationConfirmed in case earlier suites locked the shared
      * tournament — score PUTs are 403'd otherwise. */
-    await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: false });
+    await apiUpdateTournament(adminPage, tournamentId, { mrQualificationConfirmed: false });
 
     // Setup GP qualification with 2 players on the shared tournament.
     // POST /gp is upsert-friendly: re-running replaces the previous GP setup.
@@ -1160,7 +1160,7 @@ async function runTc615(adminPage) {
     const { tournamentId } = setup;
 
     /* The bracket action button requires qualificationConfirmed. */
-    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: true });
+    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { mrQualificationConfirmed: true });
     if (confirmRes.s !== 200) throw new Error(`Failed to confirm qualification (${confirmRes.s})`);
 
     /* Previous tests may have left a bracket behind. Reset it so
@@ -1274,7 +1274,7 @@ async function runTc616(adminPage) {
     const { tournamentId } = setup;
 
     /* Confirm qualification so the bracket action button is visible. */
-    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { qualificationConfirmed: true });
+    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { mrQualificationConfirmed: true });
     if (confirmRes.s !== 200) throw new Error(`Failed to confirm qualification (${confirmRes.s})`);
 
     // Generate an 8-player finals bracket

--- a/smkc-score-app/e2e/tc-overlay.js
+++ b/smkc-score-app/e2e/tc-overlay.js
@@ -11,7 +11,7 @@
  *   TC-907  MR admin score PUT surfaces a `match_completed` event (mode='mr')
  *   TC-908  GP admin score PUT surfaces a `match_completed` event (mode='gp',
  *           covers the points1/points2 → score1/score2 remap in the route)
- *   TC-909  PUT { qualificationConfirmed: true } surfaces a
+ *   TC-909  PUT { bmQualificationConfirmed: true } surfaces a
  *           `qualification_confirmed` event
  *   TC-910  TT entry seed (totalTime + rank) surfaces a `ta_time_recorded`
  *   TC-911  POST /overall-ranking surfaces an `overall_ranking_updated`
@@ -611,9 +611,11 @@ async function runTc911(adminPage) {
 /* ───────── TC-909: qualification_confirmed (LAST: blocks score writes) ───────── */
 async function runTc909(adminPage) {
   try {
-    const res = await apiUpdateTournament(adminPage, fixture.tournamentId, { qualificationConfirmed: true });
+    /* qualificationConfirmedAt (overlay event source) updates whenever any
+     * per-mode flag transitions to true. Use BM as the trigger here. */
+    const res = await apiUpdateTournament(adminPage, fixture.tournamentId, { bmQualificationConfirmed: true });
     if (res.s !== 200) {
-      log('TC-909', 'FAIL', `PUT qualificationConfirmed failed: ${res.s} ${JSON.stringify(res.b).slice(0, 200)}`);
+      log('TC-909', 'FAIL', `PUT bmQualificationConfirmed failed: ${res.s} ${JSON.stringify(res.b).slice(0, 200)}`);
       return;
     }
     const resp = await pollForEvent(


### PR DESCRIPTION
## Summary

Replaces the legacy `qualificationConfirmed` field in 5 e2e files with the per-mode flags introduced in PR #698.

- Unblocks 8 TCs that were silently failing because the server now ignores the legacy field
- Mode mapping: `tc-bm.js` → `bmQualificationConfirmed`, `tc-mr.js` → `mrQualificationConfirmed`, `tc-gp.js` → `gpQualificationConfirmed`, common helpers → match their helper's mode, `tc-overlay.js` (TC-909) → BM (any per-mode flag updates `qualificationConfirmedAt`)

This is a re-submission of PR #709 on a `claude/` branch to work around a persistent Cloudflare Workers build failure on the `fix/` branch (Cloudflare infra issue, not related to code changes).

## Test plan

- [ ] `npm run e2e:all` → TC-515/516/611/615/616/715/716/909 all pass
- [ ] No remaining `qualificationConfirmed:` literal in `e2e/` (only the historical test-doc comment in `tc-overlay.js` was rewritten)

Fixes #708
Supersedes #709

https://claude.ai/code/session_01A26wbDGDbaoCueeNwWZx2F

---
_Generated by [Claude Code](https://claude.ai/code/session_01A26wbDGDbaoCueeNwWZx2F)_