### PR TITLE
fix(ci): grant checks:read to wait-cloudflare-build job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,6 +50,8 @@ jobs:
     name: Wait for Cloudflare Workers Build
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      checks: read
     steps:
       - name: 'Wait for Workers Builds: smkc check'
         uses: fountainhead/action-wait-for-check@v1.2.0


### PR DESCRIPTION
## Summary
- `wait-cloudflare-build` ジョブが `checks: read` 権限を持っていないため、`fountainhead/action-wait-for-check` が `HttpError: Resource not accessible by integration` で失敗していた
- ジョブレベルで `permissions: checks: read` を付与して権限を最小限に絞りつつ通す

## Test plan
- [ ] このPR自身で `Wait for Cloudflare Workers Build` ジョブが Cloudflare のビルドを待ってから完了することを確認
- [ ] 後続の claude-review ジョブが起動すること