### PR TITLE
ci: auto-apply D1 migrations on merge to main

### DIFF
--- a/.github/workflows/d1-migrate.yml
+++ b/.github/workflows/d1-migrate.yml
@@ -1,0 +1,47 @@
+name: D1 Migrate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "smkc-score-app/migrations/**"
+      - ".github/workflows/d1-migrate.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: d1-migrate-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    name: Apply D1 migrations (remote)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: smkc-score-app
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: smkc-score-app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: List pending migrations
+        run: npx wrangler d1 migrations list smkc-db --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Apply migrations
+        run: npx wrangler d1 migrations apply smkc-db --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- `migrations/` 変更時にmainマージで `wrangler d1 migrations apply smkc-db --remote` を自動実行
- 手動 `npm run deploy` 運用と独立（migrationsパス変更時のみトリガ）
- 手動実行用に `workflow_dispatch` も付与

## なぜ
今回の0027（debug_mode追加）が未適用のまま残り、本番でトーナメント読み込みが失敗した。マージ＝マイグレーション適用、を強制する仕組みが無かったのが原因。

## 必要な設定（マージ前に登録）
GitHub repo → Settings → Secrets and variables → Actions:
- `CLOUDFLARE_API_TOKEN` — Cloudflare API Token (Account → D1 → Edit 権限)
- `CLOUDFLARE_ACCOUNT_ID` — `npx wrangler whoami` で確認できる

## Test plan
- [ ] Secrets 2件をリポジトリに登録
- [ ] このPRのマージ後、Actions タブで `D1 Migrate` が **走らないこと** を確認（migrationsに変更が無いため）
- [ ] 次回マイグレーション追加PRがマージされた時に自動実行されることを確認
- [ ] `workflow_dispatch` で手動実行も成功することを確認

## 注意
- デプロイより**先**にマイグレーションが走る形（旧コード→新スキーマの方が破綻が少ない）
- 破壊的マイグレーション（DROP COLUMN等）はPRレビュー段階で要確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)