### PR TITLE
fix(ta): align debug auto-fill button with BM/MR/GP placement

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
@@ -717,6 +717,14 @@ export default function TimeAttackPage({
               )}
             </Button>
           )}
+          {/* Debug-only auto-fill button — visible only on tournaments created
+           * with debugMode. Placed in the header action row to match
+           * BM/MR/GP qualification pages. TA has no `qualificationConfirmed`
+           * field; the lifecycle equivalent is `frozenStages.includes("qualification")`,
+           * which mirrors the server-side gate in fillTATimes (debug-fill.ts:296). */}
+          {isAdmin && debugMode && !frozenStages.includes("qualification") && entries.length > 0 && (
+            <DebugFillButton tournamentId={tournamentId} mode="ta" onFilled={refetch} />
+          )}
           {/* Legacy "Promote to Finals" button and dialog removed.
            * All promotion is now handled via the Phase 1/2/3 management card below.
            * See Phase 3 card "Go to Finals" link for the finals page entry point. */}
@@ -1281,18 +1289,6 @@ export default function TimeAttackPage({
                     ))}
                   </TableBody>
                 </Table>
-                {/* Debug-mode-only: Fill random times for ALL players via the
-                  * server-side debug-fill API. Skips entries that already have
-                  * a full set of 20 course times. */}
-                {debugMode && isAdmin && entries.length > 0 && (
-                  <div className="mt-4">
-                    <DebugFillButton
-                      tournamentId={tournamentId}
-                      mode="ta"
-                      onFilled={refetch}
-                    />
-                  </div>
-                )}
               </CardContent>
             </Card>
           </TabsContent>


### PR DESCRIPTION
## Summary
- TA's qualification page placed the new `DebugFillButton` (commit ef59c178) inside the standings table CardContent, while BM/MR/GP put it in the page header action row. This left TA visually inconsistent with the other three modes.
- Move TA's button into the header action row beside the freeze/unfreeze control, matching BM/MR/GP.
- Add a freeze gate (`!frozenStages.includes("qualification")`) that mirrors the server-side guard in `fillTATimes` (`debug-fill.ts:296`). Previously the button stayed visible after freeze and the POST would 423.

## Before / After
- **Before**: BM/MR/GP show 「予選スコア自動入力」 next to 「予選を確定」; TA shows it below the entries table.
- **After**: All four modes show the button in the same header row.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed file
- [x] `jest` 109/109 suites, 2094/2121 tests pass (rest skipped by pattern)
- [x] tdd-test-reviewer review: approved
- [ ] Verify on Cloudflare preview build that the TA debug-tournament header now shows 「予選スコア自動入力」 alongside the freeze button (BM/MR/GP unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)