### PR TITLE
fix: resolve issues #719-#726 — debounce, cleanup, CI, BM qualifying courses

### DIFF
--- a/.github/workflows/d1-migrate.yml
+++ b/.github/workflows/d1-migrate.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - "smkc-score-app/migrations/**"
-      - ".github/workflows/d1-migrate.yml"
   workflow_dispatch:
 
 concurrency:
@@ -41,7 +40,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Apply migrations
-        run: npx wrangler d1 migrations apply smkc-db --remote
+        run: npx wrangler d1 migrations apply smkc-db --remote --yes
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1018,6 +1018,17 @@
 - **期待結果**: TV# 割り当ては成功し、noCamera 警告 toast が追加で表示される
 - **スクリプト**: tc-bm.js TC-526
 
+## TC-527: BM 予選 — 同じ round-robin day の全試合が同じ startingCourseNumber を持つ (issue #724)
+- **URL**: /api/tournaments/[id]/bm (GET)
+- **authRequired**: false (GET)
+- **背景**: BM 予選セットアップ後、同じラウンドロビン Day に属する全実試合が共通の開始コース番号 (1-4) を持つ必要がある (issue #724)。
+- **手順**:
+  1. 28名予選済みの共有トーナメントの BM qualification データを GET で取得
+  2. 実試合（BYE でないもの）に `startingCourseNumber` が 1-4 の範囲で存在することを確認
+  3. 同じ `roundNumber` を持つ全試合の `startingCourseNumber` が同一であることを確認
+- **期待結果**: 全実試合が有効な `startingCourseNumber` を持ち、同一 Day 内では全て同じコース番号になる
+- **スクリプト**: tc-bm.js TC-527
+
 ---
 
 ## MR (Match Race) フルワークフローテスト

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
@@ -235,6 +235,44 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       }));
     });
 
+    // Issue #724: per-day startingCourseNumber assignment
+    it('should assign same startingCourseNumber to all matches on the same round-robin day', async () => {
+      (auth as jest.Mock).mockResolvedValue({ user: { id: 'admin1', role: 'admin' } });
+      // 4-player group → 3 days, 2 real matches each (6 matches total, no BYEs)
+      const mockPlayers = [
+        { playerId: 'p1', group: 'A', seeding: 1 },
+        { playerId: 'p2', group: 'A', seeding: 2 },
+        { playerId: 'p3', group: 'A', seeding: 3 },
+        { playerId: 'p4', group: 'A', seeding: 4 },
+      ];
+      (prisma.bMQualification.createMany as jest.Mock).mockResolvedValue({ count: 4 });
+      (prisma.bMQualification.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.bMMatch.createMany as jest.Mock).mockResolvedValue({ count: 6 });
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm', { players: mockPlayers });
+      const result = await POST(request, { params: Promise.resolve({ id: 't1' }) });
+
+      expect(result.status).toBe(201);
+      const matchData: any[] = (prisma.bMMatch.createMany as jest.Mock).mock.calls[0][0].data;
+      const realMatches = matchData.filter((m: any) => !m.isBye);
+
+      // Every real match must have a valid startingCourseNumber (1-4)
+      for (const m of realMatches) {
+        expect(m.startingCourseNumber).toBeGreaterThanOrEqual(1);
+        expect(m.startingCourseNumber).toBeLessThanOrEqual(4);
+      }
+
+      // All matches on the same day must share one startingCourseNumber
+      const byDay = new Map<number, Set<number>>();
+      for (const m of realMatches) {
+        if (!byDay.has(m.roundNumber)) byDay.set(m.roundNumber, new Set());
+        byDay.get(m.roundNumber)!.add(m.startingCourseNumber);
+      }
+      for (const [, values] of byDay) {
+        expect(values.size).toBe(1);
+      }
+    });
+
     // Authorization failure case - Returns 403 when user is not authenticated
     it('should return 403 when user is not authenticated', async () => {
       (auth as jest.Mock).mockResolvedValue(null);

--- a/smkc-score-app/e2e/cleanup.js
+++ b/smkc-score-app/e2e/cleanup.js
@@ -5,8 +5,8 @@
  * app API using the existing admin session stored in E2E_PROFILE_DIR.
  *
  * Deletes:
- * - tournaments named "E2E ..." or "Finals Ready ..." plus tc-all legacy temp
- *   names TC-315-test-* and TC-316-test-*
+ * - tournaments matching TOURNAMENT_NAME_RE (E2E, Finals Ready, TC-315/316 legacy,
+ *   BM-position-check, MR/GP/TA standalone tie/rank tests)
  * - players whose nickname starts with "e2e_" or "finals_ready_"
  *
  * Run:
@@ -19,7 +19,9 @@ const { closeBrowser, envMs, formatDuration } = require('./lib/runner');
 
 const PROFILE_DIR = process.env.E2E_PROFILE_DIR || '/tmp/playwright-smkc-profile';
 const PAGE_LIMIT = 100;
-const TOURNAMENT_NAME_RE = /^(E2E\b|Finals Ready\b|TC-315-test-|TC-316-test-)/i;
+// Matches all tournament names created by e2e test suites.
+// Includes legacy non-E2E-prefixed names from tc-bm/mr/gp/ta standalone runs.
+const TOURNAMENT_NAME_RE = /^(E2E\b|Finals Ready\b|TC-315-test-|TC-316-test-|BM-position-check\b|MR Tie\b|GP Tie\b|TA Tie\b|TA Rank Del\b)/i;
 const PLAYER_NICKNAME_RE = /^(e2e_|finals_ready_)/i;
 
 function parseArgs(argv) {

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -20,6 +20,7 @@
  *   TC-524  BM bracket startingCourseNumber randomisation per round (#671)
  *   TC-525  BM finals score dialog — startingCourseNumber autosaves on select
  *   TC-526  NoCamera player warning toast when TV# assigned to their match (#674)
+ *   TC-527  BM qualification startingCourseNumber shared per round-robin day (#724)
  *
  * Setup:
  *   - Uses Playwright persistent profile at /tmp/playwright-smkc-profile.
@@ -1758,6 +1759,44 @@ async function runTc526(adminPage) {
   }
 }
 
+/* ───────── TC-527: BM qualification startingCourseNumber per round-robin day ─────────
+ * After qualification setup, every real (non-BYE) match on the same round-robin day
+ * must share one startingCourseNumber (1-4), satisfying issue #724.
+ * Matches on different days may have different courses. */
+async function runTc527(adminPage) {
+  try {
+    if (!sharedFixture) throw new Error('shared fixture not initialised');
+    const tournamentId = sharedFixture.normalTournament.id;
+    const bmData = await apiFetchBm(adminPage, tournamentId);
+    const realMatches = (bmData.matches || []).filter((m) => !m.isBye && m.stage === 'qualification');
+    if (realMatches.length === 0) throw new Error('No real qualification matches found');
+
+    // Every real match must have a valid startingCourseNumber
+    const allValid = realMatches.every(
+      (m) => Number.isInteger(m.startingCourseNumber) && m.startingCourseNumber >= 1 && m.startingCourseNumber <= 4,
+    );
+
+    // All matches on the same roundNumber (day) must share one startingCourseNumber
+    const byDay = new Map();
+    for (const m of realMatches) {
+      if (m.roundNumber == null) continue;
+      if (!byDay.has(m.roundNumber)) byDay.set(m.roundNumber, new Set());
+      byDay.get(m.roundNumber).add(m.startingCourseNumber);
+    }
+    const daysUniform = [...byDay.values()].every((vals) => vals.size === 1);
+
+    const pass = allValid && daysUniform;
+    log('TC-527', pass ? 'PASS' : 'FAIL',
+      !allValid
+        ? `Some matches have invalid startingCourseNumber: ${JSON.stringify(realMatches.map((m) => ({ mn: m.matchNumber, sn: m.startingCourseNumber })))}`
+        : !daysUniform
+        ? `Matches on same day have different courses: ${JSON.stringify([...byDay.entries()].map(([d, s]) => ({ day: d, values: [...s] })))}`
+        : '');
+  } catch (err) {
+    log('TC-527', 'FAIL', err instanceof Error ? err.message : 'TC-527 failed');
+  }
+}
+
 /**
  * Builds the BM suite spec for composition by tc-all. When `sharedFixture` is
  * provided (tc-all flow), we reuse it and skip cleanup — the orchestrator owns
@@ -1805,6 +1844,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-524', fn: runTc524 },
       { name: 'TC-525', fn: runTc525 },
       { name: 'TC-526', fn: runTc526 },
+      { name: 'TC-527', fn: runTc527 },
       { name: 'TC-505', fn: runTc505 },
       { name: 'TC-506', fn: runTc506 },
     ],
@@ -1813,7 +1853,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 
 module.exports = {
   runTc501, runTc502, runTc322, runTc503, runTc504, runTc505, runTc506, runTc511, runTc512, runTc513,
-  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522, runTc523, runTc524, runTc525, runTc526,
+  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522, runTc523, runTc524, runTc525, runTc526, runTc527,
   getSuite,
   results,
   setSharedBmFinalsReady: (v) => { sharedBmFinalsReady = v; },

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -977,14 +977,14 @@ async function runTc713(adminPage) {
 
     // Create 3 players via admin API
     for (let i = 1; i <= 3; i++) {
-      const name = `GP Tie P${i}`;
-      const nickname = `gp_tie_${i}_${stamp}`;
+      const name = `E2E GP Tie P${i}`;
+      const nickname = `e2e_gp_tie_${i}_${stamp}`;
       const p = await uiCreatePlayer(adminPage, name, nickname);
       createdPlayers.push({ id: p.id, name, nickname });
     }
 
     // Create & activate tournament with dualReport disabled
-    const tournamentId = await uiCreateTournament(adminPage, `GP Tie ${stamp}`, { dualReportEnabled: false });
+    const tournamentId = await uiCreateTournament(adminPage, `E2E GP Tie ${stamp}`, { dualReportEnabled: false });
     createdTournaments.push(tournamentId);
 
     // Setup GP qualification with 3 players

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -1352,13 +1352,13 @@ async function runTc620(adminPage) {
     const stamp = Date.now();
 
     for (let i = 1; i <= 3; i++) {
-      const name = `MR Tie P${i}`;
-      const nickname = `mr_tie_${i}_${stamp}`;
+      const name = `E2E MR Tie P${i}`;
+      const nickname = `e2e_mr_tie_${i}_${stamp}`;
       const p = await createPlayer(adminPage, name, nickname);
       createdPlayers.push({ id: p.id, name, nickname });
     }
 
-    tournamentId = await createTournament(adminPage, `MR Tie ${stamp}`, { dualReportEnabled: false });
+    tournamentId = await createTournament(adminPage, `E2E MR Tie ${stamp}`, { dualReportEnabled: false });
 
     await setupModePlayersViaUi(adminPage, 'mr', tournamentId, createdPlayers);
 

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -746,13 +746,13 @@ async function runTc812(adminPage) {
     const stamp = Date.now();
 
     for (let i = 1; i <= 3; i++) {
-      const name = `TA Tie P${i}`;
-      const nickname = `ta_tie_${i}_${stamp}`;
+      const name = `E2E TA Tie P${i}`;
+      const nickname = `e2e_ta_tie_${i}_${stamp}`;
       const p = await uiCreatePlayer(adminPage, name, nickname);
       createdPlayers.push({ id: p.id, name, nickname });
     }
 
-    tournamentId = await uiCreateTournament(adminPage, `TA Tie ${stamp}`, { dualReportEnabled: false });
+    tournamentId = await uiCreateTournament(adminPage, `E2E TA Tie ${stamp}`, { dualReportEnabled: false });
 
     /* Register all 3 players with seeding but no time seeding — we supply our
      * own tied times below. */
@@ -823,10 +823,10 @@ async function runTc813(adminPage) {
     const stamp = Date.now();
 
     for (let i = 1; i <= 4; i++) {
-      const p = await uiCreatePlayer(adminPage, `TA Rank P${i} ${stamp}`, `ta_rank_${i}_${stamp}`);
+      const p = await uiCreatePlayer(adminPage, `E2E TA Rank P${i} ${stamp}`, `e2e_ta_rank_${i}_${stamp}`);
       createdPlayers.push({ id: p.id });
     }
-    tournamentId = await uiCreateTournament(adminPage, `TA Rank Del ${stamp}`, { dualReportEnabled: false });
+    tournamentId = await uiCreateTournament(adminPage, `E2E TA Rank Del ${stamp}`, { dualReportEnabled: false });
 
     /* Register all 4 with unique deterministic times (rank 1=fastest, 4=slowest). */
     const { entries } = await setupTaQualViaUi(adminPage, tournamentId, createdPlayers, { seedTimes: false });

--- a/smkc-score-app/prisma/schema.prisma
+++ b/smkc-score-app/prisma/schema.prisma
@@ -223,7 +223,7 @@ model BMMatch {
   completed    Boolean    @default(false)
   assignedCourses Json? // Pre-assigned courses for this match (§5.4, §6.3): ["MC1", "DP1", "GV1", "BC1"]
   rounds       Json? // [{arena: "Arena 1", winner: 1}, ...]
-  startingCourseNumber Int? // BM bracket only: starting Battle Course (1-4) for this match. NULL for qualification.
+  startingCourseNumber Int? // BM: starting Battle Course (1-4). Qualification: shared per round-robin day (issue #724). Finals/playoff: shared per bracket round.
 
   // Double elimination fields
   bracket      String?     // "winners", "losers", "grand_final"

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page.tsx
@@ -717,11 +717,7 @@ export default function TimeAttackPage({
               )}
             </Button>
           )}
-          {/* Debug-only auto-fill button — visible only on tournaments created
-           * with debugMode. Placed in the header action row to match
-           * BM/MR/GP qualification pages. TA has no `qualificationConfirmed`
-           * field; the lifecycle equivalent is `frozenStages.includes("qualification")`,
-           * which mirrors the server-side gate in fillTATimes (debug-fill.ts:296). */}
+          {/* debug: header行に配置（BM/MR/GP統一）; freeze gate は fillTATimes (debug-fill.ts:296) と対称 */}
           {isAdmin && debugMode && !frozenStages.includes("qualification") && entries.length > 0 && (
             <DebugFillButton tournamentId={tournamentId} mode="ta" onFilled={refetch} />
           )}

--- a/smkc-score-app/src/app/tournaments/page.tsx
+++ b/smkc-score-app/src/app/tournaments/page.tsx
@@ -111,6 +111,7 @@ export default function TournamentsPage() {
     debugMode: false,
   });
   const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   /**
    * Fetches the tournament list from the API.
@@ -159,7 +160,9 @@ export default function TournamentsPage() {
    */
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isSubmitting) return;
     setError("");
+    setIsSubmitting(true);
 
     try {
       const response = await fetch("/api/tournaments", {
@@ -183,6 +186,8 @@ export default function TournamentsPage() {
     } catch (err) {
       logger.error("Failed to create tournament:", { error: err });
       setError(t('failedToCreate'));
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -283,7 +288,7 @@ export default function TournamentsPage() {
         </div>
         {/* Create Tournament dialog - only rendered for admin users */}
         {isAdmin && (
-          <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+          <Dialog open={isAddDialogOpen} onOpenChange={(open) => { setIsAddDialogOpen(open); if (!open) setIsSubmitting(false); }}>
             <DialogTrigger asChild>
               <Button onClick={() => setFormData({ name: "", slug: "", date: "", dualReportEnabled: false, taPlayerSelfEdit: true, debugMode: false })}>
                 {t('createTournament')}
@@ -383,7 +388,7 @@ export default function TournamentsPage() {
                 </div>
               </div>
               <DialogFooter>
-                <Button type="submit">{t('createTournament')}</Button>
+                <Button type="submit" disabled={isSubmitting}>{t('createTournament')}</Button>
               </DialogFooter>
             </form>
           </DialogContent>

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -306,6 +306,17 @@ export function createQualificationHandlers(config: EventTypeConfig) {
       const shuffledCups = config.assignCupRandomly && config.cupList
         ? fisherYatesShuffle(config.cupList)
         : null;
+      /*
+       * BM per-round starting course: one random Battle Course (1-4) per round-robin
+       * day, shared by ALL real matches on that day across all groups (issue #724).
+       * Days in a round-robin are 1-based; we generate assignments lazily in a Map so
+       * the shuffle stays deterministic even with sparse day numbers.
+       */
+      const bmDayStartingCourses: Map<number, number> | null =
+        config.assignBmStartingCourseByDay ? new Map() : null;
+      const bmCoursePool = config.assignBmStartingCourseByDay
+        ? fisherYatesShuffle([1, 2, 3, 4])
+        : null;
       // matchSequenceIndex tracks the overall match number across all groups
       // for consistent sequential course assignment from the shared list.
       let matchSequenceIndex = 0;
@@ -371,6 +382,18 @@ export function createQualificationHandlers(config: EventTypeConfig) {
             ? shuffledCups[matchSequenceIndex % shuffledCups.length]
             : undefined;
 
+          /* BM qualification per-day starting course (issue #724).
+           * All real matches on the same round-robin day share one course (1-4).
+           * Assign lazily so the pool index stays in sync with the observed days. */
+          let bmDayStartingCourse: number | undefined;
+          if (bmDayStartingCourses && bmCoursePool && isRealMatch) {
+            if (!bmDayStartingCourses.has(m.day)) {
+              const poolIndex = bmDayStartingCourses.size % 4;
+              bmDayStartingCourses.set(m.day, bmCoursePool[poolIndex]);
+            }
+            bmDayStartingCourse = bmDayStartingCourses.get(m.day);
+          }
+
           matchData.push({
             tournamentId,
             matchNumber,
@@ -385,6 +408,8 @@ export function createQualificationHandlers(config: EventTypeConfig) {
             ...(assignedCourses ? { assignedCourses } : {}),
             /* Pre-assigned cup for the match (undefined for BM/MR without cup assignment) */
             ...(assignedCup ? { cup: assignedCup } : {}),
+            /* BM: random starting Battle Course shared by all real matches on the same day */
+            ...(bmDayStartingCourse !== undefined ? { startingCourseNumber: bmDayStartingCourse } : {}),
             /* Auto-complete BYE matches with fixed scores (§10.2) */
             ...(m.isBye ? { completed: true, ...byeData } : {}),
           });

--- a/smkc-score-app/src/lib/event-types/bm-config.ts
+++ b/smkc-score-app/src/lib/event-types/bm-config.ts
@@ -59,6 +59,9 @@ export const bmConfig: EventTypeConfig = {
    * Course, distinct from the Bowser Castle racing courses in the racing-mode pool.
    */
   fixedCourseList: ['BC1', 'BC2', 'BC3', 'BC4'] as const,
+  /* §5.4: Each round-robin day gets a random starting Battle Course (1-4) shared
+   * across ALL groups. Different days may differ; same day always shares one course. */
+  assignBmStartingCourseByDay: true,
 
   parsePutBody: (body) => {
     const { matchId, score1, score2, rounds } = body as {

--- a/smkc-score-app/src/lib/event-types/types.ts
+++ b/smkc-score-app/src/lib/event-types/types.ts
@@ -78,6 +78,14 @@ export interface EventTypeConfig {
   fixedCourseList?: readonly string[];
 
   /**
+   * Whether to assign a random starting Battle Course (1-4) per round-robin day at
+   * qualification setup time. When true, all real matches on the same day share one
+   * startingCourseNumber. Days cycle through [1,2,3,4] in shuffled order.
+   * Only used for BM qualification (issue #724).
+   */
+  assignBmStartingCourseByDay?: boolean;
+
+  /**
    * Whether to randomly assign a cup to each match at qualification setup time (§7.4).
    * When true, the POST handler shuffles cupList and assigns one cup per match (cycling via modulo).
    * GP uses this to pre-assign cups; BM/MR do not.


### PR DESCRIPTION
## Summary

- **fix(#723)**: DebugFillButton コメントを5行→1行に短縮（CLAUDE.md規約）
- **fix(#726)**: e2e cleanup regex に `BM-position-check`, `MR Tie`, `GP Tie`, `TA Tie`, `TA Rank Del` を追加。スタンドアロンテストのトーナメント名を `E2E ` プレフィックスに統一して漏れを根絶
- **fix(#725)**: トーナメント作成ボタンに `isSubmitting` ガードを追加（連打で重複作成される問題を修正）
- **fix(#719)**: `wrangler d1 migrations apply` に `--yes` フラグを追加（CI non-TTY 環境での対話待ち防止）
- **fix(#720)**: `d1-migrate.yml` の `paths` トリガーからワークフローファイル自身を削除（ワークフロー修正のみでマイグレーションが走る問題を修正）
- **feat(#724)**: BM予選のラウンドロビン各Day（round）に共通 `startingCourseNumber` (1-4) をランダム割り当て。同じ Day の全実試合が同一コース番号を共有する（決勝/プレーオフは既実装済み）

## Changes

| File | 変更内容 |
|------|----------|
| `src/lib/event-types/types.ts` | `assignBmStartingCourseByDay` フラグ追加 |
| `src/lib/event-types/bm-config.ts` | `assignBmStartingCourseByDay: true` 設定 |
| `src/lib/api-factories/qualification-route.ts` | Day ごとのコース割り当てロジック追加 |
| `src/app/tournaments/page.tsx` | `isSubmitting` によるダブルサブミット防止 |
| `src/app/tournaments/[id]/ta/page.tsx` | コメント1行化 |
| `.github/workflows/d1-migrate.yml` | `--yes` フラグ追加・paths 修正 |
| `e2e/cleanup.js` | 欠落パターンを regex に追加 |
| `e2e/tc-bm.js` | TC-527 追加（qualification per-day startingCourse） |
| `e2e/tc-gp.js` / `tc-mr.js` / `tc-ta.js` | トーナメント名を `E2E ` プレフィックスに修正 |
| `__tests__/.../bm/route.test.ts` | TC-527 対応ユニットテスト追加 |
| `prisma/schema.prisma` | スキーマコメント更新 |
| `E2E_TEST_CASES.md` | TC-527 シナリオ追加 |

## Test plan

- [x] `npx jest` — 2122 tests, 109 suites all pass
- [ ] `node e2e/tc-all.js` — 本番環境で TC-527 が PASS することを確認
- [ ] トーナメント作成ボタンを連打しても1件しか作成されないことを確認
- [ ] BM予選セットアップ後、同一 Day の試合が同じ startingCourseNumber を持つことを確認

https://claude.ai/code/session_015BXszMDeFFTuHK7r4aVCmD

---
_Generated by [Claude Code](https://claude.ai/code/session_015BXszMDeFFTuHK7r4aVCmD)_