### PR TITLE
feat(#731): BM 決勝/プレイオフブラケットのラウンド名下に開始コース表示

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1054,6 +1054,18 @@
 - **期待結果**: null 値が GET 応答で自動補充され、同一ラウンド内が揃い、後続 GET で値が安定する
 - **スクリプト**: tc-bm.js TC-530
 
+## TC-531: BM 決勝ブラケット — ラウンド名の下に startingCourseNumber が表示される (issue #731)
+- **URL**: /tournaments/[id]/bm/finals (UI)
+- **authRequired**: true (admin)
+- **背景**: issue #731 の要求に基づき、BM 決勝・プレイオフブラケットの各ラウンドヘッダー下に「バトルコース {n}」を表示するようになった。ブラケット生成後に UI ページを開き、コース番号が正しく表示されているかを確認する。
+- **手順**:
+  1. 8名 BM 決勝ブラケットを生成（TC-524 と同じ手順）
+  2. /tournaments/[id]/bm/finals を開く
+  3. 少なくとも 1 つのラウンドヘッダー下に「バトルコース」テキストが表示されていることを確認
+  4. playoff_r1 / playoff_r2 がある場合（topN=24 モード）も同様に確認
+- **期待結果**: winners_qf 等のラウンドヘッダー下に startingCourseNumber が「バトルコース {n}」として表示される
+- **スクリプト**: tc-bm.js TC-531
+
 ---
 
 ## MR (Match Race) フルワークフローテスト

--- a/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
@@ -169,3 +169,52 @@ describe("DoubleEliminationBracket TBD rendering (issue #574)", () => {
     expect(winnersQF1!.textContent).toContain(seed8.nickname);
   });
 });
+
+describe("DoubleEliminationBracket startingCourseNumber display (issue #731)", () => {
+  /* Verify that when matches carry a startingCourseNumber, the round header
+   * shows the battle course label below the round name. */
+  const player = { id: "p1", name: "Alice A", nickname: "Alice" };
+  const buildMatchesWithCourse = (courseByRound: Record<string, number>) =>
+    build8PlayerStructure().map((b) => ({
+      id: `m${b.matchNumber}`,
+      matchNumber: b.matchNumber,
+      round: b.round,
+      stage: "finals",
+      player1Id: "p1",
+      player2Id: "p1",
+      score1: 0,
+      score2: 0,
+      completed: false,
+      player1: player,
+      player2: player,
+      startingCourseNumber: b.round && courseByRound[b.round] != null ? courseByRound[b.round] : null,
+    }));
+
+  it("shows battleCourse label under round header when startingCourseNumber is set", () => {
+    const matches = buildMatchesWithCourse({ winners_qf: 2, losers_r1: 3, grand_final: 1 });
+    const { container } = render(
+      <DoubleEliminationBracket
+        matches={matches}
+        bracketStructure={build8PlayerStructure()}
+        roundNames={{}}
+      />,
+    );
+    /* finals.battleCourse translation resolves to "Battle Course {number}" in test env */
+    const text = container.textContent || "";
+    expect(text).toContain("Battle Course 2"); /* winners_qf */
+    expect(text).toContain("Battle Course 3"); /* losers_r1 */
+    expect(text).toContain("Battle Course 1"); /* grand_final */
+  });
+
+  it("hides battleCourse label when startingCourseNumber is null", () => {
+    const matches = buildMatchesWithCourse({});
+    const { container } = render(
+      <DoubleEliminationBracket
+        matches={matches}
+        bracketStructure={build8PlayerStructure()}
+        roundNames={{}}
+      />,
+    );
+    expect(container.textContent).not.toContain("Battle Course");
+  });
+});

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -1940,6 +1940,42 @@ async function runTc530(adminPage) {
   }
 }
 
+/* ───────── TC-531: BM finals bracket UI shows startingCourseNumber under round header (issue #731) ─────────
+ * After bracket generation, the /bm/finals page must display "バトルコース N"
+ * below at least one round name heading in the Winners bracket section. */
+async function runTc531(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedBmFinalsSetup(adminPage);
+    const { tournamentId } = setup;
+
+    const gen = await apiGenerateBmFinals(adminPage, tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    await adminPage.goto(`/tournaments/${tournamentId}/bm/finals`, { waitUntil: 'networkidle' });
+
+    /* Wait for bracket content to load — look for a match card or round header */
+    await adminPage.waitForFunction(
+      () => document.body.textContent?.includes('バトルコース') || document.body.textContent?.includes('Battle Course'),
+      { timeout: 15000 },
+    );
+
+    const hasCourseLabel = await adminPage.evaluate(() =>
+      document.body.textContent?.includes('バトルコース') || document.body.textContent?.includes('Battle Course'),
+    );
+    log('TC-531', hasCourseLabel ? 'PASS' : 'FAIL',
+      hasCourseLabel ? '' : 'No battle course label found under round headers on /bm/finals page');
+  } catch (err) {
+    log('TC-531', 'FAIL', err instanceof Error ? err.message : 'TC-531 failed');
+  } finally {
+    if (setup) {
+      await adminPage.evaluate(async (url) => {
+        await fetch(url, { method: 'DELETE' }).catch(() => {});
+      }, `/api/tournaments/${setup.tournamentId}/bm/finals`);
+    }
+  }
+}
+
 /**
  * Builds the BM suite spec for composition by tc-all. When `sharedFixture` is
  * provided (tc-all flow), we reuse it and skip cleanup — the orchestrator owns
@@ -1990,6 +2026,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-528', fn: runTc528 },
       { name: 'TC-529', fn: runTc529 },
       { name: 'TC-530', fn: runTc530 },
+      { name: 'TC-531', fn: runTc531 },
       { name: 'TC-505', fn: runTc505 },
       { name: 'TC-506', fn: runTc506 },
     ],
@@ -1998,7 +2035,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 
 module.exports = {
   runTc501, runTc502, runTc322, runTc503, runTc504, runTc505, runTc506, runTc511, runTc512, runTc513,
-  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522, runTc523, runTc524, runTc525, runTc526, runTc528, runTc529, runTc530,
+  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522, runTc523, runTc524, runTc525, runTc526, runTc528, runTc529, runTc530, runTc531,
   getSuite,
   results,
   setSharedBmFinalsReady: (v) => { sharedBmFinalsReady = v; },

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -38,6 +38,7 @@ interface BMMatch {
   round: string | null;
   stage?: string | null;
   tvNumber?: number | null;
+  startingCourseNumber?: number | null;
   player1Id: string;
   player2Id: string;
   score1: number;
@@ -289,6 +290,19 @@ function BracketSection({
   );
 }
 
+/** Displays a round name with the assigned starting course below it. */
+function RoundHeader({ label, course }: { label: string; course: number | null }) {
+  const tf = useTranslations("finals");
+  return (
+    <div>
+      <h4 className="text-sm font-medium text-muted-foreground">{label}</h4>
+      {course != null && (
+        <p className="text-xs font-semibold text-blue-500">{tf("battleCourse", { number: course })}</p>
+      )}
+    </div>
+  );
+}
+
 /**
  * Main Double Elimination Bracket component.
  * Renders the complete bracket with winners, losers, and grand final sections.
@@ -391,6 +405,10 @@ export function DoubleEliminationBracket({
     return { player1: isSlotTBD(1), player2: isSlotTBD(2) };
   };
 
+  /* Returns the startingCourseNumber for a given round (all matches in a round share the same value). */
+  const getCourseForRound = (round: string): number | null =>
+    matches.find((m) => m.round === round && m.startingCourseNumber != null)?.startingCourseNumber ?? null;
+
   /* Group bracket positions by round for organized display */
   const winnersR1 = bracketStructure.filter((b) => b.round === "winners_r1");
   const winnersQF = bracketStructure.filter((b) => b.round === "winners_qf");
@@ -426,9 +444,7 @@ export function DoubleEliminationBracket({
           {/* Round 1 - Only in 16-player brackets */}
           {is16Player && (
             <div className="space-y-2">
-              <h4 className="text-sm font-medium text-muted-foreground">
-                {tf("roundOne")}
-              </h4>
+              <RoundHeader label={tf("roundOne")} course={getCourseForRound("winners_r1")} />
               <div className="flex flex-col gap-2">
                 {winnersR1.map((b) => (
                   <MatchCard
@@ -451,9 +467,7 @@ export function DoubleEliminationBracket({
 
           {/* Quarter Finals */}
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-muted-foreground">
-              {tf("quarterFinals")}
-            </h4>
+            <RoundHeader label={tf("quarterFinals")} course={getCourseForRound("winners_qf")} />
             <div className="flex flex-col gap-2">
               {winnersQF.map((b) => (
                 <MatchCard
@@ -475,9 +489,7 @@ export function DoubleEliminationBracket({
 
           {/* Semi Finals - Winners of QF matches */}
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-muted-foreground">
-              {tf("semiFinals")}
-            </h4>
+            <RoundHeader label={tf("semiFinals")} course={getCourseForRound("winners_sf")} />
             <div className="flex flex-col gap-2 justify-center h-full">
               {winnersSF.map((b) => (
                 <MatchCard
@@ -499,7 +511,7 @@ export function DoubleEliminationBracket({
 
           {/* Winners Final - Winner proceeds to Grand Final undefeated */}
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-muted-foreground">{tf("bracketFinalRound")}</h4>
+            <RoundHeader label={tf("bracketFinalRound")} course={getCourseForRound("winners_final")} />
             <div className="flex flex-col gap-2 justify-center h-full">
               {winnersFinal.map((b) => (
                 <MatchCard
@@ -529,9 +541,7 @@ export function DoubleEliminationBracket({
         <div className="flex flex-col gap-6 md:flex-row md:items-start md:gap-8 overflow-x-auto pb-4">
           {/* Losers Round 1 - First matchups of eliminated players */}
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-muted-foreground">
-              {tf("roundOne")}
-            </h4>
+            <RoundHeader label={tf("roundOne")} course={getCourseForRound("losers_r1")} />
             <div className="flex flex-col gap-2">
               {losersR1.map((b) => (
                 <MatchCard
@@ -553,9 +563,7 @@ export function DoubleEliminationBracket({
 
           {/* Losers Round 2 */}
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-muted-foreground">
-              {tf("roundTwo")}
-            </h4>
+            <RoundHeader label={tf("roundTwo")} course={getCourseForRound("losers_r2")} />
             <div className="flex flex-col gap-2">
               {losersR2.map((b) => (
                 <MatchCard
@@ -577,9 +585,7 @@ export function DoubleEliminationBracket({
 
           {/* Losers Round 3 */}
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-muted-foreground">
-              {tf("roundThree")}
-            </h4>
+            <RoundHeader label={tf("roundThree")} course={getCourseForRound("losers_r3")} />
             <div className="flex flex-col gap-2">
               {losersR3.map((b) => (
                 <MatchCard
@@ -602,9 +608,7 @@ export function DoubleEliminationBracket({
           {/* Losers Round 4 - Only in 16-player brackets */}
           {losersR4.length > 0 && (
             <div className="space-y-2">
-              <h4 className="text-sm font-medium text-muted-foreground">
-                {tf("roundFour")}
-              </h4>
+              <RoundHeader label={tf("roundFour")} course={getCourseForRound("losers_r4")} />
               <div className="flex flex-col gap-2">
                 {losersR4.map((b) => (
                   <MatchCard
@@ -627,9 +631,7 @@ export function DoubleEliminationBracket({
 
           {/* Losers Semi Final */}
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-muted-foreground">
-              {tf("semiFinals")}
-            </h4>
+            <RoundHeader label={tf("semiFinals")} course={getCourseForRound("losers_sf")} />
             <div className="flex flex-col gap-2">
               {losersSF.map((b) => (
                 <MatchCard
@@ -651,7 +653,7 @@ export function DoubleEliminationBracket({
 
           {/* Losers Final - Winner advances to Grand Final */}
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-muted-foreground">{tf("bracketFinalRound")}</h4>
+            <RoundHeader label={tf("bracketFinalRound")} course={getCourseForRound("losers_final")} />
             <div className="flex flex-col gap-2">
               {losersFinal.map((b) => (
                 <MatchCard
@@ -680,9 +682,7 @@ export function DoubleEliminationBracket({
         <div className="flex flex-col gap-4 md:flex-row md:items-start md:gap-8 overflow-x-auto pb-4">
           {/* Grand Final match */}
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-muted-foreground">
-              {tf("grandFinalMatch")}
-            </h4>
+            <RoundHeader label={tf("grandFinalMatch")} course={getCourseForRound("grand_final")} />
             {grandFinal.map((b) => (
               <MatchCard
                 key={b.matchNumber}
@@ -706,9 +706,7 @@ export function DoubleEliminationBracket({
            * In true double elimination, both players must lose to be eliminated.
            */}
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-muted-foreground">
-              {tf("resetMatchLabel")}
-            </h4>
+            <RoundHeader label={tf("resetMatchLabel")} course={getCourseForRound("grand_final_reset")} />
             {grandFinalReset.map((b) => (
               <MatchCard
                 key={b.matchNumber}

--- a/smkc-score-app/src/components/tournament/playoff-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/playoff-bracket.tsx
@@ -33,6 +33,7 @@ interface BMMatch {
   round: string | null;
   stage?: string | null;
   tvNumber?: number | null;
+  startingCourseNumber?: number | null;
   player1Id: string;
   player2Id: string;
   score1: number;
@@ -281,6 +282,10 @@ export function PlayoffBracket({
   const r1RoundName = roundNames["playoff_r1"] || tf("roundOne");
   const r2RoundName = roundNames["playoff_r2"] || tf("roundTwo");
 
+  /* Returns the startingCourseNumber for a given playoff round (all matches share the same value). */
+  const getCourseForRound = (round: string): number | null =>
+    playoffMatches.find((m) => m.round === round && m.startingCourseNumber != null)?.startingCourseNumber ?? null;
+
   return (
     <Card className="border-blue-500/30">
       <CardHeader className="py-3">
@@ -298,9 +303,12 @@ export function PlayoffBracket({
         <div className="flex flex-col gap-6 md:flex-row md:items-start md:gap-8 overflow-x-auto pb-4">
           {/* Playoff Round 1 */}
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-muted-foreground">
-              {r1RoundName}
-            </h4>
+            <div>
+              <h4 className="text-sm font-medium text-muted-foreground">{r1RoundName}</h4>
+              {getCourseForRound("playoff_r1") != null && (
+                <p className="text-xs font-semibold text-blue-500">{tf("battleCourse", { number: getCourseForRound("playoff_r1")! })}</p>
+              )}
+            </div>
             <div className="flex flex-col gap-2">
               {playoffR1.map((b) => (
                 <PlayoffMatchCard
@@ -323,9 +331,12 @@ export function PlayoffBracket({
 
           {/* Playoff Round 2 */}
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-muted-foreground">
-              {r2RoundName}
-            </h4>
+            <div>
+              <h4 className="text-sm font-medium text-muted-foreground">{r2RoundName}</h4>
+              {getCourseForRound("playoff_r2") != null && (
+                <p className="text-xs font-semibold text-blue-500">{tf("battleCourse", { number: getCourseForRound("playoff_r2")! })}</p>
+              )}
+            </div>
             <div className="flex flex-col gap-2">
               {playoffR2.map((b) => (
                 <PlayoffMatchCard


### PR DESCRIPTION
## Summary

- **#731**: BM の決勝・プレイオフブラケット画面で、各ラウンド名の下に決められた開始コース（「バトルコース N」）を表示
- **PR #730 コンフリクト解決**: `claude/epic-lovelace-HOEEj` を現在の `main` (PR #728 含む) にリベースし force-push

## 変更内容

### Issue #731: ラウンド別開始コース表示

- `src/components/tournament/double-elimination-bracket.tsx`
  - `BMMatch` インターフェースに `startingCourseNumber?: number | null` を追加
  - `RoundHeader` コンポーネントを追加（ラウンド名 + コースラベルを1箇所で管理）
  - `getCourseForRound(round)` ヘルパーで各ラウンドのコース番号を導出
  - Winners / Losers / Grand Final 全ラウンドのヘッダーを `RoundHeader` に置き換え
- `src/components/tournament/playoff-bracket.tsx`
  - 同様に `startingCourseNumber` 追加・`getCourseForRound` ヘルパー追加
  - `playoff_r1` / `playoff_r2` ヘッダー下にコースラベルを表示
- `__tests__/components/tournament/double-elimination-bracket.test.tsx`
  - TC-731: コース番号あり → `"Battle Course N"` 表示のテスト追加
  - TC-731: コース番号 null → 表示なしのテスト追加
- `E2E_TEST_CASES.md` / `e2e/tc-bm.js`
  - TC-531 追加: `/bm/finals` ページでコースラベルが表示されることを UI で確認

### PR #730 コンフリクト解決

- `claude/epic-lovelace-HOEEj` を `origin/main` (`d3dd5a1` = PR #728) にリベース
- コンフリクト解決方針:
  - `e2e/tc-bm.js`: TC-528/529/530 (HEAD = PR #728) を保持、旧 TC-527 をドロップ
  - `E2E_TEST_CASES.md`: 同様
  - `cleanup.js`: より多くのパターンを含む HEAD 版を保持
  - `tournaments/page.tsx`: `isSubmitting ? t('creating') : t('createTournament')` を採用（UX改善版）

## Test plan

- [ ] TypeScript エラーなし（変更ファイル内）
- [ ] 単体テスト: `__tests__/components/tournament/double-elimination-bracket.test.tsx` PASS
- [ ] TC-531: `/bm/finals` ページでコースラベルが表示される
- [ ] PR #730 (TC-528/529/530) の E2E が引き続き PASS

https://claude.ai/code/session_01QYLDsvH2iEmMJZoiWuxHZ6

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYLDsvH2iEmMJZoiWuxHZ6)_