### PR TITLE
fix(#732,#739,#737): chunk recalculateRanks for D1 param limit + code quality fixes

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/rank-calculation.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/rank-calculation.test.ts
@@ -383,5 +383,55 @@ describe('TA Rank Calculation', () => {
 
       expect(mockPrisma.$executeRaw).not.toHaveBeenCalled();
     });
+
+    // D1 caps bound parameters at ~100. Qualification uses 9 params/entry,
+    // so batches of 10 keep each statement at 90 params (#732).
+    it('should chunk qualification updates into batches of 10 to stay under D1 param limit', async () => {
+      const makeEntry = (i: number) => ({
+        id: `entry-${i}`,
+        times: {
+          MC1: '1:00.000', DP1: '1:00.000', GV1: '1:00.000', BC1: '1:00.000',
+          MC2: '1:00.000', DP2: '1:00.000', GV2: '1:00.000', BC2: '1:00.000',
+          MC3: '1:00.000', DP3: '1:00.000', GV3: '1:00.000', BC3: '1:00.000',
+          CI1: '1:00.000', CI2: '1:00.000', RR: '1:00.000',
+          VL1: '1:00.000', VL2: '1:00.000', KB2: '1:00.000', MC4: '1:00.000', KB1: '1:00.000',
+        },
+        lives: 3,
+        eliminated: false,
+        stage: 'qualification',
+        player: { id: `player-${i}` },
+      });
+
+      // 25 entries → ceil(25/10) = 3 batches
+      mockPrisma.tTEntry.findMany.mockResolvedValue(Array.from({ length: 25 }, (_, i) => makeEntry(i)));
+
+      await recalculateRanks('tournament-1', 'qualification', mockPrisma as unknown as PrismaClient);
+
+      expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(3);
+    });
+
+    it('should chunk non-qualification updates into batches of 18 to stay under D1 param limit', async () => {
+      const makeEntry = (i: number) => ({
+        id: `entry-${i}`,
+        times: {
+          MC1: '1:00.000', DP1: '1:00.000', GV1: '1:00.000', BC1: '1:00.000',
+          MC2: '1:00.000', DP2: '1:00.000', GV2: '1:00.000', BC2: '1:00.000',
+          MC3: '1:00.000', DP3: '1:00.000', GV3: '1:00.000', BC3: '1:00.000',
+          CI1: '1:00.000', CI2: '1:00.000', RR: '1:00.000',
+          VL1: '1:00.000', VL2: '1:00.000', KB2: '1:00.000', MC4: '1:00.000', KB1: '1:00.000',
+        },
+        lives: 3,
+        eliminated: false,
+        stage: 'revival_1',
+        player: { id: `player-${i}` },
+      });
+
+      // 36 entries → ceil(36/18) = 2 batches
+      mockPrisma.tTEntry.findMany.mockResolvedValue(Array.from({ length: 36 }, (_, i) => makeEntry(i)));
+
+      await recalculateRanks('tournament-1', 'revival_1', mockPrisma as unknown as PrismaClient);
+
+      expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/smkc-score-app/src/components/tournament/playoff-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/playoff-bracket.tsx
@@ -305,9 +305,7 @@ export function PlayoffBracket({
           <div className="space-y-2">
             <div>
               <h4 className="text-sm font-medium text-muted-foreground">{r1RoundName}</h4>
-              {getCourseForRound("playoff_r1") != null && (
-                <p className="text-xs font-semibold text-blue-500">{tf("battleCourse", { number: getCourseForRound("playoff_r1")! })}</p>
-              )}
+              {(() => { const c = getCourseForRound("playoff_r1"); return c != null && <p className="text-xs font-semibold text-blue-500">{tf("battleCourse", { number: c })}</p>; })()}
             </div>
             <div className="flex flex-col gap-2">
               {playoffR1.map((b) => (
@@ -333,9 +331,7 @@ export function PlayoffBracket({
           <div className="space-y-2">
             <div>
               <h4 className="text-sm font-medium text-muted-foreground">{r2RoundName}</h4>
-              {getCourseForRound("playoff_r2") != null && (
-                <p className="text-xs font-semibold text-blue-500">{tf("battleCourse", { number: getCourseForRound("playoff_r2")! })}</p>
-              )}
+              {(() => { const c = getCourseForRound("playoff_r2"); return c != null && <p className="text-xs font-semibold text-blue-500">{tf("battleCourse", { number: c })}</p>; })()}
             </div>
             <div className="flex flex-col gap-2">
               {playoffR2.map((b) => (

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -569,16 +569,19 @@ export function createQualificationHandlers(config: EventTypeConfig) {
       );
 
       /* Update both players' qualification records in parallel (#707). */
-      await Promise.all([
+      const updates = [
         qualModel(prisma).updateMany({
           where: { tournamentId, playerId: match.player1Id },
           data: p1.qualificationData,
         }),
-        p2 && qualModel(prisma).updateMany({
+      ];
+      if (p2) {
+        updates.push(qualModel(prisma).updateMany({
           where: { tournamentId, playerId: match.player2Id },
           data: p2.qualificationData,
-        }),
-      ].filter(Boolean));
+        }));
+      }
+      await Promise.all(updates);
 
       /* Score updates change both per-mode standings and the cross-mode
        * overall ranking. Drop both caches so the next GET reflects the new

--- a/smkc-score-app/src/lib/ta/rank-calculation.ts
+++ b/smkc-score-app/src/lib/ta/rank-calculation.ts
@@ -220,44 +220,50 @@ export async function recalculateRanks(
   // Early return avoids sending an empty WHERE IN () clause to D1.
   if (entriesWithTotal.length === 0) return;
 
-  // Collapse N sequential TTEntry.update round-trips into a single bulk UPDATE
-  // using CASE WHEN expressions. On D1 (Cloudflare SQLite), each individual
-  // update costs ~185ms, so 27 entries would block the response for ~5s (#710).
-  // A single statement reduces this to ~200ms regardless of entry count.
-  const totalTimeCases = Prisma.join(
-    entriesWithTotal.map((e) => Prisma.sql`WHEN ${e.id} THEN ${e.totalTime ?? null}`),
-    ' '
-  );
-  const rankCases = Prisma.join(
-    entriesWithTotal.map((e) => Prisma.sql`WHEN ${e.id} THEN ${rankMap.get(e.id) ?? null}`),
-    ' '
-  );
-  const ids = Prisma.join(entriesWithTotal.map((e) => Prisma.sql`${e.id}`));
+  // D1 enforces a ~100 bound-parameter limit per SQL statement.
+  // Qualification CASE WHEN uses 9 params/entry (4 CASE blocks × 2 + 1 WHERE IN id).
+  // Other stages use 5 params/entry (2 CASE blocks × 2 + 1 WHERE IN id).
+  // Chunk into batches that stay under the limit (#732).
+  const BATCH_SIZE = stage === "qualification" ? 10 : 18;
 
-  if (stage === "qualification") {
-    // courseScores is a JSON column stored as text; pass the serialized string directly.
-    const courseScoresCases = Prisma.join(
-      entriesWithTotal.map((e) => Prisma.sql`WHEN ${e.id} THEN ${JSON.stringify(e.courseScores)}`),
+  for (let offset = 0; offset < entriesWithTotal.length; offset += BATCH_SIZE) {
+    const batch = entriesWithTotal.slice(offset, offset + BATCH_SIZE);
+
+    const totalTimeCases = Prisma.join(
+      batch.map((e) => Prisma.sql`WHEN ${e.id} THEN ${e.totalTime ?? null}`),
       ' '
     );
-    const qualPointsCases = Prisma.join(
-      entriesWithTotal.map((e) => Prisma.sql`WHEN ${e.id} THEN ${e.qualificationPoints ?? null}`),
+    const rankCases = Prisma.join(
+      batch.map((e) => Prisma.sql`WHEN ${e.id} THEN ${rankMap.get(e.id) ?? null}`),
       ' '
     );
-    await prisma.$executeRaw`
-      UPDATE TTEntry SET
-        totalTime = CASE id ${totalTimeCases} ELSE totalTime END,
-        rank = CASE id ${rankCases} ELSE rank END,
-        courseScores = CASE id ${courseScoresCases} ELSE courseScores END,
-        qualificationPoints = CASE id ${qualPointsCases} ELSE qualificationPoints END
-      WHERE id IN (${ids})
-    `;
-  } else {
-    await prisma.$executeRaw`
-      UPDATE TTEntry SET
-        totalTime = CASE id ${totalTimeCases} ELSE totalTime END,
-        rank = CASE id ${rankCases} ELSE rank END
-      WHERE id IN (${ids})
-    `;
+    const ids = Prisma.join(batch.map((e) => Prisma.sql`${e.id}`));
+
+    if (stage === "qualification") {
+      // courseScores is a JSON column stored as text; pass the serialized string directly.
+      const courseScoresCases = Prisma.join(
+        batch.map((e) => Prisma.sql`WHEN ${e.id} THEN ${JSON.stringify(e.courseScores)}`),
+        ' '
+      );
+      const qualPointsCases = Prisma.join(
+        batch.map((e) => Prisma.sql`WHEN ${e.id} THEN ${e.qualificationPoints ?? null}`),
+        ' '
+      );
+      await prisma.$executeRaw`
+        UPDATE TTEntry SET
+          totalTime = CASE id ${totalTimeCases} ELSE totalTime END,
+          rank = CASE id ${rankCases} ELSE rank END,
+          courseScores = CASE id ${courseScoresCases} ELSE courseScores END,
+          qualificationPoints = CASE id ${qualPointsCases} ELSE qualificationPoints END
+        WHERE id IN (${ids})
+      `;
+    } else {
+      await prisma.$executeRaw`
+        UPDATE TTEntry SET
+          totalTime = CASE id ${totalTimeCases} ELSE totalTime END,
+          rank = CASE id ${rankCases} ELSE rank END
+        WHERE id IN (${ids})
+      `;
+    }
   }
 }


### PR DESCRIPTION
## Summary

- **#732 (critical)**: `recalculateRanks` bulk UPDATE exceeds D1's ~100 bound-parameter limit for TA tournaments with ≥12 entries, causing 500 errors on DELETE/PUT and breaking TA debug-fill (#746)
- **#739**: `playoff-bracket.tsx` calls `getCourseForRound()` twice per round header (double array scan)
- **#737**: `qualification-route.ts` uses `filter(Boolean)` in `Promise.all([...])` which TypeScript cannot narrow correctly

## Changes

### fix(#732): chunk recalculateRanks batches to stay under D1 100-param limit

The bulk CASE WHEN UPDATE (#710) uses 9 params/entry (qualification) or 5 params/entry (other stages). D1 caps at ~100, so qualification breaks at ≥12 entries (12×9=108 > 100).

**Fix**: chunk into batches of ≤10 (qualification) or ≤18 (other stages), each ≤90 params. Global ranks are computed in one pass before chunking — ranking correctness unchanged.

This also fixes **#746** (TA auto-fill failing with 500 when tournament has 12+ entries).

### fix(#739): cache getCourseForRound result in playoff-bracket.tsx

Two calls per round header → one call via IIFE pattern, eliminating the double array scan.

### fix(#737): replace filter(Boolean) with typed array push in qualification-route.ts

`[..., p2 && expr].filter(Boolean)` produces a type that TypeScript cannot narrow into `Promise[]`. Replaced with an explicit typed array and conditional push — same logic, type-safe.

## Tests

- 2 new unit tests in `rank-calculation.test.ts` verify batching behaviour:
  - 25 qualification entries → 3 batches (ceil(25/10))
  - 36 revival entries → 2 batches (ceil(36/18))
- All existing tests pass (109 suites, 2105+ tests)
- TypeScript: no errors

## Related issues

- Closes #732, #746
- Closes #739, #737

https://claude.ai/code/session_01PEJLgvi1BS5zwv9De1HreV

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEJLgvi1BS5zwv9De1HreV)_