### PR TITLE
fix: startingCourseNumber clear-on-empty, QUAL_CHUNK test, E2E timeout (#769/#770/#771)

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/route.test.ts
@@ -189,10 +189,12 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
       expect(loggerMock.error).toHaveBeenCalled();
     });
 
-    // TC-530/#741: null startingCourseNumber repair must update all rows without NOT condition
-    // SQL `NOT (col = ?)` evaluates to NULL (not TRUE) when col IS NULL, so the
-    // old NOT filter silently skipped null rows — the primary legacy case to repair.
-    it('should repair all-null startingCourseNumber rows without NOT condition in updateMany (#741)', async () => {
+    // Issue #771: all-null rounds must NOT be repaired — an all-null round means
+    // the admin explicitly cleared via PATCH, so normalization must preserve it.
+    // POST (bracket creation) always assigns values via createBmRoundStartingCourses.
+    // The NOT-condition bug fix (#741) remains valid for mixed-null rounds (some
+    // matches have a value, others are null — those are still repaired without NOT).
+    it('should NOT repair all-null startingCourseNumber round — preserves intentional clear (#771)', async () => {
       const nullMatches = [
         { id: 'm1', round: 'winners_qf', startingCourseNumber: null },
         { id: 'm2', round: 'winners_qf', startingCourseNumber: null },
@@ -208,7 +210,7 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
         .mockResolvedValueOnce(nullMatches) // normalization select
         .mockResolvedValueOnce(nullMatches); // main data
 
-      (prisma.bMMatch.updateMany as jest.Mock).mockResolvedValue({ count: 4 });
+      (prisma.bMMatch.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm/finals');
       const params = Promise.resolve({ id: 't1' });
@@ -218,13 +220,8 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
       const repairCall = updateManyCalls.find(([args]) =>
         args?.where?.stage === 'finals' && args?.where?.round === 'winners_qf',
       );
-      expect(repairCall).toBeTruthy();
-      // Fixed: no NOT condition — SQL null rows would be skipped by NOT
-      expect(repairCall[0].where.NOT).toBeUndefined();
-      // Assigned value must be in valid [1, 4] range
-      const assigned = repairCall[0].data.startingCourseNumber;
-      expect(assigned).toBeGreaterThanOrEqual(1);
-      expect(assigned).toBeLessThanOrEqual(4);
+      // All-null rounds must not be touched — no repair updateMany should fire
+      expect(repairCall).toBeUndefined();
     });
   });
 

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -432,7 +432,11 @@ describe('Finals Route Factory', () => {
       expect(updateCall[0].where).not.toHaveProperty('NOT');
     });
 
-    it('repairs all-null round by drawing a fresh value in [1,4] (BM finals)', async () => {
+    /* Issue #771: all-null rounds must NOT be re-filled by normalization.
+     * POST (bracket creation) assigns values via createBmRoundStartingCourses.
+     * An all-null round means the admin explicitly cleared it via PATCH.
+     * Re-filling would silently undo that intentional clear. */
+    it('does not repair all-null round — preserves intentional clear (BM finals, #771)', async () => {
       const finalsMatches = [
         createMockMatch({ id: 'f1', stage: 'finals', round: 'winners_qf', startingCourseNumber: null }),
         createMockMatch({ id: 'f2', stage: 'finals', round: 'winners_qf', startingCourseNumber: null }),
@@ -454,15 +458,12 @@ describe('Finals Route Factory', () => {
       const response = await GET(request, { params: Promise.resolve({ id: 'tournament-123' }) });
 
       expect(response.status).toBe(200);
+      /* No updateMany should target this all-null round. */
       const updateManyCalls = (prisma.bMMatch as any).updateMany.mock.calls;
       const repairCall = updateManyCalls.find(
         (c: any[]) => c[0]?.where?.stage === 'finals' && c[0]?.where?.round === 'winners_qf',
       );
-      expect(repairCall).toBeDefined();
-      const value = repairCall[0].data.startingCourseNumber;
-      expect(Number.isInteger(value)).toBe(true);
-      expect(value).toBeGreaterThanOrEqual(1);
-      expect(value).toBeLessThanOrEqual(4);
+      expect(repairCall).toBeUndefined();
     });
 
     it('does not repair when assignBmStartingCourseByRound is off', async () => {

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -353,6 +353,44 @@ describe('Qualification Route Factory', () => {
       expect(totalMatches).toBe(28);
     });
 
+    it('should chunk qual createMany when record count exceeds QUAL_CHUNK=24 (#769)', async () => {
+      // 28 players in one group → 28 qual records > QUAL_CHUNK=24
+      // Expected: ceil(28/24) = 2 createMany calls with slices [0..24, 24..28]
+      // 28 is even so no BYE rounds are generated.
+      const players = Array.from({ length: 28 }, (_, i) => ({
+        playerId: `player-${i + 1}`,
+        group: 'A',
+        seeding: i + 1,
+      }));
+
+      (prisma.bMQualification as any).createMany.mockResolvedValue({ count: 24 });
+      (prisma.bMQualification as any).findMany.mockResolvedValue([]);
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 8 });
+      (prisma.bMMatch as any).findMany.mockResolvedValue([]);
+
+      const config = createMockConfig();
+      const { POST } = createQualificationHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ players }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(201);
+
+      // 28 qual records → 2 chunks: first 24, then remaining 4
+      const qualCalls = (prisma.bMQualification as any).createMany.mock.calls;
+      expect(qualCalls).toHaveLength(2);
+      expect(qualCalls[0][0].data).toHaveLength(24);
+      expect(qualCalls[1][0].data).toHaveLength(4);
+      // Total qual records across all chunks = 28
+      const totalQuals = qualCalls.reduce((sum: number, call: any[]) => sum + call[0].data.length, 0);
+      expect(totalQuals).toBe(28);
+    });
+
     it('should create audit log when auditAction is configured', async () => {
       const players = createMockPlayers();
 

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -1861,8 +1861,11 @@ async function uiSetTaEntryTimes(page, tournamentId, entry, times) {
     await timesTab.first().click().catch(() => {});
   }
 
-  /* Each entry row has an "Edit Times" button; filter the row by nickname. */
+  /* Each entry row has an "Edit Times" button; filter the row by nickname.
+   * Wait for the row to appear before clicking (D1 cold-start can push render
+   * past the default 30s timeout — TC-312/313 regression #770). */
   const row = page.getByRole('row').filter({ hasText: entry.nickname }).first();
+  await row.waitFor({ state: 'visible', timeout: 40000 });
   await row.getByRole('button', { name: /^(Edit Times|タイム編集)$/ }).click();
 
   const dialog = page.getByRole('dialog').filter({

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3315,6 +3315,8 @@ async function main() {
         const r = await fetch(`/api/tournaments/${tid}/bm`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          // seeding is optional in the API schema (seeding?: number); omitted here
+          // to verify chunking works regardless of seeding presence (#768).
           body: JSON.stringify({ players: pids.map(id => ({ playerId: id, group: 'A' })) }),
         });
         return { s: r.status, ms: Date.now() - start };
@@ -3335,6 +3337,7 @@ async function main() {
         const r = await fetch(`/api/tournaments/${tid}/mr`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          // seeding is optional; same omission as BM above (#768)
           body: JSON.stringify({ players: pids.map(id => ({ playerId: id, group: 'A' })) }),
         });
         return { s: r.status };

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -390,8 +390,16 @@ async function normalizeRoundStartingCoursesToSingleValue(
     const distinctValues = counts.size;
     const totalWithValue = Array.from(counts.values()).reduce((a, b) => a + b, 0);
     const roundMatchCount = matches.filter((m) => m.round === round).length;
-    /* Repair when: round has no value yet, values disagree, or some null gaps. */
-    if (distinctValues !== 1 || totalWithValue !== roundMatchCount) {
+    /* Repair only genuine inconsistencies:
+     *   - distinctValues > 1: matches in the round have different non-null values.
+     *   - distinctValues === 1 && totalWithValue < roundMatchCount: one value exists
+     *     but some matches still have null — fill the gaps with the dominant value.
+     *
+     * All-null rounds (distinctValues === 0) are intentionally skipped.
+     * New brackets are created with values from createBmRoundStartingCourses, so
+     * an all-null round means the admin explicitly cleared it via PATCH. Re-filling
+     * would silently undo that intentional clear (TC-525). */
+    if (distinctValues > 1 || (distinctValues === 1 && totalWithValue < roundMatchCount)) {
       roundsNeedingRepair.add(round);
     }
   }


### PR DESCRIPTION
## Summary

- **#771** `fix(finals-route)`: `normalizeRoundStartingCoursesToSingleValue` was treating all-null rounds as needing repair, so clearing a startingCourseNumber via PATCH was immediately re-filled on the next GET. Fixed to only repair genuine inconsistencies (mixed null/value or conflicting values). All-null rounds (explicitly cleared or legacy) are now preserved.
- **#769** `test(qualification-route)`: Add QUAL_CHUNK=24 boundary unit test — 28-player group → 2 `createMany` calls (24 + 4), verifying the chunking logic added in PR #767.
- **#770** `fix(e2e)`: TC-312/313 timeout — add `row.waitFor(40s)` before clicking the 'Edit Times' button in `uiSetTaEntryTimes`. D1 cold-start can push page render past the default 30s Playwright timeout.
- **#768** `fix(e2e)`: Add inline comment to TC-353 BM/MR payloads clarifying that `seeding` is optional in the API schema.

## Test plan

- [ ] TypeScript passes (`npx tsc --noEmit`)
- [ ] All 109 test suites pass (`npx jest --no-coverage`)
- [ ] Lint passes with 0 errors (`npm run lint`)
- [ ] BM finals score dialog: selecting '-' clears startingCourseNumber (GET no longer re-fills it)
- [ ] TC-525 passes in E2E (startingCourseNumber clear-on-empty)
- [ ] TC-312/313 no longer timeout under D1 saturation

https://claude.ai/code/session_01HeMXEQFkgqj6yXBE67tx5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeMXEQFkgqj6yXBE67tx5i)_