### PR TITLE
refactor: audit log .catch(), resolveAuditUserId, fontsource comment, D1 timeout constant (#772/#773/#774/#777)

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/bracket/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/bracket/route.test.ts
@@ -32,7 +32,7 @@ jest.mock('@/lib/auth', () => ({ auth: jest.fn() }));
 jest.mock('@/lib/logger', () => ({ createLogger: jest.fn(() => ({ error: jest.fn(), warn: jest.fn() })) }));
 jest.mock('@/lib/rate-limit', () => ({ getServerSideIdentifier: jest.fn(), checkRateLimit: jest.fn().mockResolvedValue({ success: true, remaining: 100 }) }));
 jest.mock('@/lib/sanitize', () => ({ sanitizeInput: jest.fn((data) => data) }));
-jest.mock('@/lib/audit-log', () => ({ createAuditLog: jest.fn(() => Promise.resolve()), AUDIT_ACTIONS: { CREATE_BRACKET: 'CREATE_BRACKET' } }));
+jest.mock('@/lib/audit-log', () => ({ createAuditLog: jest.fn(() => Promise.resolve()), AUDIT_ACTIONS: { CREATE_BRACKET: 'CREATE_BRACKET' }, resolveAuditUserId: jest.fn((s) => s?.user?.id) }));
 jest.mock('@/lib/tournament/double-elimination', () => ({ generateDoubleEliminationBracket: jest.fn() }));
 jest.mock('next/server', () => ({ NextResponse: { json: jest.fn() } }));
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/matches/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/matches/route.test.ts
@@ -29,7 +29,7 @@ jest.mock('@/lib/auth', () => ({ auth: jest.fn() }));
 jest.mock('@/lib/logger', () => ({ createLogger: jest.fn(() => ({ error: jest.fn(), warn: jest.fn() })) }));
 jest.mock('@/lib/rate-limit', () => ({ getServerSideIdentifier: jest.fn(), checkRateLimit: jest.fn().mockResolvedValue({ success: true, remaining: 100 }) }));
 jest.mock('@/lib/sanitize', () => ({ sanitizeInput: jest.fn((data) => data) }));
-jest.mock('@/lib/audit-log', () => ({ createAuditLog: jest.fn(), AUDIT_ACTIONS: { CREATE_BM_MATCH: 'CREATE_BM_MATCH' } }));
+jest.mock('@/lib/audit-log', () => ({ createAuditLog: jest.fn(), AUDIT_ACTIONS: { CREATE_BM_MATCH: 'CREATE_BM_MATCH' }, resolveAuditUserId: jest.fn((s) => s?.user?.id) }));
 jest.mock('next/server', () => ({ NextResponse: { json: jest.fn() } }));
 
 import prisma from '@/lib/prisma';

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
@@ -29,7 +29,7 @@ jest.mock('@/lib/logger', () => ({ createLogger: jest.fn(() => ({ error: jest.fn
 jest.mock('@/lib/rate-limit', () => ({ checkRateLimit: jest.fn().mockResolvedValue({ success: true, remaining: 100 }) }));
 jest.mock('@/lib/request-utils', () => ({ getServerSideIdentifier: jest.fn(), getClientIdentifier: jest.fn().mockReturnValue('127.0.0.1'), getUserAgent: jest.fn().mockReturnValue('jest-test') }));
 jest.mock('@/lib/sanitize', () => ({ sanitizeInput: jest.fn((data) => data) }));
-jest.mock('@/lib/audit-log', () => ({ createAuditLog: jest.fn(), AUDIT_ACTIONS: { CREATE_BM_MATCH: 'CREATE_BM_MATCH' } }));
+jest.mock('@/lib/audit-log', () => ({ createAuditLog: jest.fn(), AUDIT_ACTIONS: { CREATE_BM_MATCH: 'CREATE_BM_MATCH' }, resolveAuditUserId: jest.fn((s) => s?.user?.id) }));
 jest.mock('next/server', () => ({ NextResponse: { json: jest.fn() } }));
 /* Mock qualification-confirmed-check: the qualification-route factory now checks
  * if qualification is locked before allowing score edits. Return null (= not locked). */

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/bracket/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/bracket/route.test.ts
@@ -35,7 +35,7 @@ jest.mock('@/lib/tournament/double-elimination', () => ({
     grandFinal: null,
   })),
 }));
-jest.mock('@/lib/audit-log', () => ({ createAuditLog: jest.fn(() => Promise.resolve()), AUDIT_ACTIONS: { CREATE_BRACKET: 'CREATE_BRACKET' } }));
+jest.mock('@/lib/audit-log', () => ({ createAuditLog: jest.fn(() => Promise.resolve()), AUDIT_ACTIONS: { CREATE_BRACKET: 'CREATE_BRACKET' }, resolveAuditUserId: jest.fn((s) => s?.user?.id) }));
 jest.mock('@/lib/logger', () => ({ createLogger: jest.fn(() => ({ error: jest.fn(), warn: jest.fn() })) }));
 jest.mock('next/server', () => ({ NextResponse: { json: jest.fn() } }));
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/matches/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/matches/route.test.ts
@@ -27,7 +27,7 @@
 
 
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }));
-jest.mock('@/lib/audit-log', () => ({ createAuditLog: jest.fn(() => Promise.resolve()), AUDIT_ACTIONS: { CREATE_MR_MATCH: 'CREATE_MR_MATCH' } }));
+jest.mock('@/lib/audit-log', () => ({ createAuditLog: jest.fn(() => Promise.resolve()), AUDIT_ACTIONS: { CREATE_MR_MATCH: 'CREATE_MR_MATCH' }, resolveAuditUserId: jest.fn((s) => s?.user?.id) }));
 jest.mock('@/lib/sanitize', () => ({ sanitizeInput: jest.fn((data) => data) }));
 jest.mock('@/lib/logger', () => ({ createLogger: jest.fn(() => ({ error: jest.fn(), warn: jest.fn() })) }));
 jest.mock('next/server', () => ({ NextResponse: { json: jest.fn() } }));

--- a/smkc-score-app/__tests__/lib/api-factories/finals-bracket-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-bracket-route.test.ts
@@ -27,6 +27,7 @@ jest.mock('@/lib/tournament/double-elimination', () => ({
 jest.mock('@/lib/audit-log', () => ({
   createAuditLog: jest.fn(() => Promise.resolve()),
   AUDIT_ACTIONS: { CREATE_BRACKET: 'CREATE_BRACKET' },
+  resolveAuditUserId: jest.fn((s: { user?: { id?: string } } | null) => s?.user?.id),
 }));
 jest.mock('@/lib/logger', () => ({
   createLogger: jest.fn(() => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() })),

--- a/smkc-score-app/__tests__/lib/api-factories/finals-matches-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-matches-route.test.ts
@@ -22,6 +22,7 @@ jest.mock('@/lib/auth', () => ({ auth: jest.fn() }));
 jest.mock('@/lib/audit-log', () => ({
   createAuditLog: jest.fn(() => Promise.resolve()),
   AUDIT_ACTIONS: { CREATE_BM_MATCH: 'CREATE_BM_MATCH' },
+  resolveAuditUserId: jest.fn((s: { user?: { id?: string } } | null) => s?.user?.id),
 }));
 jest.mock('@/lib/sanitize', () => ({
   sanitizeInput: jest.fn((data: unknown) => data),

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -58,7 +58,7 @@ jest.mock('@/lib/standings-cache', () => ({
 }));
 
 import { auth } from '@/lib/auth';
-import { createAuditLog } from '@/lib/audit-log';
+import { createAuditLog, resolveAuditUserId } from '@/lib/audit-log';
 import { getServerSideIdentifier } from '@/lib/request-utils';
 import { sanitizeInput } from '@/lib/sanitize';
 import { createLogger } from '@/lib/logger';
@@ -109,6 +109,10 @@ describe('Qualification Route Factory', () => {
     (createLogger as jest.Mock).mockReturnValue(mockLogger);
     mockSanitizeInput.mockImplementation((input) => input);
     mockCreateAuditLog.mockResolvedValue(undefined);
+    /* resolveAuditUserId returns the session user's id for admin sessions */
+    (resolveAuditUserId as jest.Mock).mockImplementation(
+      (s: { user?: { id?: string } } | null) => s?.user?.id,
+    );
     mockGetServerSideIdentifier.mockResolvedValue('192.168.1.1');
 
     // Default tournament for resolveTournament(); individual tests override

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -18,6 +18,10 @@ const path = require('path');
 
 const BASE = process.env.E2E_BASE_URL || 'https://smkc.bluemoon.works';
 const NAV_WAIT_MS = 8000;
+/** D1 cold-start can push page render well past the default 30s Playwright timeout.
+ * Use this constant for any waitFor/click/locator that depends on admin-gated UI
+ * or API responses that may be delayed by D1 initialization (#777). */
+const D1_COLD_START_TIMEOUT_MS = 40_000;
 const apiLogContexts = new WeakSet();
 
 function formatApiLogUrl(rawUrl) {
@@ -1155,7 +1159,7 @@ async function uiPhaseStartRound(page, tournamentId, phase) {
   }
   const startBtn = page.getByRole('button', { name: /^(Start Round \d+|ラウンド\s*\d+\s*開始)$/ }).first();
   /* 40s to absorb D1 cold-start + fetchWithRetry delays (issue #678, #701) */
-  await startBtn.waitFor({ state: 'visible', timeout: 40000 });
+  await startBtn.waitFor({ state: 'visible', timeout: D1_COLD_START_TIMEOUT_MS });
 
   const responsePromise = page.waitForResponse((res) =>
     res.url().includes(`/api/tournaments/${tournamentId}/ta/phases`) &&
@@ -1865,7 +1869,7 @@ async function uiSetTaEntryTimes(page, tournamentId, entry, times) {
    * Wait for the row to appear before clicking (D1 cold-start can push render
    * past the default 30s timeout — TC-312/313 regression #770). */
   const row = page.getByRole('row').filter({ hasText: entry.nickname }).first();
-  await row.waitFor({ state: 'visible', timeout: 40000 });
+  await row.waitFor({ state: 'visible', timeout: D1_COLD_START_TIMEOUT_MS });
   await row.getByRole('button', { name: /^(Edit Times|タイム編集)$/ }).click();
 
   const dialog = page.getByRole('dialog').filter({

--- a/smkc-score-app/src/app/layout.tsx
+++ b/smkc-score-app/src/app/layout.tsx
@@ -31,7 +31,10 @@ import { NavLabelClient } from "@/components/NavLabel";
 import { WebVitalsReporter } from "./web-vitals";
 
 /* Font wiring using @fontsource local files — no build-time network calls.
- * CSS variable names match globals.css @theme declarations. */
+ * CSS variable names match globals.css @theme declarations.
+ * NOTE: paths reference node_modules directly using @fontsource v5.x file layout
+ * (files/<family>-<subset>-<weight>-normal.woff2). When upgrading @fontsource
+ * packages, verify the file naming convention has not changed (#774). */
 const fontDisplay = localFont({
   src: "../../node_modules/@fontsource/anton/files/anton-latin-400-normal.woff2",
   variable: "--font-anton",

--- a/smkc-score-app/src/lib/api-factories/finals-bracket-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-bracket-route.ts
@@ -17,7 +17,7 @@ import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
 import { generateDoubleEliminationBracket, BracketPlayer } from '@/lib/tournament/double-elimination';
-import { createAuditLog, AUDIT_ACTIONS } from '@/lib/audit-log';
+import { createAuditLog, AUDIT_ACTIONS, resolveAuditUserId } from '@/lib/audit-log';
 import { createLogger } from '@/lib/logger';
 import { createErrorResponse, createSuccessResponse, handleValidationError, handleRateLimitError } from '@/lib/error-handling';
 import { checkRateLimit } from '@/lib/rate-limit';
@@ -165,7 +165,7 @@ export function createFinalsBracketHandlers(config: FinalsBracketConfig) {
       /* Record audit log for bracket generation (security and accountability).
        * Fire-and-forget: .catch() handles async failures without blocking the response. */
       createAuditLog({
-        userId: session.user.id,
+        userId: resolveAuditUserId(session),
         ipAddress: request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown',
         userAgent: request.headers.get('user-agent') || 'unknown',
         action: AUDIT_ACTIONS.CREATE_BRACKET,

--- a/smkc-score-app/src/lib/api-factories/finals-matches-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-matches-route.ts
@@ -15,7 +15,7 @@ import { NextRequest } from 'next/server';
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
-import { createAuditLog } from '@/lib/audit-log';
+import { createAuditLog, resolveAuditUserId } from '@/lib/audit-log';
 import { sanitizeInput } from '@/lib/sanitize';
 import { z } from 'zod';
 import { createLogger } from '@/lib/logger';
@@ -157,7 +157,7 @@ export function createFinalsMatchesHandlers(config: FinalsMatchesConfig) {
       /* Record audit log for match creation (security and accountability).
        * Fire-and-forget: .catch() handles async failures without blocking the response. */
       createAuditLog({
-        userId: session.user.id,
+        userId: resolveAuditUserId(session),
         ipAddress: request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown',
         userAgent: request.headers.get('user-agent') || 'unknown',
         action: config.auditAction,

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -13,7 +13,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
-import { createAuditLog } from '@/lib/audit-log';
+import { createAuditLog, resolveAuditUserId } from '@/lib/audit-log';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { getClientIdentifier, getServerSideIdentifier } from '@/lib/request-utils';
 import { sanitizeInput } from '@/lib/sanitize';
@@ -468,7 +468,7 @@ export function createQualificationHandlers(config: EventTypeConfig) {
           const ip = await getServerSideIdentifier();
           const userAgent = request.headers.get('user-agent') || 'unknown';
           createAuditLog({
-            userId: currentSession.user.id,
+            userId: resolveAuditUserId(currentSession),
             ipAddress: ip,
             userAgent,
             action: config.auditAction,

--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -253,10 +253,8 @@ export async function promoteToPhase1(
     orderBy: { rank: "asc" },
   });
 
-  // Fire-and-forget audit logs — createAuditLog internally handles errors;
-  // using void keeps them off the critical response path
   for (const entry of createdEntries) {
-    void createAuditLog({
+    createAuditLog({
       userId,
       ipAddress,
       userAgent,
@@ -269,7 +267,7 @@ export async function promoteToPhase1(
         playerNickname: (entry as TTEntry & { player: { nickname: string } }).player.nickname,
         promotedTo: "phase1",
       },
-    });
+    }).catch((err) => logger.warn("Failed to create audit log", { error: err }));
   }
 
   return {
@@ -383,7 +381,7 @@ export async function promoteToPhase2(
   });
 
   for (const entry of createdEntries) {
-    void createAuditLog({
+    createAuditLog({
       userId, ipAddress, userAgent,
       action: AUDIT_ACTIONS.CREATE_TA_ENTRY,
       targetId: entry.id,
@@ -391,7 +389,7 @@ export async function promoteToPhase2(
       details: { tournamentId, playerId: entry.playerId,
         playerNickname: (entry as TTEntry & { player: { nickname: string } }).player.nickname,
         promotedTo: "phase2" },
-    });
+    }).catch((err) => logger.warn("Failed to create audit log", { error: err }));
   }
 
   return {
@@ -504,7 +502,7 @@ export async function promoteToPhase3(
   });
 
   for (const entry of createdEntries) {
-    void createAuditLog({
+    createAuditLog({
       userId, ipAddress, userAgent,
       action: AUDIT_ACTIONS.CREATE_TA_ENTRY,
       targetId: entry.id,
@@ -512,7 +510,7 @@ export async function promoteToPhase3(
       details: { tournamentId, playerId: entry.playerId,
         playerNickname: (entry as TTEntry & { player: { nickname: string } }).player.nickname,
         promotedTo: "phase3", initialLives: config.initialLives },
-    });
+    }).catch((err) => logger.warn("Failed to create audit log", { error: err }));
   }
 
   return {


### PR DESCRIPTION
## Summary

- **#772** `refactor(ta/finals-phase-manager)`: Add `.catch(err => logger.warn(...))` to the `void createAuditLog` calls in `promoteToPhase1/2/3` for-loops — consistent with the pattern used in every other audit log call in the same file.
- **#773** `refactor(api-factories)`: Use `resolveAuditUserId(session)` instead of `session.user.id` in `finals-bracket-route.ts`, `finals-matches-route.ts`, and `qualification-route.ts` audit log calls. Guards against a future player-session FK violation. Test mocks updated accordingly.
- **#774** `docs(layout.tsx)`: Add comment explaining the `@fontsource` node_modules path relies on v5.x file naming convention — flag for verification on package upgrades.
- **#777** `refactor(e2e/lib/common.js)`: Extract `40000` to `D1_COLD_START_TIMEOUT_MS` constant for consistent D1 cold-start timeout management across the helper file.

## Test plan

- [ ] TypeScript passes (`npx tsc --noEmit`)
- [ ] All 109 test suites pass (`npx jest --no-coverage`)
- [ ] Lint passes with 0 errors (`npm run lint`)

https://claude.ai/code/session_01HeMXEQFkgqj6yXBE67tx5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeMXEQFkgqj6yXBE67tx5i)_