### PR TITLE
fix(#779/#780/#782): audit .catch() test coverage, redundant comment removal, SQL stage filter

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -14,7 +14,12 @@ import {
   getPhaseStatus,
   undoLastPhaseRound,
   startPhaseRound,
+  promoteToPhase1,
+  promoteToPhase2,
+  promoteToPhase3,
 } from "@/lib/ta/finals-phase-manager";
+import { createAuditLog } from "@/lib/audit-log";
+import { createLogger } from "@/lib/logger";
 
 // Mock Prisma client
 const mockPrismaClient = {
@@ -22,6 +27,7 @@ const mockPrismaClient = {
     findMany: jest.fn(),
     findUnique: jest.fn(),
     create: jest.fn(),
+    createMany: jest.fn(),
     update: jest.fn(),
     updateMany: jest.fn(),
   },
@@ -617,5 +623,107 @@ describe("TA Finals Phase Manager", () => {
     // which cannot be reliably mocked in Jest without module-level mocking.
     // The retry loop logic (continue on P2002, throw on non-P2002 or
     // exhausted attempts) is verified through code review.
+  });
+
+  // === AUDIT LOG .catch() ERROR PATH (#779) ===
+
+  describe("promoteToPhase audit log .catch() resilience", () => {
+    const context = {
+      tournamentId: "t1",
+      userId: "u1",
+      ipAddress: "127.0.0.1",
+      userAgent: "jest",
+    };
+
+    /** Minimal qual-player shape returned by getQualificationPlayersByRank */
+    const makeQualPlayer = (playerId: string, rank: number) => ({
+      id: `entry-${playerId}`,
+      playerId,
+      stage: "qualification",
+      rank,
+      totalTime: 100,
+      lives: 0,
+      eliminated: false,
+      times: [],
+      player: { id: playerId, name: `P${rank}`, nickname: `P${rank}` },
+    });
+
+    /** Phase-entry shape returned by the post-createMany findMany */
+    const makePhaseEntry = (playerId: string) => ({
+      id: `phase-entry-${playerId}`,
+      playerId,
+      player: { id: playerId, name: `P-${playerId}`, nickname: `P-${playerId}` },
+    });
+
+    it("should call logger.warn when audit log rejects in promoteToPhase1", async () => {
+      (createAuditLog as jest.Mock).mockRejectedValue(new Error("Audit failed"));
+
+      // 1) getQualificationPlayersByRank — ranks 17-24
+      (mockPrismaClient.tTEntry.findMany as jest.Mock)
+        .mockResolvedValueOnce([makeQualPlayer("p1", 17)])
+        // 2) bulk-check existing phase1 entries
+        .mockResolvedValueOnce([])
+        // 3) fetch created entries for audit loop
+        .mockResolvedValueOnce([makePhaseEntry("p1")]);
+      (mockPrismaClient.tTEntry.createMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      const result = await promoteToPhase1(mockPrismaClient as never, context);
+
+      // Drain the micro-task queue so the fire-and-forget .catch() callback runs
+      await Promise.resolve();
+
+      const mockLogger = (createLogger as jest.Mock).mock.results[0].value;
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Failed to create audit log",
+        expect.objectContaining({ error: expect.any(Error) }),
+      );
+      expect(result.entries).toHaveLength(1);
+    });
+
+    it("should call logger.warn when audit log rejects in promoteToPhase2", async () => {
+      (createAuditLog as jest.Mock).mockRejectedValue(new Error("Audit failed"));
+
+      // promoteToPhase2: 1) phase1 survivors, 2) qual ranks 13-16, 3) existing check, 4) created entries
+      (mockPrismaClient.tTEntry.findMany as jest.Mock)
+        .mockResolvedValueOnce([])                          // phase1 survivors (none)
+        .mockResolvedValueOnce([makeQualPlayer("p2", 13)]) // qualification ranks 13-16
+        .mockResolvedValueOnce([])                          // existing phase2 entries
+        .mockResolvedValueOnce([makePhaseEntry("p2")]);     // created entries for audit loop
+      (mockPrismaClient.tTEntry.createMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      const result = await promoteToPhase2(mockPrismaClient as never, context);
+
+      await Promise.resolve();
+
+      const mockLogger = (createLogger as jest.Mock).mock.results[0].value;
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Failed to create audit log",
+        expect.objectContaining({ error: expect.any(Error) }),
+      );
+      expect(result.entries).toHaveLength(1);
+    });
+
+    it("should call logger.warn when audit log rejects in promoteToPhase3", async () => {
+      (createAuditLog as jest.Mock).mockRejectedValue(new Error("Audit failed"));
+
+      // promoteToPhase3: 1) phase2 survivors, 2) qual ranks 1-12, 3) existing check, 4) created entries
+      (mockPrismaClient.tTEntry.findMany as jest.Mock)
+        .mockResolvedValueOnce([])                         // phase2 survivors (none)
+        .mockResolvedValueOnce([makeQualPlayer("p3", 1)]) // qualification ranks 1-12
+        .mockResolvedValueOnce([])                         // existing phase3 entries
+        .mockResolvedValueOnce([makePhaseEntry("p3")]);    // created entries for audit loop
+      (mockPrismaClient.tTEntry.createMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      const result = await promoteToPhase3(mockPrismaClient as never, context);
+
+      await Promise.resolve();
+
+      const mockLogger = (createLogger as jest.Mock).mock.results[0].value;
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Failed to create audit log",
+        expect.objectContaining({ error: expect.any(Error) }),
+      );
+      expect(result.entries).toHaveLength(1);
+    });
   });
 });

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -20,7 +20,7 @@ const BASE = process.env.E2E_BASE_URL || 'https://smkc.bluemoon.works';
 const NAV_WAIT_MS = 8000;
 /** D1 cold-start can push page render well past the default 30s Playwright timeout.
  * Use this constant for any waitFor/click/locator that depends on admin-gated UI
- * or API responses that may be delayed by D1 initialization (#777). */
+ * or API responses that may be delayed by D1 initialization (#678, #701, #777). */
 const D1_COLD_START_TIMEOUT_MS = 40_000;
 const apiLogContexts = new WeakSet();
 
@@ -1158,7 +1158,6 @@ async function uiPhaseStartRound(page, tournamentId, phase) {
     await page.waitForTimeout(300);
   }
   const startBtn = page.getByRole('button', { name: /^(Start Round \d+|ラウンド\s*\d+\s*開始)$/ }).first();
-  /* 40s to absorb D1 cold-start + fetchWithRetry delays (issue #678, #701) */
   await startBtn.waitFor({ state: 'visible', timeout: D1_COLD_START_TIMEOUT_MS });
 
   const responsePromise = page.waitForResponse((res) =>

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -407,7 +407,8 @@ async function normalizeRoundStartingCoursesToSingleValue(
      *   WHERE stage IN ('finals','playoff') AND startingCourseNumber IS NULL
      *   GROUP BY tournamentId, round
      *   HAVING c = (SELECT COUNT(*) FROM BMMatch m2
-     *               WHERE m2.tournamentId=BMMatch.tournamentId AND m2.round=BMMatch.round);
+     *               WHERE m2.tournamentId=BMMatch.tournamentId AND m2.round=BMMatch.round
+     *               AND m2.stage IN ('finals','playoff'));
      * If meaningful data is found, apply a targeted one-time migration. */
     if (distinctValues > 1 || (distinctValues === 1 && totalWithValue < roundMatchCount)) {
       roundsNeedingRepair.add(round);


### PR DESCRIPTION
## Summary

- **#779** `test(finals-phase-manager)`: Add three tests for the fire-and-forget `createAuditLog().catch()` error path in `promoteToPhase1/2/3`. Each test injects a rejecting `createAuditLog` mock and asserts that `logger.warn("Failed to create audit log", ...)` is called while the function still returns success. Also adds `createMany` to the Prisma client mock and imports `promoteToPhase1/2/3` from the function under test.

- **#780** `refactor(e2e/common.js)`: The `D1_COLD_START_TIMEOUT_MS` JSDoc is updated to include issue references `#678` and `#701`. The now-redundant inline comment `/* 40s to absorb D1 cold-start + fetchWithRetry delays (issue #678, #701) */` is removed from `uiPhaseStartRound`.

- **#782** `fix(finals-route)`: Add `AND m2.stage IN ('finals','playoff')` to the HAVING subquery in the reference SQL comment added for #776. Without it, the row count could be inflated by same `tournamentId+round` pairs in other stages. Comment-only change; no production code affected.

## Test plan

- [ ] All 109 test suites pass (`npx jest --no-coverage`) — 3 new tests added
- [ ] Lint passes with 0 errors (`npm run lint`)

https://claude.ai/code/session_01HeMXEQFkgqj6yXBE67tx5i