### PR TITLE
refactor: fix type safety, null guard, and test robustness (#784 #786 #787 #788)

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -672,7 +672,7 @@ describe("TA Finals Phase Manager", () => {
       // Drain the micro-task queue so the fire-and-forget .catch() callback runs
       await Promise.resolve();
 
-      const mockLogger = (createLogger as jest.Mock).mock.results[0].value;
+      const mockLogger = (createLogger as jest.Mock).mock.results.at(-1)!.value;
       expect(mockLogger.warn).toHaveBeenCalledWith(
         "Failed to create audit log",
         expect.objectContaining({ error: expect.any(Error) }),
@@ -695,7 +695,7 @@ describe("TA Finals Phase Manager", () => {
 
       await Promise.resolve();
 
-      const mockLogger = (createLogger as jest.Mock).mock.results[0].value;
+      const mockLogger = (createLogger as jest.Mock).mock.results.at(-1)!.value;
       expect(mockLogger.warn).toHaveBeenCalledWith(
         "Failed to create audit log",
         expect.objectContaining({ error: expect.any(Error) }),
@@ -718,7 +718,7 @@ describe("TA Finals Phase Manager", () => {
 
       await Promise.resolve();
 
-      const mockLogger = (createLogger as jest.Mock).mock.results[0].value;
+      const mockLogger = (createLogger as jest.Mock).mock.results.at(-1)!.value;
       expect(mockLogger.warn).toHaveBeenCalledWith(
         "Failed to create audit log",
         expect.objectContaining({ error: expect.any(Error) }),

--- a/smkc-score-app/__tests__/lib/ta/initial-data.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/initial-data.test.ts
@@ -1,0 +1,83 @@
+// @ts-nocheck - uses complex mock types
+/**
+ * Unit tests for fetchTaInitialData (src/lib/ta/initial-data.ts).
+ *
+ * Covers:
+ * - Returns null when resolveTournament returns null (issue #786).
+ * - Returns null when an error is thrown (catch-all fallback).
+ * - Returns correct TaInitialData when tournament exists.
+ * - Sets qualificationRegistrationLocked=true when a knockout entry exists.
+ */
+
+import { fetchTaInitialData } from '@/lib/ta/initial-data';
+
+jest.mock('@/lib/prisma');
+jest.mock('@/lib/tournament-identifier');
+
+import prisma from '@/lib/prisma';
+import { resolveTournament } from '@/lib/tournament-identifier';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockResolveTournament = resolveTournament as jest.Mock;
+
+describe('fetchTaInitialData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null when resolveTournament returns null', async () => {
+    mockResolveTournament.mockResolvedValue(null);
+
+    const result = await fetchTaInitialData('nonexistent-id');
+
+    expect(result).toBeNull();
+    // Prisma queries should NOT be called when tournament is not found.
+    expect(mockPrisma.tTEntry.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.player.findMany).not.toHaveBeenCalled();
+  });
+
+  it('returns null when an unexpected error is thrown', async () => {
+    mockResolveTournament.mockRejectedValue(new Error('DB error'));
+
+    const result = await fetchTaInitialData('some-id');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns TaInitialData with qualificationRegistrationLocked=false when no knockout entries exist', async () => {
+    mockResolveTournament.mockResolvedValue({ id: 'tid-1', frozenStages: [] });
+
+    const mockEntries = [{ id: 'e1', stage: 'qualification' }];
+    const mockPlayers = [{ id: 'p1', name: 'Alice', nickname: 'alice', country: null, noCamera: false }];
+
+    mockPrisma.tTEntry.findMany
+      // qualification entries
+      .mockResolvedValueOnce(mockEntries)
+      // knockout check (findFirst returns null → not started)
+      .mockResolvedValueOnce(null as never);
+    mockPrisma.tTEntry.findFirst = jest.fn().mockResolvedValue(null);
+    mockPrisma.player.findMany.mockResolvedValue(mockPlayers);
+
+    const result = await fetchTaInitialData('tid-1');
+
+    expect(result).not.toBeNull();
+    expect(result!.entries).toEqual(mockEntries);
+    expect(result!.allPlayers).toEqual(mockPlayers);
+    expect(result!.qualificationRegistrationLocked).toBe(false);
+    expect(result!.frozenStages).toEqual([]);
+  });
+
+  it('returns qualificationRegistrationLocked=true when a phase1 entry exists', async () => {
+    mockResolveTournament.mockResolvedValue({ id: 'tid-2', frozenStages: ['phase1'] });
+
+    mockPrisma.tTEntry.findMany.mockResolvedValue([]);
+    mockPrisma.tTEntry.findFirst = jest.fn().mockResolvedValue({ id: 'phase-entry' });
+    mockPrisma.player.findMany.mockResolvedValue([]);
+
+    const result = await fetchTaInitialData('tid-2');
+
+    expect(result).not.toBeNull();
+    expect(result!.qualificationRegistrationLocked).toBe(true);
+    expect(result!.frozenStages).toEqual(['phase1']);
+  });
+});

--- a/smkc-score-app/src/lib/api-factories/qual-initial-data.ts
+++ b/smkc-score-app/src/lib/api-factories/qual-initial-data.ts
@@ -15,14 +15,20 @@ import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { resolveTournament } from '@/lib/tournament-identifier';
 import { computeQualificationRanks } from '@/lib/server-ranking';
 import type { EventTypeConfig } from '@/lib/event-types/types';
+import type { Player } from '@/lib/types';
 
-/** Combined initial data shape that usePolling seeds from.
- *  Must stay in sync with the return value of fetchTournamentData in
- *  each bm/mr/gp page-client.tsx. */
+/**
+ * Combined initial data shape that usePolling seeds from.
+ * Must stay in sync with the return value of fetchTournamentData in each bm/mr/gp page-client.tsx.
+ *
+ * `qualifications` and `matches` are mode-specific Prisma records (BM/MR/GP delegate payloads
+ * augmented with computed rank fields). They remain `unknown[]` here because this interface is
+ * shared across all three modes; each page-client casts to its concrete type.
+ */
 export interface QualInitialData {
   qualifications: unknown[];
   matches: unknown[];
-  allPlayers: unknown[];
+  allPlayers: Player[];
   qualificationConfirmed: boolean;
 }
 
@@ -54,10 +60,8 @@ export async function fetchQualInitialData(
     if (!tournament) return null;
 
     const tournamentId = tournament.id;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const qualModel = (p: any) => p[config.qualificationModel];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const matchModel = (p: any) => p[config.matchModel];
+    const qualModel = (p: typeof prisma) => p[config.qualificationModel];
+    const matchModel = (p: typeof prisma) => p[config.matchModel];
 
     const [qualifications, matches, allPlayers] = await Promise.all([
       qualModel(prisma).findMany({

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -86,10 +86,8 @@ function getAssignedCourses(shuffled: string[], matchIndex: number): string[] {
  * @returns Object with GET, POST, PUT, PATCH handler functions
  */
 export function createQualificationHandlers(config: EventTypeConfig) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const qualModel = (p: any) => p[config.qualificationModel];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const matchModel = (p: any) => p[config.matchModel];
+  const qualModel = (p: typeof prisma) => p[config.qualificationModel];
+  const matchModel = (p: typeof prisma) => p[config.matchModel];
 
   /**
    * GET handler: Fetch qualification standings and matches for a tournament.

--- a/smkc-score-app/src/lib/event-types/types.ts
+++ b/smkc-score-app/src/lib/event-types/types.ts
@@ -30,6 +30,12 @@ export type QualificationPutData = {
   races?: Array<{ course: string; position1: number; position2: number }>;
 };
 
+/** Prisma client property keys for qualification delegate models (camelCase). */
+export type QualificationModelKey = 'bMQualification' | 'mRQualification' | 'gPQualification';
+
+/** Prisma client property keys for match delegate models (camelCase). */
+export type MatchModelKey = 'bMMatch' | 'mRMatch' | 'gPMatch';
+
 /**
  * Configuration interface for a tournament event type.
  *
@@ -41,10 +47,10 @@ export type QualificationPutData = {
 export interface EventTypeConfig {
   /** Event type code for mode-specific logic (e.g., bye scores) */
   eventTypeCode: 'bm' | 'mr' | 'gp';
-  /** Prisma model name for qualification records (e.g., 'bMQualification') */
-  qualificationModel: string;
-  /** Prisma model name for match records (e.g., 'bMMatch') */
-  matchModel: string;
+  /** Prisma client property for qualification records. */
+  qualificationModel: QualificationModelKey;
+  /** Prisma client property for match records. */
+  matchModel: MatchModelKey;
 
   /**
    * Score field names on the match model used to determine H2H winner.

--- a/smkc-score-app/src/lib/ta/initial-data.ts
+++ b/smkc-score-app/src/lib/ta/initial-data.ts
@@ -59,7 +59,9 @@ async function hasKnockoutStageStarted(tournamentId: string): Promise<boolean> {
 export async function fetchTaInitialData(id: string): Promise<TaInitialData | null> {
   try {
     const tournament = await resolveTournament(id, { id: true, frozenStages: true });
-    const tournamentId = tournament?.id ?? id;
+    // Return null so the client falls back to its own first poll, same as qual-initial-data.ts.
+    if (!tournament) return null;
+    const tournamentId = tournament.id;
 
     const [entries, knockoutStarted, allPlayers] = await Promise.all([
       prisma.tTEntry.findMany({
@@ -80,7 +82,7 @@ export async function fetchTaInitialData(id: string): Promise<TaInitialData | nu
       entries,
       allPlayers,
       qualificationRegistrationLocked: knockoutStarted,
-      frozenStages: (tournament?.frozenStages as string[]) ?? [],
+      frozenStages: (tournament.frozenStages as string[]) ?? [],
     };
   } catch {
     // Intentionally swallowed: the client component handles data === null


### PR DESCRIPTION
## Summary

- **fix(#786)**: `fetchTaInitialData` が `resolveTournament` で null を返したとき早期 return しておらず、空データを返していたバグを修正。`qual-initial-data.ts` と同じパターンに統一。ユニットテストも追加
- **fix(#784)**: `finals-phase-manager.test.ts` の `mock.results[0]` を `mock.results.at(-1)!` に変更し、テストスイート内で `createLogger` が複数回呼ばれた場合でも正しいインスタンスを取得するよう修正
- **refactor(#788)**: `EventTypeConfig.qualificationModel` / `matchModel` を `string` から `QualificationModelKey` / `MatchModelKey` 型へ変更。`qual-initial-data.ts` と `qualification-route.ts` の `(p: any)` アクセサを `(p: typeof prisma)` に置き換え、eslint-disable コメントを削除
- **refactor(#787)**: `QualInitialData.allPlayers` を `unknown[]` から `Player[]` に具体化。`qualifications` / `matches` が `unknown[]` のままである理由をコメントで説明

## Test plan

- [ ] `__tests__/lib/ta/initial-data.test.ts` — null tournament 早期 return、エラー catch、正常系、knockout lock 検証
- [ ] `__tests__/lib/ta/finals-phase-manager.test.ts` — `.at(-1)!` で正しいロガーインスタンスを取得していること
- [ ] TypeScript ビルドエラーなし (`QualificationModelKey`/`MatchModelKey` union が `bm-config.ts`/`mr-config.ts`/`gp-config.ts` の値と一致)

https://claude.ai/code/session_01U5dBoSCJdjXQVJ3SzN6tRi

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5dBoSCJdjXQVJ3SzN6tRi)_