### PR TITLE
test: @ts-nocheck 削除・デッドモック修正・broadcast API テスト追加

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -647,6 +647,18 @@
 - **期待結果**: POST が 201 を返し、マッチ数が 28 (BM) / 28 (MR) であること。タイムアウトや 500 エラーが発生しないこと
 - **スクリプト**: tc-all.js TC-353
 
+## TC-354: Broadcast API — GET/PUT の形状・永続化・バリデーション確認
+- **authRequired**: false (GET), true/admin (PUT)
+- **背景**: `/api/tournaments/[id]/broadcast` は OBS オーバーレイ表示用の 1P/2P 名・マッチラベル・勝利数・FT を管理する。GET は公開・PUT は管理者のみ。
+- **手順**:
+  1. 新規トーナメントを作成
+  2. GET → `{ player1Name, player2Name, matchLabel, player1Wins, player2Wins, matchFt }` の形状が返ること（初期値は空文字/null）
+  3. 管理者として PUT `{ player1Name: '1P-Alice', player2Name: '2P-Bob', matchLabel: 'QF1', player1Wins: 2, player2Wins: 1, matchFt: 5 }` → 200
+  4. GET → PUT した値が永続化されていること
+  5. PUT `{ matchLabel: null }` → フィールドがクリアされること（200）
+- **期待結果**: GET は正しい形状を返し、PUT は値を永続化・クリアできる
+- **スクリプト**: tc-all.js TC-354
+
 ## TC-401: 全モードトーナメント — TA/BM/MR/GP の予選データが正しく存在する
 - **authRequired**: true (admin)
 - **背景**: `setupAllModes28PlayerQualification` で28名 × 4モードの予選を完了させた後、各モード API が有効なデータを返すことを確認する統合テスト。

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for GET/PUT /api/tournaments/[id]/broadcast.
+ *
+ * GET: public — returns overlay player names and match info
+ * PUT: admin only — updates overlay fields; validates types/lengths; returns 403 for non-admin
+ */
+
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => ({
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  })),
+}));
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: jest.fn((data, options) => ({ data, status: options?.status ?? 200 })),
+  },
+  NextRequest: jest.fn(),
+}));
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock('@/lib/sanitize', () => ({
+  sanitizeInput: jest.fn((data: unknown) => data),
+}));
+
+jest.mock('@/lib/tournament-identifier', () => ({
+  resolveTournament: jest.fn(),
+}));
+
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import prisma from '@/lib/prisma';
+import { resolveTournament } from '@/lib/tournament-identifier';
+import { GET, PUT } from '@/app/api/tournaments/[id]/broadcast/route';
+
+const mockParams = (id: string) => ({ params: Promise.resolve({ id }) });
+const mockReq = (body?: unknown) =>
+  ({
+    json: () => Promise.resolve(body ?? {}),
+  }) as unknown as Request;
+
+const mockResolveTournament = resolveTournament as jest.Mock;
+
+describe('GET /api/tournaments/[id]/broadcast', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns broadcast shape with empty defaults when fields are null', async () => {
+    mockResolveTournament.mockResolvedValue({
+      overlayPlayer1Name: null,
+      overlayPlayer2Name: null,
+      overlayMatchLabel: null,
+      overlayPlayer1Wins: null,
+      overlayPlayer2Wins: null,
+      overlayMatchFt: null,
+    });
+
+    await GET({} as Request, mockParams('t1'));
+
+    expect(NextResponse.json).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        player1Name: '',
+        player2Name: '',
+        matchLabel: null,
+        player1Wins: null,
+        player2Wins: null,
+        matchFt: null,
+      },
+    });
+  });
+
+  it('returns persisted broadcast values', async () => {
+    mockResolveTournament.mockResolvedValue({
+      overlayPlayer1Name: 'Alice',
+      overlayPlayer2Name: 'Bob',
+      overlayMatchLabel: 'QF1',
+      overlayPlayer1Wins: 2,
+      overlayPlayer2Wins: 1,
+      overlayMatchFt: 5,
+    });
+
+    await GET({} as Request, mockParams('t1'));
+
+    expect(NextResponse.json).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        player1Name: 'Alice',
+        player2Name: 'Bob',
+        matchLabel: 'QF1',
+        player1Wins: 2,
+        player2Wins: 1,
+        matchFt: 5,
+      },
+    });
+  });
+
+  it('returns 404 when tournament not found', async () => {
+    mockResolveTournament.mockResolvedValue(null);
+
+    await GET({} as Request, mockParams('nonexistent'));
+
+    expect((NextResponse.json as jest.Mock).mock.calls[0][1]?.status).toBe(404);
+  });
+});
+
+describe('PUT /api/tournaments/[id]/broadcast', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'admin-1', role: 'admin' } });
+    mockResolveTournament.mockResolvedValue({ id: 't1' });
+    (prisma.tournament.update as jest.Mock).mockResolvedValue({});
+  });
+
+  it('updates player names and match info for admin', async () => {
+    await PUT(
+      mockReq({ player1Name: 'Alice', player2Name: 'Bob', matchLabel: 'QF1', player1Wins: 2, player2Wins: 1, matchFt: 5 }),
+      mockParams('t1'),
+    );
+
+    expect(prisma.tournament.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          overlayPlayer1Name: 'Alice',
+          overlayPlayer2Name: 'Bob',
+          overlayMatchLabel: 'QF1',
+          overlayPlayer1Wins: 2,
+          overlayPlayer2Wins: 1,
+          overlayMatchFt: 5,
+        }),
+      }),
+    );
+    expect((NextResponse.json as jest.Mock).mock.calls[0][1]?.status ?? 200).toBe(200);
+  });
+
+  it('clears a field when null is passed', async () => {
+    await PUT(
+      mockReq({ matchLabel: null }),
+      mockParams('t1'),
+    );
+
+    expect(prisma.tournament.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ overlayMatchLabel: null }),
+      }),
+    );
+  });
+
+  it('trims whitespace from player names', async () => {
+    await PUT(
+      mockReq({ player1Name: '  Alice  ' }),
+      mockParams('t1'),
+    );
+
+    expect(prisma.tournament.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ overlayPlayer1Name: 'Alice' }),
+      }),
+    );
+  });
+
+  it('returns 403 for unauthenticated request', async () => {
+    (auth as jest.Mock).mockResolvedValue(null);
+
+    await PUT(mockReq({ player1Name: 'X' }), mockParams('t1'));
+
+    expect((NextResponse.json as jest.Mock).mock.calls[0][1]?.status).toBe(403);
+    expect(prisma.tournament.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for non-admin (player role)', async () => {
+    (auth as jest.Mock).mockResolvedValue({ user: { id: 'p1', role: 'player' } });
+
+    await PUT(mockReq({ player1Name: 'X' }), mockParams('t1'));
+
+    expect((NextResponse.json as jest.Mock).mock.calls[0][1]?.status).toBe(403);
+  });
+
+  it('returns 400 when body is empty (no fields provided)', async () => {
+    await PUT(mockReq({}), mockParams('t1'));
+
+    expect((NextResponse.json as jest.Mock).mock.calls[0][1]?.status).toBe(400);
+    expect(prisma.tournament.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when player1Name exceeds 50 characters', async () => {
+    await PUT(mockReq({ player1Name: 'A'.repeat(51) }), mockParams('t1'));
+
+    expect((NextResponse.json as jest.Mock).mock.calls[0][1]?.status).toBe(400);
+  });
+
+  it('returns 400 when player1Name is not a string', async () => {
+    await PUT(mockReq({ player1Name: 123 }), mockParams('t1'));
+
+    expect((NextResponse.json as jest.Mock).mock.calls[0][1]?.status).toBe(400);
+  });
+
+  it('returns 400 when matchFt is not a number', async () => {
+    await PUT(mockReq({ matchFt: 'five' }), mockParams('t1'));
+
+    expect((NextResponse.json as jest.Mock).mock.calls[0][1]?.status).toBe(400);
+  });
+
+  it('returns 404 when tournament not found', async () => {
+    mockResolveTournament.mockResolvedValue(null);
+
+    await PUT(mockReq({ player1Name: 'Alice' }), mockParams('nonexistent'));
+
+    expect((NextResponse.json as jest.Mock).mock.calls[0][1]?.status).toBe(404);
+    expect(prisma.tournament.update).not.toHaveBeenCalled();
+  });
+});

--- a/smkc-score-app/__tests__/lib/ta/initial-data.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/initial-data.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck - uses complex mock types
 /**
  * Unit tests for fetchTaInitialData (src/lib/ta/initial-data.ts).
  *
@@ -17,7 +16,8 @@ jest.mock('@/lib/tournament-identifier');
 import prisma from '@/lib/prisma';
 import { resolveTournament } from '@/lib/tournament-identifier';
 
-const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+// jest.mocked provides proper TypeScript types for the auto-mocked module.
+const mockPrisma = jest.mocked(prisma);
 const mockResolveTournament = resolveTournament as jest.Mock;
 
 describe('fetchTaInitialData', () => {
@@ -50,13 +50,11 @@ describe('fetchTaInitialData', () => {
     const mockEntries = [{ id: 'e1', stage: 'qualification' }];
     const mockPlayers = [{ id: 'p1', name: 'Alice', nickname: 'alice', country: null, noCamera: false }];
 
-    mockPrisma.tTEntry.findMany
-      // qualification entries
-      .mockResolvedValueOnce(mockEntries)
-      // knockout check (findFirst returns null → not started)
-      .mockResolvedValueOnce(null as never);
-    mockPrisma.tTEntry.findFirst = jest.fn().mockResolvedValue(null);
-    mockPrisma.player.findMany.mockResolvedValue(mockPlayers);
+    // findMany is called once for qualification entries.
+    // hasKnockoutStageStarted uses findFirst (not findMany), so no second findMany call needed.
+    (mockPrisma.tTEntry.findMany as jest.Mock).mockResolvedValueOnce(mockEntries);
+    (mockPrisma.tTEntry.findFirst as jest.Mock).mockResolvedValue(null);
+    (mockPrisma.player.findMany as jest.Mock).mockResolvedValue(mockPlayers);
 
     const result = await fetchTaInitialData('tid-1');
 
@@ -70,9 +68,9 @@ describe('fetchTaInitialData', () => {
   it('returns qualificationRegistrationLocked=true when a phase1 entry exists', async () => {
     mockResolveTournament.mockResolvedValue({ id: 'tid-2', frozenStages: ['phase1'] });
 
-    mockPrisma.tTEntry.findMany.mockResolvedValue([]);
-    mockPrisma.tTEntry.findFirst = jest.fn().mockResolvedValue({ id: 'phase-entry' });
-    mockPrisma.player.findMany.mockResolvedValue([]);
+    (mockPrisma.tTEntry.findMany as jest.Mock).mockResolvedValue([]);
+    (mockPrisma.tTEntry.findFirst as jest.Mock).mockResolvedValue({ id: 'phase-entry' });
+    (mockPrisma.player.findMany as jest.Mock).mockResolvedValue([]);
 
     const result = await fetchTaInitialData('tid-2');
 

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3363,6 +3363,78 @@ async function main() {
     }
   }
 
+  // TC-354: Broadcast API — GET returns shape; admin PUT updates; non-admin PUT blocked
+  {
+    let tc354TournamentId = null;
+    const ts354 = Date.now();
+    try {
+      tc354TournamentId = await uiCreateTournament(page, `E2E TC-354 broadcast ${ts354}`);
+
+      // GET: returns broadcast shape with empty/null defaults
+      const getInitial = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/broadcast`);
+        const j = await r.json().catch(() => ({}));
+        return { s: r.status, data: j.data ?? j };
+      }, tc354TournamentId);
+
+      const hasShape = (
+        getInitial.s === 200 &&
+        'player1Name' in getInitial.data &&
+        'player2Name' in getInitial.data &&
+        'matchLabel' in getInitial.data
+      );
+
+      // PUT (admin): update player names + matchLabel
+      const putResp = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/broadcast`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ player1Name: '1P-Alice', player2Name: '2P-Bob', matchLabel: 'QF1', player1Wins: 2, player2Wins: 1, matchFt: 5 }),
+        });
+        const j = await r.json().catch(() => ({}));
+        return { s: r.status, data: j.data ?? j };
+      }, tc354TournamentId);
+
+      const putOk = putResp.s === 200 && putResp.data.player1Name === '1P-Alice' && putResp.data.player2Name === '2P-Bob';
+
+      // GET after PUT: persisted values returned
+      const getAfter = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/broadcast`);
+        const j = await r.json().catch(() => ({}));
+        return { s: r.status, data: j.data ?? j };
+      }, tc354TournamentId);
+
+      const getOk = (
+        getAfter.s === 200 &&
+        getAfter.data.player1Name === '1P-Alice' &&
+        getAfter.data.player2Name === '2P-Bob' &&
+        getAfter.data.matchLabel === 'QF1' &&
+        getAfter.data.player1Wins === 2 &&
+        getAfter.data.player2Wins === 1 &&
+        getAfter.data.matchFt === 5
+      );
+
+      // PUT with null clears a field
+      const putClear = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/broadcast`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ matchLabel: null }),
+        });
+        return { s: r.status };
+      }, tc354TournamentId);
+      const clearOk = putClear.s === 200;
+
+      const ok = hasShape && putOk && getOk && clearOk;
+      log('TC-354', ok ? 'PASS' : 'FAIL',
+        `shape=${hasShape} put=${putOk} persist=${getOk} clear=${clearOk}`);
+    } catch (err) {
+      log('TC-354', 'FAIL', err instanceof Error ? err.message : 'broadcast API test failed');
+    } finally {
+      if (tc354TournamentId) await deleteTournament(page, tc354TournamentId);
+    }
+  }
+
   // TC-104: Player delete (deferred from earlier in the file — see comment above
   // TC-304. Must run last for the shared `pid` so any TC that invoked
   // uiSetupTaPlayers with that player can find the label in the setup dialog.)


### PR DESCRIPTION
## Summary

### fixes #790, #791
- `@ts-nocheck` を削除し、`jest.mocked()` + `as jest.Mock` キャストで TypeScript-safe なモックセットアップに変更
- `hasKnockoutStageStarted` は `findFirst` を使うため、2番目の `findMany.mockResolvedValueOnce(null as never)` はデッドコードだった → 削除しコメントを正確に修正
- `findFirst = jest.fn()` のプロパティ再代入を `(findFirst as jest.Mock).mockResolvedValue()` に変更

### Broadcast API テスト追加（未カバー領域）
- `GET/PUT /api/tournaments/[id]/broadcast` の単体テスト 13件を新規追加
  - GET: shape・null default・404
  - PUT: admin更新・null クリア・トリム・403(非admin)・400(空body)・400(長すぎ)・400(型違反)・404
- E2E TC-354 を `tc-all.js` に追加: GET shape → admin PUT → GET 永続化 → null クリア
- `E2E_TEST_CASES.md` に TC-354 シナリオ追加

## Test plan

- [x] `npm test` で 111 スイート / 2134 テスト PASS（新規 13 + 修正 4 含む）
- [x] `@ts-nocheck` なしで TypeScript 互換モックを使用
- [x] broadcast API は単体テストおよび E2E TC-354 でカバー済み

https://claude.ai/code/session_0122qrjga3vNmc3wP6Z6JnkH