### PR TITLE
test: fix jest.mocked casts and TC-354 E2E robustness (#793 #794 #795 #796)

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/initial-data.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/initial-data.test.ts
@@ -18,7 +18,7 @@ import { resolveTournament } from '@/lib/tournament-identifier';
 
 // jest.mocked provides proper TypeScript types for the auto-mocked module.
 const mockPrisma = jest.mocked(prisma);
-const mockResolveTournament = resolveTournament as jest.Mock;
+const mockResolveTournament = jest.mocked(resolveTournament);
 
 describe('fetchTaInitialData', () => {
   beforeEach(() => {
@@ -52,9 +52,11 @@ describe('fetchTaInitialData', () => {
 
     // findMany is called once for qualification entries.
     // hasKnockoutStageStarted uses findFirst (not findMany), so no second findMany call needed.
-    (mockPrisma.tTEntry.findMany as jest.Mock).mockResolvedValueOnce(mockEntries);
-    (mockPrisma.tTEntry.findFirst as jest.Mock).mockResolvedValue(null);
-    (mockPrisma.player.findMany as jest.Mock).mockResolvedValue(mockPlayers);
+    // jest.mocked() on individual methods is required because jest.mocked(prisma) shallow-mocks
+    // only the top-level delegate references, not the methods within each delegate.
+    jest.mocked(prisma.tTEntry.findMany).mockResolvedValueOnce(mockEntries as never);
+    jest.mocked(prisma.tTEntry.findFirst).mockResolvedValue(null);
+    jest.mocked(prisma.player.findMany).mockResolvedValue(mockPlayers as never);
 
     const result = await fetchTaInitialData('tid-1');
 
@@ -68,9 +70,9 @@ describe('fetchTaInitialData', () => {
   it('returns qualificationRegistrationLocked=true when a phase1 entry exists', async () => {
     mockResolveTournament.mockResolvedValue({ id: 'tid-2', frozenStages: ['phase1'] });
 
-    (mockPrisma.tTEntry.findMany as jest.Mock).mockResolvedValue([]);
-    (mockPrisma.tTEntry.findFirst as jest.Mock).mockResolvedValue({ id: 'phase-entry' });
-    (mockPrisma.player.findMany as jest.Mock).mockResolvedValue([]);
+    jest.mocked(prisma.tTEntry.findMany).mockResolvedValue([] as never);
+    jest.mocked(prisma.tTEntry.findFirst).mockResolvedValue({ id: 'phase-entry' } as never);
+    jest.mocked(prisma.player.findMany).mockResolvedValue([] as never);
 
     const result = await fetchTaInitialData('tid-2');
 

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3395,7 +3395,8 @@ async function main() {
         return { s: r.status, data: j.data ?? j };
       }, tc354TournamentId);
 
-      const putOk = putResp.s === 200 && putResp.data.player1Name === '1P-Alice' && putResp.data.player2Name === '2P-Bob';
+      // Persistence is verified by the subsequent GET; body shape varies by implementation
+      const putOk = putResp.s === 200;
 
       // GET after PUT: persisted values returned
       const getAfter = await page.evaluate(async (tid) => {
@@ -3425,9 +3426,29 @@ async function main() {
       }, tc354TournamentId);
       const clearOk = putClear.s === 200;
 
-      const ok = hasShape && putOk && getOk && clearOk;
+      // Non-admin PUT: unauthenticated https request (outside browser session) must be blocked
+      const nonAdminPutStatus = await new Promise((resolve) => {
+        const body = JSON.stringify({ player1Name: 'hacker' });
+        const url = new URL(`${BASE}/api/tournaments/${tc354TournamentId}/broadcast`);
+        const req = https.request(
+          {
+            hostname: url.hostname,
+            path: url.pathname + url.search,
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
+          },
+          (res) => { res.resume(); resolve(res.statusCode); }
+        );
+        req.setTimeout(15000, () => { req.destroy(); resolve(0); });
+        req.on('error', () => resolve(0));
+        req.write(body);
+        req.end();
+      });
+      const nonAdminBlocked = nonAdminPutStatus === 401 || nonAdminPutStatus === 403;
+
+      const ok = hasShape && putOk && getOk && clearOk && nonAdminBlocked;
       log('TC-354', ok ? 'PASS' : 'FAIL',
-        `shape=${hasShape} put=${putOk} persist=${getOk} clear=${clearOk}`);
+        `shape=${hasShape} put=${putOk} persist=${getOk} clear=${clearOk} nonAdminBlocked=${nonAdminBlocked}(${nonAdminPutStatus})`);
     } catch (err) {
       log('TC-354', 'FAIL', err instanceof Error ? err.message : 'broadcast API test failed');
     } finally {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **#793**: `initial-data.test.ts` の `mockResolveTournament` を `as jest.Mock` から `jest.mocked(resolveTournament)` に統一
- **#794**: ネストした Prisma メソッドの `as jest.Mock` キャストを `jest.mocked(prisma.X.method)` で直接型付けに変更。Prisma デリゲートがシャローモックでは深い型推論が効かない理由をコメントで明記
- **#796**: TC-354 の `putOk` 判定をステータスコードのみに変更。PUT レスポンスのボディ形状依存を除去（値の永続化確認は直後の GET に委ねる）
- **#795**: TC-354 に非認証 `https` PUT ステップを追加し、non-admin PUT が 401/403 でブロックされることを E2E レベルで実際に検証

## Test plan

- [ ] `npm test -- __tests__/lib/ta/initial-data.test.ts` → 4 tests pass
- [ ] 全テストスイート (111 suites, 2134+ tests) pass
- [ ] TC-354 E2E: shape/put/persist/clear/nonAdminBlocked すべて PASS

https://claude.ai/code/session_01AEEiAmuwKq5yThTqWX98wY
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEEiAmuwKq5yThTqWX98wY)_