### PR TITLE
[codex] Implement GP finals cup FT scoring

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1451,7 +1451,7 @@
 - **手順**:
   1. 28名予選 + 全予選マッチ完了（TC-701同様）
   2. `POST /api/.../gp/finals { topN: 8 }` でブラケット生成（17試合）
-  3. M1 に `{ score1: 9, score2: 0 }` で API PUT → 200 受理（targetWins=3、9 >= 3 XOR 0 < 3）
+  3. M1 に `{ score1: 9, score2: 0 }` で API PUT → 200 受理（互換入力としてP1が対象FT分のカップ勝利を得る）
   4. 勝者→M5、敗者→M8 にルーティングされること
   5. クリーンアップ
 - **期待結果**: 28名予選→上位8名→GP決勝ブラケット生成・スコア入力・進行が正常動作
@@ -1524,6 +1524,44 @@
   4. クリーンアップ
 - **期待結果**: GP 決勝スコア入力は管理者のみ許可、プレイヤーは 403 拒否
 
+## TC-720: GP決勝 — FT2 は2カップ先取で決着
+- **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)
+- **authRequired**: true (admin)
+- **背景**: GP決勝のFTはドライバーズポイント合計ではなく、カップ勝利数の先取数。通常のUpper/Lower序盤ラウンドはFT2。
+- **手順**:
+  1. 28名予選 + Top-8 GP決勝ブラケット生成
+  2. M1 に1カップ分だけP1勝利の `cupResults` をPUTする
+  3. M1 は `points1=1, points2=0, completed=false` のままで、M5/M8へルーティングされないこと
+  4. M1 に2カップ分のP1勝利をPUTする
+  5. M1 は `points1=2, points2=0, completed=true` になり、勝者/敗者が次マッチへルーティングされること
+- **期待結果**: GP決勝FT2では1カップ勝利で試合が終わらず、2カップ先取で初めて完了する
+- **スクリプト**: tc-gp.js TC-720
+
+## TC-721: GP決勝 — 同点カップはサドンデスではなく次カップへ進む
+- **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)
+- **authRequired**: true (admin)
+- **背景**: GPではドライバーズポイントが同点のカップは勝敗を付けず、次のカップを行って決着する。
+- **手順**:
+  1. 28名予選 + Top-8 GP決勝ブラケット生成
+  2. M1 に1カップ目 `36-36`、2カップ目P1勝利の `cupResults` をPUTする
+  3. サドンデス指定なしで200が返り、M1は `points1=1, points2=0, completed=false`
+  4. 3カップ目P1勝利を追加してPUTする
+  5. M1は `points1=2, points2=0, completed=true` になり、`cupResults` は3件保持されること
+- **期待結果**: 同点カップは誰にもカップ勝利を与えず、必要ならFT数を超えた追加カップで決着する
+- **スクリプト**: tc-gp.js TC-721
+
+## TC-722: GP Grand Final — FT3 は3カップ先取で決着
+- **URL**: /api/tournaments/[temp-id]/gp/finals (PUT M16)
+- **authRequired**: true (admin)
+- **背景**: GPのUpper決勝/Lower決勝/最終決勝はFT3。Grand Finalも2カップ勝利では未完了で、3カップ先取が必要。
+- **手順**:
+  1. 28名予選 + Top-8 GP決勝ブラケット生成
+  2. M1〜M15をFT2で消化してM16 Grand Finalを準備する
+  3. M16に2カップ分のP1勝利をPUTし、`points1=2, completed=false` であることを確認する
+  4. M16に3カップ目P1勝利を追加してPUTし、`points1=3, completed=true` になることを確認する
+- **期待結果**: GP Grand Final はFT3として動作し、3カップ先取でチャンピオンが決まる
+- **スクリプト**: tc-gp.js TC-722
+
 ## TC-717: GP決勝 — 同じラウンドの全試合で同一カップ (PR #585 正規化)
 - **URL**: /api/tournaments/[temp-id]/gp/finals (GET)
 - **authRequired**: true (admin)
@@ -1538,14 +1576,13 @@
 ## TC-718: GP決勝 — 管理者の手動合計スコア入力 (PR #585 マニュアルフォーム)
 - **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)
 - **authRequired**: true (admin)
-- **背景**: 予選ページ同様、決勝の管理者ダイアログでチェックボックスをオンにすると 5レース入力をスキップして driver-points 合計を直接入力できる。body に `cup` / `races` が含まれない場合、保存済みのレース breakdown は温存されなければならない（`putAdditionalFields` が undefined なフィールドをスキップする契約）。
+- **背景**: GP決勝の管理者ダイアログでは、カップごとに5レース入力をスキップして driver-points 合計を直接入力できる。保存値は `cupResults` にカップ単位で保持され、`points1`/`points2` はカップ勝利数になる。
 - **手順**:
   1. 28名予選 + 決勝ブラケット生成
-  2. M1 に通常の `{ matchId, score1, score2, cup, races }` で PUT → races 配列が保存される
-  3. 続けて M1 に `{ matchId, score1: 15, score2: 12 }` のみ（cup/races を**含まない**）で PUT → 200
-  4. `GET` で M1 を再取得し、`points1=15`、`points2=12`、`cup` と `races` は手順 2 で保存した値のまま残っていることを確認
+  2. M1 に2カップ分の手動 `cupResults` をPUT → 200
+  3. `GET` で M1 を再取得し、`points1=2`、`points2=0`、`cupResults[1].points1=15`、`cupResults[1].points2=12` が保持されていることを確認
   5. クリーンアップ
-- **期待結果**: 手動合計スコア PUT で score1/score2 は上書きされ、cup と races はクリアされない
+- **期待結果**: 手動合計スコア PUT でカップ勝利数が更新され、カップごとのドライバーズポイント内訳が保持される
 
 ## TC-710: GP カップ不一致修正の拒否
 - **URL**: /api/tournaments/[temp-id]/gp (PATCH with correction)
@@ -1558,17 +1595,17 @@
   4. クリーンアップ
 - **期待結果**: 修正スコア送信時にカップが一致しない場合は 422 で拒否される
 
-## TC-712: GP 決勝 Grand Final サドンデス タイブレーク
+## TC-712: GP 決勝 Grand Final — 同点カップ後に次カップで決着
 - **URL**: /tournaments/[temp-id]/gp/finals (PUT M16)
 - **authRequired**: true (admin)
-- **背景**: Grand Final で GP ポイントが同点の場合、サドンデス勝者を指定する必要がある
+- **背景**: Grand Final でカップ内のGPポイントが同点の場合、サドンデスではなく次カップを行い、FT3に到達した時点でチャンピオンを確定する
 - **手順**:
   1. 28名予選 + 決勝ブラケット生成
   2. M1〜M15 を API で入力して Grand Final (M16) まで進める
-  3. M16 に同点スコア（score1=score2）で PUT → サドンデス勝者が設定されていなければ 400 が返ること
-  4. `suddenDeathWinner` を含めて再 PUT → 200 が返り、チャンピオンが確定すること
+  3. M16 に同点カップ1つ + P1勝利カップ3つの `cupResults` をPUTする
+  4. `suddenDeathWinnerId` なしで200が返り、`points1=3, points2=0` でチャンピオンが確定すること
   5. クリーンアップ
-- **期待結果**: GP Grand Final 同点時のサドンデス勝者指定が正しく機能する
+- **期待結果**: GP Grand Final の同点カップは次カップ継続で処理され、FT3到達時に決着する
 
 ## TC-713: GP 予選同着解決 — 同順位バーが rankOverride 設定後に消える
 - **URL**: /tournaments/[temp-id]/gp
@@ -1610,14 +1647,14 @@
   5. クリーンアップ
 - **期待結果**: ブラケット生成後は「View Tournament + Reset Bracket」、リセット後は「Generate / Start Playoff」に戻る
 
-## TC-719: GP 決勝 — 非 Grand Final マッチでのサドンデス タイブレーク (issue #604)
-- **背景**: GP の Grand Final 以外のブラケットマッチでも、同点（draws）発生時にサドンデスレースで決着できること
+## TC-719: GP 決勝 — 非 Grand Final マッチの同点カップ継続
+- **背景**: GP の Grand Final 以外のブラケットマッチでも、カップ内同点時はサドンデスではなく次カップへ進むこと
 - **手順**:
   1. 28名予選完了済みフィクスチャで 8名ブラケットを生成する
   2. winners_qf の ready なマッチを取得する
-  3. 引き分け状態（totalScore1 === totalScore2）が生じるようにスコアを PUT する
-  4. GET で `isDraw=true` または `tiebreakApplied=true` が返ること
-- **期待結果**: QF などの非 GF マッチでも同点は正しく処理される
+  3. 同点カップ + P1勝利1カップをPUTし、M1が `points1=1, completed=false` のまま次マッチへ進まないこと
+  4. P1勝利カップをさらに追加し、FT2到達でM1が `points1=2, completed=true` になり次マッチへ進むこと
+- **期待結果**: QF などの非 GF マッチでも同点カップは未決着扱いになり、次カップでFT到達時のみ進行する
 - **スクリプト**: tc-gp.js TC-719
 
 ## TC-820: MR match/[matchId] ページがview-onlyであることを確認

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/route.test.ts
@@ -630,7 +630,7 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
-      expect(result.data).toEqual({ success: false, error: 'matchId, score1, and score2 are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
+      expect(result.data).toEqual({ success: false, error: 'matchId and score data are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
       expect(result.status).toBe(400);
     });
 
@@ -640,7 +640,7 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
-      expect(result.data).toEqual({ success: false, error: 'matchId, score1, and score2 are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
+      expect(result.data).toEqual({ success: false, error: 'matchId and score data are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
       expect(result.status).toBe(400);
     });
 
@@ -650,7 +650,7 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
-      expect(result.data).toEqual({ success: false, error: 'matchId, score1, and score2 are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
+      expect(result.data).toEqual({ success: false, error: 'matchId and score data are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
       expect(result.status).toBe(400);
     });
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -90,7 +90,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
     /* finals-route defensive tournament existence check */
     (prisma.tournament.findUnique as jest.Mock).mockResolvedValue({ id: 't1' });
     /* Patch in missing gPMatch members used by PUT bracket advancement. */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     const gpMatch = prisma.gPMatch as any;
     if (!gpMatch.count) gpMatch.count = jest.fn();
     if (!gpMatch.findFirst) gpMatch.findFirst = jest.fn();
@@ -238,7 +238,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       (prisma.gPMatch.findMany as jest.Mock)
         .mockResolvedValueOnce(mixedRoundMatches)
         .mockResolvedValueOnce([]);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       (prisma.gPMatch as any).updateMany = jest.fn().mockResolvedValue({ count: 3 });
 
       (paginate as jest.Mock).mockResolvedValue({
@@ -255,7 +255,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       /* updateMany called once per round that needed repair. 'Flower' is the
        * dominant cup (2 occurrences) so it wins over Star (1) and null. The
        * NOT filter avoids touching rows that already match. */
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       const updateManyMock = (prisma.gPMatch as any).updateMany as jest.Mock;
       expect(updateManyMock).toHaveBeenCalledWith({
         where: {
@@ -287,7 +287,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       (prisma.gPMatch.findMany as jest.Mock)
         .mockResolvedValueOnce(nullRoundMatches)
         .mockResolvedValueOnce([]);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       (prisma.gPMatch as any).updateMany = jest.fn().mockResolvedValue({ count: 4 });
 
       (paginate as jest.Mock).mockResolvedValue({
@@ -301,7 +301,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const result = await GET(request, { params });
 
       expect(result.status).toBe(200);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       const updateManyMock = (prisma.gPMatch as any).updateMany as jest.Mock;
       expect(updateManyMock).toHaveBeenCalledTimes(1);
       const call = updateManyMock.mock.calls[0][0];
@@ -326,7 +326,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       (prisma.gPMatch.findMany as jest.Mock)
         .mockResolvedValueOnce(normalized)
         .mockResolvedValueOnce([]);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       (prisma.gPMatch as any).updateMany = jest.fn();
 
       (paginate as jest.Mock).mockResolvedValue({
@@ -339,7 +339,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const params = Promise.resolve({ id: 't1' });
       await GET(request, { params });
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       expect((prisma.gPMatch as any).updateMany).not.toHaveBeenCalled();
     });
   });
@@ -589,14 +589,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       );
     });
 
-    /**
-     * Admin manual total-score override (#585): when only score1/score2 are
-     * sent without cup/races, the existing race breakdown must be preserved
-     * — the PUT body's putAdditionalFields copies `cup`/`races` only when
-     * explicitly present. Regression guard: make sure manual entry doesn't
-     * wipe the stored race array.
-     */
-    it('should preserve cup and races when manual override omits them', async () => {
+    it('should keep GP finals match pending until FT2 cup wins are reached', async () => {
       const mockMatch = {
         id: 'm1',
         tournamentId: 't1',
@@ -605,8 +598,6 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         stage: 'finals',
         player1Id: 'p1',
         player2Id: 'p2',
-        cup: 'Mushroom',
-        races: [{ course: 'LC', position1: 1, position2: 2, points1: 9, points2: 6 }],
         points1: 0,
         points2: 0,
         completed: false,
@@ -615,29 +606,82 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       };
 
       (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
-      (prisma.gPMatch.update as jest.Mock).mockResolvedValue({ ...mockMatch, points1: 27, points2: 18, completed: true });
+      (prisma.gPMatch.update as jest.Mock).mockResolvedValue({ ...mockMatch, points1: 1, points2: 0, completed: false });
+      (generateBracketStructure as jest.Mock).mockReturnValue([
+        { matchNumber: 1, round: 'winners_qf', winnerGoesTo: 5, loserGoesTo: 9, position: 1 },
+      ]);
+
+      const request = new MockNextRequest(
+        'http://localhost:3000/api/tournaments/t1/gp/finals',
+        { matchId: 'm1', cupResults: [{ cup: 'Mushroom', points1: 45, points2: 0 }] },
+      );
+      const params = Promise.resolve({ id: 't1' });
+      const result = await PUT(request, { params });
+
+      const firstUpdateCall = (prisma.gPMatch.update as jest.Mock).mock.calls[0][0];
+      expect(firstUpdateCall.where).toEqual({ id: 'm1' });
+      expect(firstUpdateCall.data.points1).toBe(1);
+      expect(firstUpdateCall.data.points2).toBe(0);
+      expect(firstUpdateCall.data.completed).toBe(false);
+      expect(firstUpdateCall.data.cupResults).toHaveLength(1);
+      expect(prisma.gPMatch.findFirst).not.toHaveBeenCalled();
+      expect(result.data).toEqual({
+        match: { ...mockMatch, points1: 1, points2: 0, completed: false },
+        winnerId: null,
+        loserId: null,
+        isComplete: false,
+        champion: null,
+      });
+    });
+
+    it('should complete GP finals match once FT2 cup wins are reached', async () => {
+      const mockMatch = {
+        id: 'm1',
+        tournamentId: 't1',
+        matchNumber: 1,
+        round: 'winners_qf',
+        stage: 'finals',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        points1: 1,
+        points2: 0,
+        completed: false,
+        player1: { id: 'p1' },
+        player2: { id: 'p2' },
+      };
+
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+      (prisma.gPMatch.update as jest.Mock).mockResolvedValue({ ...mockMatch, points1: 2, points2: 0, completed: true });
       (generateBracketStructure as jest.Mock).mockReturnValue([
         { matchNumber: 1, round: 'winners_qf', winnerGoesTo: 5, loserGoesTo: 9, position: 1 },
       ]);
       (prisma.gPMatch.findFirst as jest.Mock).mockResolvedValue({ id: 'm5' });
 
-      /* Manual override body: score1/score2 only — no cup, no races. */
       const request = new MockNextRequest(
         'http://localhost:3000/api/tournaments/t1/gp/finals',
-        { matchId: 'm1', score1: 27, score2: 18 },
+        {
+          matchId: 'm1',
+          cupResults: [
+            { cup: 'Mushroom', points1: 45, points2: 0 },
+            { cup: 'Flower', points1: 45, points2: 0 },
+          ],
+        },
       );
       const params = Promise.resolve({ id: 't1' });
-      await PUT(request, { params });
+      const result = await PUT(request, { params });
 
-      /* First update call is the score write for m1; that call's data must
-       * not include cup/races so the stored values remain intact. */
-      const firstUpdateCall = (prisma.gPMatch.update as jest.Mock).mock.calls[0][0];
-      expect(firstUpdateCall.where).toEqual({ id: 'm1' });
-      expect(firstUpdateCall.data.points1).toBe(27);
-      expect(firstUpdateCall.data.points2).toBe(18);
-      expect(firstUpdateCall.data.completed).toBe(true);
-      expect(firstUpdateCall.data).not.toHaveProperty('cup');
-      expect(firstUpdateCall.data).not.toHaveProperty('races');
+      const scoreUpdate = (prisma.gPMatch.update as jest.Mock).mock.calls[0][0];
+      expect(scoreUpdate.data.points1).toBe(2);
+      expect(scoreUpdate.data.points2).toBe(0);
+      expect(scoreUpdate.data.completed).toBe(true);
+      expect(prisma.gPMatch.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'm5' },
+          data: { player1Id: 'p1' },
+        })
+      );
+      expect(result.data.winnerId).toBe('p1');
+      expect(result.data.loserId).toBe('p2');
     });
 
     // Success case - Completes tournament with winner from winners bracket
@@ -767,7 +811,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
-      expect(result.data).toEqual({ success: false, error: 'matchId, score1, and score2 are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
+      expect(result.data).toEqual({ success: false, error: 'matchId and score data are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
       expect(result.status).toBe(400);
     });
 
@@ -777,7 +821,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
-      expect(result.data).toEqual({ success: false, error: 'matchId, score1, and score2 are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
+      expect(result.data).toEqual({ success: false, error: 'matchId and score data are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
       expect(result.status).toBe(400);
     });
 
@@ -787,7 +831,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
-      expect(result.data).toEqual({ success: false, error: 'matchId, score1, and score2 are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
+      expect(result.data).toEqual({ success: false, error: 'matchId and score data are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
       expect(result.status).toBe(400);
     });
 
@@ -803,7 +847,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       expect(result.status).toBe(404);
     });
 
-    it('should require a sudden-death winner for tied GP finals scores', async () => {
+    it('should save tied GP finals score as an unresolved cup without sudden death', async () => {
       const mockMatch = {
         id: 'm1',
         stage: 'finals',
@@ -814,22 +858,21 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       };
 
       (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+      (prisma.gPMatch.update as jest.Mock).mockResolvedValue({ ...mockMatch, points1: 0, points2: 0, completed: false });
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/finals', { matchId: 'm1', score1: 2, score2: 2 });
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
-      expect(result.data).toEqual({ success: false, error: 'Tied GP finals scores require a sudden-death winner', code: 'VALIDATION_ERROR', details: { field: 'suddenDeathWinnerId' } });
-      expect(result.status).toBe(400);
+      expect(result.status).toBe(200);
+      expect(result.data.match.completed).toBe(false);
     });
 
     /**
-     * Server enforces the sudden-death rule for any tie, including 0-0
-     * (Codex review on PR #588). Regression guard for the manual-override
-     * path where the default inputs are 0/0 — the client must not let that
-     * slip through, but even if it did, the server still rejects.
+     * A tied GP cup is unresolved, including 0-0. The match stays pending
+     * until a later cup gives one player enough cup wins.
      */
-    it('should require a sudden-death winner for a 0-0 tie', async () => {
+    it('should allow a 0-0 tied cup as pending', async () => {
       const mockMatch = {
         id: 'm1',
         stage: 'finals',
@@ -840,6 +883,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       };
 
       (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+      (prisma.gPMatch.update as jest.Mock).mockResolvedValue({ ...mockMatch, points1: 0, points2: 0, completed: false });
 
       const request = new MockNextRequest(
         'http://localhost:3000/api/tournaments/t1/gp/finals',
@@ -848,8 +892,8 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
-      expect(result.status).toBe(400);
-      expect(result.data.error).toBe('Tied GP finals scores require a sudden-death winner');
+      expect(result.status).toBe(200);
+      expect(result.data.match.completed).toBe(false);
     });
 
     it('should reject negative GP finals driver points', async () => {
@@ -872,7 +916,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       expect(result.status).toBe(400);
     });
 
-    it('should allow tied GP finals scores with a sudden-death winner', async () => {
+    it('should ignore sudden-death winner on tied GP finals scores and keep match pending', async () => {
       const mockMatch = {
         id: 'm1',
         tournamentId: 't1',
@@ -888,7 +932,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         player2: { id: 'p2', name: 'Player 2' },
       };
 
-      const updatedMatch = { ...mockMatch, completed: true, suddenDeathWinnerId: 'p2' };
+      const updatedMatch = { ...mockMatch, points1: 0, points2: 0, completed: false, suddenDeathWinnerId: null };
       const mockBracket = [
         { matchNumber: 1, round: 'winners_qf', player1Seed: 1, player2Seed: 8, winnerGoesTo: 5, loserGoesTo: 9, position: 1 },
       ];
@@ -909,8 +953,8 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
 
       expect(result.data).toEqual({
         match: updatedMatch,
-        winnerId: 'p2',
-        loserId: 'p1',
+        winnerId: null,
+        loserId: null,
         isComplete: false,
         champion: null,
       });
@@ -920,10 +964,10 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         expect.objectContaining({
           where: { id: 'm1' },
           data: expect.objectContaining({
-            points1: 2,
-            points2: 2,
-            suddenDeathWinnerId: 'p2',
-            completed: true,
+            points1: 0,
+            points2: 0,
+            suddenDeathWinnerId: null,
+            completed: false,
           }),
         }),
       );

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
@@ -642,7 +642,7 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
 
-      expect(result.data).toEqual({ success: false, error: 'matchId, score1, and score2 are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
+      expect(result.data).toEqual({ success: false, error: 'matchId and score data are required', code: 'VALIDATION_ERROR', details: { field: 'request' } });
       expect(result.status).toBe(400);
     });
 

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1666,7 +1666,7 @@ describe('Finals Route Factory', () => {
 
       expect(response.status).toBe(400);
       const json = await response.json();
-      expect(json.error).toBe('matchId, score1, and score2 are required');
+      expect(json.error).toBe('matchId and score data are required');
     });
 
     it('should return 500 on database error', async () => {

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -611,6 +611,18 @@ async function apiSetGpFinalsScore(page, tournamentId, matchId, score1, score2, 
   { label: `GP finals PUT ${matchId}` });
 }
 
+async function apiSetGpFinalsCupResults(page, tournamentId, matchId, cupResults, extra = {}) {
+  return withRetry(() => page.evaluate(async ([url, reqBody]) => {
+    const r = await fetch(url, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(reqBody),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [`/api/tournaments/${tournamentId}/gp/finals`, { matchId, cupResults, ...extra }]),
+  { label: `GP finals cupResults PUT ${matchId}` });
+}
+
 async function apiGenerateGpFinals(page, tournamentId, topN = 8) {
   return withRetry(() => page.evaluate(async ([url, body]) => {
     const r = await fetch(url, {
@@ -2403,6 +2415,7 @@ module.exports = {
   apiPutGpQualScore,
   apiPutAllGpQualScores,
   apiSetGpFinalsScore,
+  apiSetGpFinalsCupResults,
   apiGenerateGpFinals,
   apiFetchGpFinalsMatches,
   apiFetchGpFinalsState,

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -14,7 +14,7 @@
  *   TC-713  GP qualification tie resolution (tie warning → resolveAllTies)
  *   TC-717  GP finals same-cup-per-round enforcement (PR #585 normalizer)
  *   TC-718  GP finals admin manual total-score override (PR #585 manual form)
- *   TC-719  GP sudden-death tiebreak in non-grand-final bracket match (issue #604)
+ *   TC-719  GP tied cup extends non-grand-final bracket match
  *
  * Setup:
  *   - Uses Playwright persistent profile at /tmp/playwright-smkc-profile.
@@ -29,7 +29,7 @@ const {
   makeResults, makeLog, nav,
   uiCreatePlayer, apiDeletePlayer, apiDeleteTournament, uiCreateTournament,
   apiFetchGp, apiPutGpQualScore,
-  apiSetGpFinalsScore, apiGenerateGpFinals, apiFetchGpFinalsMatches, apiFetchGpFinalsState,
+  apiSetGpFinalsScore, apiSetGpFinalsCupResults, apiGenerateGpFinals, apiFetchGpFinalsMatches, apiFetchGpFinalsState,
   apiUpdateTournament,
   makeRacesP1Wins, makeRacesP2Wins,
   loginPlayerBrowser,
@@ -227,7 +227,7 @@ async function runTc703(adminPage) {
     const qfNick = setup.nicknames[setup.playerIds.indexOf(qfMatches[0].player1Id)];
     const qfRendered = !!qfNick && pageText.includes(qfNick);
 
-    /* GP finals validation: targetWins=3 default. score1=9 (P1 1st in 1 race) >= 3, score2=0 < 3. */
+    /* Legacy raw score path now stores GP finals scores as cup wins. */
     const valid = await apiSetGpFinalsScore(adminPage, setup.tournamentId, m1.id, 9, 0);
     if (valid.s !== 200) throw new Error(`Score put failed (${valid.s})`);
 
@@ -236,7 +236,7 @@ async function runTc703(adminPage) {
     const winnerTarget = after.find((m) => m.matchNumber === 5);
     const loserTarget = after.find((m) => m.matchNumber === 8);
     const bracketCount = after.length === 17;
-    const scoreSaved = updated?.completed === true && updated.points1 === 9 && updated.points2 === 0;
+    const scoreSaved = updated?.completed === true && updated.points1 === 2 && updated.points2 === 0;
     const winnerRouted = [winnerTarget?.player1Id, winnerTarget?.player2Id].includes(m1.player1Id);
     const loserRouted = [loserTarget?.player1Id, loserTarget?.player2Id].includes(m1.player2Id);
 
@@ -332,7 +332,7 @@ async function runTc705(adminPage) {
     const pageText = await adminPage.locator('body').innerText();
     const championShown = pageText.includes(championNickname) &&
       (pageText.includes('Champion') || pageText.includes('チャンピオン') || pageText.includes('優勝'));
-    const m16Ok = m16.completed === true && m16.points1 === 9 && m16.points2 === 0;
+    const m16Ok = m16.completed === true && m16.points1 === 3 && m16.points2 === 0;
 
     log('TC-705', m16Ok && championShown ? 'PASS' : 'FAIL',
       !m16Ok ? 'M16 not completed'
@@ -598,11 +598,9 @@ async function runTc717(adminPage) {
  *
  * Flow:
  *   1. Generate an 8-player finals bracket.
- *   2. Enter full race data for M1 first (sets match.races on the row).
- *   3. Reset with the raw totals (score1=15, score2=12) via the same
- *      endpoint but without cup/races in the body.
- *   4. Fetch back: points1/points2 reflect the manual totals, the stored
- *      cup stays the same as before, and the races array is unchanged. */
+ *   2. Enter two manual cup totals for M1 using cupResults.
+ *   3. Fetch back: points1/points2 are cup wins, cupResults preserves the
+ *      manual driver-point totals for each cup. */
 async function runTc718(adminPage) {
   let setup = null;
   try {
@@ -616,59 +614,24 @@ async function runTc718(adminPage) {
     if (!m1) throw new Error('Match 1 missing');
     if (!m1.cup) throw new Error('Match 1 cup not assigned — normalizer may have failed');
 
-    /* Step 1: seed races via the normal cup+races path. Total = 9 per race
-     * for P1 (1st), 6 for P2 (2nd), summed across 5 races: 45-30. */
-    const raceSeed = await adminPage.evaluate(async ([u, body]) => {
-      const r = await fetch(u, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-      return { s: r.status, b: await r.json().catch(() => ({})) };
-    }, [
-      `/api/tournaments/${setup.tournamentId}/gp/finals`,
-      {
-        matchId: m1.id,
-        score1: 45,
-        score2: 30,
-        cup: m1.cup,
-        races: makeRacesP1Wins(m1.cup),
-      },
-    ]);
-    if (raceSeed.s !== 200) throw new Error(`Seed PUT failed (${raceSeed.s})`);
-
-    const afterSeed = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
-    const seeded = afterSeed.find((m) => m.id === m1.id);
-    const hadRaces = Array.isArray(seeded?.races) && seeded.races.length > 0;
-    if (!hadRaces) throw new Error('Seed PUT did not persist races');
-
-    /* Step 2: manual override — PUT without cup/races in the body. */
-    const manual = await adminPage.evaluate(async ([u, body]) => {
-      const r = await fetch(u, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-      return { s: r.status, b: await r.json().catch(() => ({})) };
-    }, [
-      `/api/tournaments/${setup.tournamentId}/gp/finals`,
-      { matchId: m1.id, score1: 15, score2: 12 },
+    const manual = await apiSetGpFinalsCupResults(adminPage, setup.tournamentId, m1.id, [
+      gpCupResult(m1.cup, 45, 30),
+      gpCupResult('Flower', 15, 12),
     ]);
     if (manual.s !== 200) throw new Error(`Manual PUT failed (${manual.s})`);
 
     const afterManual = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
     const finalMatch = afterManual.find((m) => m.id === m1.id);
-    const totalsUpdated = finalMatch?.points1 === 15 && finalMatch?.points2 === 12;
-    const cupPreserved = finalMatch?.cup === seeded.cup;
-    const racesPreserved =
-      Array.isArray(finalMatch?.races) &&
-      finalMatch.races.length === seeded.races.length;
+    const totalsUpdated = finalMatch?.points1 === 2 && finalMatch?.points2 === 0;
+    const cupResultsPreserved = Array.isArray(finalMatch?.cupResults) &&
+      finalMatch.cupResults.length === 2 &&
+      finalMatch.cupResults[1].points1 === 15 &&
+      finalMatch.cupResults[1].points2 === 12;
 
-    const ok = totalsUpdated && cupPreserved && racesPreserved;
+    const ok = totalsUpdated && cupResultsPreserved;
     log('TC-718', ok ? 'PASS' : 'FAIL',
       !totalsUpdated ? `totals: ${finalMatch?.points1}-${finalMatch?.points2}`
-      : !cupPreserved ? `cup changed: ${seeded.cup} → ${finalMatch?.cup}`
-      : !racesPreserved ? `races lost: ${finalMatch?.races?.length ?? 0}`
+      : !cupResultsPreserved ? `cupResults not preserved: ${finalMatch?.cupResults?.length ?? 0}`
       : '');
   } catch (err) {
     log('TC-718', 'FAIL', err instanceof Error ? err.message : 'GP 718 failed');
@@ -911,9 +874,8 @@ async function runTc710(adminPage) {
   }
 }
 
-/* ───────── TC-712: GP Grand Final sudden-death tiebreak ─────────
- * Validates #538: when the grand final ends in a tie, the admin can select
- * a sudden-death winner and the champion is determined correctly. */
+/* ───────── TC-712: GP Grand Final tied cup extends match ─────────
+ * Grand Final tied cups do not use sudden death; later cups decide the FT3. */
 async function runTc712(adminPage) {
   let setup = null;
   try {
@@ -934,12 +896,16 @@ async function runTc712(adminPage) {
       if (res.s !== 200) throw new Error(`Match ${mn} put failed (${res.s})`);
     }
 
-    /* M16 (grand final): tie 5-5 with sudden-death winner = player1. */
     const matchesBefore = await apiFetchGpFinalsMatches(adminPage, tournamentId);
     const m16 = matchesBefore.find((m) => m.matchNumber === 16);
     if (!m16 || !m16.player1Id) throw new Error('GF M16 not ready');
-    const sdRes = await apiSetGpFinalsScore(adminPage, tournamentId, m16.id, 5, 5, m16.player1Id);
-    if (sdRes.s !== 200) throw new Error(`M16 sudden-death put failed (${sdRes.s})`);
+    const cupRes = await apiSetGpFinalsCupResults(adminPage, tournamentId, m16.id, [
+      gpCupResult(m16.cup || 'Mushroom', 36, 36),
+      gpCupResult('Flower', 45, 0),
+      gpCupResult('Star', 45, 0),
+      gpCupResult('Special', 45, 0),
+    ]);
+    if (cupRes.s !== 200) throw new Error(`M16 cup-results put failed (${cupRes.s})`);
 
     const matchesAfter = await apiFetchGpFinalsMatches(adminPage, tournamentId);
     const m16After = matchesAfter.find((m) => m.matchNumber === 16);
@@ -950,10 +916,15 @@ async function runTc712(adminPage) {
     const pageText = await adminPage.locator('body').innerText();
     const championShown = pageText.includes(championNickname) &&
       (pageText.includes('Champion') || pageText.includes('チャンピオン') || pageText.includes('優勝'));
-    const m16Ok = m16After.completed === true && m16After.suddenDeathWinnerId === expectedChampionId;
+    const m16Ok = m16After.completed === true &&
+      m16After.points1 === 3 &&
+      m16After.points2 === 0 &&
+      Array.isArray(m16After.cupResults) &&
+      m16After.cupResults.length === 4 &&
+      !m16After.suddenDeathWinnerId;
 
     log('TC-712', m16Ok && championShown ? 'PASS' : 'FAIL',
-      !m16Ok ? `M16 sudden-death not persisted (completed=${m16After?.completed}, sdWinner=${m16After?.suddenDeathWinnerId})`
+      !m16Ok ? `M16 tied-cup FT3 not persisted (completed=${m16After?.completed}, score=${m16After?.points1}-${m16After?.points2})`
       : !championShown ? `Champion banner missing nickname ${championNickname}`
       : '');
   } catch (err) {
@@ -1077,17 +1048,14 @@ async function runTc821(adminPage) {
   }
 }
 
-/* ───────── TC-719: GP sudden-death tiebreak in non-grand-final bracket match ─────────
- * Issue #604: Validates that the GP finals API supports sudden-death winner
- * selection for tied driver points in ANY bracket match (not only grand final).
- * When score1 === score2, the PUT must be accompanied by a valid suddenDeathWinnerId.
- * Without it the API must return 400. With it, the match completes and the
- * bracket advances correctly. */
+/* ───────── TC-719: GP tied cup in non-grand-final bracket match ─────────
+ * Tied driver points for a cup do not require sudden death; the match stays
+ * pending until later cups supply enough cup wins for the round FT. */
 async function runTc719(adminPage) {
   let setup = null;
   try {
     setup = await prepareSharedGpFinalsSetup(adminPage);
-    const { tournamentId, playerIds } = setup;
+    const { tournamentId } = setup;
 
     const gen = await apiGenerateGpFinals(adminPage, tournamentId, 8);
     if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
@@ -1097,43 +1065,220 @@ async function runTc719(adminPage) {
     const qfMatch = matches.find((m) => m.round === 'winners_qf' && m.player1Id && m.player2Id);
     if (!qfMatch) throw new Error('No ready winners_qf match for TC-719');
 
-    /* Tied score without suddenDeathWinnerId must be rejected. */
-    const noSd = await apiSetGpFinalsScore(adminPage, tournamentId, qfMatch.id, 5, 5);
-    const noSdRejected = noSd.s === 400;
+    const tied = await apiSetGpFinalsCupResults(adminPage, tournamentId, qfMatch.id, [
+      gpCupResult(qfMatch.cup || 'Mushroom', 36, 36),
+      gpCupResult('Flower', 45, 0),
+    ]);
+    const tiedAccepted = tied.s === 200;
+    let after = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+    const qfAfterTie = after.find((m) => m.id === qfMatch.id);
+    const pending = qfAfterTie?.completed === false &&
+      qfAfterTie?.points1 === 1 &&
+      qfAfterTie?.points2 === 0 &&
+      !qfAfterTie?.suddenDeathWinnerId;
+    const notRouted = !after.find(
+      (m) => m.round === 'winners_sf' &&
+        (m.player1Id === qfMatch.player1Id || m.player2Id === qfMatch.player1Id),
+    );
 
-    /* Tied score with invalid suddenDeathWinnerId must be rejected. */
-    const badSd = await apiSetGpFinalsScore(adminPage, tournamentId, qfMatch.id, 5, 5, 'invalid-id');
-    const badSdRejected = badSd.s === 400;
-
-    /* Tied score with a valid suddenDeathWinnerId must succeed. */
-    const sdRes = await apiSetGpFinalsScore(adminPage, tournamentId, qfMatch.id, 5, 5, qfMatch.player1Id);
-    const sdAccepted = sdRes.s === 200;
-
-    /* Winner must be recorded as the sudden-death winner.
-     * GPMatch schema has no dedicated winnerId column; routing is verified
-     * by checking that the SD winner appears in the next bracket match. */
-    const after = await apiFetchGpFinalsMatches(adminPage, tournamentId);
-    const qfAfter = after.find((m) => m.id === qfMatch.id);
-    const sdPersisted = qfAfter?.completed === true &&
-      qfAfter?.suddenDeathWinnerId === qfMatch.player1Id;
-
-    /* Verify bracket advancement: winners_qf winner must appear in a winners_sf slot. */
+    const complete = await apiSetGpFinalsCupResults(adminPage, tournamentId, qfMatch.id, [
+      gpCupResult(qfMatch.cup || 'Mushroom', 36, 36),
+      gpCupResult('Flower', 45, 0),
+      gpCupResult('Star', 45, 0),
+    ]);
+    const completeAccepted = complete.s === 200;
+    after = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+    const qfAfterComplete = after.find((m) => m.id === qfMatch.id);
+    const completed = qfAfterComplete?.completed === true &&
+      qfAfterComplete?.points1 === 2 &&
+      qfAfterComplete?.points2 === 0;
     const nextMatch = after.find(
       (m) => m.round === 'winners_sf' &&
         (m.player1Id === qfMatch.player1Id || m.player2Id === qfMatch.player1Id),
     );
-    const winnerRouted = sdPersisted && !!nextMatch;
+    const winnerRouted = completed && !!nextMatch;
 
-    const ok = noSdRejected && badSdRejected && sdAccepted && winnerRouted;
+    const ok = tiedAccepted && pending && notRouted && completeAccepted && winnerRouted;
     log('TC-719', ok ? 'PASS' : 'FAIL',
-      !noSdRejected ? `Tied score without suddenDeathWinnerId not rejected (${noSd.s})`
-      : !badSdRejected ? `Tied score with invalid suddenDeathWinnerId not rejected (${badSd.s})`
-      : !sdAccepted ? `Tied score with valid suddenDeathWinnerId not accepted (${sdRes.s})`
-      : !sdPersisted ? `SD not persisted (completed=${qfAfter?.completed}, sdWinner=${qfAfter?.suddenDeathWinnerId})`
-      : !winnerRouted ? `SD winner not routed to winners_sf`
+      !tiedAccepted ? `Tied cup not accepted (${tied.s})`
+      : !pending ? `Match not pending after tie completed=${qfAfterTie?.completed} score=${qfAfterTie?.points1}-${qfAfterTie?.points2}`
+      : !notRouted ? 'Winner routed before FT2'
+      : !completeAccepted ? `Completion not accepted (${complete.s})`
+      : !winnerRouted ? `Winner not routed after FT2`
       : '');
   } catch (err) {
     log('TC-719', 'FAIL', err instanceof Error ? err.message : 'GP 719 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+function gpCupResult(cup, points1, points2) {
+  const courses = {
+    Mushroom: ['MC1', 'DP1', 'GV1', 'BC1', 'MC2'],
+    Flower: ['CI1', 'GV2', 'DP2', 'BC2', 'MC3'],
+    Star: ['KB1', 'CI2', 'VL1', 'BC3', 'MC4'],
+    Special: ['DP3', 'KB2', 'GV3', 'VL2', 'RR'],
+  }[cup] || ['MC1', 'DP1', 'GV1', 'BC1', 'MC2'];
+  return {
+    cup,
+    points1,
+    points2,
+    races: courses.map((course) => ({ course, position1: 1, position2: 2, points1: 0, points2: 0 })),
+  };
+}
+
+/* ───────── TC-720: GP finals FT2 requires two cup wins ───────── */
+async function runTc720(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedGpFinalsSetup(adminPage);
+    const gen = await apiGenerateGpFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    let matches = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const m1 = matches.find((m) => m.matchNumber === 1);
+    if (!m1) throw new Error('Match 1 missing');
+
+    const oneCup = await apiSetGpFinalsCupResults(adminPage, setup.tournamentId, m1.id, [
+      gpCupResult(m1.cup || 'Mushroom', 45, 0),
+    ]);
+    if (oneCup.s !== 200) throw new Error(`1-cup PUT failed (${oneCup.s})`);
+
+    matches = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const afterOne = matches.find((m) => m.id === m1.id);
+    const m5AfterOne = matches.find((m) => m.matchNumber === 5);
+    const stillOpen = afterOne?.completed === false && afterOne?.points1 === 1 && afterOne?.points2 === 0;
+    const notRouted = m5AfterOne?.player1Id !== m1.player1Id && m5AfterOne?.player2Id !== m1.player1Id;
+
+    const twoCup = await apiSetGpFinalsCupResults(adminPage, setup.tournamentId, m1.id, [
+      gpCupResult(m1.cup || 'Mushroom', 45, 0),
+      gpCupResult('Flower', 45, 0),
+    ]);
+    if (twoCup.s !== 200) throw new Error(`2-cup PUT failed (${twoCup.s})`);
+
+    matches = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const afterTwo = matches.find((m) => m.id === m1.id);
+    const m5AfterTwo = matches.find((m) => m.matchNumber === 5);
+    const completed = afterTwo?.completed === true && afterTwo?.points1 === 2 && afterTwo?.points2 === 0;
+    const routed = [m5AfterTwo?.player1Id, m5AfterTwo?.player2Id].includes(m1.player1Id);
+
+    const ok = stillOpen && notRouted && completed && routed;
+    log('TC-720', ok ? 'PASS' : 'FAIL',
+      !stillOpen ? `after one cup completed=${afterOne?.completed} score=${afterOne?.points1}-${afterOne?.points2}`
+      : !notRouted ? 'winner routed before FT2'
+      : !completed ? `after two cups completed=${afterTwo?.completed} score=${afterTwo?.points1}-${afterTwo?.points2}`
+      : !routed ? 'winner not routed after FT2'
+      : '');
+  } catch (err) {
+    log('TC-720', 'FAIL', err instanceof Error ? err.message : 'GP 720 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-721: GP finals tied cups extend to additional cups ───────── */
+async function runTc721(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedGpFinalsSetup(adminPage);
+    const gen = await apiGenerateGpFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    let matches = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const m1 = matches.find((m) => m.matchNumber === 1);
+    if (!m1) throw new Error('Match 1 missing');
+
+    const tiedThenOne = await apiSetGpFinalsCupResults(adminPage, setup.tournamentId, m1.id, [
+      gpCupResult(m1.cup || 'Mushroom', 36, 36),
+      gpCupResult('Flower', 45, 0),
+    ]);
+    if (tiedThenOne.s !== 200) throw new Error(`tie+one PUT failed (${tiedThenOne.s})`);
+
+    matches = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const afterTwoPlayed = matches.find((m) => m.id === m1.id);
+    const openWithTie = afterTwoPlayed?.completed === false &&
+      afterTwoPlayed?.points1 === 1 && afterTwoPlayed?.points2 === 0 &&
+      Array.isArray(afterTwoPlayed?.cupResults) && afterTwoPlayed.cupResults.length === 2;
+
+    const extended = await apiSetGpFinalsCupResults(adminPage, setup.tournamentId, m1.id, [
+      gpCupResult(m1.cup || 'Mushroom', 36, 36),
+      gpCupResult('Flower', 45, 0),
+      gpCupResult('Star', 45, 0),
+    ]);
+    if (extended.s !== 200) throw new Error(`extended PUT failed (${extended.s})`);
+
+    matches = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const afterExtended = matches.find((m) => m.id === m1.id);
+    const completedAfterExtension = afterExtended?.completed === true &&
+      afterExtended?.points1 === 2 && afterExtended?.points2 === 0 &&
+      Array.isArray(afterExtended?.cupResults) && afterExtended.cupResults.length === 3;
+
+    const ok = openWithTie && completedAfterExtension;
+    log('TC-721', ok ? 'PASS' : 'FAIL',
+      !openWithTie ? `tie state wrong completed=${afterTwoPlayed?.completed} score=${afterTwoPlayed?.points1}-${afterTwoPlayed?.points2} cups=${afterTwoPlayed?.cupResults?.length}`
+      : !completedAfterExtension ? `extended state wrong completed=${afterExtended?.completed} score=${afterExtended?.points1}-${afterExtended?.points2} cups=${afterExtended?.cupResults?.length}`
+      : '');
+  } catch (err) {
+    log('TC-721', 'FAIL', err instanceof Error ? err.message : 'GP 721 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-722: GP Grand Final FT3 requires three cup wins ───────── */
+async function runTc722(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedGpFinalsSetup(adminPage);
+    const { tournamentId } = setup;
+
+    const gen = await apiGenerateGpFinals(adminPage, tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    for (let mn = 1; mn <= 15; mn++) {
+      const matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+      const match = matches.find((m) => m.matchNumber === mn);
+      if (!match || !match.player1Id || !match.player2Id || match.player1Id === match.player2Id) {
+        throw new Error(`Match ${mn} not ready`);
+      }
+      const res = await apiSetGpFinalsCupResults(adminPage, tournamentId, match.id, [
+        gpCupResult(match.cup || 'Mushroom', 45, 0),
+        gpCupResult('Flower', 45, 0),
+      ]);
+      if (res.s !== 200) throw new Error(`Match ${mn} put failed (${res.s})`);
+    }
+
+    let matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+    const m16 = matches.find((m) => m.matchNumber === 16);
+    if (!m16 || !m16.player1Id || !m16.player2Id) throw new Error('M16 not ready');
+
+    const twoCup = await apiSetGpFinalsCupResults(adminPage, tournamentId, m16.id, [
+      gpCupResult(m16.cup || 'Mushroom', 45, 0),
+      gpCupResult('Flower', 45, 0),
+    ]);
+    if (twoCup.s !== 200) throw new Error(`M16 2-cup PUT failed (${twoCup.s})`);
+    matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+    const afterTwo = matches.find((m) => m.id === m16.id);
+    const stillOpen = afterTwo?.completed === false && afterTwo?.points1 === 2 && afterTwo?.points2 === 0;
+
+    const threeCup = await apiSetGpFinalsCupResults(adminPage, tournamentId, m16.id, [
+      gpCupResult(m16.cup || 'Mushroom', 45, 0),
+      gpCupResult('Flower', 45, 0),
+      gpCupResult('Star', 45, 0),
+    ]);
+    if (threeCup.s !== 200) throw new Error(`M16 3-cup PUT failed (${threeCup.s})`);
+    matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+    const afterThree = matches.find((m) => m.id === m16.id);
+    const completed = afterThree?.completed === true && afterThree?.points1 === 3 && afterThree?.points2 === 0;
+
+    const ok = stillOpen && completed;
+    log('TC-722', ok ? 'PASS' : 'FAIL',
+      !stillOpen ? `M16 after two cups completed=${afterTwo?.completed} score=${afterTwo?.points1}-${afterTwo?.points2}`
+      : !completed ? `M16 after three cups completed=${afterThree?.completed} score=${afterThree?.points1}-${afterThree?.points2}`
+      : '');
+  } catch (err) {
+    log('TC-722', 'FAIL', err instanceof Error ? err.message : 'GP 722 failed');
   } finally {
     if (setup) await setup.cleanup();
   }
@@ -1173,6 +1318,9 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-710', fn: runTc710 },
       { name: 'TC-712', fn: runTc712 },
       { name: 'TC-719', fn: runTc719 },
+      { name: 'TC-720', fn: runTc720 },
+      { name: 'TC-721', fn: runTc721 },
+      { name: 'TC-722', fn: runTc722 },
       { name: 'TC-713', fn: runTc713 },
       { name: 'TC-821', fn: runTc821 },
     ],
@@ -1182,7 +1330,8 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 module.exports = {
   runTc701, runTc702, runTc703, runTc704, runTc705, runTc706,
   runTc707, runTc708, runTc709, runTc710, runTc712, runTc713,
-  runTc715, runTc716, runTc717, runTc718, runTc719, runTc821,
+  runTc715, runTc716, runTc717, runTc718, runTc719,
+  runTc720, runTc721, runTc722, runTc821,
   getSuite,
   results,
 };

--- a/smkc-score-app/migrations/0028_gp_finals_cup_results.sql
+++ b/smkc-score-app/migrations/0028_gp_finals_cup_results.sql
@@ -1,0 +1,2 @@
+-- Store multi-cup GP finals/playoff results for FT cup-win matches.
+ALTER TABLE GPMatch ADD COLUMN cupResults TEXT;

--- a/smkc-score-app/prisma/migrations/0010_gp_finals_cup_results/migration.sql
+++ b/smkc-score-app/prisma/migrations/0010_gp_finals_cup_results/migration.sql
@@ -1,0 +1,2 @@
+-- Store multi-cup GP finals/playoff results for FT cup-win matches.
+ALTER TABLE "GPMatch" ADD COLUMN "cupResults" JSONB;

--- a/smkc-score-app/prisma/schema.prisma
+++ b/smkc-score-app/prisma/schema.prisma
@@ -367,6 +367,7 @@ model GPMatch {
   completed    Boolean    @default(false)
   suddenDeathWinnerId String? // Tied cup resolved by a one-race sudden-death playoff
   races        Json? // [{course: "MC1", position1: 1, position2: 2, points1: 9, points2: 6}, ...]
+  cupResults   Json? // Finals/playoff: [{cup, races, points1, points2, winner}], one entry per played cup
 
   // Player-reported scores (for participant score entry)
   player1ReportedPoints1 Int? // Player 1's report: points for player 1

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
@@ -8,6 +8,73 @@
 import { withApiTiming } from '@/lib/perf/api-timing';
 import { createFinalsHandlers } from '@/lib/api-factories/finals-route';
 import { getGpFinalsTargetWins } from '@/lib/finals-target-wins';
+import { CUPS, DRIVER_POINTS } from '@/lib/constants';
+
+type GpCupResultInput = {
+  cup?: unknown;
+  points1?: unknown;
+  points2?: unknown;
+  races?: unknown;
+};
+
+function sumRacePoints(races: unknown, side: 1 | 2): number | null {
+  if (!Array.isArray(races)) return null;
+  let total = 0;
+  for (const race of races) {
+    if (!race || typeof race !== 'object') return null;
+    const entry = race as Record<string, unknown>;
+    const existing = entry[side === 1 ? 'points1' : 'points2'];
+    if (Number.isInteger(existing) && Number(existing) >= 0) {
+      total += Number(existing);
+      continue;
+    }
+    const position = entry[side === 1 ? 'position1' : 'position2'];
+    if (!Number.isInteger(position)) return null;
+    total += DRIVER_POINTS[Number(position)] ?? 0;
+  }
+  return total;
+}
+
+function normalizeCupResults(input: unknown): { results?: Array<Record<string, unknown>>; error?: string } {
+  if (!Array.isArray(input) || input.length === 0) {
+    return { error: 'cupResults must be a non-empty array' };
+  }
+
+  const results: Array<Record<string, unknown>> = [];
+  for (let index = 0; index < input.length; index++) {
+    const raw = input[index] as GpCupResultInput;
+    if (!raw || typeof raw !== 'object') {
+      return { error: `cupResults[${index}] must be an object` };
+    }
+
+    const fallbackCup = CUPS[index % CUPS.length];
+    const cup = typeof raw.cup === 'string' && raw.cup.length > 0 ? raw.cup : fallbackCup;
+    const racePoints1 = sumRacePoints(raw.races, 1);
+    const racePoints2 = sumRacePoints(raw.races, 2);
+    const points1 = Number.isInteger(raw.points1) && Number(raw.points1) >= 0
+      ? Number(raw.points1)
+      : racePoints1;
+    const points2 = Number.isInteger(raw.points2) && Number(raw.points2) >= 0
+      ? Number(raw.points2)
+      : racePoints2;
+
+    if (points1 === null || points2 === null || !Number.isInteger(points1) || !Number.isInteger(points2) || points1 < 0 || points2 < 0) {
+      return { error: `cupResults[${index}] requires non-negative integer points` };
+    }
+    const p1 = points1;
+    const p2 = points2;
+
+    results.push({
+      cup,
+      points1: p1,
+      points2: p2,
+      winner: p1 > p2 ? 1 : p2 > p1 ? 2 : null,
+      ...(Array.isArray(raw.races) ? { races: raw.races } : {}),
+    });
+  }
+
+  return { results };
+}
 
 const { GET: _GET, POST, PUT, PATCH } = createFinalsHandlers({
   eventTypeCode: 'gp',
@@ -20,7 +87,7 @@ const { GET: _GET, POST, PUT, PATCH } = createFinalsHandlers({
   qualificationOrderBy: [{ group: 'asc' }, { points: 'desc' }, { score: 'desc' }],
   getStyle: 'paginated',
   putScoreFields: { dbField1: 'points1', dbField2: 'points2' },
-  putAdditionalFields: ['races', 'cup', 'tvNumber'],
+  putAdditionalFields: ['races', 'cup', 'cupResults', 'tvNumber'],
   getTargetWins: getGpFinalsTargetWins,
   getErrorMessage: 'Failed to fetch grand prix finals data',
   postErrorMessage: 'Failed to create grand prix finals bracket',
@@ -28,39 +95,91 @@ const { GET: _GET, POST, PUT, PATCH } = createFinalsHandlers({
   putRequiresAuth: true,
   assignGpCupByRound: true,
   resolveMatchResult: (match, score1, score2, body) => {
+    const targetWins = getGpFinalsTargetWins({
+      round: match.round as string | null | undefined,
+      stage: match.stage as string | null | undefined,
+    });
+
+    if (body.cupResults !== undefined) {
+      const normalized = normalizeCupResults(body.cupResults);
+      if (normalized.error || !normalized.results) {
+        return { error: normalized.error ?? 'Invalid cupResults', field: 'cupResults' };
+      }
+
+      const cupWins1 = normalized.results.filter((cup) => cup.winner === 1).length;
+      const cupWins2 = normalized.results.filter((cup) => cup.winner === 2).length;
+      const player1ReachedTarget = cupWins1 >= targetWins && cupWins1 > cupWins2;
+      const player2ReachedTarget = cupWins2 >= targetWins && cupWins2 > cupWins1;
+      const firstCup = normalized.results[0];
+      const latestCup = normalized.results[normalized.results.length - 1];
+
+      if (player1ReachedTarget || player2ReachedTarget) {
+        return {
+          winnerId: player1ReachedTarget ? match.player1Id as string : match.player2Id as string,
+          loserId: player1ReachedTarget ? match.player2Id as string : match.player1Id as string,
+          completed: true,
+          updateData: {
+            points1: cupWins1,
+            points2: cupWins2,
+            cupResults: normalized.results,
+            cup: typeof latestCup.cup === 'string' ? latestCup.cup : firstCup.cup,
+            races: latestCup.races ?? firstCup.races ?? null,
+            suddenDeathWinnerId: null,
+          },
+        };
+      }
+
+      return {
+        completed: false,
+        updateData: {
+          points1: cupWins1,
+          points2: cupWins2,
+          cupResults: normalized.results,
+          cup: typeof latestCup.cup === 'string' ? latestCup.cup : firstCup.cup,
+          races: latestCup.races ?? firstCup.races ?? null,
+          suddenDeathWinnerId: null,
+        },
+      };
+    }
+
     if (![score1, score2].every((score) => Number.isInteger(score) && score >= 0)) {
       return { error: 'Driver points must be non-negative integers', field: 'score' };
     }
 
     if (score1 !== score2) {
+      const winnerIsP1 = score1 > score2;
       return {
-        winnerId: score1 > score2 ? match.player1Id as string : match.player2Id as string,
-        loserId: score1 > score2 ? match.player2Id as string : match.player1Id as string,
-        updateData: { suddenDeathWinnerId: null },
-      };
-    }
-
-    const suddenDeathWinnerId = body.suddenDeathWinnerId;
-    if (typeof suddenDeathWinnerId !== 'string' || suddenDeathWinnerId.length === 0) {
-      return {
-        error: 'Tied GP finals scores require a sudden-death winner',
-        field: 'suddenDeathWinnerId',
-      };
-    }
-
-    if (suddenDeathWinnerId !== match.player1Id && suddenDeathWinnerId !== match.player2Id) {
-      return {
-        error: 'Sudden-death winner must be one of the match players',
-        field: 'suddenDeathWinnerId',
+        winnerId: winnerIsP1 ? match.player1Id as string : match.player2Id as string,
+        loserId: winnerIsP1 ? match.player2Id as string : match.player1Id as string,
+        updateData: {
+          points1: winnerIsP1 ? targetWins : 0,
+          points2: winnerIsP1 ? 0 : targetWins,
+          cupResults: [{
+            cup: typeof body.cup === 'string' ? body.cup : match.cup ?? CUPS[0],
+            points1: score1,
+            points2: score2,
+            winner: winnerIsP1 ? 1 : 2,
+            ...(Array.isArray(body.races) ? { races: body.races } : {}),
+          }],
+          suddenDeathWinnerId: null,
+        },
       };
     }
 
     return {
-      winnerId: suddenDeathWinnerId,
-      loserId: suddenDeathWinnerId === match.player1Id
-        ? match.player2Id as string
-        : match.player1Id as string,
-      updateData: { suddenDeathWinnerId },
+      completed: false,
+      updateData: {
+        points1: 0,
+        points2: 0,
+        cupResults: [{
+          cup: typeof body.cup === 'string' ? body.cup : match.cup ?? CUPS[0],
+          points1: score1,
+          points2: score2,
+          winner: null,
+          ...(Array.isArray(body.races) ? { races: body.races } : {}),
+        }],
+        suddenDeathWinnerId: null,
+      },
     };
   },
 });

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -81,6 +81,7 @@ import { createLogger } from "@/lib/client-logger";
 import { parseManualScore } from "@/lib/parse-manual-score";
 import type { Player } from "@/lib/types";
 import { buildMatchLabel } from "@/lib/overlay/phase";
+import { getGpFinalsTargetWins } from "@/lib/finals-target-wins";
 
 /** Client-side logger for error tracking */
 const logger = createLogger({ serviceName: 'tournaments-gp-finals' });
@@ -92,10 +93,19 @@ interface Race {
   position2: number | null;
 }
 
+interface CupScoreForm {
+  cup: string;
+  races: Race[];
+  manualEnabled: boolean;
+  manualPoints1: string;
+  manualPoints2: string;
+}
+
 /** GP finals match with cup-based race results and driver points (§7.5) */
 interface GPMatch {
   id: string;
   matchNumber: number;
+  stage?: string | null;
   player1Id: string;
   player2Id: string;
   points1: number;
@@ -111,6 +121,19 @@ interface GPMatch {
     position2: number;
     points1: number;
     points2: number;
+  }[];
+  cupResults?: {
+    cup: string;
+    points1: number;
+    points2: number;
+    winner: 1 | 2 | null;
+    races?: {
+      course: string;
+      position1: number;
+      position2: number;
+      points1: number;
+      points2: number;
+    }[];
   }[];
   player1ReportedPoints1?: number;
   player1ReportedPoints2?: number;
@@ -161,10 +184,6 @@ function getMatchWinner(match: GPMatch): Player | null {
   const score2 = getGpScore(match, 2);
   if (score1 > score2) return match.player1;
   if (score2 > score1) return match.player2;
-  /* Tied scores resolved by sudden-death: winner is whichever player's id matches */
-  if (match.suddenDeathWinnerId) {
-    return match.player1?.id === match.suddenDeathWinnerId ? match.player1 : match.player2;
-  }
   return null;
 }
 
@@ -175,15 +194,6 @@ function getCompletedChampion(matches: GPMatch[]): Player | null {
   const grandFinal = matches.find((m) => m.round === "grand_final" && m.completed);
   if (!grandFinal) return null;
   return getMatchWinner(grandFinal);
-}
-
-function hasValidGpFinalsWinner(score1: number, score2: number, suddenDeathWinnerId?: string): boolean {
-  if (score1 < 0 || score2 < 0) return false;
-  if (score1 === score2) {
-    /* Tied GP finals require a sudden-death winner (§7.5). */
-    return !!suddenDeathWinnerId && suddenDeathWinnerId.length > 0;
-  }
-  return true;
 }
 
 export default function GrandPrixFinals({
@@ -234,17 +244,11 @@ export default function GrandPrixFinals({
   const [isScoreDialogOpen, setIsScoreDialogOpen] = useState(false);
   const [selectedMatch, setSelectedMatch] = useState<GPMatch | null>(null);
   const [scoreForm, setScoreForm] = useState<{
-    suddenDeathWinnerId: string;
     cup: string;
     races: Race[];
     tvNumber: number | null;
-  }>({ suddenDeathWinnerId: "", cup: "", races: [], tvNumber: null });
-  /* Admin override: skip race entry and write raw driver-points totals.
-   * Mirrors the qualification page's manual-total form — used when the
-   * cup total needs correcting but entering every race is overkill. */
-  const [manualScoreEnabled, setManualScoreEnabled] = useState(false);
-  const [manualPoints1, setManualPoints1] = useState<string>("");
-  const [manualPoints2, setManualPoints2] = useState<string>("");
+  }>({ cup: "", races: [], tvNumber: null });
+  const [cupForms, setCupForms] = useState<CupScoreForm[]>([]);
   const [champion, setChampion] = useState<Player | null>(null);
   const [broadcasting, setBroadcasting] = useState(false);
   const [tvSaving, setTvSaving] = useState(false);
@@ -412,6 +416,52 @@ export default function GrandPrixFinals({
     return COURSE_INFO.filter((c) => c.cup === cup).map((c) => c.abbr);
   };
 
+  const nextCupName = (index: number, preferred?: string) => {
+    const cups = ["Mushroom", "Flower", "Star", "Special"];
+    if (index === 0 && preferred) return preferred;
+    return cups[index % cups.length];
+  };
+
+  const makeBlankCupForm = (index: number, preferred?: string): CupScoreForm => {
+    const cup = nextCupName(index, preferred);
+    return {
+      cup,
+      races: getCupCourses(cup).map((course) => ({ course, position1: null, position2: null })),
+      manualEnabled: false,
+      manualPoints1: "",
+      manualPoints2: "",
+    };
+  };
+
+  const getTargetWinsForMatch = (match?: Pick<GPMatch, "round"> & { stage?: string | null } | null) =>
+    getGpFinalsTargetWins({ round: match?.round, stage: match?.stage ?? "finals" });
+
+  const calculateCupPoints = (cup: CupScoreForm) => {
+    if (cup.manualEnabled) {
+      const p1 = parseManualScore(cup.manualPoints1);
+      const p2 = parseManualScore(cup.manualPoints2);
+      return { valid: p1 !== null && p2 !== null, points1: p1 ?? 0, points2: p2 ?? 0 };
+    }
+    const ready = cup.races.length === TOTAL_GP_RACES &&
+      cup.races.every((r) => r.position1 !== null && r.position2 !== null);
+    return {
+      valid: ready,
+      points1: cup.races.reduce((acc, r) => acc + (r.position1 ? getDriverPoints(r.position1) : 0), 0),
+      points2: cup.races.reduce((acc, r) => acc + (r.position2 ? getDriverPoints(r.position2) : 0), 0),
+    };
+  };
+
+  const calculateCupWins = (forms: CupScoreForm[]) => forms.reduce(
+    (acc, cup) => {
+      const points = calculateCupPoints(cup);
+      if (!points.valid) return acc;
+      if (points.points1 > points.points2) acc.p1 += 1;
+      else if (points.points2 > points.points1) acc.p2 += 1;
+      return acc;
+    },
+    { p1: 0, p2: 0 },
+  );
+
   /**
    * Persist a TV# selection from the bracket card immediately. See BM/MR
    * finals pages for rationale — the dropdown saves on change so admins
@@ -459,31 +509,40 @@ export default function GrandPrixFinals({
     const cup = match.cup || "";
     let races: Race[];
     if (match.races && match.races.length === TOTAL_GP_RACES) {
-      /* Pre-fill with existing race data for editing */
       races = match.races.map((r) => ({
         course: r.course as CourseAbbr,
         position1: r.position1,
         position2: r.position2,
       }));
     } else if (cup) {
-      /* Auto-fill courses from the assigned cup's fixed sequence */
       races = getCupCourses(cup).map((course) => ({ course, position1: null, position2: null }));
     } else {
       races = Array.from({ length: TOTAL_GP_RACES }, () => ({ course: "" as CourseAbbr, position1: null, position2: null }));
     }
+    const forms = match.cupResults && match.cupResults.length > 0
+      ? match.cupResults.map((result, index) => {
+          const resultCup = result.cup || nextCupName(index, cup);
+          return {
+            cup: resultCup,
+            races: result.races && result.races.length === TOTAL_GP_RACES
+              ? result.races.map((r) => ({
+                  course: r.course as CourseAbbr,
+                  position1: r.position1,
+                  position2: r.position2,
+                }))
+              : getCupCourses(resultCup).map((course) => ({ course, position1: null, position2: null })),
+            manualEnabled: !(result.races && result.races.length === TOTAL_GP_RACES),
+            manualPoints1: String(result.points1 ?? 0),
+            manualPoints2: String(result.points2 ?? 0),
+          };
+        })
+      : [makeBlankCupForm(0, cup)];
     setScoreForm({
-      suddenDeathWinnerId: match.suddenDeathWinnerId ?? "",
       cup,
       races,
       tvNumber: match.tvNumber ?? null,
     });
-    /* Reset the manual-override form; pre-fill with the stored totals so the
-     * admin can toggle into manual mode and tweak one side without retyping
-     * both. score1/score2 are the finals score fields; points1/points2 fall
-     * back for playoff rows. */
-    setManualScoreEnabled(false);
-    setManualPoints1(String(match.score1 ?? match.points1 ?? 0));
-    setManualPoints2(String(match.score2 ?? match.points2 ?? 0));
+    setCupForms(forms);
     setIsScoreDialogOpen(true);
   };
 
@@ -497,49 +556,34 @@ export default function GrandPrixFinals({
   const handleScoreSubmit = async () => {
     if (!selectedMatch) return;
 
-    /* Manual-override path: write the raw driver-points totals and skip the
-     * cup/races breakdown. Used when a race-by-race entry isn't needed. */
-    let points1: number;
-    let points2: number;
     const body: Record<string, unknown> = { matchId: selectedMatch.id };
 
-    if (manualScoreEnabled) {
-      /* Strict parse: reject "12.5", "1e2", etc. that parseInt would
-       * silently truncate into a valid-looking integer. */
-      const parsed1 = parseManualScore(manualPoints1);
-      const parsed2 = parseManualScore(manualPoints2);
-      if (parsed1 === null || parsed2 === null) {
+    const cupResults = [];
+    for (const cup of cupForms) {
+      const points = calculateCupPoints(cup);
+      if (!points.valid) {
         alert(tGp('manualScoreValidation'));
         return;
       }
-      points1 = parsed1;
-      points2 = parsed2;
-      body.score1 = points1;
-      body.score2 = points2;
-    } else {
-      /* Derive total driver points from race positions */
-      points1 = scoreForm.races.reduce(
-        (acc, r) => acc + (r.position1 ? getDriverPoints(r.position1) : 0),
-        0
-      );
-      points2 = scoreForm.races.reduce(
-        (acc, r) => acc + (r.position2 ? getDriverPoints(r.position2) : 0),
-        0
-      );
-      body.score1 = points1;
-      body.score2 = points2;
-      body.cup = scoreForm.cup;
-      body.races = scoreForm.races.map((r) => ({
-        course: r.course,
-        position1: r.position1,
-        position2: r.position2,
-        points1: r.position1 ? getDriverPoints(r.position1) : 0,
-        points2: r.position2 ? getDriverPoints(r.position2) : 0,
-      }));
+      cupResults.push({
+        cup: cup.cup,
+        points1: points.points1,
+        points2: points.points2,
+        races: cup.manualEnabled ? undefined : cup.races.map((r) => ({
+          course: r.course,
+          position1: r.position1,
+          position2: r.position2,
+          points1: r.position1 ? getDriverPoints(r.position1) : 0,
+          points2: r.position2 ? getDriverPoints(r.position2) : 0,
+        })),
+      });
     }
-    if (points1 === points2 && scoreForm.suddenDeathWinnerId) {
-      body.suddenDeathWinnerId = scoreForm.suddenDeathWinnerId;
-    }
+    const wins = calculateCupWins(cupForms);
+    body.score1 = wins.p1;
+    body.score2 = wins.p2;
+    body.cupResults = cupResults;
+    body.cup = cupResults[cupResults.length - 1]?.cup ?? scoreForm.cup;
+    body.races = cupResults[cupResults.length - 1]?.races;
     body.tvNumber = scoreForm.tvNumber;
 
     try {
@@ -554,10 +598,8 @@ export default function GrandPrixFinals({
         const data = unwrapApiData<{ isComplete?: boolean; champion?: string; playoffComplete?: boolean }>(json);
         setIsScoreDialogOpen(false);
         setSelectedMatch(null);
-        setScoreForm({ suddenDeathWinnerId: "", cup: "", races: [], tvNumber: null });
-        setManualScoreEnabled(false);
-        setManualPoints1("");
-        setManualPoints2("");
+        setScoreForm({ cup: "", races: [], tvNumber: null });
+        setCupForms([]);
         if (data.playoffComplete !== undefined) {
           setPlayoffComplete(data.playoffComplete);
         }
@@ -587,40 +629,9 @@ export default function GrandPrixFinals({
     }
   };
 
-  const completedMatches = matches.filter((m) => m.completed).length;
-  const totalMatches = matches.length;
   const qualificationConfirmed = pollData?.qualificationConfirmed ?? false;
-  /* Live driver points preview. In manual-override mode, reflect the raw
-   * inputs so the tied-score branch (sudden-death prompt) still works. */
-  const racePoints1 = scoreForm.races.reduce(
-    (acc, r) => acc + (r.position1 ? getDriverPoints(r.position1) : 0),
-    0
-  );
-  const racePoints2 = scoreForm.races.reduce(
-    (acc, r) => acc + (r.position2 ? getDriverPoints(r.position2) : 0),
-    0
-  );
-  const manualPointsParsed1 = parseManualScore(manualPoints1);
-  const manualPointsParsed2 = parseManualScore(manualPoints2);
-  const manualPointsValid =
-    manualPointsParsed1 !== null && manualPointsParsed2 !== null;
-  const livePoints1 = manualScoreEnabled
-    ? (manualPointsParsed1 ?? 0)
-    : racePoints1;
-  const livePoints2 = manualScoreEnabled
-    ? (manualPointsParsed2 ?? 0)
-    : racePoints2;
-  /* Pre-tiebreak readiness: the inputs are filled in enough that a submit
-   * is imminent. Used to decide when to surface the sudden-death picker
-   * for tied scores (including 0-0) — the server rejects any tie without
-   * a suddenDeathWinnerId, so the admin must always have a way to pick
-   * one once the form is otherwise complete. */
-  const scoreInputsReady = manualScoreEnabled
-    ? manualPointsValid
-    : Boolean(scoreForm.cup) &&
-      scoreForm.races.length === TOTAL_GP_RACES &&
-      scoreForm.races.every((r) => r.position1 !== null && r.position2 !== null);
-  const tiedAndReady = scoreInputsReady && livePoints1 === livePoints2;
+  const cupWins = calculateCupWins(cupForms);
+  const scoreInputsReady = cupForms.length > 0 && cupForms.every((cup) => calculateCupPoints(cup).valid);
 
   // GP stores driver points in points1/points2 (not score1/score2 like BM/MR).
   // DoubleEliminationBracket reads match.score1/score2 for winner highlighting (#759).
@@ -782,7 +793,7 @@ export default function GrandPrixFinals({
           bracketStructure={bracketStructure}
           roundNames={roundNames}
           seededPlayers={seededPlayers}
-          getTargetWins={() => 1}
+          getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
           onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
           onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
         />
@@ -793,7 +804,7 @@ export default function GrandPrixFinals({
               playoffStructure={playoffStructure}
               roundNames={roundNames}
               seededPlayers={playoffSeededPlayers}
-              getTargetWins={() => 1}
+              getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
               onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
               onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
             />
@@ -806,7 +817,7 @@ export default function GrandPrixFinals({
             playoffStructure={playoffStructure}
             roundNames={roundNames}
             seededPlayers={playoffSeededPlayers}
-            getTargetWins={() => 1}
+            getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
             onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
             onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
           />
@@ -825,7 +836,7 @@ export default function GrandPrixFinals({
           bracketStructure={bracketStructure}
           roundNames={roundNames}
           seededPlayers={seededPlayers}
-          getTargetWins={() => 1}
+          getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
           onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
           onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
         />
@@ -876,6 +887,11 @@ export default function GrandPrixFinals({
                         cup: next,
                         races: getCupCourses(next).map((course) => ({ course, position1: null, position2: null })),
                       }));
+                      setCupForms((current) => {
+                        const updated = [...current];
+                        updated[0] = makeBlankCupForm(0, next);
+                        return updated.length > 0 ? updated : [makeBlankCupForm(0, next)];
+                      });
                     }}
                   >
                     {scoreForm.cup === selectedMatch.cup
@@ -886,180 +902,158 @@ export default function GrandPrixFinals({
               </div>
             )}
 
-            {/* Manual total-score override (mirrors the qualification page).
-              When enabled, race entry is hidden and the raw driver-points
-              totals are written directly. */}
-            <div className="space-y-3 rounded-lg border p-4">
-              <div className="flex items-start gap-3">
-                <Checkbox
-                  id="gp-finals-manual-score"
-                  checked={manualScoreEnabled}
-                  onCheckedChange={(checked) => setManualScoreEnabled(checked === true)}
-                />
-                <div className="space-y-1">
-                  <Label htmlFor="gp-finals-manual-score">{tGp('manualTotalScore')}</Label>
-                  <p className="text-sm text-muted-foreground">
-                    {tGp('manualTotalScoreDesc')}
-                  </p>
-                </div>
-              </div>
+            <div className="space-y-4">
+              {cupForms.map((cup, cupIndex) => {
+                const points = calculateCupPoints(cup);
+                return (
+                  <div key={`cup-${cupIndex}`} className="space-y-3 rounded-lg border p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline">Cup {cupIndex + 1}</Badge>
+                        <Badge>{tGp('cupLabel', { cup: cup.cup })}</Badge>
+                      </div>
+                      <div className="text-sm font-medium">
+                        {selectedMatch?.player1.nickname}: {points.points1} pts / {selectedMatch?.player2.nickname}: {points.points2} pts
+                      </div>
+                    </div>
 
-              {manualScoreEnabled && selectedMatch && (
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div className="space-y-2">
-                    <Label htmlFor="finals-manual-points1">{selectedMatch.player1.nickname}</Label>
-                    <Input
-                      id="finals-manual-points1"
-                      type="number"
-                      min="0"
-                      step="1"
-                      inputMode="numeric"
-                      value={manualPoints1}
-                      onChange={(e) => setManualPoints1(e.target.value)}
-                    />
+                    <div className="flex items-start gap-3">
+                      <Checkbox
+                        id={`gp-finals-manual-score-${cupIndex}`}
+                        checked={cup.manualEnabled}
+                        onCheckedChange={(checked) => {
+                          const next = [...cupForms];
+                          next[cupIndex] = { ...cup, manualEnabled: checked === true };
+                          setCupForms(next);
+                        }}
+                      />
+                      <Label htmlFor={`gp-finals-manual-score-${cupIndex}`}>{tGp('manualTotalScore')}</Label>
+                    </div>
+
+                    {cup.manualEnabled && selectedMatch ? (
+                      <div className="grid gap-4 md:grid-cols-2">
+                        <div className="space-y-2">
+                          <Label>{selectedMatch.player1.nickname}</Label>
+                          <Input
+                            type="number"
+                            min="0"
+                            step="1"
+                            inputMode="numeric"
+                            value={cup.manualPoints1}
+                            onChange={(e) => {
+                              const next = [...cupForms];
+                              next[cupIndex] = { ...cup, manualPoints1: e.target.value };
+                              setCupForms(next);
+                            }}
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label>{selectedMatch.player2.nickname}</Label>
+                          <Input
+                            type="number"
+                            min="0"
+                            step="1"
+                            inputMode="numeric"
+                            value={cup.manualPoints2}
+                            onChange={(e) => {
+                              const next = [...cupForms];
+                              next[cupIndex] = { ...cup, manualPoints2: e.target.value };
+                              setCupForms(next);
+                            }}
+                          />
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="overflow-x-auto">
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead className="w-16">{tCommon('race')}</TableHead>
+                              <TableHead>{tCommon('course')}</TableHead>
+                              <TableHead className="text-center">{tGp('p1Position')}</TableHead>
+                              <TableHead className="text-center">{tGp('p2Position')}</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {cup.races.map((race, raceIndex) => (
+                              <TableRow key={`race-${selectedMatch?.id}-${cupIndex}-${raceIndex}`}>
+                                <TableCell className="font-medium">{tCommon('race')} {raceIndex + 1}</TableCell>
+                                <TableCell className="text-sm">
+                                  {COURSE_INFO.find((c) => c.abbr === race.course)?.name || race.course}
+                                </TableCell>
+                                <TableCell>
+                                  <Select
+                                    value={race.position1?.toString() || ""}
+                                    onValueChange={(value) => {
+                                      const next = [...cupForms];
+                                      const races = [...cup.races];
+                                      races[raceIndex] = { ...races[raceIndex], position1: value === "" ? null : parseInt(value, 10) };
+                                      next[cupIndex] = { ...cup, races };
+                                      setCupForms(next);
+                                    }}
+                                  >
+                                    <SelectTrigger>
+                                      <SelectValue placeholder={tCommon('position')} />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {GP_POSITION_OPTIONS.map((position) => (
+                                        <SelectItem key={`admin-p1-${cupIndex}-${raceIndex}-${position}`} value={position.toString()}>
+                                          {fmtPos(position)}
+                                        </SelectItem>
+                                      ))}
+                                    </SelectContent>
+                                  </Select>
+                                </TableCell>
+                                <TableCell>
+                                  <Select
+                                    value={race.position2?.toString() || ""}
+                                    onValueChange={(value) => {
+                                      const next = [...cupForms];
+                                      const races = [...cup.races];
+                                      races[raceIndex] = { ...races[raceIndex], position2: value === "" ? null : parseInt(value, 10) };
+                                      next[cupIndex] = { ...cup, races };
+                                      setCupForms(next);
+                                    }}
+                                  >
+                                    <SelectTrigger>
+                                      <SelectValue placeholder={tCommon('position')} />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {GP_POSITION_OPTIONS.map((position) => (
+                                        <SelectItem key={`admin-p2-${cupIndex}-${raceIndex}-${position}`} value={position.toString()}>
+                                          {fmtPos(position)}
+                                        </SelectItem>
+                                      ))}
+                                    </SelectContent>
+                                  </Select>
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                        </Table>
+                      </div>
+                    )}
                   </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="finals-manual-points2">{selectedMatch.player2.nickname}</Label>
-                    <Input
-                      id="finals-manual-points2"
-                      type="number"
-                      min="0"
-                      step="1"
-                      inputMode="numeric"
-                      value={manualPoints2}
-                      onChange={(e) => setManualPoints2(e.target.value)}
-                    />
-                  </div>
-                </div>
-              )}
+                );
+              })}
             </div>
 
-            {/* Race-by-race entry table (5 races per cup).
-                Wrapped in overflow-x-auto so the P2 position column is
-                reachable via horizontal scroll on narrow mobile viewports
-                (issue #810). */}
-            {!manualScoreEnabled && scoreForm.cup && (
-              <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="w-16">{tCommon('race')}</TableHead>
-                    <TableHead>{tCommon('course')}</TableHead>
-                    <TableHead className="text-center">{tGp('p1Position')}</TableHead>
-                    <TableHead className="text-center">{tGp('p2Position')}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {scoreForm.races.map((race, index) => (
-                    <TableRow key={`race-${selectedMatch?.id}-${index}`}>
-                      <TableCell className="font-medium">
-                        {tCommon('race')} {index + 1}
-                      </TableCell>
-                      <TableCell className="text-sm">
-                        {COURSE_INFO.find((c) => c.abbr === race.course)?.name || race.course}
-                      </TableCell>
-                      <TableCell>
-                        <Select
-                          value={race.position1?.toString() || ""}
-                          onValueChange={(value) => {
-                            const newRaces = [...scoreForm.races];
-                            newRaces[index] = { ...newRaces[index], position1: value === "" ? null : parseInt(value, 10) };
-                            setScoreForm((current) => ({ ...current, races: newRaces }));
-                          }}
-                        >
-                          <SelectTrigger>
-                            <SelectValue placeholder={tCommon('position')} />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {GP_POSITION_OPTIONS.map((position) => (
-                              <SelectItem key={`admin-p1-${index}-${position}`} value={position.toString()}>
-                                {fmtPos(position)}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </TableCell>
-                      <TableCell>
-                        <Select
-                          value={race.position2?.toString() || ""}
-                          onValueChange={(value) => {
-                            const newRaces = [...scoreForm.races];
-                            newRaces[index] = { ...newRaces[index], position2: value === "" ? null : parseInt(value, 10) };
-                            setScoreForm((current) => ({ ...current, races: newRaces }));
-                          }}
-                        >
-                          <SelectTrigger>
-                            <SelectValue placeholder={tCommon('position')} />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {GP_POSITION_OPTIONS.map((position) => (
-                              <SelectItem key={`admin-p2-${index}-${position}`} value={position.toString()}>
-                                {fmtPos(position)}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg bg-muted p-4">
+              <div className="text-sm font-medium">
+                Cups: {selectedMatch?.player1.nickname} {cupWins.p1} - {cupWins.p2} {selectedMatch?.player2.nickname}
               </div>
-            )}
-
-            {/* Live driver points calculation preview */}
-            <div className="bg-muted p-4 rounded-lg">
-              <p className="text-sm font-medium mb-2">{tGp('driverPoints')}</p>
-              {selectedMatch && (
-                <div className="flex flex-col gap-2 sm:flex-row sm:justify-center sm:gap-4">
-                  <div>
-                    <span className="text-sm">{selectedMatch.player1.nickname}:</span>
-                    <span className="ml-2 font-bold">{livePoints1} pts</span>
-                  </div>
-                  <div>
-                    <span className="text-sm">{selectedMatch.player2.nickname}:</span>
-                    <span className="ml-2 font-bold">{livePoints2} pts</span>
-                  </div>
-                </div>
-              )}
+              <div className="flex items-center gap-2">
+                <Badge variant="outline">FT{selectedMatch ? getTargetWinsForMatch(selectedMatch) : 1}</Badge>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCupForms((current) => [...current, makeBlankCupForm(current.length)])}
+                >
+                  Add Cup
+                </Button>
+              </div>
             </div>
-
-            {/* Sudden-death winner selection for tied totals (§7.5). Shown
-              whenever the form is otherwise submit-ready and tied, including
-              the 0-0 case (manual override or all-game-over race mode). */}
-            {tiedAndReady && (
-              <div className="space-y-2">
-                <Label>{tFinals('suddenDeathWinner')}</Label>
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                  <Button
-                    type="button"
-                    variant={scoreForm.suddenDeathWinnerId === selectedMatch?.player1Id ? "default" : "outline"}
-                    onClick={() => setScoreForm((current) => ({
-                      ...current,
-                      suddenDeathWinnerId: selectedMatch?.player1Id ?? "",
-                    }))}
-                  >
-                    {selectedMatch?.player1.nickname}
-                  </Button>
-                  <Button
-                    type="button"
-                    variant={scoreForm.suddenDeathWinnerId === selectedMatch?.player2Id ? "default" : "outline"}
-                    onClick={() => setScoreForm((current) => ({
-                      ...current,
-                      suddenDeathWinnerId: selectedMatch?.player2Id ?? "",
-                    }))}
-                  >
-                    {selectedMatch?.player2.nickname}
-                  </Button>
-                </div>
-              </div>
-            )}
-            <p className={`text-sm text-center ${
-              tiedAndReady && !scoreForm.suddenDeathWinnerId
-                ? 'text-yellow-600' : 'invisible'
-            }`}>
-              {tFinals('gpTieNeedsWinner')}
-            </p>
           </div>
           {/* TV number assignment for broadcast: explicit save button (#651)
               lets admins assign TV# before scores are entered. */}
@@ -1099,8 +1093,7 @@ export default function GrandPrixFinals({
                   setBroadcasting(true);
                   try {
                     const matchLabel = buildMatchLabel(selectedMatch.round, roundNames);
-                    /* Finals matches expose driver points as score1/score2 (per GPMatch type).
-                       No FT threshold applies to GP — points are accumulated across races. */
+                    const targetWins = getTargetWinsForMatch(selectedMatch);
                     const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`, {
                       method: "PUT",
                       headers: { "Content-Type": "application/json" },
@@ -1110,7 +1103,7 @@ export default function GrandPrixFinals({
                         matchLabel,
                         player1Wins: selectedMatch.score1,
                         player2Wins: selectedMatch.score2,
-                        matchFt: null,
+                        matchFt: targetWins,
                       }),
                     });
                     if (res.ok) {
@@ -1130,14 +1123,7 @@ export default function GrandPrixFinals({
             )}
             <Button
               onClick={handleScoreSubmit}
-              disabled={
-                !scoreInputsReady ||
-                /* Any tie — including 0-0 — needs a sudden-death winner. The
-                 * server rejects all tied scores without suddenDeathWinnerId,
-                 * so the client must not let a tie slip through even when
-                 * both totals are zero (Codex review, PR #588). */
-                (tiedAndReady && !scoreForm.suddenDeathWinnerId)
-              }
+              disabled={!scoreInputsReady}
             >
               {tCommon('saveScore')}
             </Button>

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -48,8 +48,9 @@ const BRACKET_SIZE_THRESHOLD = 20;
 const PLAYOFF_ENTRANT_COUNT = 12;
 
 interface FinalsMatchResult {
-  winnerId: string;
-  loserId: string;
+  winnerId?: string;
+  loserId?: string;
+  completed?: boolean;
   updateData?: Record<string, unknown>;
 }
 
@@ -1384,10 +1385,11 @@ export function createFinalsHandlers(config: FinalsConfig) {
     try {
       /* Defense-in-depth: always sanitize user input */
       const body = sanitizeInput(await request.json());
-      const { matchId, score1, score2 } = body;
+      const { matchId } = body;
+      let { score1, score2 } = body;
 
-      if (!matchId || score1 === undefined || score2 === undefined) {
-        return handleValidationError('matchId, score1, and score2 are required', 'request');
+      if (!matchId || (score1 === undefined || score2 === undefined) && body.cupResults === undefined) {
+        return handleValidationError('matchId and score data are required', 'request');
       }
 
       const match = await model(prisma).findUnique({
@@ -1406,8 +1408,9 @@ export function createFinalsHandlers(config: FinalsConfig) {
         return createErrorResponse('Finals match not found', 404, 'NOT_FOUND');
       }
 
-      let winnerId: string;
-      let loserId: string;
+      let winnerId: string | undefined;
+      let loserId: string | undefined;
+      let matchCompleted = true;
       let resolvedUpdateData: Record<string, unknown> = {};
 
       if (config.resolveMatchResult) {
@@ -1424,7 +1427,14 @@ export function createFinalsHandlers(config: FinalsConfig) {
 
         winnerId = resolved.winnerId;
         loserId = resolved.loserId;
+        matchCompleted = resolved.completed ?? true;
         resolvedUpdateData = resolved.updateData ?? {};
+        if (typeof resolvedUpdateData[config.putScoreFields.dbField1] === 'number') {
+          score1 = resolvedUpdateData[config.putScoreFields.dbField1];
+        }
+        if (typeof resolvedUpdateData[config.putScoreFields.dbField2] === 'number') {
+          score2 = resolvedUpdateData[config.putScoreFields.dbField2];
+        }
       } else {
         const targetWins = config.getTargetWins?.(match) ?? config.targetWins ?? 3;
         const player1ReachedTarget = score1 === targetWins && score2 < targetWins;
@@ -1443,7 +1453,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
         ...resolvedUpdateData,
         [config.putScoreFields.dbField1]: score1,
         [config.putScoreFields.dbField2]: score2,
-        completed: true,
+        completed: matchCompleted,
       };
 
       if (config.putAdditionalFields) {
@@ -1496,6 +1506,20 @@ export function createFinalsHandlers(config: FinalsConfig) {
        * stay in the playoff stage — the Upper Bracket is materialised later
        * via a Phase-2 POST that reads completed playoff results. */
       if (match.stage === 'playoff') {
+        if (!matchCompleted) {
+          return createSuccessResponse({
+            match: updatedMatch,
+            winnerId: null,
+            loserId: null,
+            stage: 'playoff',
+            playoffComplete: await isPlayoffComplete(model, tournamentId),
+          });
+        }
+
+        if (!winnerId || !loserId) {
+          return handleValidationError('Completed match must have a winner and loser', 'score');
+        }
+
         const playoffStructure = generatePlayoffStructure(PLAYOFF_ENTRANT_COUNT);
         const matchNumber = Number(match.matchNumber ?? updatedMatch.matchNumber);
         const currentPlayoff = playoffStructure.find(b => b.matchNumber === matchNumber);
@@ -1564,6 +1588,20 @@ export function createFinalsHandlers(config: FinalsConfig) {
 
       if (!currentBracketMatch) {
         return createSuccessResponse({ match: updatedMatch });
+      }
+
+      if (!matchCompleted) {
+        return createSuccessResponse({
+          match: updatedMatch,
+          winnerId: null,
+          loserId: null,
+          isComplete: false,
+          champion: null,
+        });
+      }
+
+      if (!winnerId || !loserId) {
+        return handleValidationError('Completed match must have a winner and loser', 'score');
       }
 
       const updateRoutedMatch = async (


### PR DESCRIPTION
## Summary
- Implement GP finals/playoff scoring as cup-win FT instead of single-cup driver-point winner selection
- Add `cupResults` storage and migrations for multi-cup GP finals results
- Update GP finals UI, API tests, and E2E scenarios for FT2/FT3 and tied-cup continuation

## Validation
- `npx tsc --noEmit`
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts' --runInBand`
- `node --check smkc-score-app/e2e/tc-gp.js`
- `git diff --check`

## Notes
- E2E red check was attempted before implementation; default E2E base points at the deployed app and the new TC-720/721/722 failed there with 400 responses, as expected for the old behavior.
- Local E2E execution with `E2E_BASE_URL=http://127.0.0.1:3000` could not complete because no local server was listening in this workspace.