### PR TITLE
[codex] Fix CDM export asset loading

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -65,6 +65,7 @@ import { formatDate, formatTime } from '@/lib/excel';
 import { GET } from '@/app/api/tournaments/[id]/export/route';
 import { NextResponse } from 'next/server';
 import * as XLSX from '@e965/xlsx';
+import { getCloudflareContext } from '@opennextjs/cloudflare';
 
 class MockNextRequest {
   constructor(private url: string) {}
@@ -79,6 +80,7 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (global.fetch as jest.Mock | undefined) = undefined;
+    (getCloudflareContext as jest.Mock).mockReturnValue({ env: { DB: {} } });
     (createLogger as jest.Mock).mockReturnValue(loggerMock);
     /* Re-configure NextResponse constructor and json after clearAllMocks */
     (NextResponse as unknown as jest.Mock).mockImplementation((body: string, options?: any) => ({
@@ -201,16 +203,20 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       };
 
       (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
-      global.fetch = jest.fn().mockResolvedValue({
+      const assetFetch = jest.fn().mockResolvedValue({
         ok: true,
         arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
+      });
+      (getCloudflareContext as jest.Mock).mockReturnValue({
+        env: { DB: {}, ASSETS: { fetch: assetFetch } },
       });
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
       const params = Promise.resolve({ id: 't1' });
       const result = await GET(request, { params });
 
-      expect(global.fetch).toHaveBeenCalledWith(new URL('/templates/cdm-2025-template.xlsm', request.url));
+      expect(assetFetch).toHaveBeenCalledWith(new URL('/templates/cdm-2025-template.xlsm', 'https://assets.local'));
+      expect(global.fetch).toBeUndefined();
       expect(result.data).toBeInstanceOf(Uint8Array);
       expect(result.headers['Content-Type']).toBe('application/vnd.ms-excel.sheet.macroEnabled.12');
       expect(result.headers['Content-Disposition']).toContain('.xlsm');

--- a/smkc-score-app/__tests__/components/tournament/export-button.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/export-button.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ExportButton } from '@/components/tournament/export-button';
+
+describe('ExportButton', () => {
+  const originalCreateObjectURL = window.URL.createObjectURL;
+  const originalRevokeObjectURL = window.URL.revokeObjectURL;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    window.URL.createObjectURL = jest.fn(() => 'blob:cdm-export');
+    window.URL.revokeObjectURL = jest.fn();
+  });
+
+  afterEach(() => {
+    window.URL.createObjectURL = originalCreateObjectURL;
+    window.URL.revokeObjectURL = originalRevokeObjectURL;
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('fetches the CDM export URL and downloads an XLSM filename from the response header', async () => {
+    const workbook = new Blob(['PK\x03\x04 workbook'], {
+      type: 'application/vnd.ms-excel.sheet.macroEnabled.12',
+    });
+    global.fetch = jest.fn().mockResolvedValue(new Response(workbook, {
+      status: 200,
+      headers: {
+        'content-disposition': 'attachment; filename="Grand_Prix-cdm-2026-04-29.xlsm"',
+      },
+    }));
+    const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();
+    const originalCreateElement = document.createElement.bind(document);
+    const anchors: HTMLAnchorElement[] = [];
+    jest.spyOn(document, 'createElement').mockImplementation(((tagName: string, options?: ElementCreationOptions) => {
+      const element = originalCreateElement(tagName, options);
+      if (tagName.toLowerCase() === 'a') anchors.push(element as HTMLAnchorElement);
+      return element;
+    }) as typeof document.createElement);
+
+    render(
+      <ExportButton tournamentId="tournament-1" tournamentName="Grand Prix" format="cdm">
+        CDM Export
+      </ExportButton>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /CDM Export/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/tournaments/tournament-1/export?format=cdm');
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(anchors[0]).toMatchObject({
+      href: 'blob:cdm-export',
+      download: 'Grand_Prix-cdm-2026-04-29.xlsm',
+    });
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:cdm-export');
+  });
+});

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -9,6 +9,7 @@
  * Run: node e2e/tc-all.js  (from smkc-score-app/)
  */
 const { chromium } = require('playwright');
+const fs = require('fs');
 const https = require('https');
 const {
   apiActivateTournament,
@@ -2990,45 +2991,68 @@ async function main() {
     }
   }
 
-  // TC-358: CDM export API returns a downloadable XLSM for authenticated admins
+  // TC-358: CDM Export button fetches the CDM workbook and triggers an XLSM download
   {
     const exportTid = sharedFixture?.tournamentId ?? TID;
     if (exportTid) {
       try {
-        const resp = await page.evaluate(async (url) => {
+        const session = await page.evaluate(async () => {
           const sessionResp = await fetch('/api/auth/session-status', { credentials: 'same-origin' });
-          const sessionBody = await sessionResp.json().catch(() => ({}));
-          const r = await fetch(url, { credentials: 'same-origin' });
-          const buf = await r.arrayBuffer();
-          const bytes = new Uint8Array(buf);
-          return {
-            status: r.status,
-            authenticated: sessionBody?.data?.authenticated === true,
-            contentType: r.headers.get('content-type'),
-            disposition: r.headers.get('content-disposition'),
-            length: bytes.length,
-            signature: [bytes[0], bytes[1], bytes[2], bytes[3]],
-          };
-        }, `${BASE}/api/tournaments/${exportTid}/export?format=cdm`);
+          const body = await sessionResp.json().catch(() => ({}));
+          return { authenticated: body?.data?.authenticated === true };
+        });
 
-        const contentType = (resp.contentType || '').toLowerCase();
-        const disposition = resp.disposition || '';
+        await nav(page, `/tournaments/${exportTid}`);
+        const cdmButton = page.getByRole('button', { name: /CDM Export/i });
+        await cdmButton.waitFor({ state: 'visible', timeout: 30000 });
+
+        const responsePromise = page.waitForResponse((response) => {
+          const url = new URL(response.url());
+          return url.pathname === `/api/tournaments/${exportTid}/export` &&
+            url.searchParams.get('format') === 'cdm';
+        }, { timeout: 60000 });
+        const downloadPromise = page.waitForEvent('download', { timeout: 60000 });
+
+        const [, apiResponse, download] = await Promise.all([
+          cdmButton.click(),
+          responsePromise,
+          downloadPromise,
+        ]);
+
+        const downloadPath = await download.path();
+        const downloadError = await download.failure();
+        const bytes = downloadPath ? fs.readFileSync(downloadPath) : Buffer.alloc(0);
+        const headers = apiResponse.headers();
+        const contentType = headers['content-type'] || '';
+        const disposition = headers['content-disposition'] || '';
+        const filename = download.suggestedFilename();
+
         const isXlsm = contentType.includes('application/vnd.ms-excel.sheet.macroenabled.12');
         const hasXlsmAttachment = disposition.includes('attachment') && /\.xlsm(?:[";]|$)/i.test(disposition);
-        const hasBody = resp.length > 1000;
-        const hasZipSignature = resp.signature[0] === 0x50 && resp.signature[1] === 0x4B;
+        const hasDownloadedXlsmName = /\.xlsm$/i.test(filename);
+        const hasBody = bytes.length > 1000;
+        const hasZipSignature = bytes[0] === 0x50 && bytes[1] === 0x4B;
 
         log('TC-358',
-          resp.authenticated && resp.status === 200 && isXlsm && hasXlsmAttachment && hasBody && hasZipSignature ? 'PASS' : 'FAIL',
-          !resp.authenticated ? 'No authenticated admin session'
-          : resp.status !== 200 ? `HTTP ${resp.status}`
-          : !isXlsm ? `content-type: ${resp.contentType}`
-          : !hasXlsmAttachment ? `content-disposition: ${resp.disposition}`
-          : !hasBody ? `workbook too small: ${resp.length} bytes`
-          : !hasZipSignature ? `unexpected XLSM signature: ${resp.signature.join(',')}`
+          session.authenticated &&
+            apiResponse.status() === 200 &&
+            !downloadError &&
+            isXlsm &&
+            hasXlsmAttachment &&
+            hasDownloadedXlsmName &&
+            hasBody &&
+            hasZipSignature ? 'PASS' : 'FAIL',
+          !session.authenticated ? 'No authenticated admin session'
+          : apiResponse.status() !== 200 ? `HTTP ${apiResponse.status()}`
+          : downloadError ? `download failed: ${downloadError}`
+          : !isXlsm ? `content-type: ${contentType}`
+          : !hasXlsmAttachment ? `content-disposition: ${disposition}`
+          : !hasDownloadedXlsmName ? `download filename: ${filename}`
+          : !hasBody ? `workbook too small: ${bytes.length} bytes`
+          : !hasZipSignature ? `unexpected XLSM signature: ${Array.from(bytes.slice(0, 4)).join(',')}`
           : '');
       } catch (err) {
-        log('TC-358', 'FAIL', err instanceof Error ? err.message : 'CDM export API test failed');
+        log('TC-358', 'FAIL', err instanceof Error ? err.message : 'CDM export button test failed');
       }
     } else {
       log('TC-358', 'SKIP', 'No tournament ID available');

--- a/smkc-score-app/package-lock.json
+++ b/smkc-score-app/package-lock.json
@@ -54,6 +54,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "jest-fetch-mock": "^3.0.3",
+        "playwright": "^1.59.1",
         "prisma": "^6.19.2",
         "tailwindcss": "^4",
         "ts-node": "^10.9.2",
@@ -16043,6 +16044,53 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/po-parser": {

--- a/smkc-score-app/package.json
+++ b/smkc-score-app/package.json
@@ -74,6 +74,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-fetch-mock": "^3.0.3",
+    "playwright": "^1.59.1",
     "prisma": "^6.19.2",
     "tailwindcss": "^4",
     "ts-node": "^10.9.2",

--- a/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
@@ -20,6 +20,7 @@
  * Response: CSV file download
  */
 import { NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
 import * as XLSX from "@e965/xlsx";
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import prisma from "@/lib/prisma";
@@ -27,6 +28,8 @@ import { formatDate, formatTime } from "@/lib/excel";
 import { createLogger } from "@/lib/logger";
 import { createErrorResponse } from "@/lib/error-handling";
 import { resolveTournamentId } from "@/lib/tournament-identifier";
+
+const CDM_TEMPLATE_PATH = "/templates/cdm-2025-template.xlsm";
 
 type PlayerPublic = {
   id: string;
@@ -166,6 +169,30 @@ function sortQualifications<T extends ModeQualification>(items: T[]): T[] {
     (a.seeding ?? Number.MAX_SAFE_INTEGER) - (b.seeding ?? Number.MAX_SAFE_INTEGER) ||
     a.player.nickname.localeCompare(b.player.nickname)
   );
+}
+
+async function loadCDMTemplate(request: Request): Promise<
+  | { ok: true; buffer: ArrayBuffer }
+  | { ok: false; status: number; source: string }
+> {
+  try {
+    const assets = getCloudflareContext().env.ASSETS;
+    if (assets?.fetch) {
+      const response = await assets.fetch(new URL(CDM_TEMPLATE_PATH, "https://assets.local"));
+      if (response.ok) {
+        return { ok: true, buffer: await response.arrayBuffer() };
+      }
+      return { ok: false, status: response.status, source: "ASSETS" };
+    }
+  } catch {
+    // Outside the Cloudflare runtime, fall back to the public asset URL below.
+  }
+
+  const response = await fetch(new URL(CDM_TEMPLATE_PATH, request.url));
+  if (response.ok) {
+    return { ok: true, buffer: await response.arrayBuffer() };
+  }
+  return { ok: false, status: response.status, source: "fetch" };
 }
 
 function writePlayerHub(
@@ -570,13 +597,17 @@ export async function GET(
     }
 
     if (exportFormat === "cdm") {
-      const templateResponse = await fetch(new URL("/templates/cdm-2025-template.xlsm", request.url));
-      if (!templateResponse.ok) {
-        logger.error("Failed to load CDM export template", { status: templateResponse.status, tournamentId });
+      const template = await loadCDMTemplate(request);
+      if (!template.ok) {
+        logger.error("Failed to load CDM export template", {
+          source: template.source,
+          status: template.status,
+          tournamentId,
+        });
         return createErrorResponse("Failed to load CDM export template", 500);
       }
 
-      const workbookBuffer = createCDMWorkbook(await templateResponse.arrayBuffer(), tournament);
+      const workbookBuffer = createCDMWorkbook(template.buffer, tournament);
       const filename = `${tournament.name.replace(/[^a-zA-Z0-9]/g, "_")}-cdm-${formatDate(new Date(tournament.date))}.xlsm`;
 
       return new NextResponse(new Uint8Array(workbookBuffer), {


### PR DESCRIPTION
## Summary

Fixes #842.

CDM workbook export failed in production because the API route loaded the `.xlsm` template by self-fetching `/templates/cdm-2025-template.xlsm` from inside the Worker. Wrangler tail showed that self-fetch returning 522, causing TC-358 to fail with HTTP 500.

## Changes

- Loads the CDM template from the Cloudflare `ASSETS` binding when available, with the public URL fetch retained only as a local/dev fallback.
- Expands TC-358 so E2E clicks the real `CDM Export` admin button and validates both the API response and browser download.
- Adds an `ExportButton` unit test that verifies the CDM query path, blob URL download, `.xlsm` filename from `Content-Disposition`, and cleanup.
- Adds `playwright` as a dev dependency so `npm run e2e:all` can run from a fresh install.

## Validation

- `node --check smkc-score-app/e2e/tc-all.js`
- `git diff --check`
- `npx eslint src/app/api/tournaments/'[id]'/export/route.ts __tests__/app/api/tournaments/'[id]'/export/route.test.ts __tests__/components/tournament/export-button.test.tsx src/components/tournament/export-button.tsx`
- `npm run lint` (0 errors; existing warnings only)
- `npx tsc --noEmit`
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/export/route.test.ts' '__tests__/components/tournament/export-button.test.tsx'`
- `npm run build:cf`

## E2E / Tail follow-up

`npm run e2e:all` completed against production but exited 1 before this fix was pushed. Non-CDM failures are tracked in #843. Wrangler tail slow-query/hung-request findings are tracked in #844.