### PR TITLE
[codex] Harden CDM export downloads

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -241,6 +241,22 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       expect(prisma.tournament.findUnique).not.toHaveBeenCalled();
     });
 
+    it('should return 403 when CDM export is requested by a non-admin user', async () => {
+      (auth as jest.Mock).mockResolvedValue({ user: { id: 'player-1', role: 'player' } });
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
+      const params = Promise.resolve({ id: 't1' });
+      const result = await GET(request, { params });
+
+      expect(result.data).toEqual(expect.objectContaining({
+        success: false,
+        error: 'Admin access required',
+        code: 'FORBIDDEN',
+      }));
+      expect(result.status).toBe(403);
+      expect(prisma.tournament.findUnique).not.toHaveBeenCalled();
+    });
+
     it('should return 500 when the CDM template self-fetch fails', async () => {
       const mockTournament = {
         id: 't1',

--- a/smkc-score-app/__tests__/components/tournament/export-button.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/export-button.test.tsx
@@ -112,7 +112,7 @@ describe('ExportButton', () => {
       }));
     });
 
-    expect(screen.getByRole('alert')).toHaveTextContent('network down');
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to export tournament');
     expect(clickSpy).not.toHaveBeenCalled();
     expect(window.URL.createObjectURL).not.toHaveBeenCalled();
   });

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -33,6 +33,7 @@
     "noPlayersSelected": "No players selected yet",
     "selectedPlayers": "Selected Players ({count})",
     "exportAll": "Export All",
+    "exportFailed": "Failed to export tournament",
     "goToFinals": "Go to Finals",
     "setupGroups": "Setup Groups",
     "resetSetup": "Reset Setup",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -33,6 +33,7 @@
     "noPlayersSelected": "プレイヤーが選択されていません",
     "selectedPlayers": "選択済みプレイヤー ({count})",
     "exportAll": "全データエクスポート",
+    "exportFailed": "トーナメントのエクスポートに失敗しました",
     "goToFinals": "決勝へ",
     "setupGroups": "グループ設定",
     "resetSetup": "設定リセット",

--- a/smkc-score-app/src/components/tournament/export-button.tsx
+++ b/smkc-score-app/src/components/tournament/export-button.tsx
@@ -132,7 +132,7 @@ export function ExportButton({
        */
       const metadata = error instanceof Error ? { message: error.message, stack: error.stack } : { error };
       logger.error("Export failed", metadata);
-      setErrorMessage(error instanceof Error ? error.message : "Failed to export tournament");
+      setErrorMessage(t("exportFailed"));
     }
   };
 


### PR DESCRIPTION
## Summary
- require an admin session for CDM workbook export while leaving CSV export behavior unchanged
- make CDM template load failures explicit, including ASSETS.fetch errors that should not silently fall back to self-fetch
- surface ExportButton failures with localized UI text and add missing failure/fallback tests
- enable Playwright persistent-context downloads and improve TC-358 diagnostics
- guard TA sudden-death submission when parent round results are null

Supersedes #849 because GitHub kept that PR head pinned to the pre-review-fix commit after a force-push.

Closes #835
Closes #836
Closes #846
Closes #847
Closes #848
Closes #826
Closes #850
Closes #851

## Validation
- npm run lint
- npm test -- --runInBand
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/export/route.test.ts' __tests__/components/tournament/export-button.test.tsx __tests__/i18n/messages.test.ts --runInBand
- npm run build
- node --check e2e/tc-all.js

## E2E Notes
- Verified via Computer Use that the production SMKC page is in an authenticated admin session and exposes the CDM Export button.
- Full `npm run e2e:all` is a multi-hour production run per the suite comments; not run locally before this PR.