### PR TITLE
Address CDM export review follow-ups

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -201,7 +201,7 @@
   4. `/players` ページを開き、プレイヤー数が既定 limit (50) を超える場合にページャー UI が出ること
 - **期待結果**: ページネーションが API/UI 双方で機能し、limit クランプが効いている
 
-## TC-109: CDM Export 失敗時の原因ヒント表示
+## TC-359: CDM Export 失敗時の原因ヒント表示
 - **URL**: /tournaments/[id]
 - **authRequired**: true (admin)
 - **手順**:

--- a/smkc-score-app/__tests__/components/tournament/export-button.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/export-button.test.tsx
@@ -114,6 +114,26 @@ describe('ExportButton', () => {
     expect(window.URL.createObjectURL).not.toHaveBeenCalled();
   });
 
+  it('shows a forbidden export hint when the API returns 401', async () => {
+    global.fetch = jest.fn().mockResolvedValue(new Response('Unauthorized', { status: 401 }));
+    const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();
+
+    render(
+      <ExportButton tournamentId="tournament-1" tournamentName="Grand Prix" format="cdm">
+        CDM Export
+      </ExportButton>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /CDM Export/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to export tournament: Forbidden or session expired');
+    });
+
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(window.URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
   it('logs and skips download when fetch throws', async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error('network down'));
     const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();


### PR DESCRIPTION
## Summary
- Align the CDM export E2E scenario number with the implemented TC-359 check
- Add unit coverage for HTTP 401 export failures sharing the forbidden/session-expired hint

## Issues
Closes #855
Closes #856

## Validation
- npm run test -- --runTestsByPath __tests__/components/tournament/export-button.test.tsx
- node --check e2e/tc-all.js
- npm run lint
- npx tsc --noEmit