### PR TITLE
Fix 16-player finals loser routing

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1401,6 +1401,16 @@
 - **期待結果**: 有効値は受け付け、無効値は 422 で拒否される
 - **スクリプト**: tc-mr.js TC-621
 
+## TC-858: MR Top-24 決勝 Winners R1 敗者の Losers R1 反映 (issue #858)
+- **背景**: Top-24 から生成される16人決勝では Winners R1 の敗者が Losers R1 に落ちる。偶数側の Winners R1 敗者は Losers R1 の player2 スロットに入る必要がある
+- **手順**:
+  1. 28名予選完了済みフィクスチャで MR Top-24 playoff を生成する
+  2. playoff_r1/playoff_r2 を完了し、16人決勝ブラケットを生成する
+  3. Winners R1 M2 を player1 勝利で完了する
+  4. Losers R1 M16 の `player2Id` が Winners R1 M2 の敗者になっていることを確認
+- **期待結果**: Winners R1 M2 の敗者が M16 `player2Id` に反映され、`player1Id` を上書きしない
+- **スクリプト**: tc-mr.js TC-858
+
 ## TC-611: BM/MR/GP予選確定 — スコアロック検証
 - **URL**: /api/tournaments/[temp-id]/mr (PUT), /api/tournaments/[temp-id]/mr/match/[matchId]/report (POST)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
@@ -484,6 +484,51 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
       expect(result.status).toBe(200);
     });
 
+    it('should place a 16-player Winners R1 loser into the paired Losers R1 player2 slot', async () => {
+      const mockMatch = {
+        id: 'm2',
+        matchNumber: 2,
+        round: 'winners_r1',
+        stage: 'finals',
+        player1Id: 'p8',
+        player2Id: 'p9',
+        player1: { id: 'p8', name: 'Player 8' },
+        player2: { id: 'p9', name: 'Player 9' },
+      };
+      const mockUpdatedMatch = { ...mockMatch, score1: 5, score2: 1, completed: true };
+
+      (prisma.mRMatch.count as jest.Mock).mockResolvedValue(31);
+      (generateBracketStructure as jest.Mock).mockReturnValue([
+        { matchNumber: 2, round: 'winners_r1', winnerGoesTo: 9, loserGoesTo: 16, position: 2 },
+      ]);
+      (prisma.mRMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+      (prisma.mRMatch.update as jest.Mock).mockResolvedValue(mockUpdatedMatch);
+      (prisma.mRMatch.findFirst as jest.Mock)
+        .mockResolvedValueOnce({ id: 'm9' })
+        .mockResolvedValueOnce({ id: 'm16' });
+
+      const request = new MockNextRequest(
+        'http://localhost:3000/api/tournaments/t1/mr/finals',
+        { matchId: 'm2', score1: 5, score2: 1 },
+      );
+      const params = Promise.resolve({ id: 't1' });
+      const result = await PUT(request, { params });
+
+      expect(result.status).toBe(200);
+      expect(prisma.mRMatch.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'm16' },
+          data: { player2Id: 'p9' },
+        }),
+      );
+      expect(prisma.mRMatch.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { tournamentId: 't1', matchNumber: 16, stage: 'finals' },
+          data: { player2Id: 'p9' },
+        }),
+      );
+    });
+
     /**
      * Admin manual total-score override: when only score1/score2 are sent
      * without rounds[], the existing rounds[] breakdown must be preserved.

--- a/smkc-score-app/__tests__/lib/double-elimination.test.ts
+++ b/smkc-score-app/__tests__/lib/double-elimination.test.ts
@@ -507,6 +507,21 @@ describe('Double Elimination Bracket Structure', () => {
     });
   });
 
+  describe('getNextMatchInfo with 16-player finals bracket', () => {
+    it('should route Winners R1 losers into paired Losers R1 slots', () => {
+      const matches16 = generateBracketStructure(16);
+
+      expect(getNextMatchInfo(matches16, 1, false)).toEqual({
+        nextMatchNumber: 16,
+        position: 1,
+      });
+      expect(getNextMatchInfo(matches16, 2, false)).toEqual({
+        nextMatchNumber: 16,
+        position: 2,
+      });
+    });
+  });
+
   describe('roundNames', () => {
     it('should include playoff round names', () => {
       expect(roundNames.playoff_r1).toBeDefined();

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -27,6 +27,7 @@
  *  TC-618  MR finals admin manual total-score override (PR #585 manual form)
  *  TC-620  MR qualification tie resolution (tie warning → resolveAllTies)
  *  TC-621  MR per-round target-wins API validation (issue #528: FT3/FT4/FT5)
+ *  TC-858  MR Top-24 finals Winners R1 loser populates Losers R1 player2
  *
  * Uses Playwright persistent profile at /tmp/playwright-smkc-profile.
  * Admin session must already exist in the profile (Discord OAuth).
@@ -1486,6 +1487,58 @@ async function runTc621(adminPage) {
   }
 }
 
+/* ───────── TC-858: MR Top-24 finals Winners R1 loser propagation (#858) ─────────
+ * Creates a Top-24 playoff, completes playoff matches to materialise the
+ * 16-player finals bracket, then completes Winners R1 match 2. Its loser must
+ * enter Losers R1 match 16 as player2, not overwrite player1. */
+async function runTc858(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedMrFinalsSetup(adminPage);
+    const { tournamentId } = setup;
+
+    const genPlayoff = await generateMrFinalsBracket(adminPage, tournamentId, 24);
+    if (genPlayoff.s !== 201 && genPlayoff.s !== 200) {
+      throw new Error(`24-player MR playoff gen failed (${genPlayoff.s})`);
+    }
+
+    for (let guard = 0; guard < 8; guard++) {
+      const state = await apiFetchMrFinalsState(adminPage, tournamentId);
+      if (state.playoffComplete) break;
+      const ready = (state.playoffMatches || []).find((m) =>
+        !m.completed && m.player1Id && m.player2Id
+      );
+      if (!ready) throw new Error('No ready playoff match found while building Top-16 finals');
+      const target = mrFinalsTargetWinsForMatch(ready);
+      const put = await setMrFinalsScore(adminPage, tournamentId, ready.id, target, Math.max(0, target - 2));
+      if (put.s !== 200) throw new Error(`Playoff score PUT failed for M${ready.matchNumber} (${put.s})`);
+    }
+
+    const genFinals = await generateMrFinalsBracket(adminPage, tournamentId, 24);
+    if (genFinals.s !== 201 && genFinals.s !== 200) {
+      throw new Error(`16-player MR finals gen failed (${genFinals.s})`);
+    }
+
+    const before = await fetchMrFinalsMatches(adminPage, tournamentId);
+    const r1m2 = before.find((m) => m.stage === 'finals' && m.matchNumber === 2 && m.round === 'winners_r1');
+    if (!r1m2?.player1Id || !r1m2?.player2Id) throw new Error('Winners R1 M2 is not ready');
+    const expectedLoserId = r1m2.player2Id;
+    const target = mrFinalsTargetWinsForMatch(r1m2);
+    const put = await setMrFinalsScore(adminPage, tournamentId, r1m2.id, target, Math.max(0, target - 3));
+    if (put.s !== 200) throw new Error(`Winners R1 M2 score PUT failed (${put.s})`);
+
+    const after = await fetchMrFinalsMatches(adminPage, tournamentId);
+    const losersR1M16 = after.find((m) => m.stage === 'finals' && m.matchNumber === 16 && m.round === 'losers_r1');
+    const ok = losersR1M16?.player2Id === expectedLoserId;
+    log('TC-858', ok ? 'PASS' : 'FAIL',
+      ok ? '' : `expected loser ${expectedLoserId} in M16 player2, got ${losersR1M16?.player2Id || 'empty'}`);
+  } catch (err) {
+    log('TC-858', 'FAIL', err instanceof Error ? err.message : 'MR 858 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
 /* See tc-bm.js::getSuite for the shared-fixture composition contract. */
 function getSuite({ sharedFixture: externalFixture = null } = {}) {
   const ownsFixture = !externalFixture;
@@ -1524,6 +1577,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-615', fn: runTc615 },
       { name: 'TC-616', fn: runTc616 },
       { name: 'TC-621', fn: runTc621 },
+      { name: 'TC-858', fn: runTc858 },
     ],
   };
 }
@@ -1531,7 +1585,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 module.exports = {
   runTc601, runTc602, runTc603, runTc604, runTc605, runTc606, runTc607,
   runTc608, runTc609, runTc610, runTc611, runTc612, runTc620, runTc820, runTc822,
-  runTc615, runTc616, runTc617, runTc618, runTc621,
+  runTc615, runTc616, runTc617, runTc618, runTc621, runTc858,
   getSuite,
   results,
 };

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -1657,7 +1657,9 @@ export function createFinalsHandlers(config: FinalsConfig) {
         });
 
         let loserPosition: 1 | 2 = 1;
-        if (currentBracketMatch.round === 'winners_qf') {
+        if (currentBracketMatch.round === 'winners_r1') {
+          loserPosition = (((matchNumber - 1) % 2) + 1) as 1 | 2;
+        } else if (currentBracketMatch.round === 'winners_qf') {
           /* 16-player: losers from QF enter L_R2 at position 2.
            * 8-player: uses parity-based calculation ((matchNumber-1)%2 + 1). */
           loserPosition = bracketSize === 16 ? 2 : (((matchNumber - 1) % 2) + 1) as 1 | 2;


### PR DESCRIPTION
## Summary
- Route 16-player Winners R1 losers into the correct paired Losers R1 slot instead of defaulting to player1.
- Add MR finals route/unit coverage and TC-858 E2E scenario coverage for the Top-24 to Top-16 finals path.

## Issues
Closes #858

## Validation
- npm test -- --runTestsByPath __tests__/lib/double-elimination.test.ts __tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
- node --check e2e/tc-mr.js
- node --check e2e/tc-all.js
- git diff --check
- npm run lint (0 errors, existing warnings)
- npx tsc --noEmit