### PR TITLE
[codex] Stabilize E2E browser bootstrap

### DIFF
--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import os from 'os';
+import path from 'path';
+import * as common from '../../e2e/lib/common';
+
+describe('E2E browser launch helpers', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.E2E_BROWSER_HOME;
+    delete process.env.PLAYWRIGHT_BROWSERS_PATH;
+    delete process.env.PLAYWRIGHT_SKIP_BROWSER_GC;
+    delete process.env.E2E_EXECUTABLE_PATH;
+    delete process.env.E2E_BROWSER_CHANNEL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('defaults Playwright browsers to a writable temp path', () => {
+    expect(common.resolveE2EBrowserHome()).toBe(path.join(os.tmpdir(), 'playwright-e2e-home'));
+    expect(common.resolvePlaywrightBrowsersPath()).toBe(
+      path.join(os.tmpdir(), 'playwright-e2e-home', 'ms-playwright'),
+    );
+  });
+
+  it('respects caller-provided browser home and installs path env', () => {
+    process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
+    const env = common.createPlaywrightBrowserInstallEnv();
+
+    expect(env.PLAYWRIGHT_BROWSERS_PATH).toBe('/tmp/jsmkc-browser-home/ms-playwright');
+    expect(env.PLAYWRIGHT_SKIP_BROWSER_GC).toBe('1');
+  });
+
+  it('syncs Playwright browser cache into process.env before launch', () => {
+    process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
+
+    const env = common.ensurePlaywrightBrowserRuntimeEnv();
+
+    expect(process.env.PLAYWRIGHT_BROWSERS_PATH).toBe('/tmp/jsmkc-browser-home/ms-playwright');
+    expect(process.env.PLAYWRIGHT_SKIP_BROWSER_GC).toBe('1');
+    expect(env.PLAYWRIGHT_BROWSERS_PATH).toBe(process.env.PLAYWRIGHT_BROWSERS_PATH);
+  });
+
+  it('propagates explicit executable path into the chromium launch config', () => {
+    process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
+    process.env.E2E_EXECUTABLE_PATH = '/Applications/Chromium.app/Contents/MacOS/Chromium';
+    process.env.E2E_BROWSER_CHANNEL = 'chrome';
+
+    const config = common.getChromiumLaunchConfig();
+
+    expect(config.executablePath).toBe('/Applications/Chromium.app/Contents/MacOS/Chromium');
+    expect(config.channel).toBeUndefined();
+    expect(config.env.PLAYWRIGHT_BROWSERS_PATH).toBe('/tmp/jsmkc-browser-home/ms-playwright');
+    expect(config.env.HOME).toBe('/tmp/jsmkc-browser-home');
+  });
+
+  it('uses browser channel when no explicit executable path is set', () => {
+    process.env.E2E_BROWSER_CHANNEL = 'chrome';
+
+    const config = common.getChromiumLaunchConfig();
+
+    expect(config.channel).toBe('chrome');
+    expect(config.executablePath).toBeUndefined();
+  });
+});

--- a/smkc-score-app/e2e/cleanup.js
+++ b/smkc-score-app/e2e/cleanup.js
@@ -13,8 +13,7 @@
  *   npm run e2e:cleanup
  *   npm run e2e:cleanup -- --dry-run
  */
-const { chromium } = require('playwright');
-const { BASE, installApiLogging, getChromiumArgs } = require('./lib/common');
+const { BASE, installApiLogging, launchPersistentChromiumContext } = require('./lib/common');
 const { closeBrowser, envMs, formatDuration } = require('./lib/runner');
 
 const PROFILE_DIR = process.env.E2E_PROFILE_DIR || '/tmp/playwright-smkc-profile';
@@ -175,10 +174,9 @@ async function main() {
   if (dryRun) console.log('[cleanup] dry run: no data will be deleted');
 
   try {
-    browser = await chromium.launchPersistentContext(PROFILE_DIR, {
+    browser = await launchPersistentChromiumContext(PROFILE_DIR, {
       headless: process.env.E2E_HEADLESS === '1',
       viewport: { width: 1280, height: 720 },
-      args: getChromiumArgs(),
     });
     installApiLogging(browser, 'cleanup');
 

--- a/smkc-score-app/e2e/install-browser.js
+++ b/smkc-score-app/e2e/install-browser.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process');
+const {
+  createPlaywrightBrowserInstallEnv,
+  resolvePlaywrightBrowsersPath,
+} = require('./lib/common');
+
+function printUsage() {
+  console.log([
+    'Install the Playwright-managed browser used by the E2E scripts.',
+    '',
+    'Usage:',
+    '  node e2e/install-browser.js [browser]',
+    '',
+    'Examples:',
+    '  node e2e/install-browser.js',
+    '  node e2e/install-browser.js chromium',
+  ].join('\n'));
+}
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  printUsage();
+  process.exit(0);
+}
+
+const browser = process.argv[2] || 'chromium';
+const env = createPlaywrightBrowserInstallEnv();
+
+console.log(`[e2e:install-browser] browser: ${browser}`);
+console.log(`[e2e:install-browser] PLAYWRIGHT_BROWSERS_PATH=${resolvePlaywrightBrowsersPath()}`);
+
+const result = spawnSync(
+  process.platform === 'win32' ? 'npx.cmd' : 'npx',
+  ['playwright', 'install', browser],
+  { stdio: 'inherit', env },
+);
+
+if (result.error) {
+  console.error('[e2e:install-browser] failed:', result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -11,10 +11,26 @@
  *   without needing to know which IDs were created. The closure is also called
  *   internally if setup throws partway through, so partial state never leaks.
  */
-const { chromium } = require('playwright');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+
+const DEFAULT_E2E_BROWSER_HOME = path.join(os.tmpdir(), 'playwright-e2e-home');
+
+function bootstrapPlaywrightProcessEnv() {
+  const browserHome = process.env.E2E_BROWSER_HOME || DEFAULT_E2E_BROWSER_HOME;
+  const browsersPath = process.env.PLAYWRIGHT_BROWSERS_PATH || path.join(browserHome, 'ms-playwright');
+  fs.mkdirSync(browserHome, { recursive: true });
+  fs.mkdirSync(browsersPath, { recursive: true });
+  process.env.PLAYWRIGHT_BROWSERS_PATH = browsersPath;
+  if (!process.env.PLAYWRIGHT_SKIP_BROWSER_GC) {
+    process.env.PLAYWRIGHT_SKIP_BROWSER_GC = '1';
+  }
+}
+
+bootstrapPlaywrightProcessEnv();
+
+const { chromium } = require('playwright');
 
 const BASE = process.env.E2E_BASE_URL || 'https://smkc.bluemoon.works';
 const NAV_WAIT_MS = 8000;
@@ -206,6 +222,35 @@ function getChromiumArgs() {
   ];
 }
 
+function resolveE2EBrowserHome() {
+  return process.env.E2E_BROWSER_HOME || DEFAULT_E2E_BROWSER_HOME;
+}
+
+function resolvePlaywrightBrowsersPath(baseHome = resolveE2EBrowserHome()) {
+  return process.env.PLAYWRIGHT_BROWSERS_PATH || path.join(baseHome, 'ms-playwright');
+}
+
+function createPlaywrightBrowserInstallEnv() {
+  const browserHome = resolveE2EBrowserHome();
+  const browsersPath = resolvePlaywrightBrowsersPath(browserHome);
+  fs.mkdirSync(browserHome, { recursive: true });
+  fs.mkdirSync(browsersPath, { recursive: true });
+  return {
+    ...process.env,
+    PLAYWRIGHT_BROWSERS_PATH: browsersPath,
+    /* Prevent Playwright from garbage-collecting the shared cache between
+     * separate automation runs that all rely on the same temp location. */
+    PLAYWRIGHT_SKIP_BROWSER_GC: process.env.PLAYWRIGHT_SKIP_BROWSER_GC || '1',
+  };
+}
+
+function ensurePlaywrightBrowserRuntimeEnv() {
+  const env = createPlaywrightBrowserInstallEnv();
+  process.env.PLAYWRIGHT_BROWSERS_PATH = env.PLAYWRIGHT_BROWSERS_PATH;
+  process.env.PLAYWRIGHT_SKIP_BROWSER_GC = env.PLAYWRIGHT_SKIP_BROWSER_GC;
+  return env;
+}
+
 /* ───────── Browser launch environment setup ───────── */
 /**
  * Create isolated browser environment with crashpad disabled.
@@ -213,18 +258,78 @@ function getChromiumArgs() {
  * This prevents the admin's persistent browser profile from being corrupted.
  */
 function createBrowserLaunchEnv() {
-  const baseHome = process.env.E2E_BROWSER_HOME || path.join(os.tmpdir(), 'playwright-e2e-home');
+  const baseHome = resolveE2EBrowserHome();
   const configHome = path.join(baseHome, '.config');
   const cacheHome = path.join(baseHome, '.cache');
   for (const dir of [baseHome, configHome, cacheHome]) {
     fs.mkdirSync(dir, { recursive: true });
   }
   return {
-    ...process.env,
+    ...ensurePlaywrightBrowserRuntimeEnv(),
     HOME: baseHome,
     XDG_CONFIG_HOME: configHome,
     XDG_CACHE_HOME: cacheHome,
   };
+}
+
+function getChromiumLaunchConfig() {
+  const executablePath = process.env.E2E_EXECUTABLE_PATH?.trim();
+  const channel = process.env.E2E_BROWSER_CHANNEL?.trim();
+  const env = createBrowserLaunchEnv();
+
+  const config = {
+    args: getChromiumArgs(),
+    env,
+  };
+
+  if (executablePath) {
+    config.executablePath = executablePath;
+  } else if (channel) {
+    config.channel = channel;
+  }
+
+  return config;
+}
+
+function addChromiumLaunchHelp(error) {
+  if (!(error instanceof Error)) return error;
+  const msg = error.message || '';
+  if (!msg.includes("Executable doesn't exist")) return error;
+
+  const browsersPath = resolvePlaywrightBrowsersPath();
+  const installHint =
+    `\n` +
+    `Chromium is not installed in the Playwright cache for this E2E environment.\n` +
+    `Recommended bootstrap:\n` +
+    `  PLAYWRIGHT_BROWSERS_PATH=${browsersPath} npm run e2e:install-browser\n` +
+    `Optional overrides:\n` +
+    `  E2E_EXECUTABLE_PATH=/absolute/path/to/chromium-compatible-browser\n` +
+    `  E2E_BROWSER_CHANNEL=chrome`;
+
+  error.message = `${msg}${installHint}`;
+  return error;
+}
+
+async function launchChromium(options = {}) {
+  try {
+    return await chromium.launch({
+      ...options,
+      ...getChromiumLaunchConfig(),
+    });
+  } catch (error) {
+    throw addChromiumLaunchHelp(error);
+  }
+}
+
+async function launchPersistentChromiumContext(profileDir, options = {}) {
+  try {
+    return await chromium.launchPersistentContext(profileDir, {
+      ...options,
+      ...getChromiumLaunchConfig(),
+    });
+  } catch (error) {
+    throw addChromiumLaunchHelp(error);
+  }
 }
 
 /* ───────── Player credentials login (separate browser context) ─────────
@@ -232,11 +337,7 @@ function createBrowserLaunchEnv() {
  * untouched. Caller must close the returned browser. */
 
 async function loginPlayerBrowser(nickname, password) {
-  const browser = await chromium.launch({
-    headless: false,
-    args: getChromiumArgs(),
-    env: createBrowserLaunchEnv(),
-  });
+  const browser = await launchChromium({ headless: false });
   const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
   installApiLogging(context, 'player');
   const page = await context.newPage();
@@ -2396,6 +2497,13 @@ module.exports = {
   /* player browser */
   loginPlayerBrowser,
   createBrowserLaunchEnv,
+  createPlaywrightBrowserInstallEnv,
+  ensurePlaywrightBrowserRuntimeEnv,
+  resolveE2EBrowserHome,
+  resolvePlaywrightBrowsersPath,
+  getChromiumLaunchConfig,
+  launchChromium,
+  launchPersistentChromiumContext,
   /* retry */
   withRetry,
   /* BM */

--- a/smkc-score-app/e2e/lib/runner.js
+++ b/smkc-score-app/e2e/lib/runner.js
@@ -1,5 +1,9 @@
-const { chromium } = require('playwright');
-const { createBrowserLaunchEnv, installApiLogging, nav, getChromiumArgs } = require('./common');
+const {
+  createBrowserLaunchEnv,
+  installApiLogging,
+  nav,
+  launchPersistentChromiumContext,
+} = require('./common');
 
 const DEFAULT_PROFILE_DIR = '/tmp/playwright-smkc-profile';
 const DEFAULT_TEST_TIMEOUT_MS = 10 * 60 * 1000;
@@ -245,10 +249,9 @@ async function runSuite({ suiteName, results, log, tests, beforeAll = null, afte
   try {
     const profileDir = process.env.E2E_PROFILE_DIR || DEFAULT_PROFILE_DIR;
     const headless = process.env.E2E_HEADLESS === '1';
-    browser = await chromium.launchPersistentContext(profileDir, {
+    browser = await launchPersistentChromiumContext(profileDir, {
       headless,
       viewport: { width: 1280, height: 720 },
-      args: getChromiumArgs(),
     });
     installApiLogging(browser, suiteName);
     page = browser.pages()[0] || await browser.newPage();

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -8,7 +8,6 @@
  *
  * Run: node e2e/tc-all.js  (from smkc-score-app/)
  */
-const { chromium } = require('playwright');
 const fs = require('fs');
 const https = require('https');
 const {
@@ -35,18 +34,18 @@ const {
   setupModePlayersViaUi,
   makeTaTimesForRank,
   resolveAllTies,
+  launchChromium,
+  launchPersistentChromiumContext,
 } = require('./lib/common');
 const { createSharedE2eFixture } = require('./lib/fixtures');
 const {
   closeBrowser,
-  createBrowserLaunchEnv,
   createProgressWatchdog,
   envMs,
   exitAfterCleanup,
   formatDuration,
   runSuiteInBrowser,
 } = require('./lib/runner');
-const { getChromiumArgs } = require('./lib/common');
 const bmModule = require('./tc-bm');
 const mrModule = require('./tc-mr');
 const gpModule = require('./tc-gp');
@@ -175,14 +174,12 @@ async function main() {
   };
 
   try {
-    browser = await chromium.launchPersistentContext(
+    browser = await launchPersistentChromiumContext(
       process.env.E2E_PROFILE_DIR || '/tmp/playwright-smkc-profile',
       {
         headless: process.env.E2E_HEADLESS === '1',
         viewport: { width: 1280, height: 720 },
         acceptDownloads: true,
-        env: createBrowserLaunchEnv(),
-        args: getChromiumArgs(),
       },
     );
     installApiLogging(browser, 'tc-all');
@@ -653,10 +650,8 @@ async function main() {
   if (pid && playerTempPassword) {
     let playerBrowser = null;
     try {
-      playerBrowser = await chromium.launch({
+      playerBrowser = await launchChromium({
         headless: false,
-        env: createBrowserLaunchEnv(),
-        args: getChromiumArgs(),
       });
       const playerContext = await playerBrowser.newContext({ viewport: { width: 1280, height: 720 } });
       const playerPage = await playerContext.newPage();
@@ -727,10 +722,8 @@ async function main() {
         { id: gpPlayer2Id, name: gpPlayer2Name, nickname: gpPlayer2Nick },
       ]);
 
-      playerBrowser = await chromium.launch({
+      playerBrowser = await launchChromium({
         headless: false,
-        env: createBrowserLaunchEnv(),
-        args: getChromiumArgs(),
       });
       const playerContext = await playerBrowser.newContext({ viewport: { width: 1280, height: 720 } });
       const playerPage = await playerContext.newPage();
@@ -858,10 +851,8 @@ async function main() {
        * needed. */
       await uiPromoteTaPhase(page, taTournamentId, 'promote_phase1');
 
-      playerBrowser = await chromium.launch({
+      playerBrowser = await launchChromium({
         headless: false,
-        env: createBrowserLaunchEnv(),
-        args: getChromiumArgs(),
       });
       const playerContext = await playerBrowser.newContext({ viewport: { width: 1280, height: 720 } });
       const playerPage = await playerContext.newPage();
@@ -1139,10 +1130,8 @@ async function main() {
       let partnerBrowser = null;
       let step3 = false;
       try {
-        partnerBrowser = await chromium.launch({
+        partnerBrowser = await launchChromium({
           headless: false,
-          env: createBrowserLaunchEnv(),
-          args: getChromiumArgs(),
         });
         const partnerCtx = await partnerBrowser.newContext({ viewport: { width: 1280, height: 720 } });
         const partnerPage = await partnerCtx.newPage();
@@ -2658,10 +2647,8 @@ async function main() {
       });
 
       // 2. Log in as player and call the same endpoint — expect 200
-      tc341PlayerBrowser = await chromium.launch({
+      tc341PlayerBrowser = await launchChromium({
         headless: false,
-        env: createBrowserLaunchEnv(),
-        args: getChromiumArgs(),
       });
       const tc341PlayerCtx = await tc341PlayerBrowser.newContext({ viewport: { width: 1280, height: 720 } });
       const tc341PlayerPage = await tc341PlayerCtx.newPage();

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -49,6 +49,7 @@ const {
   uiActivateTournament,
   uiCreatePlayer,
   uiCreateTournament,
+  launchPersistentChromiumContext,
 } = require('./lib/common');
 const { createSharedE2eFixture, setupModePlayersViaUi, ensurePlayerPassword } = require('./lib/fixtures');
 const { runSuite } = require('./lib/runner');
@@ -421,8 +422,7 @@ async function runTc513(adminPage) {
     const matchUrl = `/tournaments/${tournamentId}/bm/match/${match.id}`;
 
     /* 1. Unauthenticated user sees sign-in prompt */
-    const { chromium } = require('playwright');
-    const anonContext = await chromium.launchPersistentContext('/tmp/playwright-smkc-anon', { headless: true });
+    const anonContext = await launchPersistentChromiumContext('/tmp/playwright-smkc-anon', { headless: true });
     const anonPage = await anonContext.newPage();
     await anonPage.goto(`https://smkc.bluemoon.works${matchUrl}`, { waitUntil: 'domcontentloaded' });
     /* 35s: NextAuth sessionStatus stays 'loading' until D1 resolves the session lookup;

--- a/smkc-score-app/package.json
+++ b/smkc-score-app/package.json
@@ -10,6 +10,7 @@
     "test": "SKIP_OPENNEXT_CLOUDFLARE_DEV=1 NODE_ENV=test NODE_OPTIONS='--max-old-space-size=4096' jest",
     "test:watch": "npm test -- --watch",
     "test:coverage": "npm test -- --coverage",
+    "e2e:install-browser": "node e2e/install-browser.js",
     "e2e:all": "node e2e/tc-all.js",
     "e2e:cleanup": "node e2e/cleanup.js",
     "e2e:bm": "node e2e/tc-bm.js",

--- a/smkc-score-app/scripts/create-finals-ready-tournament.js
+++ b/smkc-score-app/scripts/create-finals-ready-tournament.js
@@ -18,7 +18,6 @@ if (baseUrlArg) {
   process.env.E2E_BASE_URL = baseUrlArg;
 }
 
-const { chromium } = require('playwright');
 const {
   BASE,
   installApiLogging,
@@ -34,6 +33,7 @@ const {
   apiGenerateMrFinals,
   apiGenerateGpFinals,
   uiFreezeTaQualification,
+  launchPersistentChromiumContext,
 } = require('../e2e/lib/common');
 const { closeBrowser, envMs, formatDuration } = require('../e2e/lib/runner');
 
@@ -397,7 +397,7 @@ async function main() {
     console.log(`[finals-ready] profile: ${options.profileDir}`);
     console.log(`[finals-ready] modes: ${options.modes.join(', ')}`);
 
-    browser = await chromium.launchPersistentContext(options.profileDir, {
+    browser = await launchPersistentChromiumContext(options.profileDir, {
       headless: options.headless,
       viewport: { width: 1280, height: 720 },
     });

--- a/smkc-score-app/scripts/reapply-rank-overrides.js
+++ b/smkc-score-app/scripts/reapply-rank-overrides.js
@@ -14,11 +14,11 @@ if (baseUrlArg) {
   process.env.E2E_BASE_URL = baseUrlArg;
 }
 
-const { chromium } = require('playwright');
 const {
   BASE,
   installApiLogging,
   resolveAllTies,
+  launchPersistentChromiumContext,
 } = require('../e2e/lib/common');
 const { closeBrowser, envMs, formatDuration } = require('../e2e/lib/runner');
 
@@ -274,7 +274,7 @@ async function main() {
     console.log(`[rank-override] tournament: ${options.tournament}`);
     console.log(`[rank-override] modes: ${options.modes.join(', ')}`);
 
-    browser = await chromium.launchPersistentContext(options.profileDir, {
+    browser = await launchPersistentChromiumContext(options.profileDir, {
       headless: options.headless,
       viewport: { width: 1280, height: 720 },
     });


### PR DESCRIPTION
## What changed

- centralized E2E Chromium launch setup in `e2e/lib/common.js`
- defaulted Playwright browser cache to a writable temp location for automation runs
- added `E2E_EXECUTABLE_PATH` and `E2E_BROWSER_CHANNEL` overrides for explicit browser selection
- added `npm run e2e:install-browser` to install the Playwright-managed browser into the same cache path the E2E helpers use
- moved the main E2E entrypoints and utility scripts onto the shared launch helpers
- added unit coverage for the new browser-launch environment resolution

## Why

The production E2E loop could fail before any test executed when Playwright browsers were missing from `~/Library/Caches/ms-playwright`. Even after installing into a writable temp path, runtime launch still resolved the executable from the default user cache unless `PLAYWRIGHT_BROWSERS_PATH` was initialized before importing Playwright.

This change makes the browser bootstrap path deterministic for automation and gives us a supported way to preinstall the required browser without depending on the user's home cache.

## Impact

- E2E scripts now use a shared writable Playwright cache by default
- first-time setup is now `npm run e2e:install-browser`
- explicit browser overrides remain possible when needed
- missing-browser failures now point to the correct install command

## Validation

- `npm test -- --runTestsByPath __tests__/lib/e2e-browser-launch.test.ts`
- `npm run e2e:install-browser`
- smoke test: `launchChromium({ headless: true })` + `page.goto('https://example.com')` returned `Example Domain`
