### PR TITLE
Fix duplicate finals routing writes

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
@@ -521,10 +521,9 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
           data: { player2Id: 'p9' },
         }),
       );
-      expect(prisma.mRMatch.updateMany).toHaveBeenCalledWith(
+      expect(prisma.mRMatch.updateMany).not.toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { tournamentId: 't1', matchNumber: 16, stage: 'finals' },
-          data: { player2Id: 'p9' },
+          where: expect.objectContaining({ tournamentId: 't1', matchNumber: 16, stage: 'finals' }),
         }),
       );
     });
@@ -731,6 +730,16 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
 
       expect(result.status).toBe(200);
       expect(prisma.mRMatch.update).toHaveBeenCalledTimes(3);
+      expect(prisma.mRMatch.updateMany).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ tournamentId: 't1', matchNumber: 5, stage: 'finals' }),
+        }),
+      );
+      expect(prisma.mRMatch.updateMany).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ tournamentId: 't1', matchNumber: 8, stage: 'finals' }),
+        }),
+      );
     });
 
     // Edge case - Handles grand final reset scenario

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -1640,7 +1640,6 @@ export function createFinalsHandlers(config: FinalsConfig) {
             data:
               position === 1 ? { player1Id: winnerId } : { player2Id: winnerId },
           });
-          await updateRoutedMatch(currentBracketMatch.winnerGoesTo, position, winnerId);
         } else {
           await updateRoutedMatch(currentBracketMatch.winnerGoesTo, currentBracketMatch.position || 1, winnerId);
         }
@@ -1679,7 +1678,6 @@ export function createFinalsHandlers(config: FinalsConfig) {
                 ? { player1Id: loserId }
                 : { player2Id: loserId },
           });
-          await updateRoutedMatch(currentBracketMatch.loserGoesTo, loserPosition, loserId);
         } else {
           await updateRoutedMatch(currentBracketMatch.loserGoesTo, loserPosition, loserId);
         }


### PR DESCRIPTION
## Summary
- Remove duplicate updateMany routing writes when the target finals match was already found by ID.
- Add MR finals regression assertions for winner and loser routing paths.

## Issues
Closes #861

## Validation
- npm test -- --runTestsByPath "__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts"
- npm run lint -- src/lib/api-factories/finals-route.ts "__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts"