### PR TITLE
Avoid E2E env mutation on common import

### DIFF
--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -1,10 +1,22 @@
-import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import os from 'os';
 import path from 'path';
-import * as common from '../../e2e/lib/common';
+
+type E2ECommon = typeof import('../../e2e/lib/common');
+
+function loadCommon() {
+  let loaded: E2ECommon | undefined;
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    loaded = require('../../e2e/lib/common') as E2ECommon;
+  });
+  if (!loaded) throw new Error('Failed to load e2e common helpers');
+  return loaded;
+}
 
 describe('E2E browser launch helpers', () => {
   const originalEnv = { ...process.env };
+  let common: E2ECommon;
 
   beforeEach(() => {
     process.env = { ...originalEnv };
@@ -13,6 +25,7 @@ describe('E2E browser launch helpers', () => {
     delete process.env.PLAYWRIGHT_SKIP_BROWSER_GC;
     delete process.env.E2E_EXECUTABLE_PATH;
     delete process.env.E2E_BROWSER_CHANNEL;
+    common = loadCommon();
   });
 
   afterEach(() => {
@@ -26,6 +39,21 @@ describe('E2E browser launch helpers', () => {
     );
   });
 
+  it('does not mutate Playwright process env during module load', () => {
+    process.env = {
+      ...originalEnv,
+      E2E_BROWSER_HOME: '/tmp/jsmkc-browser-home',
+    };
+    delete process.env.PLAYWRIGHT_BROWSERS_PATH;
+    delete process.env.PLAYWRIGHT_SKIP_BROWSER_GC;
+
+    common = loadCommon();
+
+    expect(process.env.PLAYWRIGHT_BROWSERS_PATH).toBeUndefined();
+    expect(process.env.PLAYWRIGHT_SKIP_BROWSER_GC).toBeUndefined();
+    expect(common.resolvePlaywrightBrowsersPath()).toBe('/tmp/jsmkc-browser-home/ms-playwright');
+  });
+
   it('respects caller-provided browser home and installs path env', () => {
     process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
     const env = common.createPlaywrightBrowserInstallEnv();
@@ -34,10 +62,10 @@ describe('E2E browser launch helpers', () => {
     expect(env.PLAYWRIGHT_SKIP_BROWSER_GC).toBe('1');
   });
 
-  it('syncs Playwright browser cache into process.env before launch', () => {
+  it('syncs Playwright browser cache into process.env during explicit runtime initialization', () => {
     process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
 
-    const env = common.ensurePlaywrightBrowserRuntimeEnv();
+    const env = common.initializePlaywrightBrowserRuntimeEnv();
 
     expect(process.env.PLAYWRIGHT_BROWSERS_PATH).toBe('/tmp/jsmkc-browser-home/ms-playwright');
     expect(process.env.PLAYWRIGHT_SKIP_BROWSER_GC).toBe('1');

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -17,19 +17,6 @@ const path = require('path');
 
 const DEFAULT_E2E_BROWSER_HOME = path.join(os.tmpdir(), 'playwright-e2e-home');
 
-function bootstrapPlaywrightProcessEnv() {
-  const browserHome = process.env.E2E_BROWSER_HOME || DEFAULT_E2E_BROWSER_HOME;
-  const browsersPath = process.env.PLAYWRIGHT_BROWSERS_PATH || path.join(browserHome, 'ms-playwright');
-  fs.mkdirSync(browserHome, { recursive: true });
-  fs.mkdirSync(browsersPath, { recursive: true });
-  process.env.PLAYWRIGHT_BROWSERS_PATH = browsersPath;
-  if (!process.env.PLAYWRIGHT_SKIP_BROWSER_GC) {
-    process.env.PLAYWRIGHT_SKIP_BROWSER_GC = '1';
-  }
-}
-
-bootstrapPlaywrightProcessEnv();
-
 const { chromium } = require('playwright');
 
 const BASE = process.env.E2E_BASE_URL || 'https://smkc.bluemoon.works';
@@ -244,11 +231,15 @@ function createPlaywrightBrowserInstallEnv() {
   };
 }
 
-function ensurePlaywrightBrowserRuntimeEnv() {
+function initializePlaywrightBrowserRuntimeEnv() {
   const env = createPlaywrightBrowserInstallEnv();
   process.env.PLAYWRIGHT_BROWSERS_PATH = env.PLAYWRIGHT_BROWSERS_PATH;
   process.env.PLAYWRIGHT_SKIP_BROWSER_GC = env.PLAYWRIGHT_SKIP_BROWSER_GC;
   return env;
+}
+
+function ensurePlaywrightBrowserRuntimeEnv() {
+  return initializePlaywrightBrowserRuntimeEnv();
 }
 
 /* ───────── Browser launch environment setup ───────── */
@@ -265,7 +256,7 @@ function createBrowserLaunchEnv() {
     fs.mkdirSync(dir, { recursive: true });
   }
   return {
-    ...ensurePlaywrightBrowserRuntimeEnv(),
+    ...initializePlaywrightBrowserRuntimeEnv(),
     HOME: baseHome,
     XDG_CONFIG_HOME: configHome,
     XDG_CACHE_HOME: cacheHome,
@@ -2498,6 +2489,7 @@ module.exports = {
   loginPlayerBrowser,
   createBrowserLaunchEnv,
   createPlaywrightBrowserInstallEnv,
+  initializePlaywrightBrowserRuntimeEnv,
   ensurePlaywrightBrowserRuntimeEnv,
   resolveE2EBrowserHome,
   resolvePlaywrightBrowsersPath,


### PR DESCRIPTION
## Summary
- Stop e2e/lib/common.js from mutating Playwright process env during module load.
- Add explicit runtime initialization and regression coverage for import isolation.

## Issues
Closes #866

## Validation
- npm test -- --runTestsByPath __tests__/lib/e2e-browser-launch.test.ts
- npm run lint -- __tests__/lib/e2e-browser-launch.test.ts
- node -c e2e/lib/common.js