### PR TITLE
Remove redundant E2E env alias

### DIFF
--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -238,10 +238,6 @@ function initializePlaywrightBrowserRuntimeEnv() {
   return env;
 }
 
-function ensurePlaywrightBrowserRuntimeEnv() {
-  return initializePlaywrightBrowserRuntimeEnv();
-}
-
 /* ───────── Browser launch environment setup ───────── */
 /**
  * Create isolated browser environment with crashpad disabled.
@@ -2490,7 +2486,6 @@ module.exports = {
   createBrowserLaunchEnv,
   createPlaywrightBrowserInstallEnv,
   initializePlaywrightBrowserRuntimeEnv,
-  ensurePlaywrightBrowserRuntimeEnv,
   resolveE2EBrowserHome,
   resolvePlaywrightBrowsersPath,
   getChromiumLaunchConfig,


### PR DESCRIPTION
## Summary
- Remove the redundant ensurePlaywrightBrowserRuntimeEnv alias from e2e common helpers.
- Keep callers on the explicit initializePlaywrightBrowserRuntimeEnv API.

## Issues
Closes #869

## Validation
- npm test -- --runTestsByPath __tests__/lib/e2e-browser-launch.test.ts
- npm run lint -- __tests__/lib/e2e-browser-launch.test.ts
- node -c e2e/lib/common.js
- rg -n "ensurePlaywrightBrowserRuntimeEnv" smkc-score-app