### PR TITLE
Clarify E2E browser path resolution

### DIFF
--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -62,6 +62,16 @@ describe('E2E browser launch helpers', () => {
     expect(env.PLAYWRIGHT_SKIP_BROWSER_GC).toBe('1');
   });
 
+  it('uses explicit Playwright browsers path env when provided', () => {
+    process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
+    process.env.PLAYWRIGHT_BROWSERS_PATH = '/tmp/jsmkc-explicit-browsers';
+
+    const env = common.createPlaywrightBrowserInstallEnv();
+
+    expect(common.resolvePlaywrightBrowsersPath()).toBe('/tmp/jsmkc-explicit-browsers');
+    expect(env.PLAYWRIGHT_BROWSERS_PATH).toBe('/tmp/jsmkc-explicit-browsers');
+  });
+
   it('syncs Playwright browser cache into process.env during explicit runtime initialization', () => {
     process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
 

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -213,13 +213,13 @@ function resolveE2EBrowserHome() {
   return process.env.E2E_BROWSER_HOME || DEFAULT_E2E_BROWSER_HOME;
 }
 
-function resolvePlaywrightBrowsersPath(baseHome = resolveE2EBrowserHome()) {
-  return process.env.PLAYWRIGHT_BROWSERS_PATH || path.join(baseHome, 'ms-playwright');
+function resolvePlaywrightBrowsersPath() {
+  return process.env.PLAYWRIGHT_BROWSERS_PATH || path.join(resolveE2EBrowserHome(), 'ms-playwright');
 }
 
 function createPlaywrightBrowserInstallEnv() {
   const browserHome = resolveE2EBrowserHome();
-  const browsersPath = resolvePlaywrightBrowsersPath(browserHome);
+  const browsersPath = resolvePlaywrightBrowsersPath();
   fs.mkdirSync(browserHome, { recursive: true });
   fs.mkdirSync(browsersPath, { recursive: true });
   return {


### PR DESCRIPTION
## Summary
- Remove the unused baseHome parameter from resolvePlaywrightBrowsersPath.
- Add regression coverage for explicit PLAYWRIGHT_BROWSERS_PATH precedence.

## Issues
Closes #865

## Validation
- npm test -- --runTestsByPath __tests__/lib/e2e-browser-launch.test.ts
- npm run lint -- __tests__/lib/e2e-browser-launch.test.ts
- node -c e2e/lib/common.js