### PR TITLE
Address TA time layout review follow-ups

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
@@ -3,9 +3,8 @@ import { TA_TIME_ENTRY_CUP_GRID_CLASS } from "@/lib/ta/time-entry-layout";
 describe("TA time entry layout", () => {
   it("stacks cup cards on mobile and restores two columns from md", () => {
     expect(TA_TIME_ENTRY_CUP_GRID_CLASS.split(" ")).toEqual(
-      expect.arrayContaining(["grid-cols-1", "md:grid-cols-2", "gap-4"]),
+      expect.arrayContaining(["grid", "grid-cols-1", "md:grid-cols-2", "gap-4"]),
     );
     expect(TA_TIME_ENTRY_CUP_GRID_CLASS).not.toContain("grid-cols-2 gap-4");
   });
 });
-

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -273,10 +273,34 @@ async function runTc839(adminPage) {
     const firstInput = await dialog.locator('input[placeholder="M:SS.mm"]').first().boundingBox();
     const inputWideEnough = Boolean(firstInput && firstInput.width >= 150);
 
-    log('TC-839', stacked && inputWideEnough ? 'PASS' : 'FAIL',
-      stacked && inputWideEnough
-        ? `inputWidth=${Math.round(firstInput.width)}`
-        : `stacked=${stacked} inputWidth=${firstInput ? Math.round(firstInput.width) : 'none'}`);
+    if (!stacked || !inputWideEnough) {
+      throw new Error(`edit layout stacked=${stacked} inputWidth=${firstInput ? Math.round(firstInput.width) : 'none'}`);
+    }
+    await dialog.getByRole('button', { name: /^(Cancel|キャンセル)$/ }).click();
+    await dialog.waitFor({ state: 'hidden', timeout: 15000 }).catch(() => {});
+
+    const otherRow = ctx.page.getByRole('row').filter({ hasNotText: player.nickname }).filter({
+      has: ctx.page.getByRole('button', { name: /^(View Times|タイム閲覧)$/ }),
+    }).first();
+    await otherRow.getByRole('button', { name: /^(View Times|タイム閲覧)$/ }).click();
+
+    const viewDialog = ctx.page.getByRole('dialog').filter({
+      has: ctx.page.locator('[data-testid="ta-time-entry-cup-grid-readonly"]'),
+    }).first();
+    await viewDialog.waitFor({ state: 'visible', timeout: 15000 });
+
+    const readonlyCards = viewDialog.locator('[data-testid="ta-time-entry-cup-card-readonly"]');
+    const readonlyBoxes = [];
+    for (let i = 0; i < await readonlyCards.count(); i++) {
+      const box = await readonlyCards.nth(i).boundingBox();
+      if (!box) throw new Error(`readonly cup card ${i + 1} has no bounding box`);
+      readonlyBoxes.push(box);
+    }
+    const readonlyStacked = readonlyBoxes.length === 4 &&
+      readonlyBoxes.every((box, index) => index === 0 || box.y > readonlyBoxes[index - 1].y + 1);
+    if (!readonlyStacked) throw new Error('readonly cup cards are not stacked on mobile');
+
+    log('TC-839', 'PASS', `editInputWidth=${Math.round(firstInput.width)} readonlyCards=${readonlyBoxes.length}`);
   } catch (err) {
     log('TC-839', 'FAIL', err instanceof Error ? err.message : 'TA mobile time-entry layout failed');
   } finally {

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
@@ -1487,9 +1487,9 @@ export default function TimeAttackPageClient({
           </DialogHeader>
           <div className="py-4">
             {/* Course times displayed as read-only text, organized by cup */}
-            <div className={TA_TIME_ENTRY_CUP_GRID_CLASS}>
+            <div className={TA_TIME_ENTRY_CUP_GRID_CLASS} data-testid="ta-time-entry-cup-grid-readonly">
               {CUP_NAMES.map((cup) => (
-                <Card key={cup}>
+                <Card key={cup} data-testid="ta-time-entry-cup-card-readonly">
                   <CardHeader className="py-2">
                     <CardTitle className="text-sm">{t('cup', { cup })}</CardTitle>
                   </CardHeader>


### PR DESCRIPTION
## Summary
- Assert the base `grid` class in the TA time-entry layout unit test.
- Add readonly TA time-view grid test ids.
- Extend TC-839 to verify both edit and readonly cup grids stack on mobile.

## Issues
Closes #873
Closes #874

## Validation
- npm test -- --runTestsByPath __tests__/lib/ta/time-entry-layout.test.ts
- node --check e2e/tc-ta.js && npx tsc --noEmit && git diff --check
- npm run lint (54 existing warnings, 0 errors)
