### PR TITLE
Fix CDM export progress feedback

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -211,6 +211,18 @@
   4. エラー alert の文言を確認
 - **期待結果**: 汎用エラーだけではなく、Forbidden / セッション切れなど原因を切り分けられるヒントが表示される
 
+## TC-360: CDM Export 進行中表示と連打防止
+- **URL**: /tournaments/[id]
+- **authRequired**: true (admin)
+- **背景**: CDM エクスポートは workbook 生成とダウンロードに時間がかかるため、クリック後に進行中であることを表示し、二重クリックで重複リクエストを送らない。
+- **手順**:
+  1. 管理者で大会詳細ページを開く
+  2. CDM Export API のレスポンスを一時的に遅延させる
+  3. `CDM Export` ボタンをクリック
+  4. API 応答前にボタンの状態とリクエスト数を確認
+- **期待結果**: ボタンが `Exporting...` 表示になり disabled/`aria-busy=true` になる。遅延中に二重クリックしても `/export?format=cdm` リクエストは1回だけ送信される。
+- **スクリプト**: tc-all.js TC-360
+
 ## TC-201: 各モードページのデータ読み込み確認
 - **URL**: /tournaments/[id]/ta, /bm, /mr, /gp
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/components/tournament/export-button.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/export-button.test.tsx
@@ -71,6 +71,43 @@ describe('ExportButton', () => {
     expect(window.URL.revokeObjectURL).toHaveBeenCalledWith('blob:cdm-export');
   });
 
+  it('shows export progress and prevents duplicate clicks while a request is pending', async () => {
+    let resolveResponse: (response: Response) => void = () => {};
+    const responsePromise = new Promise<Response>((resolve) => {
+      resolveResponse = resolve;
+    });
+    global.fetch = jest.fn(() => responsePromise);
+    const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();
+
+    render(
+      <ExportButton tournamentId="tournament-1" tournamentName="Grand Prix" format="cdm">
+        CDM Export
+      </ExportButton>,
+    );
+
+    const button = screen.getByRole('button', { name: /CDM Export/i });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('button', { name: /Exporting/i })).toBeInTheDocument();
+
+    resolveResponse(new Response(new Blob(['PK\x03\x04 workbook']), {
+      status: 200,
+      headers: {
+        'content-disposition': 'attachment; filename="Grand_Prix-cdm-2026-04-29.xlsm"',
+      },
+    }));
+
+    await waitFor(() => {
+      expect(button).not.toBeDisabled();
+      expect(button).toHaveAttribute('aria-busy', 'false');
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('logs and skips download when the export response is not OK', async () => {
     global.fetch = jest.fn().mockResolvedValue(new Response('template missing', { status: 500 }));
     const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3091,6 +3091,68 @@ async function main() {
     }
   }
 
+  // TC-360: CDM Export button shows progress and blocks duplicate requests
+  {
+    const exportTid = sharedFixture?.tournamentId ?? TID;
+    if (exportTid) {
+      let cdmExportHandler = null;
+      let releaseExport = null;
+      let requestCount = 0;
+      try {
+        await nav(page, `/tournaments/${exportTid}`);
+        const releasePromise = new Promise((resolve) => {
+          releaseExport = resolve;
+        });
+        cdmExportHandler = async (route) => {
+          requestCount += 1;
+          await releasePromise;
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/vnd.ms-excel.sheet.macroEnabled.12',
+            headers: {
+              'content-disposition': 'attachment; filename="e2e-cdm-export.xlsm"',
+            },
+            body: 'PK\u0003\u0004 workbook',
+          });
+        };
+        await page.route(`**/api/tournaments/${exportTid}/export?format=cdm`, cdmExportHandler);
+
+        const cdmButton = page.getByTestId('export-button-cdm');
+        await cdmButton.click();
+        const loadingVisible = await page.getByRole('button', { name: /Exporting|エクスポート中/i }).isVisible({ timeout: 5000 }).catch(() => false);
+        const isBusy = await cdmButton.getAttribute('aria-busy') === 'true';
+        const isDisabled = await cdmButton.isDisabled();
+        await cdmButton.click({ timeout: 1000 }).catch(() => {});
+        await page.waitForTimeout(250);
+
+        const responsePromise = page.waitForResponse((response) => {
+          const url = new URL(response.url());
+          return url.pathname === `/api/tournaments/${exportTid}/export` &&
+            url.searchParams.get('format') === 'cdm';
+        }, { timeout: 10000 }).catch(() => null);
+        releaseExport();
+        await responsePromise;
+        await page.getByRole('button', { name: /CDM Export/i }).waitFor({ state: 'visible', timeout: 10000 }).catch(() => {});
+
+        log('TC-360',
+          loadingVisible && isBusy && isDisabled && requestCount === 1 ? 'PASS' : 'FAIL',
+          !loadingVisible ? 'Exporting label was not visible'
+          : !isBusy ? 'aria-busy was not true while exporting'
+          : !isDisabled ? 'button was not disabled while exporting'
+          : requestCount !== 1 ? `expected 1 export request, got ${requestCount}`
+          : '');
+      } catch (err) {
+        log('TC-360', 'FAIL', err instanceof Error ? err.message : 'CDM export progress test failed');
+      } finally {
+        if (cdmExportHandler) {
+          await page.unroute(`**/api/tournaments/${exportTid}/export?format=cdm`, cdmExportHandler).catch(() => {});
+        }
+      }
+    } else {
+      log('TC-360', 'SKIP', 'No tournament ID available');
+    }
+  }
+
   // TC-348: Character stats API — admin gets stats shape, non-admin gets 403
   {
     const statsPid = sharedFixture?.playerIds?.[0];

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -33,6 +33,7 @@
     "noPlayersSelected": "No players selected yet",
     "selectedPlayers": "Selected Players ({count})",
     "exportAll": "Export All",
+    "exporting": "Exporting...",
     "exportFailed": "Failed to export tournament",
     "exportFailedForbidden": "Forbidden or session expired",
     "exportFailedHttpStatus": "Server returned HTTP {status}",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -33,6 +33,7 @@
     "noPlayersSelected": "プレイヤーが選択されていません",
     "selectedPlayers": "選択済みプレイヤー ({count})",
     "exportAll": "全データエクスポート",
+    "exporting": "エクスポート中...",
     "exportFailed": "トーナメントのエクスポートに失敗しました",
     "exportFailedForbidden": "権限がないか、セッションが切れています",
     "exportFailedHttpStatus": "サーバーが HTTP {status} を返しました",

--- a/smkc-score-app/src/components/tournament/export-button.tsx
+++ b/smkc-score-app/src/components/tournament/export-button.tsx
@@ -14,7 +14,7 @@
  */
 
 import { Button } from "@/components/ui/button";
-import { Download } from "lucide-react";
+import { Download, Loader2 } from "lucide-react";
 import { createLogger } from "@/lib/client-logger";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -109,13 +109,17 @@ export function ExportButton({
 }: ExportButtonProps) {
   const t = useTranslations("common");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isExporting, setIsExporting] = useState(false);
 
   /**
    * Handles the export action: fetches the file, extracts the filename,
    * and triggers a browser download.
    */
   const handleExport = async () => {
+    if (disabled || isExporting) return;
+
     try {
+      setIsExporting(true);
       setErrorMessage(null);
       const query = format === "cdm" ? "?format=cdm" : "";
       const response = await fetch(`/api/tournaments/${tournamentId}/export${query}`);
@@ -169,8 +173,13 @@ export function ExportButton({
       const metadata = error instanceof Error ? { message: error.message, stack: error.stack } : { error };
       logger.error("Export failed", metadata);
       setErrorMessage(buildExportErrorMessage(error, t));
+    } finally {
+      setIsExporting(false);
     }
   };
+
+  const isDisabled = disabled || isExporting;
+  const label = isExporting ? t("exporting") : children || t("exportAll");
 
   return (
     <div className="inline-flex flex-col items-start gap-1">
@@ -178,10 +187,16 @@ export function ExportButton({
         onClick={handleExport}
         variant={variant}
         size={size}
-        disabled={disabled}
+        disabled={isDisabled}
+        aria-busy={isExporting}
+        data-testid={`export-button-${format}`}
       >
-        <Download className="w-4 h-4 mr-2" />
-        {children || t("exportAll")}
+        {isExporting ? (
+          <Loader2 className="w-4 h-4 mr-2 animate-spin" aria-hidden="true" />
+        ) : (
+          <Download className="w-4 h-4 mr-2" aria-hidden="true" />
+        )}
+        {label}
       </Button>
       {errorMessage ? (
         <p role="alert" className="text-sm text-red-600">


### PR DESCRIPTION
## Summary
- Add an in-progress state to the CDM/export button with spinner text and aria-busy.
- Disable the export button while a request is pending to prevent duplicate export requests.
- Add component coverage plus TC-360 E2E scenario documentation and automation for the duplicate-click path.

## Issues
Closes #877

## Validation
- npm test -- --runTestsByPath __tests__/components/tournament/export-button.test.tsx __tests__/i18n/messages.test.ts --runInBand
- npm run lint
- WRANGLER_LOG_PATH=/private/tmp/wrangler-logs WRANGLER_CONFIG_DIR=/private/tmp/wrangler-config XDG_CONFIG_HOME=/private/tmp npm run build
