### PR TITLE
test: cover CDM export retry after error

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -223,6 +223,18 @@
 - **期待結果**: ボタンが `Exporting...` 表示になり disabled/`aria-busy=true` になる。遅延中に二重クリックしても `/export?format=cdm` リクエストは1回だけ送信される。
 - **スクリプト**: tc-all.js TC-360
 
+## TC-361: CDM Export エラー後の再試行
+- **URL**: /tournaments/[id]
+- **authRequired**: true (admin)
+- **背景**: CDM エクスポート API が失敗しても、ボタンが disabled のまま残ると管理者が再試行できない。
+- **手順**:
+  1. 管理者で大会詳細ページを開く
+  2. CDM Export API が 500 を返す状態を作る
+  3. `CDM Export` ボタンをクリック
+  4. エラー alert 表示後のボタン状態を確認し、もう一度クリックする
+- **期待結果**: エラー alert が表示され、ボタンは disabled 解除かつ `aria-busy=false` になる。再クリックで `/export?format=cdm` リクエストが再送される。
+- **スクリプト**: tc-all.js TC-361
+
 ## TC-201: 各モードページのデータ読み込み確認
 - **URL**: /tournaments/[id]/ta, /bm, /mr, /gp
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/components/tournament/export-button.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/export-button.test.tsx
@@ -131,6 +131,37 @@ describe('ExportButton', () => {
     expect(window.URL.createObjectURL).not.toHaveBeenCalled();
   });
 
+  it('re-enables the button after an HTTP error so the export can be retried', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(new Response('template missing', { status: 500 }))
+      .mockResolvedValueOnce(new Response('template missing', { status: 500 }));
+    const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();
+
+    render(
+      <ExportButton tournamentId="tournament-1" tournamentName="Grand Prix" format="cdm">
+        CDM Export
+      </ExportButton>,
+    );
+
+    const button = screen.getByRole('button', { name: /CDM Export/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Failed to export tournament: Server returned HTTP 500');
+      expect(button).not.toBeDisabled();
+      expect(button).toHaveAttribute('aria-busy', 'false');
+    });
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(window.URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
   it('shows a forbidden export hint when the API returns 403', async () => {
     global.fetch = jest.fn().mockResolvedValue(new Response('Forbidden', { status: 403 }));
     const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3153,6 +3153,57 @@ async function main() {
     }
   }
 
+  // TC-361: CDM Export button re-enables after an HTTP error so admins can retry
+  {
+    const exportTid = sharedFixture?.tournamentId ?? TID;
+    if (exportTid) {
+      let cdmExportHandler = null;
+      let requestCount = 0;
+      try {
+        await nav(page, `/tournaments/${exportTid}`);
+        cdmExportHandler = async (route) => {
+          requestCount += 1;
+          await route.fulfill({
+            status: 500,
+            contentType: 'text/plain',
+            body: 'template missing',
+          });
+        };
+        await page.route(`**/api/tournaments/${exportTid}/export?format=cdm`, cdmExportHandler);
+
+        const cdmButton = page.getByTestId('export-button-cdm');
+        await cdmButton.click();
+        const alert = page.getByRole('alert');
+        await alert.waitFor({ state: 'visible', timeout: 10000 });
+        const firstAlertText = await alert.innerText();
+        const reenabledAfterError = !(await cdmButton.isDisabled());
+        const busyAfterError = await cdmButton.getAttribute('aria-busy') === 'true';
+
+        await cdmButton.click();
+        await page.waitForTimeout(100);
+
+        log('TC-361',
+          firstAlertText.includes('Failed to export tournament') &&
+            reenabledAfterError &&
+            !busyAfterError &&
+            requestCount === 2 ? 'PASS' : 'FAIL',
+          !firstAlertText.includes('Failed to export tournament') ? firstAlertText
+          : !reenabledAfterError ? 'button stayed disabled after export error'
+          : busyAfterError ? 'aria-busy stayed true after export error'
+          : requestCount !== 2 ? `expected retry request count 2, got ${requestCount}`
+          : '');
+      } catch (err) {
+        log('TC-361', 'FAIL', err instanceof Error ? err.message : 'CDM export retry-after-error test failed');
+      } finally {
+        if (cdmExportHandler) {
+          await page.unroute(`**/api/tournaments/${exportTid}/export?format=cdm`, cdmExportHandler).catch(() => {});
+        }
+      }
+    } else {
+      log('TC-361', 'SKIP', 'No tournament ID available');
+    }
+  }
+
   // TC-348: Character stats API — admin gets stats shape, non-admin gets 403
   {
     const statsPid = sharedFixture?.playerIds?.[0];


### PR DESCRIPTION
## Summary
- Add TC-361 to document CDM Export retry behavior after API errors.
- Add automated E2E coverage for retrying after a failed CDM export response.
- Add ExportButton component regression coverage that verifies the button re-enables and can send a retry request after HTTP 500.

## Issues
Closes #880

## Validation
- `npm test -- --runTestsByPath __tests__/components/tournament/export-button.test.tsx` - PASS
- `npm run lint` - PASS with existing warnings
- `node --check e2e/tc-all.js` - PASS
- `git diff --check` - PASS
- `WRANGLER_LOG_PATH=/private/tmp/wrangler-logs WRANGLER_CONFIG_DIR=/private/tmp/wrangler-config XDG_CONFIG_HOME=/private/tmp npm run build` - PASS
- `E2E_HEADLESS=1 E2E_TEST=TC-361 npm run e2e:all` - NOT RUN: Chromium exits before test execution with `bootstrap_check_in ... MachPortRendezvousServer ... Permission denied (1100)` in this sandbox.
