### PR TITLE
test: wait for CDM export retry response

### DIFF
--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3179,8 +3179,14 @@ async function main() {
         const reenabledAfterError = !(await cdmButton.isDisabled());
         const busyAfterError = await cdmButton.getAttribute('aria-busy') === 'true';
 
+        const retryResponsePromise = page.waitForResponse((response) => {
+          const url = new URL(response.url());
+          return url.pathname === `/api/tournaments/${exportTid}/export` &&
+            url.searchParams.get('format') === 'cdm' &&
+            response.status() === 500;
+        }, { timeout: 10000 });
         await cdmButton.click();
-        await page.waitForTimeout(100);
+        await retryResponsePromise;
 
         log('TC-361',
           firstAlertText.includes('Failed to export tournament') &&


### PR DESCRIPTION
## Summary
- Replace TC-361's fixed retry wait with a `page.waitForResponse` condition for the CDM export retry response.

## Issues
Closes #882

## Validation
- `node --check e2e/tc-all.js` - PASS
- `git diff --check` - PASS
- `npm run lint` - PASS with existing warnings
- `E2E_HEADLESS=1 E2E_TEST=TC-361 npm run e2e:all` - NOT RUN in this follow-up: the same sandbox Chromium launch failure from #881 blocks E2E before test execution (`bootstrap_check_in ... MachPortRendezvousServer ... Permission denied (1100)`).
