### PR TITLE
test: wait for failed CDM retry response

### DIFF
--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3183,7 +3183,7 @@ async function main() {
           const url = new URL(response.url());
           return url.pathname === `/api/tournaments/${exportTid}/export` &&
             url.searchParams.get('format') === 'cdm' &&
-            response.status() === 500;
+            !response.ok();
         }, { timeout: 10000 });
         await cdmButton.click();
         await retryResponsePromise;


### PR DESCRIPTION
## Summary
- Relax TC-361's retry response wait from an exact HTTP 500 match to any non-OK CDM export response.

## Issues
Closes #884

## Validation
- `node --check e2e/tc-all.js` - PASS
- `git diff --check` - PASS
- `npm run lint` - PASS with existing warnings
- `E2E_HEADLESS=1 E2E_TEST=TC-361 npm run e2e:all` - NOT RUN: sandbox Chromium launch fails before test execution with `bootstrap_check_in ... MachPortRendezvousServer ... Permission denied (1100)`.
