### PR TITLE
test: clarify TC-839 readonly card assertion

### DIFF
--- a/smkc-score-app/__tests__/e2e/layout-assertions.test.ts
+++ b/smkc-score-app/__tests__/e2e/layout-assertions.test.ts
@@ -1,0 +1,27 @@
+import { assertStackedCardBoxes } from '../../e2e/lib/layout-assertions';
+
+describe('E2E layout assertions', () => {
+  it('accepts stacked card boxes without requiring an exact card count', () => {
+    expect(() => {
+      assertStackedCardBoxes([
+        { y: 10 },
+        { y: 80 },
+        { y: 150 },
+      ], 'readonly cup');
+    }).not.toThrow();
+  });
+
+  it('throws a count-specific error when there are too few card boxes', () => {
+    expect(() => assertStackedCardBoxes([{ y: 10 }], 'readonly cup'))
+      .toThrow('expected at least 2 readonly cup cards, got 1');
+  });
+
+  it('throws a layout-specific error when boxes are not stacked', () => {
+    expect(() => {
+      assertStackedCardBoxes([
+        { y: 10 },
+        { y: 10.5 },
+      ], 'readonly cup');
+    }).toThrow('readonly cup cards are not stacked on mobile');
+  });
+});

--- a/smkc-score-app/e2e/lib/layout-assertions.js
+++ b/smkc-score-app/e2e/lib/layout-assertions.js
@@ -1,0 +1,14 @@
+function assertStackedCardBoxes(boxes, label) {
+  if (boxes.length < 2) {
+    throw new Error(`expected at least 2 ${label} cards, got ${boxes.length}`);
+  }
+
+  const stacked = boxes.every((box, index) => index === 0 || box.y > boxes[index - 1].y + 1);
+  if (!stacked) {
+    throw new Error(`${label} cards are not stacked on mobile`);
+  }
+}
+
+module.exports = {
+  assertStackedCardBoxes,
+};

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -45,6 +45,7 @@ const {
   escapeRegex,
 } = require('./lib/common');
 const { createSharedE2eFixture, setupTaEntriesFromShared, ensurePlayerPassword } = require('./lib/fixtures');
+const { assertStackedCardBoxes } = require('./lib/layout-assertions');
 const { runSuite } = require('./lib/runner');
 
 const results = makeResults();
@@ -296,9 +297,7 @@ async function runTc839(adminPage) {
       if (!box) throw new Error(`readonly cup card ${i + 1} has no bounding box`);
       readonlyBoxes.push(box);
     }
-    const readonlyStacked = readonlyBoxes.length === 4 &&
-      readonlyBoxes.every((box, index) => index === 0 || box.y > readonlyBoxes[index - 1].y + 1);
-    if (!readonlyStacked) throw new Error('readonly cup cards are not stacked on mobile');
+    assertStackedCardBoxes(readonlyBoxes, 'readonly cup');
 
     log('TC-839', 'PASS', `editInputWidth=${Math.round(firstInput.width)} readonlyCards=${readonlyBoxes.length}`);
   } catch (err) {


### PR DESCRIPTION
## Summary
- Extract TC-839 readonly mobile card stacking validation into a reusable E2E layout assertion helper.
- Replace the hard-coded `readonlyBoxes.length === 4` gate with an explicit minimum-card-count error and a separate stacked-layout error.
- Add focused Jest coverage for the helper so changed card counts do not produce misleading layout failures.

## Issues
Closes #876

## Validation
- `git diff --check`
- `npm test -- --runTestsByPath __tests__/e2e/layout-assertions.test.ts --runInBand`
- `npm run lint -- __tests__/e2e/layout-assertions.test.ts`
- `node --check e2e/tc-ta.js`
- `E2E_HEADLESS=1 E2E_TEST=TC-839 npm run e2e:ta` (blocked before test execution: Chromium launch failed with `bootstrap_check_in ... Permission denied (1100)` / SIGTRAP in this macOS sandbox)
