### PR TITLE
test: type E2E layout assertions

### DIFF
--- a/smkc-score-app/__tests__/e2e/layout-assertions.test.ts
+++ b/smkc-score-app/__tests__/e2e/layout-assertions.test.ts
@@ -1,4 +1,4 @@
-import { assertStackedCardBoxes } from '../../e2e/lib/layout-assertions';
+import { assertStackedCardBoxes } from '../../e2e/lib/layout-assertions.ts';
 
 describe('E2E layout assertions', () => {
   it('accepts stacked card boxes without requiring an exact card count', () => {

--- a/smkc-score-app/e2e/lib/layout-assertions.ts
+++ b/smkc-score-app/e2e/lib/layout-assertions.ts
@@ -1,4 +1,8 @@
-function assertStackedCardBoxes(boxes, label) {
+export interface BoundingBox {
+  y: number;
+}
+
+export function assertStackedCardBoxes(boxes: BoundingBox[], label: string): void {
   if (boxes.length < 2) {
     throw new Error(`expected at least 2 ${label} cards, got ${boxes.length}`);
   }
@@ -8,7 +12,3 @@ function assertStackedCardBoxes(boxes, label) {
     throw new Error(`${label} cards are not stacked on mobile`);
   }
 }
-
-module.exports = {
-  assertStackedCardBoxes,
-};

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -44,8 +44,9 @@ const {
   setupTaQualViaUi,
   escapeRegex,
 } = require('./lib/common');
+require('ts-node/register/transpile-only');
 const { createSharedE2eFixture, setupTaEntriesFromShared, ensurePlayerPassword } = require('./lib/fixtures');
-const { assertStackedCardBoxes } = require('./lib/layout-assertions');
+const { assertStackedCardBoxes } = require('./lib/layout-assertions.ts');
 const { runSuite } = require('./lib/runner');
 
 const results = makeResults();


### PR DESCRIPTION
## Summary
- Migrates the shared E2E layout assertion helper from JavaScript to TypeScript.
- Adds an explicit bounding-box type and updates the TA E2E runner/test imports to use the typed helper.

## Issues
Closes #895

## Validation
- `node --check e2e/tc-ta.js`
- `npm test -- --runInBand __tests__/e2e/layout-assertions.test.ts`
- `node -e "require('ts-node/register/transpile-only'); const { assertStackedCardBoxes } = require('./e2e/lib/layout-assertions.ts'); assertStackedCardBoxes([{ y: 1 }, { y: 3 }], 'smoke'); console.log('ok')"`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
- `WRANGLER_HOME=/private/tmp/jsmkc-wrangler-home XDG_CONFIG_HOME=/private/tmp/jsmkc-wrangler-config npm run build`
