### PR TITLE
test: clarify TA E2E TypeScript helper loading

### DIFF
--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -30,6 +30,9 @@
  *
  * Run: node e2e/tc-ta.js  (from smkc-score-app/)
  */
+// Required before loading TypeScript E2E helper modules.
+require('ts-node/register/transpile-only');
+
 const {
   makeResults, makeLog, nav,
   uiSetTaEntryTimes,
@@ -44,9 +47,8 @@ const {
   setupTaQualViaUi,
   escapeRegex,
 } = require('./lib/common');
-require('ts-node/register/transpile-only');
 const { createSharedE2eFixture, setupTaEntriesFromShared, ensurePlayerPassword } = require('./lib/fixtures');
-const { assertStackedCardBoxes } = require('./lib/layout-assertions.ts');
+const { assertStackedCardBoxes } = require('./lib/layout-assertions');
 const { runSuite } = require('./lib/runner');
 
 const results = makeResults();


### PR DESCRIPTION
## Summary
- Moves the ts-node registration to the top of the TA E2E entrypoint.
- Documents why the side-effect registration is required before loading TypeScript E2E helpers.
- Uses extensionless runtime import for the TA runner after ts-node registration.

## Issues
Closes #900

## Validation
- `node --check e2e/tc-ta.js`
- `npm test -- --runInBand __tests__/e2e/layout-assertions.test.ts`
- `node -e "require('./e2e/tc-ta.js');"`
- `git diff --check`

Note: #899 was validated separately and closed as false-positive because extensionless test import currently resolves to `layout-assertions.js` under Jest/SWC and fails.
