### PR TITLE
[codex] Improve TA mobile time input hints

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
@@ -2,6 +2,7 @@ import {
   TA_FINALS_ROUND_ENTRY_ROW_CLASS,
   TA_FINALS_ROUND_PLAYER_NAME_CLASS,
   TA_TIME_ENTRY_CUP_GRID_CLASS,
+  TA_TIME_INPUT_PLACEHOLDER,
   TA_TIME_INPUT_PROPS,
 } from "@/lib/ta/time-entry-layout";
 
@@ -18,7 +19,9 @@ describe("TA time entry layout", () => {
       inputMode: "decimal",
       pattern: "[0-9:.]*",
       autoComplete: "off",
+      title: "Enter 123.45 or 1:23.45",
     });
+    expect(TA_TIME_INPUT_PLACEHOLDER).toBe("123.45");
   });
 
   it("keeps TA finals player names on their own mobile row before sm layout", () => {

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -83,6 +83,7 @@ import {
   TA_FINALS_ROUND_PLAYER_LABEL_CLASS,
   TA_FINALS_ROUND_PLAYER_NAME_CLASS,
   TA_FINALS_TIME_INPUT_CLASS,
+  TA_TIME_INPUT_PLACEHOLDER,
   TA_TIME_INPUT_PROPS,
 } from "@/lib/ta/time-entry-layout";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
@@ -879,7 +880,7 @@ export default function TimeAttackFinals({
                   <Input
                     type="text"
                     {...TA_TIME_INPUT_PROPS}
-                    placeholder={tTaFinals('timePlaceholder')}
+                    placeholder={TA_TIME_INPUT_PLACEHOLDER}
                     value={suddenDeathTimes[entry.playerId] || ""}
                     onChange={(e) => setSuddenDeathTimes((prev) => ({ ...prev, [entry.playerId]: e.target.value }))}
                     className={TA_FINALS_TIME_INPUT_CLASS}
@@ -955,7 +956,7 @@ export default function TimeAttackFinals({
                     <Input
                       type="text"
                       {...TA_TIME_INPUT_PROPS}
-                      placeholder={tTaFinals('timePlaceholder')}
+                      placeholder={TA_TIME_INPUT_PLACEHOLDER}
                       value={courseTimes[entry.playerId] || ""}
                       onChange={(e) =>
                         handleTimeChange(entry.playerId, e.target.value)

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
@@ -67,7 +67,7 @@ import { COURSE_INFO, POLLING_INTERVAL, TOTAL_COURSES, TV_NUMBER_OPTIONS } from 
 import { applyAutoPairsToSetup } from "@/lib/ta/pair-utils";
 import { canEditTaEntry } from "@/lib/ta/entry-access";
 import { calculateCourseFirstPlaceCounts } from "@/lib/ta/qualification-results";
-import { TA_TIME_ENTRY_CUP_GRID_CLASS, TA_TIME_INPUT_PROPS } from "@/lib/ta/time-entry-layout";
+import { TA_TIME_ENTRY_CUP_GRID_CLASS, TA_TIME_INPUT_PLACEHOLDER, TA_TIME_INPUT_PROPS } from "@/lib/ta/time-entry-layout";
 import { extractArrayData } from "@/lib/api-response";
 import { autoFormatTime, generateRandomTimeString, msToDisplayTime, timeToMs } from "@/lib/ta/time-utils";
 import { usePolling } from "@/lib/hooks/usePolling";
@@ -1500,7 +1500,7 @@ export default function TimeAttackPageClient({
                         <Input
                           type="text"
                           {...TA_TIME_INPUT_PROPS}
-                          placeholder="M:SS.mm"
+                          placeholder={TA_TIME_INPUT_PLACEHOLDER}
                           value={timeInputs[course.abbr] || ""}
                           onChange={(e) =>
                             handleTimeChange(course.abbr, e.target.value)

--- a/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
@@ -38,7 +38,7 @@ import { AlertTriangle, Trophy, Users, Timer, LogIn, Dice5, Lock } from 'lucide-
 import Link from 'next/link';
 import { COURSE_INFO, POLLING_INTERVAL, TOTAL_COURSES } from '@/lib/constants';
 import { autoFormatTime, generateRandomTimeString, msToDisplayTime } from '@/lib/ta/time-utils';
-import { TA_TIME_ENTRY_CUP_GRID_CLASS, TA_TIME_INPUT_PROPS } from '@/lib/ta/time-entry-layout';
+import { TA_TIME_ENTRY_CUP_GRID_CLASS, TA_TIME_INPUT_PLACEHOLDER, TA_TIME_INPUT_PROPS } from '@/lib/ta/time-entry-layout';
 import { toast } from 'sonner';
 import { createLogger } from '@/lib/client-logger';
 import { fetchWithRetry } from "@/lib/fetch-with-retry";
@@ -579,7 +579,7 @@ export default function TimeAttackParticipantPage({
                                   <Input
                                     type="text"
                                     {...TA_TIME_INPUT_PROPS}
-                                    placeholder="M:SS.mm"
+                                    placeholder={TA_TIME_INPUT_PLACEHOLDER}
                                     value={partnerTimeInputs[course.abbr] || ''}
                                     onChange={(e) => handlePartnerTimeChange(course.abbr, e.target.value)}
                                     onBlur={() => handlePartnerTimeBlur(course.abbr)}
@@ -673,7 +673,7 @@ export default function TimeAttackParticipantPage({
                                   <Input
                                     type="text"
                                     {...TA_TIME_INPUT_PROPS}
-                                    placeholder="M:SS.mm"
+                                    placeholder={TA_TIME_INPUT_PLACEHOLDER}
                                     value={timeInputs[course.abbr] || ''}
                                     onChange={(e) => handleTimeChange(course.abbr, e.target.value)}
                                     onBlur={() => handleTimeBlur(course.abbr)}

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -66,6 +66,7 @@ import {
   TA_FINALS_ROUND_PLAYER_LABEL_CLASS,
   TA_FINALS_ROUND_PLAYER_NAME_CLASS,
   TA_FINALS_TIME_INPUT_CLASS,
+  TA_TIME_INPUT_PLACEHOLDER,
   TA_TIME_INPUT_PROPS,
 } from "@/lib/ta/time-entry-layout";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
@@ -812,7 +813,7 @@ export default function TAEliminationPhase({
                   <Input
                     type="text"
                     {...TA_TIME_INPUT_PROPS}
-                    placeholder="M:SS.mm"
+                    placeholder={TA_TIME_INPUT_PLACEHOLDER}
                     value={suddenDeathTimes[entry.playerId] || ""}
                     onChange={(e) => setSuddenDeathTimes((prev) => ({ ...prev, [entry.playerId]: e.target.value }))}
                     className={TA_FINALS_TIME_INPUT_CLASS}
@@ -881,7 +882,7 @@ export default function TAEliminationPhase({
                     <Input
                       type="text"
                       {...TA_TIME_INPUT_PROPS}
-                      placeholder="M:SS.mm"
+                      placeholder={TA_TIME_INPUT_PLACEHOLDER}
                       value={courseTimes[entry.playerId] || ""}
                       onChange={(e) =>
                         handleTimeChange(entry.playerId, e.target.value)

--- a/smkc-score-app/src/lib/ta/time-entry-layout.ts
+++ b/smkc-score-app/src/lib/ta/time-entry-layout.ts
@@ -1,9 +1,12 @@
 export const TA_TIME_ENTRY_CUP_GRID_CLASS = "grid grid-cols-1 gap-4 md:grid-cols-2";
 
+export const TA_TIME_INPUT_PLACEHOLDER = "123.45";
+
 export const TA_TIME_INPUT_PROPS = {
   inputMode: "decimal",
   pattern: "[0-9:.]*",
   autoComplete: "off",
+  title: "Enter 123.45 or 1:23.45",
 } as const;
 
 export const TA_FINALS_ROUND_ENTRY_ROW_CLASS =


### PR DESCRIPTION
## Summary
- Keep TA time fields on the iOS decimal keyboard path, but make colon-free input the visible default.
- Replace TA time placeholders with `123.45` across admin, participant, finals, and elimination time inputs.
- Keep `:` accepted for users who can type `1:23.45`, and add a shared title hint for both accepted forms.

## Why
iOS decimal keyboards expose `.` but not `:`, so the UI should not imply that colon entry is required on mobile. Existing auto-formatting already converts inputs such as `123.45` / `123456` into `1:23.45` style values on blur.

Related: #897

## Validation
- `npm run lint -- --fix src/lib/ta/time-entry-layout.ts 'src/app/tournaments/[id]/ta/page-client.tsx' 'src/app/tournaments/[id]/ta/participant/page.tsx' 'src/app/tournaments/[id]/ta/finals/page.tsx' src/components/tournament/ta-elimination-phase.tsx __tests__/lib/ta/time-entry-layout.test.ts`
- `npm test -- --runTestsByPath __tests__/lib/ta/time-entry-layout.test.ts __tests__/lib/ta/time-utils.test.ts`
