### PR TITLE
[codex] Derive TA Nb count expectation

### DIFF
--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -346,7 +346,7 @@ async function runTc837(adminPage) {
       .innerText({ timeout: 15000 })
       .catch(() => '');
     const expectedP1Count = TA_COURSES.length - 1;
-    const expectedP2Count = 1;
+    const expectedP2Count = TA_COURSES.length - expectedP1Count;
     const valueOk =
       p1CellText.trim() === String(expectedP1Count) &&
       p2CellText.trim() === String(expectedP2Count);


### PR DESCRIPTION
## Summary

- derive TC-837 expectedP2Count from TA_COURSES.length and expectedP1Count

## Validation

- node --check e2e/tc-ta.js

Follow-up to #909.
Fixes #911
