### PR TITLE
[codex] Fix TA phase3 life reset eliminations

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -671,14 +671,98 @@ describe("TA Finals Phase Manager", () => {
     });
 
     it("returns a sudden-death request for tied slowest players", async () => {
+      mockPrismaClient.tTEntry.findMany.mockResolvedValue([
+        { playerId: "p1", eliminated: false },
+        { playerId: "p2", eliminated: false },
+        { playerId: "p3", eliminated: false },
+        { playerId: "p4", eliminated: false },
+        { playerId: "p5", eliminated: false },
+      ]);
+      mockPrismaClient.tTPhaseSuddenDeathRound.create.mockResolvedValue({
+        id: "sd1",
+        phaseRoundId: "round1",
+        sequence: 1,
+        course: "DP1",
+        targetPlayerIds: ["p4", "p5"],
+        resolved: false,
+      });
+
       const result = await submitRoundResults(mockPrismaClient as any, context, "phase1", 1, [
         { playerId: "p1", timeMs: 80000 },
-        { playerId: "p2", timeMs: 90000 },
-        { playerId: "p3", timeMs: 90000 },
+        { playerId: "p2", timeMs: 81000 },
+        { playerId: "p3", timeMs: 82000 },
+        { playerId: "p4", timeMs: 90000 },
+        { playerId: "p5", timeMs: 90000 },
       ]);
 
       expect(result.tieBreakRequired).toBe(true);
       expect(result.suddenDeathRound).toEqual(expect.objectContaining({ id: "sd1" }));
+      expect(mockPrismaClient.tTEntry.update).not.toHaveBeenCalled();
+    });
+
+    it("returns a sudden-death request for tied slowest players in phase2", async () => {
+      mockPrismaClient.tTPhaseRound.findUnique.mockResolvedValue({
+        id: "round1",
+        tournamentId: "t1",
+        phase: "phase2",
+        roundNumber: 1,
+        course: "MC1",
+        results: [],
+      });
+      mockPrismaClient.tTEntry.findMany.mockResolvedValue([
+        { playerId: "p1", eliminated: false },
+        { playerId: "p2", eliminated: false },
+        { playerId: "p3", eliminated: false },
+        { playerId: "p4", eliminated: false },
+        { playerId: "p5", eliminated: false },
+      ]);
+      mockPrismaClient.tTPhaseSuddenDeathRound.create.mockResolvedValue({
+        id: "sd1",
+        phaseRoundId: "round1",
+        sequence: 1,
+        course: "DP1",
+        targetPlayerIds: ["p4", "p5"],
+        resolved: false,
+      });
+
+      const result = await submitRoundResults(mockPrismaClient as any, context, "phase2", 1, [
+        { playerId: "p1", timeMs: 80000 },
+        { playerId: "p2", timeMs: 81000 },
+        { playerId: "p3", timeMs: 82000 },
+        { playerId: "p4", timeMs: 90000 },
+        { playerId: "p5", timeMs: 90000 },
+      ]);
+
+      expect(result.tieBreakRequired).toBe(true);
+      expect(mockPrismaClient.tTPhaseSuddenDeathRound.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            phase: "phase2",
+            targetPlayerIds: ["p4", "p5"],
+          }),
+        })
+      );
+      expect(mockPrismaClient.tTEntry.update).not.toHaveBeenCalled();
+    });
+
+    it("does not create phase1 sudden death after the survivor threshold is already reached", async () => {
+      mockPrismaClient.tTEntry.findMany.mockResolvedValue([
+        { playerId: "p1", eliminated: false },
+        { playerId: "p2", eliminated: false },
+        { playerId: "p3", eliminated: false },
+        { playerId: "p4", eliminated: false },
+      ]);
+
+      const result = await submitRoundResults(mockPrismaClient as any, context, "phase1", 1, [
+        { playerId: "p1", timeMs: 80000 },
+        { playerId: "p2", timeMs: 81000 },
+        { playerId: "p3", timeMs: 90000 },
+        { playerId: "p4", timeMs: 90000 },
+      ]);
+
+      expect(result.tieBreakRequired).toBeUndefined();
+      expect(result.eliminatedIds).toEqual([]);
+      expect(mockPrismaClient.tTPhaseSuddenDeathRound.create).not.toHaveBeenCalled();
       expect(mockPrismaClient.tTEntry.update).not.toHaveBeenCalled();
     });
 
@@ -837,6 +921,135 @@ describe("TA Finals Phase Manager", () => {
           data: expect.objectContaining({
             targetPlayerIds: ["p2", "p3"],
           }),
+        })
+      );
+    });
+
+    it("requires phase3 sudden death when tied eliminations would skip the 8-player life reset", async () => {
+      mockPrismaClient.tTPhaseRound.findUnique.mockResolvedValue({
+        id: "round1",
+        tournamentId: "t1",
+        phase: "phase3",
+        roundNumber: 1,
+        course: "MC1",
+        results: [],
+      });
+      mockPrismaClient.tTEntry.findMany.mockResolvedValue(
+        Array.from({ length: 9 }, (_, index) => ({
+          playerId: `p${index + 1}`,
+          eliminated: false,
+          lives: index >= 5 ? 1 : 3,
+        }))
+      );
+      mockPrismaClient.tTPhaseRound.findMany.mockResolvedValue([]);
+      mockPrismaClient.tTPhaseSuddenDeathRound.count.mockResolvedValue(0);
+      mockPrismaClient.tTPhaseSuddenDeathRound.create.mockResolvedValue({
+        id: "sd1",
+        targetPlayerIds: ["p8", "p9"],
+        resolved: false,
+      });
+
+      const result = await submitRoundResults(mockPrismaClient as any, context, "phase3", 1, [
+        { playerId: "p1", timeMs: 80000 },
+        { playerId: "p2", timeMs: 81000 },
+        { playerId: "p3", timeMs: 82000 },
+        { playerId: "p4", timeMs: 83000 },
+        { playerId: "p5", timeMs: 84000 },
+        { playerId: "p6", timeMs: 85000 },
+        { playerId: "p7", timeMs: 86000 },
+        { playerId: "p8", timeMs: 90000 },
+        { playerId: "p9", timeMs: 90000 },
+      ]);
+
+      expect(result.tieBreakRequired).toBe(true);
+      expect(mockPrismaClient.tTEntry.update).not.toHaveBeenCalled();
+      expect(mockPrismaClient.tTPhaseSuddenDeathRound.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            targetPlayerIds: ["p8", "p9"],
+          }),
+        })
+      );
+    });
+
+    it("resolves phase3 sudden death by eliminating only enough players to hit 8 and reset lives", async () => {
+      mockPrismaClient.tTPhaseSuddenDeathRound.findUnique.mockResolvedValue({
+        id: "sd1",
+        tournamentId: "t1",
+        phase: "phase3",
+        phaseRoundId: "round1",
+        targetPlayerIds: ["p8", "p9"],
+        resolved: false,
+        phaseRound: {
+          id: "round1",
+          course: "MC1",
+          results: [
+            { playerId: "p1", timeMs: 80000 },
+            { playerId: "p2", timeMs: 81000 },
+            { playerId: "p3", timeMs: 82000 },
+            { playerId: "p4", timeMs: 83000 },
+            { playerId: "p5", timeMs: 84000 },
+            { playerId: "p6", timeMs: 85000 },
+            { playerId: "p7", timeMs: 86000 },
+            { playerId: "p8", timeMs: 90000 },
+            { playerId: "p9", timeMs: 90000 },
+          ],
+        },
+      });
+      mockPrismaClient.tTPhaseSuddenDeathRound.update.mockResolvedValue({});
+      mockPrismaClient.tTEntry.findMany
+        .mockResolvedValueOnce(
+          Array.from({ length: 9 }, (_, index) => ({
+            id: `entry-p${index + 1}`,
+            playerId: `p${index + 1}`,
+            eliminated: false,
+            lives: index >= 5 ? 1 : 3,
+          }))
+        )
+        .mockResolvedValueOnce(
+          Array.from({ length: 8 }, (_, index) => ({
+            id: `entry-p${index + 1}`,
+            playerId: `p${index + 1}`,
+            eliminated: false,
+            lives: index >= 5 ? 0 : 3,
+          }))
+        );
+      mockPrismaClient.tTEntry.findUnique.mockImplementation(({ where }) => {
+        const playerId = where.tournamentId_playerId_stage.playerId;
+        const index = Number(playerId.slice(1));
+        return Promise.resolve({
+          id: `entry-${playerId}`,
+          playerId,
+          eliminated: false,
+          lives: index >= 6 ? 1 : 3,
+        });
+      });
+      mockPrismaClient.tTEntry.update.mockResolvedValue({});
+      mockPrismaClient.tTEntry.updateMany.mockResolvedValue({ count: 8 });
+
+      const result = await submitSuddenDeathResults(mockPrismaClient as any, context, "phase3", "sd1", [
+        { playerId: "p8", timeMs: 88000 },
+        { playerId: "p9", timeMs: 89000 },
+      ]);
+
+      expect(result.eliminatedIds).toEqual(["p9"]);
+      expect(result.livesReset).toBe(true);
+      expect(mockPrismaClient.tTEntry.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "entry-p9" },
+          data: { lives: 0, eliminated: true },
+        })
+      );
+      expect(mockPrismaClient.tTEntry.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "entry-p8" },
+          data: expect.objectContaining({ eliminated: true }),
+        })
+      );
+      expect(mockPrismaClient.tTEntry.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { tournamentId: "t1", stage: "phase3", eliminated: false },
+          data: { lives: 3 },
         })
       );
     });

--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -73,6 +73,18 @@ export const PHASE_CONFIG = {
   },
 } as const;
 
+function getNextPhase3ResetThreshold(activeCount: number): number | null {
+  const thresholds = [...PHASE_CONFIG.phase3.lifeResetThresholds]
+    .filter((threshold) => threshold < activeCount)
+    .sort((a, b) => b - a);
+  return thresholds[0] ?? (activeCount > 1 ? 1 : null);
+}
+
+function getPhase3EliminationLimit(activeCount: number): number {
+  const nextThreshold = getNextPhase3ResetThreshold(activeCount);
+  return nextThreshold === null ? Number.POSITIVE_INFINITY : activeCount - nextThreshold;
+}
+
 /**
  * Context for promotion/phase operations.
  * Contains user identity and request metadata for audit logging.
@@ -660,6 +672,15 @@ export async function processPhase3Result(
   const halfwayPoint = Math.ceil(sortedResults.length / 2);
   const bottomHalf = sortedResults.slice(halfwayPoint);
 
+  const eliminationLimit = getPhase3EliminationLimit(activePlayers.length);
+  const currentLivesByPlayer = new Map(activePlayers.map((entry) => [entry.playerId, entry.lives]));
+  const selectedEliminationIds = new Set(
+    bottomHalf
+      .filter((result) => (currentLivesByPlayer.get(result.playerId) ?? 0) - 1 <= 0)
+      .sort((a, b) => b.timeMs - a.timeMs)
+      .slice(0, eliminationLimit)
+      .map((result) => result.playerId)
+  );
   const eliminatedPlayers: string[] = [];
 
   for (const result of bottomHalf) {
@@ -677,17 +698,18 @@ export async function processPhase3Result(
     if (entry && !entry.eliminated) {
       const newLives = entry.lives - 1;
       const isEliminated = newLives <= 0;
+      const selectedForElimination = isEliminated && selectedEliminationIds.has(result.playerId);
 
       // Update lives and elimination status
       await prisma.tTEntry.update({
         where: { id: entry.id },
         data: {
           lives: Math.max(0, newLives),
-          eliminated: isEliminated,
+          eliminated: selectedForElimination,
         },
       });
 
-      if (isEliminated) {
+      if (selectedForElimination) {
         eliminatedPlayers.push(result.playerId);
       }
 
@@ -703,7 +725,7 @@ export async function processPhase3Result(
           details: {
             tournamentId,
             phase: "phase3",
-            action: isEliminated ? "eliminated" : "life_lost",
+            action: selectedForElimination ? "eliminated" : "life_lost",
             oldLives: entry.lives,
             newLives: Math.max(0, newLives),
             timeMs: result.timeMs,
@@ -869,16 +891,21 @@ export interface SuddenDeathResultInput {
 
 interface TieBreakDecision {
   targetPlayerIds: string[];
-  reason: "slowest_tie" | "phase3_boundary_tie";
+  reason: "slowest_tie" | "phase3_boundary_tie" | "phase3_reset_elimination_tie";
 }
 
 function detectTieBreakRequired(
   phase: "phase1" | "phase2" | "phase3",
-  courseResults: CourseResult[]
+  courseResults: CourseResult[],
+  activePlayers: TTEntry[] = []
 ): TieBreakDecision | null {
   if (courseResults.length < 2) return null;
 
   if (phase === "phase1" || phase === "phase2") {
+    const config = PHASE_CONFIG[phase];
+    if (activePlayers.length > 0 && activePlayers.length <= config.survivorsNeeded) {
+      return null;
+    }
     const maxTime = Math.max(...courseResults.map((result) => result.timeMs));
     const tiedSlowest = courseResults.filter((result) => result.timeMs === maxTime);
     return tiedSlowest.length > 1
@@ -889,6 +916,28 @@ function detectTieBreakRequired(
   const sorted = [...courseResults].sort((a, b) => a.timeMs - b.timeMs);
   const halfwayPoint = Math.ceil(sorted.length / 2);
   if (halfwayPoint <= 0 || halfwayPoint >= sorted.length) return null;
+  const bottomHalf = sorted.slice(halfwayPoint);
+
+  const eliminationLimit = getPhase3EliminationLimit(activePlayers.length || sorted.length);
+  if (Number.isFinite(eliminationLimit)) {
+    const currentLivesByPlayer = new Map(activePlayers.map((entry) => [entry.playerId, entry.lives]));
+    const eliminationCandidates = bottomHalf
+      .filter((result) => (currentLivesByPlayer.get(result.playerId) ?? PHASE_CONFIG.phase3.initialLives) - 1 <= 0)
+      .sort((a, b) => b.timeMs - a.timeMs);
+    if (eliminationCandidates.length > eliminationLimit) {
+      const lastEliminated = eliminationCandidates[eliminationLimit - 1];
+      const firstSaved = eliminationCandidates[eliminationLimit];
+      if (lastEliminated?.timeMs === firstSaved?.timeMs) {
+        const boundaryTime = lastEliminated.timeMs;
+        return {
+          targetPlayerIds: eliminationCandidates
+            .filter((result) => result.timeMs === boundaryTime)
+            .map((result) => result.playerId),
+          reason: "phase3_reset_elimination_tie",
+        };
+      }
+    }
+  }
 
   const boundarySafe = sorted[halfwayPoint - 1];
   const boundaryUnsafe = sorted[halfwayPoint];
@@ -942,7 +991,9 @@ function getSuddenDeathContinuationTargets(
   const safeSuddenTime = suddenByPlayer.get(safeBoundary.playerId);
   const unsafeSuddenTime = suddenByPlayer.get(unsafeBoundary.playerId);
   if (safeSuddenTime === undefined || unsafeSuddenTime === undefined || safeSuddenTime !== unsafeSuddenTime) {
-    return [];
+    const slowestSuddenTime = Math.max(...suddenDeathResults.map((result) => result.timeMs));
+    const stillTiedForElimination = suddenDeathResults.filter((result) => result.timeMs === slowestSuddenTime);
+    return stillTiedForElimination.length > 1 ? stillTiedForElimination.map((result) => result.playerId) : [];
   }
 
   return suddenDeathResults
@@ -1257,7 +1308,7 @@ export async function submitRoundResults(
   let eliminatedIds: string[] = [];
   let livesReset = false;
 
-  const tieBreak = detectTieBreakRequired(phase, processedResults);
+  const tieBreak = detectTieBreakRequired(phase, processedResults, activePlayers);
   if (tieBreak) {
     await prisma.tTPhaseRound.update({
       where: { id: round.id },


### PR DESCRIPTION
## Summary
- Fix TA phase3 life-based elimination so player counts stop at reset thresholds instead of skipping from 9 to 5 when multiple bottom-half players hit 0 lives.
- Add sudden-death detection for tied elimination boundaries that would otherwise decide who is eliminated at the 8-player reset threshold.
- Keep phase1/phase2 sudden death scoped to active elimination rounds, and cover phase2 plus completed-threshold behavior in unit tests.

## Validation
- npx eslint --fix src/lib/ta/finals-phase-manager.ts __tests__/lib/ta/finals-phase-manager.test.ts
- npm test -- __tests__/lib/ta/finals-phase-manager.test.ts --runInBand
- npx tsc --noEmit --allowImportingTsExtensions
- git diff --check

## Notes
- Full npm run lint was attempted after autofix, but it still fails on an existing unrelated react-hooks/set-state-in-effect error in src/app/tournaments/[id]/gp/participant/page.tsx.
