### PR TITLE
[codex] Share TA finals course history across phases

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
@@ -2,13 +2,13 @@
  * Tests for TA Finals Random Course Selection
  *
  * Validates the "no repeat until all 20 used" rule:
- * - Each phase has its own independent 20-course cycle
+ * - Finals phases share one 20-course cycle in phase order
  * - Courses are removed from the pool as they are played
  * - When all 20 are used, the cycle resets
  * - getAvailableCourses is a pure function for easy testing
  */
 
-import { getAvailableCourses, isValidCourseAbbr } from "@/lib/ta/course-selection";
+import { getAvailableCourses, getPlayedCoursesWithSuddenDeath, isValidCourseAbbr } from "@/lib/ta/course-selection";
 import { COURSES } from "@/lib/constants";
 
 describe("getAvailableCourses", () => {
@@ -108,5 +108,96 @@ describe("isValidCourseAbbr", () => {
   it("returns false for a lowercase version of a valid abbreviation", () => {
     // Course abbreviations are case-sensitive; "mc1" is not in the list
     expect(isValidCourseAbbr("mc1")).toBe(false);
+  });
+});
+
+describe("getPlayedCoursesWithSuddenDeath", () => {
+  it("carries course history forward from phase1 to phase2", async () => {
+    const prisma = {
+      tTPhaseRound: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: "p2-r1",
+            phase: "phase2",
+            roundNumber: 1,
+            course: "DP1",
+            suddenDeathRounds: [],
+          },
+          {
+            id: "p1-r1",
+            phase: "phase1",
+            roundNumber: 1,
+            course: "KB1",
+            suddenDeathRounds: [],
+          },
+        ]),
+      },
+    };
+
+    const played = await getPlayedCoursesWithSuddenDeath(prisma as any, "t1", "phase2");
+
+    expect(prisma.tTPhaseRound.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { tournamentId: "t1", phase: { in: ["phase1", "phase2"] } },
+      })
+    );
+    expect(played).toEqual(["KB1", "DP1"]);
+    expect(getAvailableCourses(played)).not.toContain("KB1");
+  });
+
+  it("counts sudden-death courses from earlier phases as consumed", async () => {
+    const prisma = {
+      tTPhaseRound: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: "p1-r1",
+            phase: "phase1",
+            roundNumber: 1,
+            course: "MC1",
+            suddenDeathRounds: [
+              { id: "sd1", course: "KB1" },
+            ],
+          },
+          {
+            id: "p2-r1",
+            phase: "phase2",
+            roundNumber: 1,
+            course: "DP1",
+            suddenDeathRounds: [],
+          },
+        ]),
+      },
+    };
+
+    const played = await getPlayedCoursesWithSuddenDeath(prisma as any, "t1", "phase2");
+
+    expect(played).toEqual(["MC1", "KB1", "DP1"]);
+    expect(getAvailableCourses(played)).not.toContain("KB1");
+  });
+
+  it("excludes an unresolved sudden-death round when changing that course", async () => {
+    const prisma = {
+      tTPhaseRound: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: "p1-r1",
+            phase: "phase1",
+            roundNumber: 1,
+            course: "MC1",
+            suddenDeathRounds: [
+              { id: "sd-old", course: "KB1" },
+              { id: "sd-current", course: "DP1" },
+            ],
+          },
+        ]),
+      },
+    };
+
+    const played = await getPlayedCoursesWithSuddenDeath(prisma as any, "t1", "phase1", {
+      excludeSuddenDeathRoundId: "sd-current",
+    });
+
+    expect(played).toEqual(["MC1", "KB1"]);
+    expect(played).not.toContain("DP1");
   });
 });

--- a/smkc-score-app/src/lib/ta/course-selection.ts
+++ b/smkc-score-app/src/lib/ta/course-selection.ts
@@ -2,7 +2,7 @@
  * Random Course Selection for TA Finals Phases
  *
  * Implements the "no repeat until all 20 used" rule from the SMK tournament rulebook:
- * - Each phase maintains its own independent course cycle
+ * - Finals phases share one course cycle in phase order
  * - Courses are selected randomly from the pool of unplayed courses
  * - Once all 20 courses have been played, the cycle resets (all become available again)
  * - Selection is server-side to prevent race conditions between concurrent admins
@@ -22,6 +22,14 @@ import type { PrismaTransaction } from "@/types/prisma-extended";
  * for race-condition-safe round creation.
  */
 type DbClient = PrismaClient | PrismaTransaction;
+
+const PHASE_ORDER = ["phase1", "phase2", "phase3"] as const;
+
+function getCourseHistoryPhases(phase: string): string[] {
+  const phaseIndex = PHASE_ORDER.indexOf(phase as (typeof PHASE_ORDER)[number]);
+  if (phaseIndex === -1) return [phase];
+  return PHASE_ORDER.slice(0, phaseIndex + 1);
+}
 
 /**
  * Fetch the ordered list of courses already played in the current phase.
@@ -48,6 +56,12 @@ export async function getPlayedCourses(
 
 /**
  * Fetch played courses including adopted sudden-death courses.
+ *
+ * Course history is shared across TA finals phases. Asking for phase2 includes
+ * phase1 and phase2 courses; asking for phase3 includes all finals phases up
+ * through phase3. This prevents repeats such as KB1 appearing in both phase1
+ * and phase2 before the 20-course cycle is exhausted.
+ *
  * A sudden-death course is "adopted" as soon as its row exists; if an admin
  * changes an unresolved sudden-death course, the row is updated, so only the
  * final selected course remains in this history.
@@ -58,12 +72,15 @@ export async function getPlayedCoursesWithSuddenDeath(
   phase: string,
   options: { excludeSuddenDeathRoundId?: string } = {}
 ): Promise<string[]> {
+  const phases = getCourseHistoryPhases(phase);
   const rounds = await prisma.tTPhaseRound.findMany({
-    where: { tournamentId, phase },
-    orderBy: { roundNumber: "asc" },
+    where: { tournamentId, phase: { in: phases } },
+    orderBy: [{ phase: "asc" }, { roundNumber: "asc" }],
     select: {
       id: true,
+      phase: true,
       course: true,
+      roundNumber: true,
       suddenDeathRounds: {
         orderBy: { sequence: "asc" },
         select: { id: true, course: true },
@@ -72,7 +89,11 @@ export async function getPlayedCoursesWithSuddenDeath(
   });
 
   const courses: string[] = [];
-  for (const round of rounds) {
+  const orderedRounds = [...rounds].sort((a, b) => {
+    const phaseDiff = phases.indexOf(a.phase) - phases.indexOf(b.phase);
+    return phaseDiff || a.roundNumber - b.roundNumber;
+  });
+  for (const round of orderedRounds) {
     courses.push(round.course);
     for (const suddenDeathRound of round.suddenDeathRounds ?? []) {
       if (suddenDeathRound.id !== options.excludeSuddenDeathRoundId) {
@@ -142,7 +163,7 @@ export function isValidCourseAbbr(value: string): value is CourseAbbr {
 /**
  * Select a random course for the next round in a phase.
  *
- * Combines getPlayedCourses + getAvailableCourses to select a random
+ * Combines cumulative played-course history + getAvailableCourses to select a random
  * unplayed course from the current 20-course cycle.
  *
  * @param prisma - Prisma client instance

--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -32,7 +32,6 @@ import { createAuditLog, AUDIT_ACTIONS } from "@/lib/audit-log";
 import { createLogger } from "@/lib/logger";
 import {
   selectRandomCourse,
-  getPlayedCourses,
   getAvailableCourses,
   getPlayedCoursesWithSuddenDeath,
   selectRandomAvailableCourse,
@@ -1044,7 +1043,7 @@ async function createSuddenDeathRound(
 /**
  * Start a new round for a phase.
  *
- * Selects a random course from the unused pool (20-course cycle per phase),
+ * Selects a random course from the unused pool (20-course cycle shared across TA finals phases),
  * creates a TTPhaseRound record with an empty results array,
  * and returns the round number and selected course.
  *
@@ -1109,7 +1108,7 @@ export async function startPhaseRound(
       }
       // Validate the course is still available in the current cycle
       // (not already played in the current 20-course block)
-      const playedCourses = await getPlayedCourses(prisma, tournamentId, phase);
+      const playedCourses = await getPlayedCoursesWithSuddenDeath(prisma, tournamentId, phase);
       const available = getAvailableCourses(playedCourses);
       if (!available.includes(manualCourse as CourseAbbr)) {
         throw new Error(


### PR DESCRIPTION
## Summary
- Share TA finals course history across phase1, phase2, and phase3 so a course used in an earlier phase is consumed in later phases until the 20-course cycle resets.
- Include sudden-death courses in that shared history, including sudden-death courses from previous phases.
- Validate manual course overrides against the same shared history so admins cannot manually select an already-consumed course.

## Validation
- npm test -- __tests__/lib/ta/course-selection.test.ts __tests__/lib/ta/finals-phase-manager.test.ts --runInBand
- npx eslint src/lib/ta/course-selection.ts src/lib/ta/finals-phase-manager.ts __tests__/lib/ta/course-selection.test.ts
- npx tsc --noEmit --allowImportingTsExtensions
- npm test -- --runTestsByPath __tests__/app/api/tournaments/[id]/ta/phases/route.test.ts --runInBand
- git diff --check
