### PR TITLE
fix: limit GP finals cupResults

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1595,6 +1595,18 @@
 - **期待結果**: GP決勝FT2では1カップ勝利で試合が終わらず、2カップ先取で初めて完了する
 - **スクリプト**: tc-gp.js TC-720
 
+## TC-832: GP決勝 — `cupResults` の過大配列を拒否
+- **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)
+- **authRequired**: true (admin)
+- **背景**: GP決勝の `cupResults` は通常FT2/FT3の数カップだけを保持する。過大な配列は不要な処理負荷になるため、APIで上限を持つ。
+- **手順**:
+  1. 28名予選 + Top-8 GP決勝ブラケット生成
+  2. M1 に21件の `cupResults` をPUTする
+  3. HTTP 400 と `cupResults must not exceed 20 entries` が返ること
+  4. M1 を再取得し、`points1=0`、`points2=0`、`completed=false` のまま変更されていないこと
+- **期待結果**: GP決勝APIは21件以上の `cupResults` を拒否し、マッチ状態を更新しない
+- **スクリプト**: tc-gp.js TC-832
+
 ## TC-721: GP決勝 — 同点カップはサドンデスではなく次カップへ進む
 - **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -634,6 +634,46 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       });
     });
 
+    it('should reject excessive GP finals cupResults before updating the match', async () => {
+      const mockMatch = {
+        id: 'm1',
+        tournamentId: 't1',
+        matchNumber: 1,
+        round: 'winners_qf',
+        stage: 'finals',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        points1: 0,
+        points2: 0,
+        completed: false,
+        player1: { id: 'p1' },
+        player2: { id: 'p2' },
+      };
+
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+
+      const cupResults = Array.from({ length: 21 }, (_, index) => ({
+        cup: ['Mushroom', 'Flower', 'Star', 'Special'][index % 4],
+        points1: 45,
+        points2: 0,
+      }));
+      const request = new MockNextRequest(
+        'http://localhost:3000/api/tournaments/t1/gp/finals',
+        { matchId: 'm1', cupResults },
+      );
+      const params = Promise.resolve({ id: 't1' });
+      const result = await PUT(request, { params });
+
+      expect(result.data).toEqual({
+        success: false,
+        error: 'cupResults must not exceed 20 entries',
+        code: 'VALIDATION_ERROR',
+        details: { field: 'cupResults' },
+      });
+      expect(result.status).toBe(400);
+      expect(prisma.gPMatch.update).not.toHaveBeenCalled();
+    });
+
     it('should complete GP finals match once FT2 cup wins are reached', async () => {
       const mockMatch = {
         id: 'm1',

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -1177,6 +1177,43 @@ async function runTc720(adminPage) {
   }
 }
 
+/* ───────── TC-832: GP finals rejects excessive cupResults ───────── */
+async function runTc832(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedGpFinalsSetup(adminPage);
+    const gen = await apiGenerateGpFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    const matches = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const m1 = matches.find((m) => m.matchNumber === 1);
+    if (!m1) throw new Error('Match 1 missing');
+
+    const cupResults = Array.from({ length: 21 }, (_, index) =>
+      gpCupResult(['Mushroom', 'Flower', 'Star', 'Special'][index % 4], 45, 0));
+    const excessive = await apiSetGpFinalsCupResults(adminPage, setup.tournamentId, m1.id, cupResults);
+    const rejected = excessive.s === 400 &&
+      typeof excessive.b?.error === 'string' &&
+      excessive.b.error.includes('cupResults must not exceed 20 entries');
+
+    const after = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const m1After = after.find((m) => m.id === m1.id);
+    const unchanged = m1After?.completed === false &&
+      m1After?.points1 === 0 &&
+      m1After?.points2 === 0 &&
+      (!Array.isArray(m1After?.cupResults) || m1After.cupResults.length === 0);
+
+    log('TC-832', rejected && unchanged ? 'PASS' : 'FAIL',
+      !rejected ? `excessive cupResults accepted/status=${excessive.s} error=${excessive.b?.error ?? ''}`
+      : !unchanged ? `match mutated completed=${m1After?.completed} score=${m1After?.points1}-${m1After?.points2} cups=${m1After?.cupResults?.length ?? 0}`
+      : '');
+  } catch (err) {
+    log('TC-832', 'FAIL', err instanceof Error ? err.message : 'GP 832 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
 /* ───────── TC-721: GP finals tied cups extend to additional cups ───────── */
 async function runTc721(adminPage) {
   let setup = null;
@@ -1319,6 +1356,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-712', fn: runTc712 },
       { name: 'TC-719', fn: runTc719 },
       { name: 'TC-720', fn: runTc720 },
+      { name: 'TC-832', fn: runTc832 },
       { name: 'TC-721', fn: runTc721 },
       { name: 'TC-722', fn: runTc722 },
       { name: 'TC-713', fn: runTc713 },
@@ -1331,7 +1369,7 @@ module.exports = {
   runTc701, runTc702, runTc703, runTc704, runTc705, runTc706,
   runTc707, runTc708, runTc709, runTc710, runTc712, runTc713,
   runTc715, runTc716, runTc717, runTc718, runTc719,
-  runTc720, runTc721, runTc722, runTc821,
+  runTc720, runTc721, runTc722, runTc821, runTc832,
   getSuite,
   results,
 };

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
@@ -17,6 +17,8 @@ type GpCupResultInput = {
   races?: unknown;
 };
 
+const MAX_GP_CUP_RESULTS = 20;
+
 function sumRacePoints(races: unknown, side: 1 | 2): number | null {
   if (!Array.isArray(races)) return null;
   let total = 0;
@@ -38,6 +40,9 @@ function sumRacePoints(races: unknown, side: 1 | 2): number | null {
 function normalizeCupResults(input: unknown): { results?: Array<Record<string, unknown>>; error?: string } {
   if (!Array.isArray(input) || input.length === 0) {
     return { error: 'cupResults must be a non-empty array' };
+  }
+  if (input.length > MAX_GP_CUP_RESULTS) {
+    return { error: `cupResults must not exceed ${MAX_GP_CUP_RESULTS} entries` };
   }
 
   const results: Array<Record<string, unknown>> = [];


### PR DESCRIPTION
## Summary
- Add TC-832 to document and exercise the GP finals oversized `cupResults` API guard.
- Reject `cupResults` arrays over 20 entries before updating the GP finals match.
- Cover the validation with a focused route unit test.

## Issues
Closes #832

## Validation
- `node --check e2e/tc-gp.js`
- `git diff --check`
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts' --runInBand`
- `npm run lint -- '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts' e2e/tc-gp.js 'src/app/api/tournaments/[id]/gp/finals/route.ts'` (passes with existing warnings for unused jsonMock and ignored e2e path)
- `WRANGLER_HOME=/private/tmp/jsmkc-wrangler-home XDG_CONFIG_HOME=/private/tmp/jsmkc-wrangler-config npm run build`
- `E2E_HEADLESS=1 E2E_TEST=TC-832 npm run e2e:gp` (blocked before test execution by Chromium `MachPortRendezvousServer ... Permission denied (1100)` in this sandbox)
