### PR TITLE
docs: explain GP cupResults limit

### DIFF
--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
@@ -17,6 +17,8 @@ type GpCupResultInput = {
   races?: unknown;
 };
 
+// GP finals normally resolves within a few FT2/FT3 cups; 20 leaves generous
+// headroom for tied cups while rejecting malformed oversized payloads early.
 const MAX_GP_CUP_RESULTS = 20;
 
 function sumRacePoints(races: unknown, side: 1 | 2): number | null {


### PR DESCRIPTION
## Summary
- Document why the GP finals `cupResults` limit uses 20 entries.
- Keep the existing API behavior from #930 unchanged.

## Issues
Closes #931

## Validation
- `git diff --check`
- `npm test -- --runTestsByPath __tests__/app/api/tournaments/[id]/gp/finals/route.test.ts --runInBand`
- `npm run lint -- src/app/api/tournaments/[id]/gp/finals/route.ts`
