### PR TITLE
refactor: remove TA phase status fallback

### DIFF
--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -802,14 +802,6 @@ type PhaseCountRow = {
   eliminated: boolean;
   _count: { _all: number };
 };
-type PhaseGroupBy = (args: {
-  by: ["stage", "eliminated"];
-  where: {
-    tournamentId: string;
-    stage: { in: PhaseStage[] };
-  };
-  _count: { _all: true };
-}) => Promise<PhaseCountRow[]>;
 
 /**
  * Get the current phase status for a tournament.
@@ -838,49 +830,14 @@ export async function getPhaseStatus(
    * `/ta/phases` endpoint.
    */
   const phaseStages: PhaseStage[] = ["phase1", "phase2", "phase3"];
-  const ttEntry = prisma.tTEntry as typeof prisma.tTEntry & {
-    groupBy?: PhaseGroupBy;
-    findFirst?: typeof prisma.tTEntry.findFirst;
-  };
-  let fallbackPhase3Winner: string | null = null;
-  let phaseCountRows: PhaseCountRow[];
-  if (typeof ttEntry.groupBy === "function") {
-    phaseCountRows = (await ttEntry.groupBy({
-      by: ["stage", "eliminated"],
-      where: {
-        tournamentId,
-        stage: { in: phaseStages },
-      },
-      _count: { _all: true },
-    })) as PhaseCountRow[];
-  } else {
-    const fallbackEntries = (
-      await Promise.all(
-        phaseStages.map(async (stage) => {
-          const entries = await prisma.tTEntry.findMany({
-            where: {
-              tournamentId,
-              stage,
-            },
-            select: {
-              stage: true,
-              eliminated: true,
-              player: { select: { nickname: true } },
-            },
-          });
-          return entries.map((entry) => ({
-            ...entry,
-            stage: entry.stage ?? stage,
-          }));
-        })
-      )
-    ).flat();
-    phaseCountRows = buildPhaseCountsFromEntries(fallbackEntries);
-    const activePhase3Entries = fallbackEntries
-      .filter((entry) => entry.stage === "phase3" && !entry.eliminated);
-    fallbackPhase3Winner =
-      activePhase3Entries.length === 1 ? activePhase3Entries[0].player?.nickname ?? null : null;
-  }
+  const phaseCountRows = (await prisma.tTEntry.groupBy({
+    by: ["stage", "eliminated"],
+    where: {
+      tournamentId,
+      stage: { in: phaseStages },
+    },
+    _count: { _all: true },
+  })) as PhaseCountRow[];
 
   const counts = {
     phase1: { total: 0, active: 0, eliminated: 0 },
@@ -907,12 +864,10 @@ export async function getPhaseStatus(
   const phase3Base = buildBase("phase3");
   const phase3Winner =
     phase3Base?.active === 1
-      ? typeof ttEntry.findFirst === "function"
-        ? (await ttEntry.findFirst({
-            where: { tournamentId, stage: "phase3", eliminated: false },
-            select: { player: { select: { nickname: true } } },
-          }))?.player.nickname ?? null
-        : fallbackPhase3Winner
+      ? (await prisma.tTEntry.findFirst({
+          where: { tournamentId, stage: "phase3", eliminated: false },
+          select: { player: { select: { nickname: true } } },
+        }))?.player.nickname ?? null
       : null;
   const phase3Status = phase3Base ? { ...phase3Base, winner: phase3Winner } : null;
 
@@ -931,29 +886,6 @@ export async function getPhaseStatus(
     phase3: phase3Status,
     currentPhase,
   };
-}
-
-function buildPhaseCountsFromEntries(
-  entries: Array<{ stage: string; eliminated: boolean }>
-) {
-  const counts = new Map<string, PhaseCountRow>();
-  for (const entry of entries) {
-    if (entry.stage !== "phase1" && entry.stage !== "phase2" && entry.stage !== "phase3") {
-      continue;
-    }
-    const key = `${entry.stage}:${entry.eliminated ? "1" : "0"}`;
-    const existing = counts.get(key);
-    if (existing) {
-      existing._count._all += 1;
-    } else {
-      counts.set(key, {
-        stage: entry.stage,
-        eliminated: entry.eliminated,
-        _count: { _all: 1 },
-      });
-    }
-  }
-  return Array.from(counts.values());
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove the runtime `groupBy` feature-detection branch from TA phase status aggregation.
- Drop the unused `findMany` fallback count builder now that Prisma `groupBy` is required and test-covered.
- Keep the `groupBy` call explicitly typed so production Cloudflare builds pass TypeScript.

## Issues
Closes #937

## Validation
- npm test -- --runTestsByPath __tests__/lib/ta/finals-phase-manager.test.ts --runInBand
- npm run lint -- src/lib/ta/finals-phase-manager.ts __tests__/lib/ta/finals-phase-manager.test.ts
- WRANGLER_HOME=/private/tmp/jsmkc-wrangler-home XDG_CONFIG_HOME=/private/tmp/jsmkc-wrangler-config npm run build:cf
- git diff --check
