### PR TITLE
fix: type TA phase status groupBy

### DIFF
--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -802,6 +802,14 @@ type PhaseCountRow = {
   eliminated: boolean;
   _count: { _all: number };
 };
+type PhaseGroupBy = (args: {
+  by: ["stage", "eliminated"];
+  where: {
+    tournamentId: string;
+    stage: { in: PhaseStage[] };
+  };
+  _count: { _all: true };
+}) => Promise<PhaseCountRow[]>;
 
 /**
  * Get the current phase status for a tournament.
@@ -830,14 +838,17 @@ export async function getPhaseStatus(
    * `/ta/phases` endpoint.
    */
   const phaseStages: PhaseStage[] = ["phase1", "phase2", "phase3"];
-  const phaseCountRows = (await prisma.tTEntry.groupBy({
+  const ttEntry = prisma.tTEntry as typeof prisma.tTEntry & {
+    groupBy: PhaseGroupBy;
+  };
+  const phaseCountRows = await ttEntry.groupBy({
     by: ["stage", "eliminated"],
     where: {
       tournamentId,
       stage: { in: phaseStages },
     },
     _count: { _all: true },
-  })) as PhaseCountRow[];
+  });
 
   const counts = {
     phase1: { total: 0, active: 0, eliminated: 0 },


### PR DESCRIPTION
## Summary
- Remove the runtime `groupBy` feature-detection branch from TA phase status aggregation.
- Drop the unused `findMany` fallback count builder now that Prisma `groupBy` is required and test-covered.
- Keep the `groupBy` call explicitly typed so production Cloudflare builds pass TypeScript.

## Issues
Closes #937

## Validation
- npm test -- --runTestsByPath __tests__/lib/ta/finals-phase-manager.test.ts --runInBand
- npm run lint -- src/lib/ta/finals-phase-manager.ts __tests__/lib/ta/finals-phase-manager.test.ts
- WRANGLER_HOME=/private/tmp/jsmkc-wrangler-home XDG_CONFIG_HOME=/private/tmp/jsmkc-wrangler-config npm run build:cf
- git diff --check
