### PR TITLE
Reduce qualification score update query cost

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1000,7 +1000,8 @@
   5. レスポンスに `mismatch: true` が含まれることを確認
   6. 管理者APIでマッチが completed=false のままであることを確認
   7. 管理者がPUTでスコアを確定し、completed=true になることを確認
-  8. クリーンアップ
+  8. 管理者PUTレスポンスの `match` は `player1Id/player2Id` を含み、不要な `player1/player2` 展開を含まないことを確認する
+  9. クリーンアップ
 - **期待結果**: 不一致時はマッチが未完了のままで管理者レビュー待ちになる
 
 ## TC-509: BM二重報告 — previousReports表示確認
@@ -1218,8 +1219,9 @@
   2. MRグループ設定を行い、pendingマッチを生成する
   3. 管理者APIでscore1=2, score2=2（引き分け）をPUTで送信する
   4. HTTP 200で受理されることを確認する
-  5. マッチがcompletedかつscore1=2, score2=2で保存されていることを確認する
-  6. 一時トーナメントと一時プレイヤーを削除する
+  5. PUTレスポンスの `match` は `player1Id/player2Id` を含み、不要な `player1/player2` 展開を含まないことを確認する
+  6. マッチがcompletedかつscore1=2, score2=2で保存されていることを確認する
+  7. 一時トーナメントと一時プレイヤーを削除する
 - **期待結果**: 2-2の引き分けスコアがバリデーションを通過し正常に保存される
 
 ## TC-604: MR予選28名フル + 決勝ブラケット生成 + race-format UI スコア入力
@@ -1564,7 +1566,8 @@
   3. P1 が race position 1-vs-5 で送信、P2 が race position 5-vs-1 で送信（不一致）
   4. レスポンスに `mismatch: true` が含まれ、マッチは completed=false のまま
   5. 管理者 PUT (`{ matchId, cup, races }`) で確定 → completed=true
-  6. クリーンアップ
+  6. 管理者PUTレスポンスの `match` は `player1Id/player2Id` を含み、不要な `player1/player2` 展開を含まないことを確認する
+  7. クリーンアップ
 - **期待結果**: 不一致時はマッチが未完了のまま管理者レビュー待ちになる
 
 ## TC-709: GP決勝 — 非管理者のスコア入力拒否

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
@@ -44,6 +44,18 @@ import { createLogger } from '@/lib/logger';
 import { GET, POST, PUT } from '@/app/api/tournaments/[id]/bm/route';
 import { configureNextResponseMock } from '../../../../../helpers/next-response-mock';
 
+const EXPECTED_MATCH_UPDATE_SELECT = {
+  id: true,
+  tournamentId: true,
+  player1Id: true,
+  player2Id: true,
+  score1: true,
+  score2: true,
+  rounds: true,
+  completed: true,
+  isBye: true,
+};
+
 const requestUtilsMock = jest.requireMock('@/lib/request-utils') as { getServerSideIdentifier: jest.Mock };
 const _sanitizeMock = jest.requireMock('@/lib/sanitize') as { sanitizeInput: jest.Mock };
 const auditLogMock = jest.requireMock('@/lib/audit-log') as { createAuditLog: jest.Mock };
@@ -427,7 +439,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       expect(prisma.bMMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: null, completed: true },
-        include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } },
+        select: EXPECTED_MATCH_UPDATE_SELECT,
       });
       expect(prisma.bMQualification.updateMany).toHaveBeenCalledTimes(2);
     });
@@ -457,7 +469,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       expect(prisma.bMMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 2, score2: 2, rounds: null, completed: true },
-        include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } },
+        select: EXPECTED_MATCH_UPDATE_SELECT,
       });
     });
 
@@ -494,7 +506,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       expect(prisma.bMMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: [1, 2, 3, 4], completed: true },
-        include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } },
+        select: EXPECTED_MATCH_UPDATE_SELECT,
       });
     });
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/route.test.ts
@@ -34,6 +34,19 @@ import { createLogger } from '@/lib/logger';
 import { GET, POST, PUT } from '@/app/api/tournaments/[id]/gp/route';
 import { configureNextResponseMock } from '../../../../../helpers/next-response-mock';
 
+const EXPECTED_MATCH_UPDATE_SELECT = {
+  id: true,
+  tournamentId: true,
+  player1Id: true,
+  player2Id: true,
+  cup: true,
+  points1: true,
+  points2: true,
+  races: true,
+  completed: true,
+  isBye: true,
+};
+
 const rateLimitMock = jest.requireMock('@/lib/rate-limit') as { getServerSideIdentifier: jest.Mock };
 const _sanitizeMock = jest.requireMock('@/lib/sanitize') as { sanitizeInput: jest.Mock };
 const _auditLogMock = jest.requireMock('@/lib/audit-log') as { createAuditLog: jest.Mock };
@@ -435,7 +448,7 @@ describe('GP API Route - /api/tournaments/[id]/gp', () => {
           races: expect.any(Array),
           completed: true,
         }),
-        include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } },
+        select: EXPECTED_MATCH_UPDATE_SELECT,
       });
       expect(prisma.gPQualification.updateMany).toHaveBeenCalledTimes(2);
     });

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
@@ -39,6 +39,18 @@ import { createLogger } from '@/lib/logger';
 import { GET, POST, PUT } from '@/app/api/tournaments/[id]/mr/route';
 import { configureNextResponseMock } from '../../../../../helpers/next-response-mock';
 
+const EXPECTED_MATCH_UPDATE_SELECT = {
+  id: true,
+  tournamentId: true,
+  player1Id: true,
+  player2Id: true,
+  score1: true,
+  score2: true,
+  rounds: true,
+  completed: true,
+  isBye: true,
+};
+
 const _rateLimitMock = jest.requireMock('@/lib/rate-limit') as { getServerSideIdentifier: jest.Mock };
 const sanitizeMock = jest.requireMock('@/lib/sanitize') as { sanitizeInput: jest.Mock };
 const _NextResponseMock = jest.requireMock('next/server') as { NextResponse: { json: jest.Mock } };
@@ -350,7 +362,7 @@ describe('MR API Route - /api/tournaments/[id]/mr', () => {
       expect(prisma.mRMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: null, completed: true },
-        include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } },
+        select: EXPECTED_MATCH_UPDATE_SELECT,
       });
       expect(prisma.mRQualification.updateMany).toHaveBeenCalledTimes(2);
     });
@@ -403,7 +415,7 @@ describe('MR API Route - /api/tournaments/[id]/mr', () => {
       expect(prisma.mRMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: validRounds, completed: true },
-        include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } },
+        select: EXPECTED_MATCH_UPDATE_SELECT,
       });
     });
 

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -64,6 +64,11 @@ function sharedBmPlayers(count = 28) {
   return sharedFixture.players.slice(0, count);
 }
 
+function matchUpdateUsesLeanPayload(putResult) {
+  const match = putResult?.b?.data?.match || putResult?.b?.match;
+  return Boolean(match?.id && match.player1Id && match.player2Id && !match.player1 && !match.player2);
+}
+
 async function loginSharedPlayer(adminPage, player) {
   await ensurePlayerPassword(adminPage, player);
   return loginPlayerBrowser(player.nickname, player.password);
@@ -1059,12 +1064,14 @@ async function runTc508(adminPage) {
     const finalData = await apiFetchBm(adminPage, tournamentId);
     const finalMatch = (finalData.matches || []).find((m) => m.id === match.id);
     const adminConfirmed = adminPut.s === 200 && finalMatch?.completed === true;
+    const leanUpdatePayload = matchUpdateUsesLeanPayload(adminPut);
 
-    const ok = mismatchFlag && stillIncomplete && adminConfirmed;
+    const ok = mismatchFlag && stillIncomplete && adminConfirmed && leanUpdatePayload;
     log('TC-508', ok ? 'PASS' : 'FAIL',
       !mismatchFlag ? `mismatch flag missing (status=${r2.s})`
       : !stillIncomplete ? 'match auto-completed despite mismatch'
       : !adminConfirmed ? `admin PUT failed (${adminPut.s}) or not completed`
+      : !leanUpdatePayload ? 'admin PUT returned expanded player payload'
       : '');
   } catch (err) {
     log('TC-508', 'FAIL', err instanceof Error ? err.message : 'BM 508 failed');

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -49,6 +49,11 @@ function sharedGpPlayers(count = 28) {
   return sharedFixture.players.slice(0, count);
 }
 
+function matchUpdateUsesLeanPayload(putResult) {
+  const match = putResult?.b?.data?.match || putResult?.b?.match;
+  return Boolean(match?.id && match.player1Id && match.player2Id && !match.player1 && !match.player2);
+}
+
 async function loginSharedPlayer(adminPage, player) {
   await ensurePlayerPassword(adminPage, player);
   return loginPlayerBrowser(player.nickname, player.password);
@@ -493,12 +498,14 @@ async function runTc708(adminPage) {
     const finalData = await apiFetchGp(adminPage, tournamentId);
     const finalMatch = (finalData.matches || []).find((m) => m.id === match.id);
     const adminConfirmed = adminPut.s === 200 && finalMatch?.completed === true;
+    const leanUpdatePayload = matchUpdateUsesLeanPayload(adminPut);
 
-    const ok = mismatchFlag && stillIncomplete && adminConfirmed;
+    const ok = mismatchFlag && stillIncomplete && adminConfirmed && leanUpdatePayload;
     log('TC-708', ok ? 'PASS' : 'FAIL',
       !mismatchFlag ? `mismatch flag missing (status=${r2.s})`
       : !stillIncomplete ? 'match auto-completed despite mismatch'
       : !adminConfirmed ? `admin PUT failed (${adminPut.s})`
+      : !leanUpdatePayload ? 'admin PUT returned expanded player payload'
       : '');
   } catch (err) {
     log('TC-708', 'FAIL', err instanceof Error ? err.message : 'GP 708 failed');

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -63,6 +63,11 @@ function sharedMrPlayers(count = 28) {
   return sharedFixture.players.slice(0, count);
 }
 
+function matchUpdateUsesLeanPayload(putResult) {
+  const match = putResult?.b?.data?.match || putResult?.b?.match;
+  return Boolean(match?.id && match.player1Id && match.player2Id && !match.player1 && !match.player2);
+}
+
 /* Mirrors src/lib/finals-target-wins.ts:getMrFinalsTargetWins so tests can
  * derive the per-round FT target needed for a valid score PUT (issue #559
  * introduced FT5/FT7/FT9 by round; before that everything was FT3, which is
@@ -299,15 +304,17 @@ async function runTc603(adminPage) {
 
     const drawRes = await apiPutMrQualScore(adminPage, tournamentId, match.id, 2, 2);
     const drawAccepted = drawRes.s === 200;
+    const leanUpdatePayload = matchUpdateUsesLeanPayload(drawRes);
 
     const updated = await apiFetchMr(adminPage, tournamentId);
     const updatedMatch = (updated.matches || []).find((m) => m.id === match.id);
     const drawPersisted = updatedMatch?.completed === true &&
       updatedMatch.score1 === 2 && updatedMatch.score2 === 2;
 
-    log('TC-603', drawAccepted && drawPersisted ? 'PASS' : 'FAIL',
+    log('TC-603', drawAccepted && drawPersisted && leanUpdatePayload ? 'PASS' : 'FAIL',
       !drawAccepted ? `Draw rejected (${drawRes.s})`
       : !drawPersisted ? `Draw not persisted: ${updatedMatch?.score1}-${updatedMatch?.score2}`
+      : !leanUpdatePayload ? 'admin PUT returned expanded player payload'
       : '');
   } catch (err) {
     log('TC-603', 'FAIL', err instanceof Error ? err.message : 'MR draw test failed');

--- a/smkc-score-app/prisma/migrations/0012_match_player_lookup_indexes/migration.sql
+++ b/smkc-score-app/prisma/migrations/0012_match_player_lookup_indexes/migration.sql
@@ -1,0 +1,12 @@
+-- Speed up qualification score recalculation.
+-- Each score update fetches completed matches for both involved players.
+-- These indexes let D1 constrain by tournament/stage/player side instead of
+-- scanning every qualification match in the tournament.
+CREATE INDEX IF NOT EXISTS "BMMatch_tournamentId_stage_player1Id_idx" ON "BMMatch"("tournamentId", "stage", "player1Id");
+CREATE INDEX IF NOT EXISTS "BMMatch_tournamentId_stage_player2Id_idx" ON "BMMatch"("tournamentId", "stage", "player2Id");
+
+CREATE INDEX IF NOT EXISTS "MRMatch_tournamentId_stage_player1Id_idx" ON "MRMatch"("tournamentId", "stage", "player1Id");
+CREATE INDEX IF NOT EXISTS "MRMatch_tournamentId_stage_player2Id_idx" ON "MRMatch"("tournamentId", "stage", "player2Id");
+
+CREATE INDEX IF NOT EXISTS "GPMatch_tournamentId_stage_player1Id_idx" ON "GPMatch"("tournamentId", "stage", "player1Id");
+CREATE INDEX IF NOT EXISTS "GPMatch_tournamentId_stage_player2Id_idx" ON "GPMatch"("tournamentId", "stage", "player2Id");

--- a/smkc-score-app/prisma/schema.prisma
+++ b/smkc-score-app/prisma/schema.prisma
@@ -244,6 +244,8 @@ model BMMatch {
   updatedAt    DateTime   @updatedAt
 
   @@unique([tournamentId, matchNumber, stage])
+  @@index([tournamentId, stage, player1Id])
+  @@index([tournamentId, stage, player2Id])
 }
 
 // ==========================================
@@ -317,6 +319,8 @@ model MRMatch {
   updatedAt    DateTime   @updatedAt
 
   @@unique([tournamentId, matchNumber, stage])
+  @@index([tournamentId, stage, player1Id])
+  @@index([tournamentId, stage, player2Id])
 }
 
 // ==========================================
@@ -384,6 +388,8 @@ model GPMatch {
   updatedAt    DateTime   @updatedAt
 
   @@unique([tournamentId, matchNumber, stage])
+  @@index([tournamentId, stage, player1Id])
+  @@index([tournamentId, stage, player2Id])
 }
 
 // ==========================================

--- a/smkc-score-app/src/lib/event-types/bm-config.ts
+++ b/smkc-score-app/src/lib/event-types/bm-config.ts
@@ -7,7 +7,6 @@
  */
 
 import { EventTypeConfig, MatchResult } from './types';
-import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { AUDIT_ACTIONS } from '@/lib/audit-log';
 import { validateBattleModeScores } from '@/lib/score-validation';
 
@@ -89,7 +88,17 @@ export const bmConfig: EventTypeConfig = {
         rounds: data.rounds || null,
         completed: true,
       },
-      include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } },
+      select: {
+        id: true,
+        tournamentId: true,
+        player1Id: true,
+        player2Id: true,
+        score1: true,
+        score2: true,
+        rounds: true,
+        completed: true,
+        isBye: true,
+      },
     });
     return { match, score1OrPoints1: data.score1!, score2OrPoints2: data.score2! };
   },

--- a/smkc-score-app/src/lib/event-types/gp-config.ts
+++ b/smkc-score-app/src/lib/event-types/gp-config.ts
@@ -9,7 +9,6 @@
  */
 
 import { EventTypeConfig, MatchResult } from './types';
-import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { AUDIT_ACTIONS } from '@/lib/audit-log';
 import { validateGPRacePosition } from '@/lib/score-validation';
 import { DRIVER_POINTS, CUPS, CUP_SUBSTITUTIONS, TOTAL_GP_RACES } from '@/lib/constants';
@@ -147,7 +146,18 @@ export const gpConfig: EventTypeConfig = {
           completed: true,
           version: { increment: 1 },
         },
-        include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } },
+        select: {
+          id: true,
+          tournamentId: true,
+          player1Id: true,
+          player2Id: true,
+          cup: true,
+          points1: true,
+          points2: true,
+          races: true,
+          completed: true,
+          isBye: true,
+        },
       });
     });
 

--- a/smkc-score-app/src/lib/event-types/mr-config.ts
+++ b/smkc-score-app/src/lib/event-types/mr-config.ts
@@ -13,7 +13,6 @@
  */
 
 import { EventTypeConfig, MatchResult } from './types';
-import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { AUDIT_ACTIONS } from '@/lib/audit-log';
 import { validateMatchRaceScores } from '@/lib/score-validation';
 
@@ -102,7 +101,17 @@ export const mrConfig: EventTypeConfig = {
         rounds: data.rounds || null,
         completed: true,
       },
-      include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } },
+      select: {
+        id: true,
+        tournamentId: true,
+        player1Id: true,
+        player2Id: true,
+        score1: true,
+        score2: true,
+        rounds: true,
+        completed: true,
+        isBye: true,
+      },
     });
     return { match, score1OrPoints1: data.score1!, score2OrPoints2: data.score2! };
   },


### PR DESCRIPTION
## Summary
- add BM/MR/GP match lookup indexes for qualification standings recalculation
- reduce qualification PUT update payloads to the match fields needed for recalculation
- extend BM/MR/GP route tests and E2E scenarios to cover lean score-update payloads

## Issues
Closes #951

## Validation
- `node --check e2e/tc-bm.js && node --check e2e/tc-mr.js && node --check e2e/tc-gp.js`
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/bm/route.test.ts' '__tests__/app/api/tournaments/[id]/mr/route.test.ts' '__tests__/app/api/tournaments/[id]/gp/route.test.ts'`
- `npm run lint -- 'src/lib/event-types/bm-config.ts' 'src/lib/event-types/mr-config.ts' 'src/lib/event-types/gp-config.ts' '__tests__/app/api/tournaments/[id]/bm/route.test.ts' '__tests__/app/api/tournaments/[id]/mr/route.test.ts' '__tests__/app/api/tournaments/[id]/gp/route.test.ts' 'e2e/tc-bm.js' 'e2e/tc-mr.js' 'e2e/tc-gp.js'` (warnings only: existing unused vars and E2E ignored-file warnings)
- `git diff --check`
- `WRANGLER_HOME=/private/tmp/jsmkc-wrangler-home XDG_CONFIG_HOME=/private/tmp/jsmkc-wrangler-config npm run build:cf`
