### PR TITLE
test: share lean match payload E2E helper

### DIFF
--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -685,6 +685,11 @@ async function apiPutGpQualScore(page, tournamentId, matchId, cup, races) {
   { label: `GP qual PUT ${matchId}` });
 }
 
+function matchUpdateUsesLeanPayload(putResult) {
+  const match = putResult?.b?.data?.match || putResult?.b?.match;
+  return Boolean(match?.id && match.player1Id && match.player2Id && !match.player1 && !match.player2);
+}
+
 async function apiSetGpFinalsScore(page, tournamentId, matchId, score1, score2, suddenDeathWinnerId = null) {
   const body = { matchId, score1, score2 };
   if (suddenDeathWinnerId) {
@@ -2504,6 +2509,7 @@ module.exports = {
   launchPersistentChromiumContext,
   /* retry */
   withRetry,
+  matchUpdateUsesLeanPayload,
   /* BM */
   apiSetupBmGroup,
   apiFetchBm,

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -39,6 +39,7 @@
  */
 const {
   makeResults, makeLog, nav, escapeRegex,
+  matchUpdateUsesLeanPayload,
   apiFetchBm, apiPutBmQualScore,
   apiSetBmFinalsScore, apiGenerateBmFinals, apiFetchBmFinalsMatches, apiFetchBmFinalsState,
   apiUpdateTournament,
@@ -62,11 +63,6 @@ let sharedFixture = null;
 function sharedBmPlayers(count = 28) {
   if (!sharedFixture) throw new Error('Shared BM fixture is not initialized');
   return sharedFixture.players.slice(0, count);
-}
-
-function matchUpdateUsesLeanPayload(putResult) {
-  const match = putResult?.b?.data?.match || putResult?.b?.match;
-  return Boolean(match?.id && match.player1Id && match.player2Id && !match.player1 && !match.player2);
 }
 
 async function loginSharedPlayer(adminPage, player) {

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -28,6 +28,7 @@
  */
 const {
   makeResults, makeLog, nav,
+  matchUpdateUsesLeanPayload,
   uiCreatePlayer, apiDeletePlayer, apiDeleteTournament, uiCreateTournament,
   apiFetchGp, apiPutGpQualScore,
   apiSetGpFinalsScore, apiSetGpFinalsCupResults, apiGenerateGpFinals, apiFetchGpFinalsMatches, apiFetchGpFinalsState,
@@ -47,11 +48,6 @@ let sharedFixture = null;
 function sharedGpPlayers(count = 28) {
   if (!sharedFixture) throw new Error('Shared GP fixture is not initialized');
   return sharedFixture.players.slice(0, count);
-}
-
-function matchUpdateUsesLeanPayload(putResult) {
-  const match = putResult?.b?.data?.match || putResult?.b?.match;
-  return Boolean(match?.id && match.player1Id && match.player2Id && !match.player1 && !match.player2);
 }
 
 async function loginSharedPlayer(adminPage, player) {

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -36,6 +36,7 @@
  */
 const {
   makeResults, makeLog, nav,
+  matchUpdateUsesLeanPayload,
   uiCreatePlayer: createPlayer,
   uiCreateTournament: createTournament,
   apiDeletePlayer: deletePlayer,
@@ -61,11 +62,6 @@ let sharedFixture = null;
 function sharedMrPlayers(count = 28) {
   if (!sharedFixture) throw new Error('Shared MR fixture is not initialized');
   return sharedFixture.players.slice(0, count);
-}
-
-function matchUpdateUsesLeanPayload(putResult) {
-  const match = putResult?.b?.data?.match || putResult?.b?.match;
-  return Boolean(match?.id && match.player1Id && match.player2Id && !match.player1 && !match.player2);
 }
 
 /* Mirrors src/lib/finals-target-wins.ts:getMrFinalsTargetWins so tests can


### PR DESCRIPTION
## Summary
- move `matchUpdateUsesLeanPayload` into the shared E2E common helper module
- import the helper from BM/MR/GP E2E runners instead of duplicating it per file

## Issues
Closes #952

## Validation
- `node --check e2e/lib/common.js && node --check e2e/tc-bm.js && node --check e2e/tc-mr.js && node --check e2e/tc-gp.js`
- `node -e "const { matchUpdateUsesLeanPayload } = require('./e2e/lib/common'); if (!matchUpdateUsesLeanPayload({ b: { data: { match: { id: 'm1', player1Id: 'p1', player2Id: 'p2' } } } })) process.exit(1); if (matchUpdateUsesLeanPayload({ b: { data: { match: { id: 'm1', player1Id: 'p1', player2Id: 'p2', player1: {} } } } })) process.exit(2);"`
- `npm run lint -- 'e2e/lib/common.js' 'e2e/tc-bm.js' 'e2e/tc-mr.js' 'e2e/tc-gp.js'` (warnings only: E2E paths are ignored by eslint config)
- `git diff --check`
