### PR TITLE
Add D1 match lookup index migration

### DIFF
--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -685,6 +685,11 @@ async function apiPutGpQualScore(page, tournamentId, matchId, cup, races) {
   { label: `GP qual PUT ${matchId}` });
 }
 
+function matchUpdateUsesLeanPayload(putResult) {
+  const match = putResult?.b?.data?.match || putResult?.b?.match;
+  return Boolean(match?.id && match.player1Id && match.player2Id && !match.player1 && !match.player2);
+}
+
 async function apiSetGpFinalsScore(page, tournamentId, matchId, score1, score2, suddenDeathWinnerId = null) {
   const body = { matchId, score1, score2 };
   if (suddenDeathWinnerId) {
@@ -2504,6 +2509,7 @@ module.exports = {
   launchPersistentChromiumContext,
   /* retry */
   withRetry,
+  matchUpdateUsesLeanPayload,
   /* BM */
   apiSetupBmGroup,
   apiFetchBm,

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -39,6 +39,7 @@
  */
 const {
   makeResults, makeLog, nav, escapeRegex,
+  matchUpdateUsesLeanPayload,
   apiFetchBm, apiPutBmQualScore,
   apiSetBmFinalsScore, apiGenerateBmFinals, apiFetchBmFinalsMatches, apiFetchBmFinalsState,
   apiUpdateTournament,
@@ -62,11 +63,6 @@ let sharedFixture = null;
 function sharedBmPlayers(count = 28) {
   if (!sharedFixture) throw new Error('Shared BM fixture is not initialized');
   return sharedFixture.players.slice(0, count);
-}
-
-function matchUpdateUsesLeanPayload(putResult) {
-  const match = putResult?.b?.data?.match || putResult?.b?.match;
-  return Boolean(match?.id && match.player1Id && match.player2Id && !match.player1 && !match.player2);
 }
 
 async function loginSharedPlayer(adminPage, player) {

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -28,6 +28,7 @@
  */
 const {
   makeResults, makeLog, nav,
+  matchUpdateUsesLeanPayload,
   uiCreatePlayer, apiDeletePlayer, apiDeleteTournament, uiCreateTournament,
   apiFetchGp, apiPutGpQualScore,
   apiSetGpFinalsScore, apiSetGpFinalsCupResults, apiGenerateGpFinals, apiFetchGpFinalsMatches, apiFetchGpFinalsState,
@@ -47,11 +48,6 @@ let sharedFixture = null;
 function sharedGpPlayers(count = 28) {
   if (!sharedFixture) throw new Error('Shared GP fixture is not initialized');
   return sharedFixture.players.slice(0, count);
-}
-
-function matchUpdateUsesLeanPayload(putResult) {
-  const match = putResult?.b?.data?.match || putResult?.b?.match;
-  return Boolean(match?.id && match.player1Id && match.player2Id && !match.player1 && !match.player2);
 }
 
 async function loginSharedPlayer(adminPage, player) {

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -36,6 +36,7 @@
  */
 const {
   makeResults, makeLog, nav,
+  matchUpdateUsesLeanPayload,
   uiCreatePlayer: createPlayer,
   uiCreateTournament: createTournament,
   apiDeletePlayer: deletePlayer,
@@ -61,11 +62,6 @@ let sharedFixture = null;
 function sharedMrPlayers(count = 28) {
   if (!sharedFixture) throw new Error('Shared MR fixture is not initialized');
   return sharedFixture.players.slice(0, count);
-}
-
-function matchUpdateUsesLeanPayload(putResult) {
-  const match = putResult?.b?.data?.match || putResult?.b?.match;
-  return Boolean(match?.id && match.player1Id && match.player2Id && !match.player1 && !match.player2);
 }
 
 /* Mirrors src/lib/finals-target-wins.ts:getMrFinalsTargetWins so tests can

--- a/smkc-score-app/migrations/0029_match_player_lookup_indexes.sql
+++ b/smkc-score-app/migrations/0029_match_player_lookup_indexes.sql
@@ -1,0 +1,11 @@
+-- Speed up qualification score recalculation in production D1.
+-- Score updates fetch completed matches for each involved player; these
+-- composite indexes let D1 constrain by tournament, stage, and player side.
+CREATE INDEX IF NOT EXISTS "BMMatch_tournamentId_stage_player1Id_idx" ON "BMMatch"("tournamentId", "stage", "player1Id");
+CREATE INDEX IF NOT EXISTS "BMMatch_tournamentId_stage_player2Id_idx" ON "BMMatch"("tournamentId", "stage", "player2Id");
+
+CREATE INDEX IF NOT EXISTS "MRMatch_tournamentId_stage_player1Id_idx" ON "MRMatch"("tournamentId", "stage", "player1Id");
+CREATE INDEX IF NOT EXISTS "MRMatch_tournamentId_stage_player2Id_idx" ON "MRMatch"("tournamentId", "stage", "player2Id");
+
+CREATE INDEX IF NOT EXISTS "GPMatch_tournamentId_stage_player1Id_idx" ON "GPMatch"("tournamentId", "stage", "player1Id");
+CREATE INDEX IF NOT EXISTS "GPMatch_tournamentId_stage_player2Id_idx" ON "GPMatch"("tournamentId", "stage", "player2Id");


### PR DESCRIPTION
## Summary
- add the Wrangler/D1 production migration for match lookup indexes added in PR #948

## Validation
- sqlite3 syntax check against minimal BM/MR/GP match tables

## Notes
- wrangler.toml uses migrations_dir = "migrations", so this applies the indexes to production D1.
