### PR TITLE
Optimize TA delete reranking

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/route.test.ts
@@ -65,6 +65,7 @@ jest.mock('@/lib/audit-log', () => ({
 // Mock rank-calculation
 jest.mock('@/lib/ta/rank-calculation', () => ({
   recalculateRanks: jest.fn(() => Promise.resolve()),
+  rerankStageAfterDelete: jest.fn(() => Promise.resolve()),
 }));
 
 // Mock time-utils: preserve real Zod schemas (TimeStringSchema, TimesObjectSchema)
@@ -139,6 +140,11 @@ const rateLimitMock = jest.requireMock('@/lib/rate-limit') as {
 
 const loggerMock = jest.requireMock('@/lib/logger') as {
   createLogger: jest.Mock;
+};
+
+const rankCalculationMock = jest.requireMock('@/lib/ta/rank-calculation') as {
+  recalculateRanks: jest.Mock;
+  rerankStageAfterDelete: jest.Mock;
 };
 
 // Valid CUIDs for tests — the TA route uses z.string().cuid() for validation
@@ -916,6 +922,12 @@ describe('/api/tournaments/[id]/ta', () => {
           message: 'Entry deleted successfully',
         },
       });
+      expect(rankCalculationMock.rerankStageAfterDelete).toHaveBeenCalledWith(
+        VALID_UUID,
+        'qualification',
+        prisma,
+      );
+      expect(rankCalculationMock.recalculateRanks).not.toHaveBeenCalled();
     });
 
     it('should return 403 without admin auth (null session)', async () => {

--- a/smkc-score-app/__tests__/lib/ta/rank-calculation.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/rank-calculation.test.ts
@@ -17,7 +17,13 @@
  *   query parameters, $transaction usage, and handling of incomplete times
  */
 // @ts-nocheck - This test file uses complex mock types that are difficult to type correctly
-import { calculateEntryTotal, sortByStage, assignRanks, recalculateRanks } from '@/lib/ta/rank-calculation';
+import {
+  calculateEntryTotal,
+  sortByStage,
+  assignRanks,
+  recalculateRanks,
+  rerankStageAfterDelete,
+} from '@/lib/ta/rank-calculation';
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { PrismaClient } from '@prisma/client';
 
@@ -432,6 +438,29 @@ describe('TA Rank Calculation', () => {
       await recalculateRanks('tournament-1', 'revival_1', mockPrisma as unknown as PrismaClient);
 
       expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(2);
+    });
+
+    it('should rerank qualification after delete with a single rank-only update', async () => {
+      await rerankStageAfterDelete('tournament-1', 'qualification', mockPrisma as unknown as PrismaClient);
+
+      expect(mockPrisma.tTEntry.findMany).not.toHaveBeenCalled();
+      expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
+      const templateStrings = mockPrisma.$executeRaw.mock.calls[0][0] as TemplateStringsArray;
+      const sqlText = templateStrings.raw.join('');
+      expect(sqlText).toContain('ROW_NUMBER() OVER');
+      expect(sqlText).toContain('qualificationPoints');
+      expect(sqlText).not.toContain('courseScores');
+    });
+
+    it('should rerank revival after delete and clear ranks for entries without totalTime', async () => {
+      await rerankStageAfterDelete('tournament-1', 'revival_1', mockPrisma as unknown as PrismaClient);
+
+      expect(mockPrisma.tTEntry.findMany).not.toHaveBeenCalled();
+      expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
+      const templateStrings = mockPrisma.$executeRaw.mock.calls[0][0] as TemplateStringsArray;
+      const sqlText = templateStrings.raw.join('');
+      expect(sqlText).toContain('totalTime IS NOT NULL');
+      expect(sqlText).not.toContain('qualificationPoints');
     });
   });
 });

--- a/smkc-score-app/migrations/0030_ttentry_stage_rerank_indexes.sql
+++ b/smkc-score-app/migrations/0030_ttentry_stage_rerank_indexes.sql
@@ -1,0 +1,3 @@
+-- Speed up TA rank-only recalculation after entry deletion.
+CREATE INDEX IF NOT EXISTS "TTEntry_tournamentId_stage_idx" ON "TTEntry"("tournamentId", "stage");
+CREATE INDEX IF NOT EXISTS "TTEntry_tournamentId_stage_qualificationPoints_totalTime_idx" ON "TTEntry"("tournamentId", "stage", "qualificationPoints", "totalTime");

--- a/smkc-score-app/prisma/migrations/0013_ttentry_stage_rerank_indexes/migration.sql
+++ b/smkc-score-app/prisma/migrations/0013_ttentry_stage_rerank_indexes/migration.sql
@@ -1,0 +1,3 @@
+-- Speed up TA rank-only recalculation after entry deletion.
+CREATE INDEX IF NOT EXISTS "TTEntry_tournamentId_stage_idx" ON "TTEntry"("tournamentId", "stage");
+CREATE INDEX IF NOT EXISTS "TTEntry_tournamentId_stage_qualificationPoints_totalTime_idx" ON "TTEntry"("tournamentId", "stage", "qualificationPoints", "totalTime");

--- a/smkc-score-app/prisma/schema.prisma
+++ b/smkc-score-app/prisma/schema.prisma
@@ -533,6 +533,8 @@ model TTEntry {
   updatedAt    DateTime   @updatedAt
 
   @@unique([tournamentId, playerId, stage])
+  @@index([tournamentId, stage])
+  @@index([tournamentId, stage, qualificationPoints, totalTime])
 }
 
 // ==========================================

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
@@ -30,7 +30,7 @@ import { auth } from "@/lib/auth";
 import type { Session } from "next-auth";
 import { z } from "zod";
 import { COURSES, type CourseAbbr } from "@/lib/constants";
-import { recalculateRanks } from "@/lib/ta/rank-calculation";
+import { recalculateRanks, rerankStageAfterDelete } from "@/lib/ta/rank-calculation";
 import { timeToMs, TimesObjectSchema } from "@/lib/ta/time-utils";
 // Promotion functions moved to /api/tournaments/[id]/ta/phases endpoint
 import { createLogger } from "@/lib/logger";
@@ -756,8 +756,8 @@ export async function DELETE(
       where: { id: entryId }
     });
 
-    // Recalculate ranks for the affected stage after deletion
-    await recalculateRanks(tournamentId, entryToDelete.stage, prisma);
+    // Deletion only shifts ranks; remaining times and course scores are unchanged.
+    await rerankStageAfterDelete(tournamentId, entryToDelete.stage, prisma);
 
     // Audit log for deletion accountability
     const ipAddress = getClientIdentifier(request);

--- a/smkc-score-app/src/lib/ta/rank-calculation.ts
+++ b/smkc-score-app/src/lib/ta/rank-calculation.ts
@@ -267,3 +267,61 @@ export async function recalculateRanks(
     }
   }
 }
+
+/**
+ * Re-rank an existing stage after deleting an entry.
+ *
+ * Deletion does not change any remaining player's times or qualification
+ * course scores, so the full recalculateRanks pipeline is unnecessary. This
+ * keeps the delete path to a single D1 statement instead of repeatedly
+ * rewriting every calculated field in small parameter-limited batches.
+ */
+export async function rerankStageAfterDelete(
+  tournamentId: string,
+  stage: string = "qualification",
+  prisma: PrismaClient
+): Promise<void> {
+  if (stage === "revival_1" || stage === "revival_2") {
+    await prisma.$executeRaw`
+      WITH ranked AS (
+        SELECT
+          id,
+          ROW_NUMBER() OVER (ORDER BY totalTime ASC, id ASC) AS newRank
+        FROM TTEntry
+        WHERE tournamentId = ${tournamentId}
+          AND stage = ${stage}
+          AND totalTime IS NOT NULL
+      )
+      UPDATE TTEntry
+      SET rank = (
+        SELECT newRank FROM ranked WHERE ranked.id = TTEntry.id
+      )
+      WHERE tournamentId = ${tournamentId}
+        AND stage = ${stage}
+    `;
+    return;
+  }
+
+  await prisma.$executeRaw`
+    WITH ranked AS (
+      SELECT
+        id,
+        ROW_NUMBER() OVER (
+          ORDER BY
+            COALESCE(qualificationPoints, 0) DESC,
+            totalTime IS NULL ASC,
+            totalTime ASC,
+            id ASC
+        ) AS newRank
+      FROM TTEntry
+      WHERE tournamentId = ${tournamentId}
+        AND stage = ${stage}
+    )
+    UPDATE TTEntry
+    SET rank = (
+      SELECT newRank FROM ranked WHERE ranked.id = TTEntry.id
+    )
+    WHERE tournamentId = ${tournamentId}
+      AND stage = ${stage}
+  `;
+}


### PR DESCRIPTION
## Summary
- replace full TA rank recalculation after entry deletion with a single rank-only SQL update
- add TTEntry stage/ranking indexes for D1
- cover delete reranking in TA route and rank-calculation tests

## Validation
- npm test -- --runTestsByPath __tests__/lib/ta/rank-calculation.test.ts '__tests__/app/api/tournaments/[id]/ta/route.test.ts' --ci --forceExit\n- npm run lint\n- npm test -- --ci --forceExit\n- npm run build:cf\n\n## Production evidence\n- wrangler tail during production E2E showed repeated TTEntry.delete and rank recalculation $executeRaw slow_query warnings on DELETE /api/tournaments/:id/ta\n