### PR TITLE
Optimize TA write reranking and audit logs

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/route.test.ts
@@ -54,6 +54,7 @@ jest.mock('@/lib/sanitize', () => ({
 // Mock audit-log
 jest.mock('@/lib/audit-log', () => ({
   createAuditLog: jest.fn(() => Promise.resolve()),
+  createAuditLogs: jest.fn(() => Promise.resolve()),
   AUDIT_ACTIONS: {
     CREATE_TA_ENTRY: 'CREATE_TA_ENTRY',
     UPDATE_TA_ENTRY: 'UPDATE_TA_ENTRY',
@@ -145,6 +146,11 @@ const loggerMock = jest.requireMock('@/lib/logger') as {
 const rankCalculationMock = jest.requireMock('@/lib/ta/rank-calculation') as {
   recalculateRanks: jest.Mock;
   rerankStageAfterDelete: jest.Mock;
+};
+
+const auditLogMock = jest.requireMock('@/lib/audit-log') as {
+  createAuditLog: jest.Mock;
+  createAuditLogs: jest.Mock;
 };
 
 // Valid CUIDs for tests — the TA route uses z.string().cuid() for validation
@@ -335,6 +341,13 @@ describe('/api/tournaments/[id]/ta', () => {
         { success: true, data: { entries: [mockEntry] }, message: 'Player(s) added to time attack' },
         { status: 201 }
       );
+      expect(auditLogMock.createAuditLogs).toHaveBeenCalledWith([
+        expect.objectContaining({
+          action: 'CREATE_TA_ENTRY',
+          targetId: VALID_ENTRY_ID,
+          targetType: 'TTEntry',
+        }),
+      ]);
     });
 
     it('should return 409 when knockout has already started', async () => {

--- a/smkc-score-app/__tests__/lib/ta/rank-calculation.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/rank-calculation.test.ts
@@ -390,9 +390,7 @@ describe('TA Rank Calculation', () => {
       expect(mockPrisma.$executeRaw).not.toHaveBeenCalled();
     });
 
-    // D1 caps bound parameters at ~100. Qualification uses 9 params/entry,
-    // so batches of 10 keep each statement at 90 params (#732).
-    it('should chunk qualification updates into batches of 10 to stay under D1 param limit', async () => {
+    it('should update large qualification stages with one JSON-backed statement', async () => {
       const makeEntry = (i: number) => ({
         id: `entry-${i}`,
         times: {
@@ -408,15 +406,16 @@ describe('TA Rank Calculation', () => {
         player: { id: `player-${i}` },
       });
 
-      // 25 entries → ceil(25/10) = 3 batches
       mockPrisma.tTEntry.findMany.mockResolvedValue(Array.from({ length: 25 }, (_, i) => makeEntry(i)));
 
       await recalculateRanks('tournament-1', 'qualification', mockPrisma as unknown as PrismaClient);
 
-      expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(3);
+      expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
+      const templateStrings = mockPrisma.$executeRaw.mock.calls[0][0] as TemplateStringsArray;
+      expect(templateStrings.raw.join('')).toContain('json_each');
     });
 
-    it('should chunk non-qualification updates into batches of 18 to stay under D1 param limit', async () => {
+    it('should update large non-qualification stages with one JSON-backed statement', async () => {
       const makeEntry = (i: number) => ({
         id: `entry-${i}`,
         times: {
@@ -432,12 +431,13 @@ describe('TA Rank Calculation', () => {
         player: { id: `player-${i}` },
       });
 
-      // 36 entries → ceil(36/18) = 2 batches
       mockPrisma.tTEntry.findMany.mockResolvedValue(Array.from({ length: 36 }, (_, i) => makeEntry(i)));
 
       await recalculateRanks('tournament-1', 'revival_1', mockPrisma as unknown as PrismaClient);
 
-      expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
+      const templateStrings = mockPrisma.$executeRaw.mock.calls[0][0] as TemplateStringsArray;
+      expect(templateStrings.raw.join('')).toContain('json_each');
     });
 
     it('should rerank qualification after delete with a single rank-only update', async () => {

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
@@ -23,7 +23,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import type { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
-import { createAuditLog, AUDIT_ACTIONS, resolveAuditUserId } from "@/lib/audit-log";
+import { createAuditLog, createAuditLogs, AUDIT_ACTIONS, resolveAuditUserId } from "@/lib/audit-log";
 import { getClientIdentifier, getUserAgent } from "@/lib/request-utils";
 import { sanitizeInput } from "@/lib/sanitize";
 import { auth } from "@/lib/auth";
@@ -326,34 +326,21 @@ export async function POST(
           include: { player: { select: PLAYER_PUBLIC_SELECT } },
         });
 
-        // Audit logs in parallel. createAuditLog never throws (it catches
-        // and logs its own errors internally — see audit-log.ts), so wrap
-        // the whole batch in a defensive try/catch instead of per-promise.
-        try {
-          await Promise.all(
-            createdEntries.map((entry) =>
-              createAuditLog({
-                userId: resolveAuditUserId(authResult.session),
-                ipAddress,
-                userAgent,
-                action: AUDIT_ACTIONS.CREATE_TA_ENTRY,
-                targetId: entry.id,
-                targetType: "TTEntry",
-                details: {
-                  tournamentId,
-                  playerId: entry.playerId,
-                  playerNickname: entry.player.nickname,
-                },
-              }),
-            ),
-          );
-        } catch (logError) {
-          logger.warn("Failed to create audit log", {
-            error: logError,
-            tournamentId,
-            action: "CREATE_TA_ENTRY",
-          });
-        }
+        await createAuditLogs(
+          createdEntries.map((entry) => ({
+            userId: resolveAuditUserId(authResult.session),
+            ipAddress,
+            userAgent,
+            action: AUDIT_ACTIONS.CREATE_TA_ENTRY,
+            targetId: entry.id,
+            targetType: "TTEntry",
+            details: {
+              tournamentId,
+              playerId: entry.playerId,
+              playerNickname: entry.player.nickname,
+            },
+          })),
+        );
       }
     }
 

--- a/smkc-score-app/src/lib/audit-log.ts
+++ b/smkc-score-app/src/lib/audit-log.ts
@@ -197,46 +197,27 @@ export interface AuditLogParams {
  */
 export async function createAuditLog(params: AuditLogParams): Promise<void> {
   try {
-    // Sanitize all string inputs to prevent log injection attacks.
-    // Unlike sanitizeInput (XSS prevention), this targets log injection
-    // which uses newlines, control characters, and ANSI escapes.
-    const sanitizedIpAddress = sanitizeForAuditLog(params.ipAddress);
-    const sanitizedUserAgent = sanitizeForAuditLog(params.userAgent);
-    const sanitizedAction = sanitizeForAuditLog(params.action);
-
-    // Sanitize optional fields only when present
-    const sanitizedTargetId = params.targetId
-      ? sanitizeForAuditLog(params.targetId)
-      : undefined;
-    const sanitizedTargetType = params.targetType
-      ? sanitizeForAuditLog(params.targetType)
-      : undefined;
-
-    // Sanitize the details object if provided.
-    // This recursively sanitizes all string values within the JSON.
-    const sanitizedDetails = params.details
-      ? sanitizeObjectForAuditLog(params.details)
-      : undefined;
+    const sanitized = sanitizeAuditLogParams(params);
 
     // Create the audit log entry in the database.
     // The AuditLog model has indexes on timestamp, userId, action,
     // and (targetType, targetId) for efficient querying.
     await prisma.auditLog.create({
       data: {
-        userId: params.userId || null,
-        ipAddress: sanitizedIpAddress,
-        userAgent: sanitizedUserAgent,
-        action: sanitizedAction,
-        targetId: sanitizedTargetId,
-        targetType: sanitizedTargetType,
-        details: sanitizedDetails ? JSON.parse(JSON.stringify(sanitizedDetails)) : undefined,
+        userId: sanitized.userId,
+        ipAddress: sanitized.ipAddress,
+        userAgent: sanitized.userAgent,
+        action: sanitized.action,
+        targetId: sanitized.targetId,
+        targetType: sanitized.targetType,
+        details: sanitized.details,
       },
     });
 
     logger.debug('Audit log created', {
-      action: sanitizedAction,
-      targetType: sanitizedTargetType,
-      targetId: sanitizedTargetId,
+      action: sanitized.action,
+      targetType: sanitized.targetType,
+      targetId: sanitized.targetId,
     });
   } catch (error) {
     // CRITICAL: Never let audit logging failures bubble up to the caller.
@@ -244,6 +225,39 @@ export async function createAuditLog(params: AuditLogParams): Promise<void> {
     // We log the failure for operations teams to investigate.
     logger.error('Failed to create audit log', {
       action: params.action,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function sanitizeAuditLogParams(params: AuditLogParams) {
+  const sanitizedDetails = params.details
+    ? sanitizeObjectForAuditLog(params.details)
+    : undefined;
+
+  return {
+    userId: params.userId || null,
+    ipAddress: sanitizeForAuditLog(params.ipAddress),
+    userAgent: sanitizeForAuditLog(params.userAgent),
+    action: sanitizeForAuditLog(params.action),
+    targetId: params.targetId ? sanitizeForAuditLog(params.targetId) : undefined,
+    targetType: params.targetType ? sanitizeForAuditLog(params.targetType) : undefined,
+    details: sanitizedDetails ? JSON.parse(JSON.stringify(sanitizedDetails)) : undefined,
+  };
+}
+
+export async function createAuditLogs(paramsList: AuditLogParams[]): Promise<void> {
+  if (paramsList.length === 0) return;
+
+  try {
+    await prisma.auditLog.createMany({
+      data: paramsList.map(sanitizeAuditLogParams),
+    });
+
+    logger.debug('Audit logs created', { count: paramsList.length });
+  } catch (error) {
+    logger.error('Failed to create audit logs', {
+      count: paramsList.length,
       error: error instanceof Error ? error.message : String(error),
     });
   }

--- a/smkc-score-app/src/lib/ta/rank-calculation.ts
+++ b/smkc-score-app/src/lib/ta/rank-calculation.ts
@@ -23,7 +23,7 @@ import { COURSES } from "@/lib/constants";
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { timeToMs } from "@/lib/ta/time-utils";
 import { calculateAllCourseScores } from "@/lib/ta/qualification-scoring";
-import { PrismaClient, Prisma } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 
 /**
  * Represents a tournament entry with its calculated total time and scoring data.
@@ -220,52 +220,50 @@ export async function recalculateRanks(
   // Early return avoids sending an empty WHERE IN () clause to D1.
   if (entriesWithTotal.length === 0) return;
 
-  // D1 enforces a ~100 bound-parameter limit per SQL statement.
-  // Qualification CASE WHEN uses 9 params/entry (4 CASE blocks × 2 + 1 WHERE IN id).
-  // Other stages use 5 params/entry (2 CASE blocks × 2 + 1 WHERE IN id).
-  // Chunk into batches that stay under the limit (#732).
-  const BATCH_SIZE = stage === "qualification" ? 10 : 18;
+  const rankUpdates = entriesWithTotal.map((entry) => ({
+    id: entry.id,
+    totalTime: entry.totalTime,
+    rank: rankMap.get(entry.id) ?? null,
+    courseScores: entry.courseScores,
+    qualificationPoints: entry.qualificationPoints,
+  }));
 
-  for (let offset = 0; offset < entriesWithTotal.length; offset += BATCH_SIZE) {
-    const batch = entriesWithTotal.slice(offset, offset + BATCH_SIZE);
-
-    const totalTimeCases = Prisma.join(
-      batch.map((e) => Prisma.sql`WHEN ${e.id} THEN ${e.totalTime ?? null}`),
-      ' '
-    );
-    const rankCases = Prisma.join(
-      batch.map((e) => Prisma.sql`WHEN ${e.id} THEN ${rankMap.get(e.id) ?? null}`),
-      ' '
-    );
-    const ids = Prisma.join(batch.map((e) => Prisma.sql`${e.id}`));
-
-    if (stage === "qualification") {
-      // courseScores is a JSON column stored as text; pass the serialized string directly.
-      const courseScoresCases = Prisma.join(
-        batch.map((e) => Prisma.sql`WHEN ${e.id} THEN ${JSON.stringify(e.courseScores)}`),
-        ' '
-      );
-      const qualPointsCases = Prisma.join(
-        batch.map((e) => Prisma.sql`WHEN ${e.id} THEN ${e.qualificationPoints ?? null}`),
-        ' '
-      );
-      await prisma.$executeRaw`
-        UPDATE TTEntry SET
-          totalTime = CASE id ${totalTimeCases} ELSE totalTime END,
-          rank = CASE id ${rankCases} ELSE rank END,
-          courseScores = CASE id ${courseScoresCases} ELSE courseScores END,
-          qualificationPoints = CASE id ${qualPointsCases} ELSE qualificationPoints END
-        WHERE id IN (${ids})
-      `;
-    } else {
-      await prisma.$executeRaw`
-        UPDATE TTEntry SET
-          totalTime = CASE id ${totalTimeCases} ELSE totalTime END,
-          rank = CASE id ${rankCases} ELSE rank END
-        WHERE id IN (${ids})
-      `;
-    }
+  if (stage === "qualification") {
+    await prisma.$executeRaw`
+      WITH updates AS (
+        SELECT
+          json_extract(value, '$.id') AS id,
+          json_extract(value, '$.totalTime') AS totalTime,
+          json_extract(value, '$.rank') AS rank,
+          json_extract(value, '$.courseScores') AS courseScores,
+          json_extract(value, '$.qualificationPoints') AS qualificationPoints
+        FROM json_each(${JSON.stringify(rankUpdates)})
+      )
+      UPDATE TTEntry
+      SET
+        totalTime = (SELECT totalTime FROM updates WHERE updates.id = TTEntry.id),
+        rank = (SELECT rank FROM updates WHERE updates.id = TTEntry.id),
+        courseScores = (SELECT courseScores FROM updates WHERE updates.id = TTEntry.id),
+        qualificationPoints = (SELECT qualificationPoints FROM updates WHERE updates.id = TTEntry.id)
+      WHERE id IN (SELECT id FROM updates)
+    `;
+    return;
   }
+
+  await prisma.$executeRaw`
+    WITH updates AS (
+      SELECT
+        json_extract(value, '$.id') AS id,
+        json_extract(value, '$.totalTime') AS totalTime,
+        json_extract(value, '$.rank') AS rank
+      FROM json_each(${JSON.stringify(rankUpdates)})
+    )
+    UPDATE TTEntry
+    SET
+      totalTime = (SELECT totalTime FROM updates WHERE updates.id = TTEntry.id),
+      rank = (SELECT rank FROM updates WHERE updates.id = TTEntry.id)
+    WHERE id IN (SELECT id FROM updates)
+  `;
 }
 
 /**


### PR DESCRIPTION
## Summary
- collapse TA rank persistence into one JSON-backed D1 update instead of parameter-limited batches
- add bulk audit log creation and use it for TA qualification registration
- update TA route/rank tests for the new bulk paths

## Validation
- npm test -- --runTestsByPath __tests__/lib/ta/rank-calculation.test.ts '__tests__/app/api/tournaments/[id]/ta/route.test.ts' __tests__/lib/audit-log.test.ts --ci --forceExit\n- npm run lint\n- npm test -- --ci --forceExit\n- npm run build:cf