### PR TITLE
Assert bulk audit failure logging

### DIFF
--- a/smkc-score-app/__tests__/lib/audit-log.test.ts
+++ b/smkc-score-app/__tests__/lib/audit-log.test.ts
@@ -291,6 +291,13 @@ describe('Audit Log', () => {
       ]);
 
       expect(result).toBeUndefined();
+      expect(loggerModuleMock.__auditLogger.error).toHaveBeenCalledWith(
+        'Failed to create audit logs',
+        {
+          count: 1,
+          error: 'Database connection failed',
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- assert createAuditLogs logs bulk failure metadata when createMany rejects

Fixes #966

## Validation
- npm test -- --runTestsByPath __tests__/lib/audit-log.test.ts --ci --forceExit
- npm run lint