### PR TITLE
Update bulk audit failure test name

### DIFF
--- a/smkc-score-app/__tests__/lib/audit-log.test.ts
+++ b/smkc-score-app/__tests__/lib/audit-log.test.ts
@@ -279,7 +279,7 @@ describe('Audit Log', () => {
       expect(loggerModuleMock.__auditLogger.debug).toHaveBeenCalledWith('Audit logs created', { count: 2 });
     });
 
-    it('should not throw when bulk audit creation fails', async () => {
+    it('should not throw and should log error metadata when bulk audit creation fails', async () => {
       (prismaMock.auditLog.createMany as any).mockRejectedValue(new Error('Database connection failed'));
 
       const result = await createAuditLogs([


### PR DESCRIPTION
## Summary
- rename the bulk audit failure test to include the error metadata assertion

Fixes #968

## Validation
- npm test -- --runTestsByPath __tests__/lib/audit-log.test.ts --ci --forceExit
- npm run lint