### PR TITLE
Require explicit TA delete rerank stage

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/rank-calculation.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/rank-calculation.test.ts
@@ -440,6 +440,10 @@ describe('TA Rank Calculation', () => {
       expect(templateStrings.raw.join('')).toContain('json_each');
     });
 
+    it('requires callers to pass the stage explicitly', () => {
+      expect(rerankStageAfterDelete).toHaveLength(3);
+    });
+
     it('should rerank qualification after delete with a single rank-only update', async () => {
       await rerankStageAfterDelete('tournament-1', 'qualification', mockPrisma as unknown as PrismaClient);
 

--- a/smkc-score-app/src/lib/ta/rank-calculation.ts
+++ b/smkc-score-app/src/lib/ta/rank-calculation.ts
@@ -276,7 +276,7 @@ export async function recalculateRanks(
  */
 export async function rerankStageAfterDelete(
   tournamentId: string,
-  stage: string = "qualification",
+  stage: string,
   prisma: PrismaClient
 ): Promise<void> {
   if (stage === "revival_1" || stage === "revival_2") {


### PR DESCRIPTION
## Summary
- remove the implicit qualification default from `rerankStageAfterDelete`
- add a focused unit assertion that the helper requires tournament, stage, and prisma arguments

## Issues
Closes #958

## Validation
- npm test -- --runTestsByPath __tests__/lib/ta/rank-calculation.test.ts '__tests__/app/api/tournaments/[id]/ta/route.test.ts' --ci --forceExit
- npm run lint
