### PR TITLE
Bulk insert qualification matches for large setup

### DIFF
--- a/smkc-score-app/__mocks__/lib/prisma.ts
+++ b/smkc-score-app/__mocks__/lib/prisma.ts
@@ -76,6 +76,7 @@ const mockPrisma = {
     deleteMany: jest.fn(),
   },
   $transaction: jest.fn(),
+  $executeRaw: jest.fn(),
 };
 
 export const prisma = mockPrisma;

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -310,9 +310,9 @@ describe('Qualification Route Factory', () => {
       expect(matchCall.data).toHaveLength(7);
     });
 
-    it('should chunk createMany into batches of 8 for matches when row count exceeds chunk size (#736)', async () => {
+    it('should use one JSON-backed raw insert when match row count exceeds the D1 createMany chunk size', async () => {
       // 8 players in a single group → 8×7/2 = 28 matches (exceeds MATCH_CHUNK=8)
-      // Expected: ceil(28/8) = 4 createMany calls with slices [0-8, 8-16, 16-24, 24-28]
+      // Expected: one JSON-backed raw insert instead of 4 sequential createMany chunks.
       const players = [
         { playerId: 'player-1', group: 'A', seeding: 1 },
         { playerId: 'player-2', group: 'A', seeding: 2 },
@@ -328,6 +328,7 @@ describe('Qualification Route Factory', () => {
       (prisma.bMQualification as any).findMany.mockResolvedValue([]);
       (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 8 });
       (prisma.bMMatch as any).findMany.mockResolvedValue([]);
+      (prisma as any).$executeRaw.mockResolvedValue(28);
 
       const config = createMockConfig();
       const { POST } = createQualificationHandlers(config);
@@ -345,16 +346,13 @@ describe('Qualification Route Factory', () => {
       // 8 qual records fit in 1 QUAL_CHUNK=24 → 1 call
       expect((prisma.bMQualification as any).createMany).toHaveBeenCalledTimes(1);
 
-      // 28 matches split into 4 chunks of [8, 8, 8, 4]
-      const matchCalls = (prisma.bMMatch as any).createMany.mock.calls;
-      expect(matchCalls).toHaveLength(4);
-      expect(matchCalls[0][0].data).toHaveLength(8);
-      expect(matchCalls[1][0].data).toHaveLength(8);
-      expect(matchCalls[2][0].data).toHaveLength(8);
-      expect(matchCalls[3][0].data).toHaveLength(4);
-      // Total matches across all chunks = 28
-      const totalMatches = matchCalls.reduce((sum: number, call: any[]) => sum + call[0].data.length, 0);
-      expect(totalMatches).toBe(28);
+      expect((prisma.bMMatch as any).createMany).not.toHaveBeenCalled();
+      expect((prisma as any).$executeRaw).toHaveBeenCalledTimes(1);
+      const templateStrings = (prisma as any).$executeRaw.mock.calls[0][0] as TemplateStringsArray;
+      expect(templateStrings.raw.join('')).toContain('json_each');
+      expect(templateStrings.raw.join('')).toContain('INSERT INTO BMMatch');
+      const payload = JSON.parse((prisma as any).$executeRaw.mock.calls[0][1]);
+      expect(payload).toHaveLength(28);
     });
 
     it('should chunk qual createMany when record count exceeds QUAL_CHUNK=24 (#769)', async () => {

--- a/smkc-score-app/jest.setup.js
+++ b/smkc-score-app/jest.setup.js
@@ -155,6 +155,7 @@ jest.mock('@/lib/prisma', () => {
       create: jest.fn(),
       deleteMany: jest.fn(),
     },
+    $executeRaw: jest.fn(),
   }
 
   return {

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -79,6 +79,130 @@ function getAssignedCourses(shuffled: string[], matchIndex: number): string[] {
   );
 }
 
+function createCuidLikeId(): string {
+  const random = Array.from(crypto.getRandomValues(new Uint8Array(12)))
+    .map((byte) => byte.toString(36).padStart(2, '0'))
+    .join('');
+  return `c${Date.now().toString(36)}${random}`.slice(0, 25);
+}
+
+async function insertQualificationMatches(
+  eventTypeCode: EventTypeConfig['eventTypeCode'],
+  matchData: Array<Record<string, unknown>>,
+): Promise<boolean> {
+  if (matchData.length === 0) return true;
+
+  const rows = matchData.map((match) => ({
+    id: createCuidLikeId(),
+    tournamentId: match.tournamentId,
+    matchNumber: match.matchNumber,
+    stage: match.stage,
+    player1Id: match.player1Id,
+    player2Id: match.player2Id,
+    player1Side: match.player1Side,
+    player2Side: match.player2Side,
+    roundNumber: match.roundNumber ?? null,
+    isBye: match.isBye ? 1 : 0,
+    completed: match.completed ? 1 : 0,
+    score1: match.score1 ?? 0,
+    score2: match.score2 ?? 0,
+    points1: match.points1 ?? 0,
+    points2: match.points2 ?? 0,
+    assignedCourses: match.assignedCourses ?? null,
+    cup: match.cup ?? null,
+  }));
+  const payload = JSON.stringify(rows);
+
+  if (eventTypeCode === 'bm') {
+    await prisma.$executeRaw`
+      INSERT INTO BMMatch (
+        id, tournamentId, matchNumber, stage, player1Id, player2Id,
+        player1Side, player2Side, roundNumber, isBye, completed,
+        score1, score2, assignedCourses, createdAt, updatedAt
+      )
+      SELECT
+        json_extract(value, '$.id'),
+        json_extract(value, '$.tournamentId'),
+        json_extract(value, '$.matchNumber'),
+        json_extract(value, '$.stage'),
+        json_extract(value, '$.player1Id'),
+        json_extract(value, '$.player2Id'),
+        json_extract(value, '$.player1Side'),
+        json_extract(value, '$.player2Side'),
+        json_extract(value, '$.roundNumber'),
+        json_extract(value, '$.isBye'),
+        json_extract(value, '$.completed'),
+        json_extract(value, '$.score1'),
+        json_extract(value, '$.score2'),
+        json_extract(value, '$.assignedCourses'),
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      FROM json_each(${payload})
+    `;
+    return true;
+  }
+
+  if (eventTypeCode === 'mr') {
+    await prisma.$executeRaw`
+      INSERT INTO MRMatch (
+        id, tournamentId, matchNumber, stage, player1Id, player2Id,
+        player1Side, player2Side, roundNumber, isBye, completed,
+        score1, score2, assignedCourses, createdAt, updatedAt
+      )
+      SELECT
+        json_extract(value, '$.id'),
+        json_extract(value, '$.tournamentId'),
+        json_extract(value, '$.matchNumber'),
+        json_extract(value, '$.stage'),
+        json_extract(value, '$.player1Id'),
+        json_extract(value, '$.player2Id'),
+        json_extract(value, '$.player1Side'),
+        json_extract(value, '$.player2Side'),
+        json_extract(value, '$.roundNumber'),
+        json_extract(value, '$.isBye'),
+        json_extract(value, '$.completed'),
+        json_extract(value, '$.score1'),
+        json_extract(value, '$.score2'),
+        json_extract(value, '$.assignedCourses'),
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      FROM json_each(${payload})
+    `;
+    return true;
+  }
+
+  if (eventTypeCode === 'gp') {
+    await prisma.$executeRaw`
+      INSERT INTO GPMatch (
+        id, tournamentId, matchNumber, stage, player1Id, player2Id,
+        player1Side, player2Side, roundNumber, isBye, completed,
+        points1, points2, cup, createdAt, updatedAt
+      )
+      SELECT
+        json_extract(value, '$.id'),
+        json_extract(value, '$.tournamentId'),
+        json_extract(value, '$.matchNumber'),
+        json_extract(value, '$.stage'),
+        json_extract(value, '$.player1Id'),
+        json_extract(value, '$.player2Id'),
+        json_extract(value, '$.player1Side'),
+        json_extract(value, '$.player2Side'),
+        json_extract(value, '$.roundNumber'),
+        json_extract(value, '$.isBye'),
+        json_extract(value, '$.completed'),
+        json_extract(value, '$.points1'),
+        json_extract(value, '$.points2'),
+        json_extract(value, '$.cup'),
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      FROM json_each(${payload})
+    `;
+    return true;
+  }
+
+  return false;
+}
+
 /**
  * Create qualification route handlers from an event type configuration.
  *
@@ -424,14 +548,22 @@ export function createQualificationHandlers(config: EventTypeConfig) {
         }
       }
 
-      // D1 bound-parameter limit is ~100 per SQL statement (#736).
-      // Match rows have up to 12 columns (9 base + isBye BYE fields: completed/score1/score2,
-      // and optional MR/GP fields: assignedCourses/cup) → chunk at 8 rows (96 params worst-case)
-      // to stay safely under the limit regardless of which optional fields are present.
       if (matchData.length > 0) {
-        const MATCH_CHUNK = 8;
-        for (let i = 0; i < matchData.length; i += MATCH_CHUNK) {
-          await matchModel(prisma).createMany({ data: matchData.slice(i, i + MATCH_CHUNK) });
+        /*
+         * D1's bound-parameter limit previously forced createMany into 8-row
+         * chunks. A 28-player E2E seed then spent dozens of sequential
+         * round-trips creating matches and could trip production request
+         * limits. For large inserts, pass one JSON payload to SQLite's JSON1
+         * table function and insert every qualification match in one query.
+         * Small inserts stay on Prisma createMany so unit tests and ordinary
+         * admin edits keep their narrower, familiar path.
+         */
+        const RAW_INSERT_THRESHOLD = 8;
+        const insertedWithRaw = matchData.length > RAW_INSERT_THRESHOLD
+          ? await insertQualificationMatches(config.eventTypeCode, matchData)
+          : false;
+        if (!insertedWithRaw) {
+          await matchModel(prisma).createMany({ data: matchData });
         }
       }
 


### PR DESCRIPTION
## Summary
- insert large BM/MR/GP qualification match batches with one JSON-backed D1 raw insert
- keep small qualification setup on Prisma createMany
- update qualification route tests and Prisma mocks for the raw insert path

## Validation
- npm test -- --runTestsByPath __tests__/lib/api-factories/qualification-route.test.ts --runInBand
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/bm/route.test.ts' '__tests__/app/api/tournaments/[id]/mr/route.test.ts' '__tests__/app/api/tournaments/[id]/gp/route.test.ts' --runInBand
- npm run lint
- npm run build:cf
- npm test -- --runInBand
