### PR TITLE
Cover qualification raw insert followups

### DIFF
--- a/smkc-score-app/__mocks__/lib/prisma.ts
+++ b/smkc-score-app/__mocks__/lib/prisma.ts
@@ -77,6 +77,7 @@ const mockPrisma = {
   },
   $transaction: jest.fn(),
   $executeRaw: jest.fn(),
+  $executeRawUnsafe: jest.fn(),
 };
 
 export const prisma = mockPrisma;

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -328,7 +328,7 @@ describe('Qualification Route Factory', () => {
       (prisma.bMQualification as any).findMany.mockResolvedValue([]);
       (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 8 });
       (prisma.bMMatch as any).findMany.mockResolvedValue([]);
-      (prisma as any).$executeRaw.mockResolvedValue(28);
+      (prisma as any).$executeRawUnsafe.mockResolvedValue(28);
 
       const config = createMockConfig();
       const { POST } = createQualificationHandlers(config);
@@ -347,12 +347,133 @@ describe('Qualification Route Factory', () => {
       expect((prisma.bMQualification as any).createMany).toHaveBeenCalledTimes(1);
 
       expect((prisma.bMMatch as any).createMany).not.toHaveBeenCalled();
-      expect((prisma as any).$executeRaw).toHaveBeenCalledTimes(1);
-      const templateStrings = (prisma as any).$executeRaw.mock.calls[0][0] as TemplateStringsArray;
-      expect(templateStrings.raw.join('')).toContain('json_each');
-      expect(templateStrings.raw.join('')).toContain('INSERT INTO BMMatch');
-      const payload = JSON.parse((prisma as any).$executeRaw.mock.calls[0][1]);
+      expect((prisma as any).$executeRawUnsafe).toHaveBeenCalledTimes(1);
+      const sql = (prisma as any).$executeRawUnsafe.mock.calls[0][0] as string;
+      expect(sql).toContain('json_each');
+      expect(sql).toContain('INSERT INTO BMMatch');
+      const payload = JSON.parse((prisma as any).$executeRawUnsafe.mock.calls[0][1]);
       expect(payload).toHaveLength(28);
+    });
+
+    it('should use the MR raw insert mapping for large qualification setup', async () => {
+      const players = Array.from({ length: 8 }, (_, i) => ({
+        playerId: `player-${i + 1}`,
+        group: 'A',
+        seeding: i + 1,
+      }));
+
+      (prisma.mRQualification as any).createMany.mockResolvedValue({ count: 8 });
+      (prisma.mRQualification as any).findMany.mockResolvedValue([]);
+      (prisma.mRMatch as any).findMany.mockResolvedValue([]);
+      (prisma as any).$executeRawUnsafe.mockResolvedValue(28);
+
+      const config = createMockConfig({
+        eventTypeCode: 'mr',
+        matchModel: 'mRMatch',
+        qualificationModel: 'mRQualification',
+        assignCoursesRandomly: true,
+      });
+      const { POST } = createQualificationHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ players }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(201);
+      expect((prisma.mRMatch as any).createMany).not.toHaveBeenCalled();
+      const sql = (prisma as any).$executeRawUnsafe.mock.calls[0][0] as string;
+      expect(sql).toContain('INSERT INTO MRMatch');
+      expect(sql).toContain('assignedCourses');
+      const payload = JSON.parse((prisma as any).$executeRawUnsafe.mock.calls[0][1]);
+      expect(payload).toHaveLength(28);
+      expect(payload.find((row: any) => row.assignedCourses)).toEqual(
+        expect.objectContaining({ assignedCourses: expect.any(Array) }),
+      );
+    });
+
+    it('should use the GP raw insert mapping for large qualification setup', async () => {
+      const players = Array.from({ length: 8 }, (_, i) => ({
+        playerId: `player-${i + 1}`,
+        group: 'A',
+        seeding: i + 1,
+      }));
+
+      (prisma.gPQualification as any).createMany.mockResolvedValue({ count: 8 });
+      (prisma.gPQualification as any).findMany.mockResolvedValue([]);
+      (prisma.gPMatch as any).findMany.mockResolvedValue([]);
+      (prisma as any).$executeRawUnsafe.mockResolvedValue(28);
+
+      const cupList = ['Mushroom', 'Flower', 'Star', 'Special'] as const;
+      const config = createMockConfig({
+        eventTypeCode: 'gp',
+        matchModel: 'gPMatch',
+        qualificationModel: 'gPQualification',
+        assignCupRandomly: true,
+        cupList,
+      });
+      const { POST } = createQualificationHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ players }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(201);
+      expect((prisma.gPMatch as any).createMany).not.toHaveBeenCalled();
+      const sql = (prisma as any).$executeRawUnsafe.mock.calls[0][0] as string;
+      expect(sql).toContain('INSERT INTO GPMatch');
+      expect(sql).toContain('points1, points2, cup');
+      const payload = JSON.parse((prisma as any).$executeRawUnsafe.mock.calls[0][1]);
+      expect(payload).toHaveLength(28);
+      expect(payload.find((row: any) => row.cup)).toEqual(
+        expect.objectContaining({ cup: expect.stringMatching(/Mushroom|Flower|Star|Special/) }),
+      );
+    });
+
+    it('should fail explicitly instead of falling back to createMany for unsupported large raw insert modes', async () => {
+      const players = Array.from({ length: 8 }, (_, i) => ({
+        playerId: `player-${i + 1}`,
+        group: 'A',
+        seeding: i + 1,
+      }));
+
+      (prisma.bMQualification as any).createMany.mockResolvedValue({ count: 8 });
+      (prisma.bMQualification as any).findMany.mockResolvedValue([]);
+      (prisma.bMMatch as any).findMany.mockResolvedValue([]);
+
+      const config = createMockConfig({
+        eventTypeCode: 'xx',
+      });
+      const { POST } = createQualificationHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ players }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+      const result = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(result).toEqual({ success: false, error: 'Failed to setup Battle Mode', code: 'INTERNAL_ERROR' });
+      expect((prisma.bMMatch as any).createMany).not.toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to setup Battle Mode',
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: 'Unsupported qualification match bulk insert mode: xx',
+          }),
+          tournamentId: 'tournament-123',
+        }),
+      );
     });
 
     it('should chunk qual createMany when record count exceeds QUAL_CHUNK=24 (#769)', async () => {

--- a/smkc-score-app/jest.setup.js
+++ b/smkc-score-app/jest.setup.js
@@ -156,6 +156,7 @@ jest.mock('@/lib/prisma', () => {
       deleteMany: jest.fn(),
     },
     $executeRaw: jest.fn(),
+    $executeRawUnsafe: jest.fn(),
   }
 
   return {

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -86,11 +86,94 @@ function createCuidLikeId(): string {
   return `c${Date.now().toString(36)}${random}`.slice(0, 25);
 }
 
+const QUALIFICATION_MATCH_INSERT_SQL = {
+  bm: `
+    INSERT INTO BMMatch (
+      id, tournamentId, matchNumber, stage, player1Id, player2Id,
+      player1Side, player2Side, roundNumber, isBye, completed,
+      score1, score2, assignedCourses, createdAt, updatedAt
+    )
+    SELECT
+      json_extract(value, '$.id'),
+      json_extract(value, '$.tournamentId'),
+      json_extract(value, '$.matchNumber'),
+      json_extract(value, '$.stage'),
+      json_extract(value, '$.player1Id'),
+      json_extract(value, '$.player2Id'),
+      json_extract(value, '$.player1Side'),
+      json_extract(value, '$.player2Side'),
+      json_extract(value, '$.roundNumber'),
+      json_extract(value, '$.isBye'),
+      json_extract(value, '$.completed'),
+      json_extract(value, '$.score1'),
+      json_extract(value, '$.score2'),
+      json_extract(value, '$.assignedCourses'),
+      CURRENT_TIMESTAMP,
+      CURRENT_TIMESTAMP
+    FROM json_each(?)
+  `,
+  mr: `
+    INSERT INTO MRMatch (
+      id, tournamentId, matchNumber, stage, player1Id, player2Id,
+      player1Side, player2Side, roundNumber, isBye, completed,
+      score1, score2, assignedCourses, createdAt, updatedAt
+    )
+    SELECT
+      json_extract(value, '$.id'),
+      json_extract(value, '$.tournamentId'),
+      json_extract(value, '$.matchNumber'),
+      json_extract(value, '$.stage'),
+      json_extract(value, '$.player1Id'),
+      json_extract(value, '$.player2Id'),
+      json_extract(value, '$.player1Side'),
+      json_extract(value, '$.player2Side'),
+      json_extract(value, '$.roundNumber'),
+      json_extract(value, '$.isBye'),
+      json_extract(value, '$.completed'),
+      json_extract(value, '$.score1'),
+      json_extract(value, '$.score2'),
+      json_extract(value, '$.assignedCourses'),
+      CURRENT_TIMESTAMP,
+      CURRENT_TIMESTAMP
+    FROM json_each(?)
+  `,
+  gp: `
+    INSERT INTO GPMatch (
+      id, tournamentId, matchNumber, stage, player1Id, player2Id,
+      player1Side, player2Side, roundNumber, isBye, completed,
+      points1, points2, cup, createdAt, updatedAt
+    )
+    SELECT
+      json_extract(value, '$.id'),
+      json_extract(value, '$.tournamentId'),
+      json_extract(value, '$.matchNumber'),
+      json_extract(value, '$.stage'),
+      json_extract(value, '$.player1Id'),
+      json_extract(value, '$.player2Id'),
+      json_extract(value, '$.player1Side'),
+      json_extract(value, '$.player2Side'),
+      json_extract(value, '$.roundNumber'),
+      json_extract(value, '$.isBye'),
+      json_extract(value, '$.completed'),
+      json_extract(value, '$.points1'),
+      json_extract(value, '$.points2'),
+      json_extract(value, '$.cup'),
+      CURRENT_TIMESTAMP,
+      CURRENT_TIMESTAMP
+    FROM json_each(?)
+  `,
+} as const;
+
 async function insertQualificationMatches(
   eventTypeCode: EventTypeConfig['eventTypeCode'],
   matchData: Array<Record<string, unknown>>,
-): Promise<boolean> {
-  if (matchData.length === 0) return true;
+): Promise<void> {
+  if (matchData.length === 0) return;
+
+  const sql = QUALIFICATION_MATCH_INSERT_SQL[eventTypeCode];
+  if (!sql) {
+    throw new Error(`Unsupported qualification match bulk insert mode: ${eventTypeCode}`);
+  }
 
   const rows = matchData.map((match) => ({
     id: createCuidLikeId(),
@@ -111,96 +194,9 @@ async function insertQualificationMatches(
     assignedCourses: match.assignedCourses ?? null,
     cup: match.cup ?? null,
   }));
-  const payload = JSON.stringify(rows);
 
-  if (eventTypeCode === 'bm') {
-    await prisma.$executeRaw`
-      INSERT INTO BMMatch (
-        id, tournamentId, matchNumber, stage, player1Id, player2Id,
-        player1Side, player2Side, roundNumber, isBye, completed,
-        score1, score2, assignedCourses, createdAt, updatedAt
-      )
-      SELECT
-        json_extract(value, '$.id'),
-        json_extract(value, '$.tournamentId'),
-        json_extract(value, '$.matchNumber'),
-        json_extract(value, '$.stage'),
-        json_extract(value, '$.player1Id'),
-        json_extract(value, '$.player2Id'),
-        json_extract(value, '$.player1Side'),
-        json_extract(value, '$.player2Side'),
-        json_extract(value, '$.roundNumber'),
-        json_extract(value, '$.isBye'),
-        json_extract(value, '$.completed'),
-        json_extract(value, '$.score1'),
-        json_extract(value, '$.score2'),
-        json_extract(value, '$.assignedCourses'),
-        CURRENT_TIMESTAMP,
-        CURRENT_TIMESTAMP
-      FROM json_each(${payload})
-    `;
-    return true;
-  }
-
-  if (eventTypeCode === 'mr') {
-    await prisma.$executeRaw`
-      INSERT INTO MRMatch (
-        id, tournamentId, matchNumber, stage, player1Id, player2Id,
-        player1Side, player2Side, roundNumber, isBye, completed,
-        score1, score2, assignedCourses, createdAt, updatedAt
-      )
-      SELECT
-        json_extract(value, '$.id'),
-        json_extract(value, '$.tournamentId'),
-        json_extract(value, '$.matchNumber'),
-        json_extract(value, '$.stage'),
-        json_extract(value, '$.player1Id'),
-        json_extract(value, '$.player2Id'),
-        json_extract(value, '$.player1Side'),
-        json_extract(value, '$.player2Side'),
-        json_extract(value, '$.roundNumber'),
-        json_extract(value, '$.isBye'),
-        json_extract(value, '$.completed'),
-        json_extract(value, '$.score1'),
-        json_extract(value, '$.score2'),
-        json_extract(value, '$.assignedCourses'),
-        CURRENT_TIMESTAMP,
-        CURRENT_TIMESTAMP
-      FROM json_each(${payload})
-    `;
-    return true;
-  }
-
-  if (eventTypeCode === 'gp') {
-    await prisma.$executeRaw`
-      INSERT INTO GPMatch (
-        id, tournamentId, matchNumber, stage, player1Id, player2Id,
-        player1Side, player2Side, roundNumber, isBye, completed,
-        points1, points2, cup, createdAt, updatedAt
-      )
-      SELECT
-        json_extract(value, '$.id'),
-        json_extract(value, '$.tournamentId'),
-        json_extract(value, '$.matchNumber'),
-        json_extract(value, '$.stage'),
-        json_extract(value, '$.player1Id'),
-        json_extract(value, '$.player2Id'),
-        json_extract(value, '$.player1Side'),
-        json_extract(value, '$.player2Side'),
-        json_extract(value, '$.roundNumber'),
-        json_extract(value, '$.isBye'),
-        json_extract(value, '$.completed'),
-        json_extract(value, '$.points1'),
-        json_extract(value, '$.points2'),
-        json_extract(value, '$.cup'),
-        CURRENT_TIMESTAMP,
-        CURRENT_TIMESTAMP
-      FROM json_each(${payload})
-    `;
-    return true;
-  }
-
-  return false;
+  // Table/column SQL is selected from the static map above; only payload is bound.
+  await prisma.$executeRawUnsafe(sql, JSON.stringify(rows));
 }
 
 /**
@@ -559,10 +555,9 @@ export function createQualificationHandlers(config: EventTypeConfig) {
          * admin edits keep their narrower, familiar path.
          */
         const RAW_INSERT_THRESHOLD = 8;
-        const insertedWithRaw = matchData.length > RAW_INSERT_THRESHOLD
-          ? await insertQualificationMatches(config.eventTypeCode, matchData)
-          : false;
-        if (!insertedWithRaw) {
+        if (matchData.length > RAW_INSERT_THRESHOLD) {
+          await insertQualificationMatches(config.eventTypeCode, matchData);
+        } else {
           await matchModel(prisma).createMany({ data: matchData });
         }
       }


### PR DESCRIPTION
## Summary
- close #972 by covering MR and GP raw qualification match insert paths
- close #973 by moving BM/MR/GP raw insert SQL into a static mapping
- close #974 by failing explicitly for unsupported large raw insert modes instead of falling back to createMany

## Validation
- npm test -- --runTestsByPath __tests__/lib/api-factories/qualification-route.test.ts --runInBand
- npm run lint
- npm test -- --runInBand
- npm run build:cf

Closes #972
Closes #973
Closes #974
