### PR TITLE
Share TA qualification rerank order

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1398,19 +1398,19 @@
   6. クリーンアップ
 - **期待結果**: TA は手動操作なしで同着が平均ポイントで解決され、TC-324/TC-620/TC-713 と同じ同着回帰カバレッジを持つ
 
-## TC-813: TA 予選エントリー削除後のランク再計算 (issue #710)
+## TC-813: TA 予選エントリー削除後のランク再計算 (issue #710/#959)
 - **URL**: /api/tournaments/[temp-id]/ta (DELETE), /api/tournaments/[temp-id]/ta (GET)
 - **authRequired**: true (admin)
-- **背景** (issue #710): `recalculateRanks` は以前 N 件の `TTEntry.update` を直列実行していたため、27エントリー時に ~5s のレスポンス遅延が発生していた。修正により単一の `UPDATE ... CASE WHEN` 文に集約し、同じ処理を ~200ms で完了できるようになった。本 TC はその機能的正確性を確認する回帰テストである。
+- **背景** (issue #710/#959): `recalculateRanks` は以前 N 件の `TTEntry.update` を直列実行していたため、27エントリー時に ~5s のレスポンス遅延が発生していた。さらに DELETE 後の `rerankStageAfterDelete` が `recalculateRanks` と同じ TA 予選順序（`qualificationPoints DESC`, `totalTime ASC`, `id ASC`）を使わないと、削除後だけ順位がズレる。本 TC はその機能的正確性を確認する回帰テストである。
 - **手順**:
   1. テスト用プレイヤー4名 + トーナメントを作成
   2. `setupTaQualViaUi(…, { seedTimes: false })` で TA エントリーを作成
-  3. P1–P4 に `makeTaTimesForRank(1)` – `makeTaTimesForRank(4)` でそれぞれ異なるタイムを PUT
-  4. `/api/tournaments/[id]/ta` で初期ランクが P1=1, P2=2, P3=3, P4=4 であることを確認
-  5. `DELETE /api/tournaments/[id]/ta?entryId={p2EntryId}` で P2 を削除
-  6. 再度 GET し、残存エントリーのランクが P1=1, P3=2, P4=3 に再コンパクション済みであることを確認（ギャップなし）
+  3. P1 は 19 コースで最速だが 1 コースだけ大きく遅い、P2 は全体 totalTime だけなら P1 より速い、P3/P4 はそれより低いスコアになるタイムを PUT
+  4. `/api/tournaments/[id]/ta` で初期ランクが P1=1, P2=2, P3=3, P4=4 であり、P1 は P2 より totalTime が遅いが `qualificationPoints` が高いことを確認
+  5. `DELETE /api/tournaments/[id]/ta?entryId={p3EntryId}` で P3 を削除
+  6. 再度 GET し、残存エントリーのランクが P1=1, P2=2, P4=3 に再コンパクション済みであることを確認（ギャップなし、かつ totalTime-first にドリフトしていない）
   7. クリーンアップ
-- **期待結果**: エントリー削除後に `recalculateRanks` が正しく動作し、連続したランクが割り当てられる
+- **期待結果**: エントリー削除後に DELETE 専用の再ランク処理が `recalculateRanks` と同じ TA 予選順序で動作し、連続したランクが割り当てられる
 - **スクリプト**: tc-ta.js TC-813
 
 ## TC-621: MR ラウンド別 targetWins API バリデーション (issue #528)

--- a/smkc-score-app/__tests__/lib/ta/rank-calculation.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/rank-calculation.test.ts
@@ -19,15 +19,29 @@
 // @ts-nocheck - This test file uses complex mock types that are difficult to type correctly
 import {
   calculateEntryTotal,
+  compareQualificationRankOrder,
   sortByStage,
   assignRanks,
   recalculateRanks,
   rerankStageAfterDelete,
+  QUALIFICATION_RANK_ORDER_SQL,
 } from '@/lib/ta/rank-calculation';
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { PrismaClient } from '@prisma/client';
 
 jest.mock('@/lib/prisma');
+
+function sqlFromExecuteRawCall(call: unknown[]): string {
+  const templateStrings = call[0] as TemplateStringsArray;
+  const values = call.slice(1);
+  return templateStrings.raw.reduce((sql, chunk, index) => {
+    const value = values[index];
+    if (value && typeof value === 'object' && 'strings' in value && Array.isArray(value.strings)) {
+      return `${sql}${chunk}${value.strings.join('')}`;
+    }
+    return `${sql}${chunk}`;
+  }, '');
+}
 
 describe('TA Rank Calculation', () => {
   describe('calculateEntryTotal', () => {
@@ -222,6 +236,43 @@ describe('TA Rank Calculation', () => {
       expect(sorted[0].id).toBe('2');
       expect(sorted[1].id).toBe('1');
     });
+
+    it('should use id as the final deterministic qualification tiebreaker', () => {
+      const entries = [
+        {
+          id: 'b',
+          totalTime: 300000,
+          lives: 3,
+          eliminated: false,
+          stage: 'qualification',
+          courseScores: {},
+          qualificationPoints: 50,
+        },
+        {
+          id: 'a',
+          totalTime: 300000,
+          lives: 3,
+          eliminated: false,
+          stage: 'qualification',
+          courseScores: {},
+          qualificationPoints: 50,
+        },
+      ];
+
+      const sorted = sortByStage(entries, 'qualification');
+
+      expect(sorted.map((entry) => entry.id)).toEqual(['a', 'b']);
+      expect(compareQualificationRankOrder(entries[1], entries[0])).toBeLessThan(0);
+    });
+
+    it('keeps the delete-rerank SQL order aligned with the qualification comparator', () => {
+      expect(QUALIFICATION_RANK_ORDER_SQL.strings.join('')).toContain(
+        'COALESCE(qualificationPoints, 0) DESC'
+      );
+      expect(QUALIFICATION_RANK_ORDER_SQL.strings.join('')).toContain('totalTime IS NULL ASC');
+      expect(QUALIFICATION_RANK_ORDER_SQL.strings.join('')).toContain('totalTime ASC');
+      expect(QUALIFICATION_RANK_ORDER_SQL.strings.join('')).toContain('id ASC');
+    });
   });
 
   /* sortByStage finals tests removed: the "finals" sorting branch was deleted
@@ -337,8 +388,7 @@ describe('TA Rank Calculation', () => {
 
       expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
       // $executeRaw is called as a tagged template literal: first arg is TemplateStringsArray
-      const templateStrings = mockPrisma.$executeRaw.mock.calls[0][0] as TemplateStringsArray;
-      const sqlText = templateStrings.raw.join('');
+      const sqlText = sqlFromExecuteRawCall(mockPrisma.$executeRaw.mock.calls[0]);
       expect(sqlText).toContain('courseScores');
       expect(sqlText).toContain('qualificationPoints');
     });
@@ -376,8 +426,7 @@ describe('TA Rank Calculation', () => {
       await recalculateRanks('tournament-1', 'revival_1', mockPrisma as unknown as PrismaClient);
 
       expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
-      const templateStrings = mockPrisma.$executeRaw.mock.calls[0][0] as TemplateStringsArray;
-      const sqlText = templateStrings.raw.join('');
+      const sqlText = sqlFromExecuteRawCall(mockPrisma.$executeRaw.mock.calls[0]);
       expect(sqlText).not.toContain('courseScores');
       expect(sqlText).not.toContain('qualificationPoints');
     });
@@ -411,8 +460,7 @@ describe('TA Rank Calculation', () => {
       await recalculateRanks('tournament-1', 'qualification', mockPrisma as unknown as PrismaClient);
 
       expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
-      const templateStrings = mockPrisma.$executeRaw.mock.calls[0][0] as TemplateStringsArray;
-      expect(templateStrings.raw.join('')).toContain('json_each');
+      expect(sqlFromExecuteRawCall(mockPrisma.$executeRaw.mock.calls[0])).toContain('json_each');
     });
 
     it('should update large non-qualification stages with one JSON-backed statement', async () => {
@@ -436,8 +484,7 @@ describe('TA Rank Calculation', () => {
       await recalculateRanks('tournament-1', 'revival_1', mockPrisma as unknown as PrismaClient);
 
       expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
-      const templateStrings = mockPrisma.$executeRaw.mock.calls[0][0] as TemplateStringsArray;
-      expect(templateStrings.raw.join('')).toContain('json_each');
+      expect(sqlFromExecuteRawCall(mockPrisma.$executeRaw.mock.calls[0])).toContain('json_each');
     });
 
     it('requires callers to pass the stage explicitly', () => {
@@ -449,8 +496,7 @@ describe('TA Rank Calculation', () => {
 
       expect(mockPrisma.tTEntry.findMany).not.toHaveBeenCalled();
       expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
-      const templateStrings = mockPrisma.$executeRaw.mock.calls[0][0] as TemplateStringsArray;
-      const sqlText = templateStrings.raw.join('');
+      const sqlText = sqlFromExecuteRawCall(mockPrisma.$executeRaw.mock.calls[0]);
       expect(sqlText).toContain('ROW_NUMBER() OVER');
       expect(sqlText).toContain('qualificationPoints');
       expect(sqlText).not.toContain('courseScores');
@@ -461,8 +507,7 @@ describe('TA Rank Calculation', () => {
 
       expect(mockPrisma.tTEntry.findMany).not.toHaveBeenCalled();
       expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
-      const templateStrings = mockPrisma.$executeRaw.mock.calls[0][0] as TemplateStringsArray;
-      const sqlText = templateStrings.raw.join('');
+      const sqlText = sqlFromExecuteRawCall(mockPrisma.$executeRaw.mock.calls[0]);
       expect(sqlText).toContain('totalTime IS NOT NULL');
       expect(sqlText).not.toContain('qualificationPoints');
     });

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -16,7 +16,8 @@
  *   TC-812  TA qualification tie resolution — identical times yield averaged
  *           course points and ordered ranks without manual override.
  *   TC-813  TA qualification rank recalculation after entry deletion — ranks
- *           are re-compacted (no gaps) after removing one entrant (#710).
+ *           are re-compacted using qualificationPoints order after removing
+ *           one entrant (#710/#959).
  *   TC-837  TA qualification standings show per-course No.1 count (Nb #1).
  *   TC-839  TA qualification time-entry dialog stacks cup cards on mobile.
  *   TC-840  TA partner can edit the paired player's times from the TA list UI.
@@ -132,6 +133,33 @@ async function seedTaQualificationRanks(adminPage, tournamentId, entries, startR
     seeded.push({ ...entries[i], rank, times, totalMs });
   }
   return seeded;
+}
+
+function formatTc813Time(ms) {
+  const minutes = Math.floor(ms / 60000);
+  const seconds = Math.floor((ms % 60000) / 1000);
+  const hundredths = Math.floor((ms % 1000) / 10);
+  return `${minutes}:${seconds.toString().padStart(2, '0')}.${hundredths.toString().padStart(2, '0')}`;
+}
+
+function makeTc813QualificationTimes(pattern) {
+  const times = {};
+  let totalMs = 0;
+  for (const [index, course] of TA_COURSES.entries()) {
+    let courseMs;
+    if (pattern === 'points-first-total-second') {
+      courseMs = index === TA_COURSES.length - 1 ? 400000 : 60000;
+    } else if (pattern === 'total-first-points-second') {
+      courseMs = 70000;
+    } else if (pattern === 'third') {
+      courseMs = 80000;
+    } else {
+      courseMs = 90000;
+    }
+    times[course] = formatTc813Time(courseMs);
+    totalMs += courseMs;
+  }
+  return { times, totalMs };
 }
 
 async function submitTaPhaseRoundByApi(adminPage, tournamentId, phase, activeEntries) {
@@ -1209,10 +1237,13 @@ async function runTc812(adminPage) {
  * Issue #710: recalculateRanks previously issued N sequential TTEntry.update calls
  * (~185ms each on D1), causing ~5s response times for 27-entry stages. The fix
  * collapses N round-trips into a single bulk UPDATE CASE WHEN statement.
+ * Issue #959: recalculateRanks and the delete-only rerank path must share the
+ * same qualification ordering: qualificationPoints desc, totalTime asc, id asc.
  *
  * This test verifies the functional correctness of rank recalculation after an
  * entry is deleted: the surviving entries must receive consecutive ranks with no
- * gaps, reflecting the removed player's absence.
+ * gaps, reflecting the removed player's absence, while still prioritizing
+ * qualificationPoints over raw totalTime.
  *
  * Uses an isolated tournament so it does not disturb the shared phase chain. */
 async function runTc813(adminPage) {
@@ -1227,44 +1258,61 @@ async function runTc813(adminPage) {
     }
     tournamentId = await uiCreateTournament(adminPage, `E2E TA Rank Del ${stamp}`, { dualReportEnabled: false });
 
-    /* Register all 4 with unique deterministic times (rank 1=fastest, 4=slowest). */
+    /* Register all 4 with a deliberate points-vs-totalTime split. P1 wins 19
+     * courses but is very slow on RR, so totalTime alone would rank P2 first.
+     * The correct TA qualification order is still P1 before P2 because
+     * qualificationPoints is the primary key. */
     const { entries } = await setupTaQualViaUi(adminPage, tournamentId, createdPlayers, { seedTimes: false });
-    for (let i = 0; i < 4; i++) {
-      const { times, totalMs } = makeTaTimesForRank(i + 1);
-      await apiSeedTtEntry(adminPage, tournamentId, entries[i].entryId, times, totalMs, null);
+    const seededTimes = [
+      makeTc813QualificationTimes('points-first-total-second'),
+      makeTc813QualificationTimes('total-first-points-second'),
+      makeTc813QualificationTimes('third'),
+      makeTc813QualificationTimes('fourth'),
+    ];
+    for (let i = 0; i < entries.length; i++) {
+      await apiSeedTtEntry(adminPage, tournamentId, entries[i].entryId, seededTimes[i].times, seededTimes[i].totalMs, null);
     }
 
     /* Assert initial rank assignment. */
     const beforeRows = (await apiFetchTa(adminPage, tournamentId)).b?.data?.entries ?? [];
     const beforeMap = new Map(beforeRows.map((e) => [e.playerId, e]));
     const [b1, b2, b3, b4] = createdPlayers.map((p) => beforeMap.get(p.id));
-    if (b1?.rank !== 1 || b2?.rank !== 2 || b3?.rank !== 3 || b4?.rank !== 4) {
-      log('TC-813', 'FAIL', `Initial ranks wrong: P1=${b1?.rank} P2=${b2?.rank} P3=${b3?.rank} P4=${b4?.rank}`);
+    const p1SlowerButHigherPoints =
+      typeof b1?.totalTime === 'number' &&
+      typeof b2?.totalTime === 'number' &&
+      typeof b1?.qualificationPoints === 'number' &&
+      typeof b2?.qualificationPoints === 'number' &&
+      b1.totalTime > b2.totalTime &&
+      b1.qualificationPoints > b2.qualificationPoints;
+    if (b1?.rank !== 1 || b2?.rank !== 2 || b3?.rank !== 3 || b4?.rank !== 4 || !p1SlowerButHigherPoints) {
+      log('TC-813', 'FAIL', `Initial ranks/order wrong: P1 rank=${b1?.rank} points=${b1?.qualificationPoints} total=${b1?.totalTime}; P2 rank=${b2?.rank} points=${b2?.qualificationPoints} total=${b2?.totalTime}; P3=${b3?.rank} P4=${b4?.rank}`);
       return;
     }
 
-    /* Delete P2's entry — triggers recalculateRanks on the server. */
+    /* Delete P3's entry — triggers rerankStageAfterDelete on the server. */
     const del = await adminPage.evaluate(async (u) => {
       const r = await fetch(u, { method: 'DELETE' });
       return { s: r.status, ok: r.ok };
-    }, `/api/tournaments/${tournamentId}/ta?entryId=${entries[1].entryId}`);
+    }, `/api/tournaments/${tournamentId}/ta?entryId=${entries[2].entryId}`);
     if (!del.ok) {
       log('TC-813', 'FAIL', `DELETE entry failed (${del.s})`);
       return;
     }
 
-    /* After deletion the server must re-compact ranks: P1=1, P3=2, P4=3. */
+    /* After deletion the server must use the same qualification ordering and
+     * re-compact ranks: P1=1, P2=2, P4=3. If the delete-only SQL drifted to
+     * totalTime-first ordering, P2 would incorrectly become rank 1. */
     const afterRows = (await apiFetchTa(adminPage, tournamentId)).b?.data?.entries ?? [];
     const afterMap = new Map(afterRows.map((e) => [e.playerId, e]));
-    const p2Gone = !afterMap.has(createdPlayers[1].id);
+    const p3Gone = !afterMap.has(createdPlayers[2].id);
     const a1 = afterMap.get(createdPlayers[0].id);
-    const a3 = afterMap.get(createdPlayers[2].id);
+    const a2 = afterMap.get(createdPlayers[1].id);
     const a4 = afterMap.get(createdPlayers[3].id);
-    const ranksCompacted = a1?.rank === 1 && a3?.rank === 2 && a4?.rank === 3;
+    const ranksCompacted = a1?.rank === 1 && a2?.rank === 2 && a4?.rank === 3;
 
-    log('TC-813', p2Gone && ranksCompacted ? 'PASS' : 'FAIL',
-      !p2Gone ? 'P2 entry still present after DELETE'
-      : !ranksCompacted ? `ranks not re-compacted after deletion: P1=${a1?.rank} P3=${a3?.rank} P4=${a4?.rank}`
+    log('TC-813', p3Gone && ranksCompacted ? 'PASS' : 'FAIL',
+      !p3Gone ? 'P3 entry still present after DELETE'
+      : !ranksCompacted ? `ranks not re-compacted after deletion: P1=${a1?.rank} P2=${a2?.rank} P4=${a4?.rank}`
       : '');
   } catch (err) {
     log('TC-813', 'FAIL', err instanceof Error ? err.message : 'TA rank recalc after delete failed');

--- a/smkc-score-app/src/lib/ta/rank-calculation.ts
+++ b/smkc-score-app/src/lib/ta/rank-calculation.ts
@@ -23,7 +23,7 @@ import { COURSES } from "@/lib/constants";
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { timeToMs } from "@/lib/ta/time-utils";
 import { calculateAllCourseScores } from "@/lib/ta/qualification-scoring";
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 
 /**
  * Represents a tournament entry with its calculated total time and scoring data.
@@ -44,6 +44,26 @@ export interface EntryWithTotal {
   courseScores: Record<string, number>;
   /** Total qualification points: floor(sum of courseScores) */
   qualificationPoints: number;
+}
+
+export const QUALIFICATION_RANK_ORDER_SQL = Prisma.sql`
+  ORDER BY
+    COALESCE(qualificationPoints, 0) DESC,
+    totalTime IS NULL ASC,
+    totalTime ASC,
+    id ASC
+`;
+
+export function compareQualificationRankOrder(a: EntryWithTotal, b: EntryWithTotal): number {
+  if (a.qualificationPoints !== b.qualificationPoints) {
+    return b.qualificationPoints - a.qualificationPoints;
+  }
+  if (a.totalTime === null && b.totalTime !== null) return 1;
+  if (a.totalTime !== null && b.totalTime === null) return -1;
+  if (a.totalTime !== null && b.totalTime !== null && a.totalTime !== b.totalTime) {
+    return a.totalTime - b.totalTime;
+  }
+  return a.id.localeCompare(b.id);
 }
 
 /**
@@ -123,17 +143,7 @@ export function sortByStage(entries: EntryWithTotal[], stage: string): EntryWith
   } else {
     // Qualification: sort by qualification points descending, then total time ascending
     // All entries are included (even those with 0 points) so they appear in standings
-    return [...entries].sort((a, b) => {
-      // Higher points = better rank
-      if (a.qualificationPoints !== b.qualificationPoints) {
-        return b.qualificationPoints - a.qualificationPoints;
-      }
-      // Tiebreaker: faster total time wins; null times sort to the end
-      if (a.totalTime === null && b.totalTime === null) return 0;
-      if (a.totalTime === null) return 1;
-      if (b.totalTime === null) return -1;
-      return a.totalTime - b.totalTime;
-    });
+    return [...entries].sort(compareQualificationRankOrder);
   }
 }
 
@@ -305,11 +315,7 @@ export async function rerankStageAfterDelete(
       SELECT
         id,
         ROW_NUMBER() OVER (
-          ORDER BY
-            COALESCE(qualificationPoints, 0) DESC,
-            totalTime IS NULL ASC,
-            totalTime ASC,
-            id ASC
+          ${QUALIFICATION_RANK_ORDER_SQL}
         ) AS newRank
       FROM TTEntry
       WHERE tournamentId = ${tournamentId}


### PR DESCRIPTION
## Summary
- Share the TA qualification ordering between in-memory rank recalculation and DELETE-only SQL reranking.
- Extend TC-813 to cover a points-vs-totalTime case so delete rerank cannot drift to totalTime-first ordering.
- Add rank-calculation unit coverage for the deterministic qualification tiebreaker and shared SQL order fragment.

## Issues
Closes #959

## Validation
- `node --check e2e/tc-ta.js`
- `npm test -- --runTestsByPath __tests__/lib/ta/rank-calculation.test.ts --ci --forceExit`
- `npm run lint -- src/lib/ta/rank-calculation.ts __tests__/lib/ta/rank-calculation.test.ts e2e/tc-ta.js` (exit 0; existing ignored-file warning for e2e/tc-ta.js)
- `npx tsc --noEmit --allowImportingTsExtensions`
- `git diff --check`
- `WRANGLER_HOME=/private/tmp/jsmkc-wrangler-home XDG_CONFIG_HOME=/private/tmp/jsmkc-wrangler-config npm run build:cf`
- `E2E_HEADLESS=1 E2E_TEST=TC-813 npm run e2e:ta` failed before test execution because Chromium exited with `bootstrap_check_in ... MachPortRendezvousServer ... Permission denied (1100)` in this sandbox.
