### PR TITLE
Batch qualification stats updates

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
@@ -441,7 +441,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
         data: { score1: 3, score2: 1, rounds: null, completed: true },
         select: EXPECTED_MATCH_UPDATE_SELECT,
       });
-      expect(prisma.bMQualification.updateMany).toHaveBeenCalledTimes(2);
+      expect(prisma.$executeRawUnsafe).toHaveBeenCalledTimes(1);
     });
 
     // §4.1: 2-2 tie is a valid BM result (draw = 1 point each)
@@ -582,16 +582,16 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       const result = await PUT(request, { params });
 
       expect(result.status).toBe(200);
-      expect(prisma.bMQualification.updateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 't1', playerId: 'p1' },
-        data: expect.objectContaining({
+      expect(JSON.parse((prisma.$executeRawUnsafe as jest.Mock).mock.calls[0][1])).toContainEqual(
+        expect.objectContaining({
+          playerId: 'p1',
           mp: 2,
           wins: 1,
           ties: 1,
           losses: 0,
           score: 3,
         }),
-      });
+      );
     });
   });
 });

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
@@ -126,6 +126,7 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
     (prisma.gPMatch.update as jest.Mock).mockResolvedValue({});
     (prisma.gPMatch.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.gPQualification.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+    (prisma.$executeRawUnsafe as jest.Mock).mockResolvedValue({ count: 0 });
     // Reset updateWithRetry mock - it should execute the callback
     (updateWithRetry as jest.Mock).mockImplementation(async (_prisma, callback) => {
       return callback({
@@ -279,7 +280,7 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
         .mockResolvedValueOnce(updatedMatch)  // First call: score report
         .mockResolvedValueOnce(confirmedMatch); // Second call: completion
       (prisma.gPMatch.findMany as jest.Mock).mockResolvedValue([]);
-      (prisma.gPQualification.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+      (prisma.$executeRawUnsafe as jest.Mock).mockResolvedValue({ count: 1 });
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/match/m1/report', {
         reportingPlayer: 2,
@@ -300,7 +301,7 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
         status: 200
       });
       expect(createSuccessResponse).toHaveBeenCalledWith({ match: confirmedMatch, autoConfirmed: true }, 'Scores confirmed and match completed');
-      expect(prisma.gPQualification.updateMany).toHaveBeenCalledTimes(2);
+      expect(prisma.$executeRawUnsafe).toHaveBeenCalledTimes(1);
     });
 
     // Success case - Reports mismatch detected
@@ -581,7 +582,7 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
         .mockResolvedValueOnce({ version: 1 }); // updateWithRetry callback: version check
       (prisma.gPMatch.update as jest.Mock).mockResolvedValue(correctedMatch);
       (prisma.gPMatch.findMany as jest.Mock).mockResolvedValue([]);
-      (prisma.gPQualification.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+      (prisma.$executeRawUnsafe as jest.Mock).mockResolvedValue({ count: 1 });
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/match/m1/report', {
         reportingPlayer: 1,
@@ -607,9 +608,8 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
       );
       expect(handleValidationError).not.toHaveBeenCalled();
       /* Both players' qualification stats must be recalculated after a
-       * correction — the route calls recalculatePlayerStats twice, each
-       * call fires an updateMany under the hood. */
-      expect(prisma.gPQualification.updateMany).toHaveBeenCalledTimes(2);
+       * correction in one batched raw update. */
+      expect(prisma.$executeRawUnsafe).toHaveBeenCalledTimes(1);
     });
 
     it('should reject correction races that do not match the assigned cup', async () => {

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/route.test.ts
@@ -450,7 +450,7 @@ describe('GP API Route - /api/tournaments/[id]/gp', () => {
         }),
         select: EXPECTED_MATCH_UPDATE_SELECT,
       });
-      expect(prisma.gPQualification.updateMany).toHaveBeenCalledTimes(2);
+      expect(prisma.$executeRawUnsafe).toHaveBeenCalledTimes(1);
     });
 
     // Success case - Calculates tie result correctly
@@ -707,16 +707,16 @@ describe('GP API Route - /api/tournaments/[id]/gp', () => {
       const result = await PUT(request, { params });
 
       expect(result.status).toBe(200);
-      expect(prisma.gPQualification.updateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 't1', playerId: 'p1' },
-        data: expect.objectContaining({
+      expect(JSON.parse((prisma.$executeRawUnsafe as jest.Mock).mock.calls[0][1])).toContainEqual(
+        expect.objectContaining({
+          playerId: 'p1',
           mp: 2,
           wins: 1,
           ties: 0,
           losses: 1,
           score: 2,
         }),
-      });
+      );
     });
   });
 });

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
@@ -61,7 +61,7 @@ jest.mock('@/lib/api-factories/score-report-helpers', () => ({
   createCharacterUsageLog: jest.fn(),
   isDualReportEnabled: jest.fn(),
   validateCharacter: jest.fn(),
-  recalculatePlayerStats: jest.fn(),
+  recalculatePlayersStats: jest.fn().mockResolvedValue(undefined),
 }));
 /**
  * Mock optimistic-locking: the route uses updateWithRetry for all DB writes.
@@ -127,7 +127,7 @@ describe('MR Score Report API Route - /api/tournaments/[id]/mr/match/[matchId]/r
     (prisma.scoreEntryLog.create as jest.Mock).mockResolvedValue({});
     (prisma.matchCharacterUsage.create as jest.Mock).mockResolvedValue({});
     (prisma.mRMatch.update as jest.Mock).mockResolvedValue({});
-    /* Mocks for recalculatePlayerStats (called after auto-confirm) */
+    /* Mocks for recalculatePlayersStats (called after auto-confirm) */
     (prisma.mRMatch.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.mRQualification.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
   });

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
@@ -364,7 +364,7 @@ describe('MR API Route - /api/tournaments/[id]/mr', () => {
         data: { score1: 3, score2: 1, rounds: null, completed: true },
         select: EXPECTED_MATCH_UPDATE_SELECT,
       });
-      expect(prisma.mRQualification.updateMany).toHaveBeenCalledTimes(2);
+      expect(prisma.$executeRawUnsafe).toHaveBeenCalledTimes(1);
     });
 
     // Success case - Calculates tie result correctly
@@ -514,16 +514,16 @@ describe('MR API Route - /api/tournaments/[id]/mr', () => {
       const result = await PUT(request, { params });
 
       expect(result.status).toBe(200);
-      expect(prisma.mRQualification.updateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 't1', playerId: 'p1' },
-        data: expect.objectContaining({
+      expect(JSON.parse((prisma.$executeRawUnsafe as jest.Mock).mock.calls[0][1])).toContainEqual(
+        expect.objectContaining({
+          playerId: 'p1',
           mp: 2,
           wins: 1,
           ties: 1,
           losses: 0,
           score: 3,
         }),
-      });
+      );
     });
   });
 });

--- a/smkc-score-app/__tests__/lib/api-factories/match-detail-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/match-detail-route.test.ts
@@ -51,17 +51,17 @@ jest.mock('@/lib/rate-limit', () => ({
 jest.mock('@/lib/request-utils', () => ({
   getClientIdentifier: jest.fn().mockReturnValue('127.0.0.1'),
 }));
-/* Mock score-report-helpers: recalcStatsConfig invokes recalculatePlayerStats
+/* Mock score-report-helpers: recalcStatsConfig invokes recalculatePlayersStats
  * after a successful qualification-stage PUT. Tests assert the mock's call
  * history to verify the hook is wired correctly. */
 jest.mock('@/lib/api-factories/score-report-helpers', () => ({
-  recalculatePlayerStats: jest.fn().mockResolvedValue(undefined),
+  recalculatePlayersStats: jest.fn().mockResolvedValue(undefined),
 }));
 
 import { auth } from '@/lib/auth';
 import { sanitizeInput } from '@/lib/sanitize';
 import { resolveTournamentId } from '@/lib/tournament-identifier';
-import { recalculatePlayerStats } from '@/lib/api-factories/score-report-helpers';
+import { recalculatePlayersStats } from '@/lib/api-factories/score-report-helpers';
 import { createSuccessResponse, createErrorResponse, handleValidationError, handleDatabaseError } from '@/lib/error-handling';
 import { createLogger } from '@/lib/logger';
 import prisma from '@/lib/prisma';
@@ -595,7 +595,7 @@ describe('Match Detail Route Factory', () => {
   // recalcStatsConfig Hook Tests (TC-402 regression coverage)
   //
   // Ensures that when a qualification-stage match PUT succeeds and the
-  // route was wired with recalcStatsConfig, recalculatePlayerStats is
+  // route was wired with recalcStatsConfig, recalculatePlayersStats is
   // invoked once per player so the per-mode qualification aggregate
   // stays in sync with match state. Without this hook, GP's manual-
   // total admin score path left gPQualification rows at 0 across the
@@ -627,11 +627,11 @@ describe('Match Detail Route Factory', () => {
       version: 1,
       rounds: [],
     };
-    const mockRecalc = recalculatePlayerStats as jest.MockedFunction<
-      typeof recalculatePlayerStats
+    const mockRecalc = recalculatePlayersStats as jest.MockedFunction<
+      typeof recalculatePlayersStats
     >;
 
-    it('invokes recalculatePlayerStats for both players on qualification-stage PUT', async () => {
+    it('invokes recalculatePlayersStats for both players on qualification-stage PUT', async () => {
       /* Two findUnique calls: (1) stage lookup before updateMatchScore,
        * (2) updated match re-fetch after. Mock both with the same shape. */
       (prisma.bMMatch as any).findUnique.mockResolvedValue(qualificationMatch);
@@ -651,12 +651,15 @@ describe('Match Detail Route Factory', () => {
         params: Promise.resolve({ id: 'tournament-1', matchId: 'match-123' }),
       });
 
-      expect(mockRecalc).toHaveBeenCalledTimes(2);
-      expect(mockRecalc).toHaveBeenNthCalledWith(1, recalcConfig, 'tournament-1', 'player-1');
-      expect(mockRecalc).toHaveBeenNthCalledWith(2, recalcConfig, 'tournament-1', 'player-2');
+      expect(mockRecalc).toHaveBeenCalledTimes(1);
+      expect(mockRecalc).toHaveBeenCalledWith(
+        recalcConfig,
+        'tournament-1',
+        ['player-1', 'player-2'],
+      );
     });
 
-    it('does not invoke recalculatePlayerStats when recalcStatsConfig is omitted', async () => {
+    it('does not invoke recalculatePlayersStats when recalcStatsConfig is omitted', async () => {
       (prisma.bMMatch as any).findUnique.mockResolvedValue(qualificationMatch);
 
       const config = {
@@ -676,7 +679,7 @@ describe('Match Detail Route Factory', () => {
       expect(mockRecalc).not.toHaveBeenCalled();
     });
 
-    it('does not invoke recalculatePlayerStats for finals-stage matches', async () => {
+    it('does not invoke recalculatePlayersStats for finals-stage matches', async () => {
       (prisma.bMMatch as any).findUnique.mockResolvedValue(finalsMatch);
 
       const config = {
@@ -697,7 +700,7 @@ describe('Match Detail Route Factory', () => {
       expect(mockRecalc).not.toHaveBeenCalled();
     });
 
-    it('still returns success when recalculatePlayerStats throws (logged, non-fatal)', async () => {
+    it('still returns success when recalculatePlayersStats throws (logged, non-fatal)', async () => {
       (prisma.bMMatch as any).findUnique.mockResolvedValue(qualificationMatch);
       mockRecalc.mockRejectedValueOnce(new Error('recalc failed'));
 

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -710,16 +710,18 @@ describe('Qualification Route Factory', () => {
       /*
        * In a 3-player group (odd), BREAK is added → 4 participants → 3 days × 2 matches.
        * Each player receives exactly 1 BYE match (player-1, player-2, player-3 all get one).
-       * aggregatePlayerStats and updateMany must each be called 3 times (once per BYE recipient).
+       * aggregatePlayerStats must be called once per BYE recipient, and the
+       * qualification rows should be updated in one batched statement.
        */
       expect(config.aggregatePlayerStats).toHaveBeenCalledTimes(3);
-      expect((prisma.bMQualification as any).updateMany).toHaveBeenCalledTimes(3);
-      /* Verify each updateMany call targets the correct player via the where clause */
-      expect((prisma.bMQualification as any).updateMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({ tournamentId: 'tournament-123' }),
-        }),
-      );
+      expect((prisma as any).$executeRawUnsafe).toHaveBeenCalledTimes(1);
+      const [, payload, tournamentId] = (prisma as any).$executeRawUnsafe.mock.calls[0];
+      expect(tournamentId).toBe('tournament-123');
+      expect(JSON.parse(payload).map((update: { playerId: string }) => update.playerId)).toEqual([
+        'player-1',
+        'player-2',
+        'player-3',
+      ]);
     });
 
     it('should sort players by seeding within each group before generating round-robin schedule', async () => {
@@ -1150,15 +1152,13 @@ describe('Qualification Route Factory', () => {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
-      expect((prisma.bMQualification as any).updateMany).toHaveBeenCalledTimes(2);
-      expect((prisma.bMQualification as any).updateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 'tournament-123', playerId: 'player-1' },
-        data: { wins: 1, losses: 0, points: 3 },
-      });
-      expect((prisma.bMQualification as any).updateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 'tournament-123', playerId: 'player-2' },
-        data: { wins: 1, losses: 0, points: 3 },
-      });
+      expect((prisma as any).$executeRawUnsafe).toHaveBeenCalledTimes(1);
+      const [, payload, tournamentId] = (prisma as any).$executeRawUnsafe.mock.calls[0];
+      expect(tournamentId).toBe('tournament-123');
+      expect(JSON.parse(payload)).toEqual([
+        expect.objectContaining({ playerId: 'player-1', wins: 1, losses: 0, points: 3 }),
+        expect.objectContaining({ playerId: 'player-2', wins: 1, losses: 0, points: 3 }),
+      ]);
     });
 
     it('should return 400 when parsePutBody returns invalid', async () => {
@@ -1313,11 +1313,12 @@ describe('Qualification Route Factory', () => {
       expect(config.aggregatePlayerStats).toHaveBeenCalledWith(
         expect.anything(), 'player-1', config.calculateMatchResult,
       );
-      expect((prisma.bMQualification as any).updateMany).toHaveBeenCalledTimes(1);
-      expect((prisma.bMQualification as any).updateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 'tournament-123', playerId: 'player-1' },
-        data: expect.any(Object),
-      });
+      expect((prisma as any).$executeRawUnsafe).toHaveBeenCalledTimes(1);
+      const [, payload, tournamentId] = (prisma as any).$executeRawUnsafe.mock.calls[0];
+      expect(tournamentId).toBe('tournament-123');
+      expect(JSON.parse(payload)).toEqual([
+        expect.objectContaining({ playerId: 'player-1' }),
+      ]);
     });
   });
 

--- a/smkc-score-app/__tests__/lib/api-factories/score-report-helpers.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/score-report-helpers.test.ts
@@ -25,6 +25,7 @@ import {
   createScoreEntryLog,
   createCharacterUsageLog,
   recalculatePlayerStats,
+  recalculatePlayersStats,
 } from '@/lib/api-factories/score-report-helpers';
 
 import { NextRequest } from 'next/server';
@@ -332,7 +333,7 @@ describe('Score Report Helpers', () => {
     /** Config for round-differential mode (BM/MR pattern) */
     const differentialConfig: RecalculateStatsConfig = {
       matchModel: 'testMatch',
-      qualificationModel: 'testQualification',
+      qualificationModel: 'bMQualification',
       scoreFields: { p1: 'score1', p2: 'score2' },
       determineResult: (my, opp) =>
         my > opp ? 'win' : my < opp ? 'loss' : 'tie',
@@ -342,7 +343,7 @@ describe('Score Report Helpers', () => {
     /** Config for absolute-points mode (GP pattern) */
     const absoluteConfig: RecalculateStatsConfig = {
       matchModel: 'testMatch',
-      qualificationModel: 'testQualification',
+      qualificationModel: 'gPQualification',
       scoreFields: { p1: 'points1', p2: 'points2' },
       determineResult: (my, opp) =>
         my > opp ? 'win' : my < opp ? 'loss' : 'tie',
@@ -350,15 +351,27 @@ describe('Score Report Helpers', () => {
     };
 
     let mockFindMany: jest.Mock;
-    let mockUpdateMany: jest.Mock;
+    let mockExecuteRawUnsafe: jest.Mock;
 
     beforeEach(() => {
       mockFindMany = jest.fn();
-      mockUpdateMany = jest.fn();
+      mockExecuteRawUnsafe = jest.fn();
       /* Dynamic model access: prisma[config.matchModel].findMany */
       (mockPrisma as any).testMatch = { findMany: mockFindMany };
-      (mockPrisma as any).testQualification = { updateMany: mockUpdateMany };
+      (mockPrisma as any).$executeRawUnsafe = mockExecuteRawUnsafe;
     });
+
+    function expectBulkUpdateWith(
+      modelTable: 'BMQualification' | 'GPQualification',
+      expectedUpdates: Array<Record<string, unknown>>,
+    ) {
+      expect(mockExecuteRawUnsafe).toHaveBeenCalledTimes(1);
+      const [sql, payload, tournamentId] = mockExecuteRawUnsafe.mock.calls[0];
+      expect(sql).toContain(`UPDATE ${modelTable}`);
+      expect(sql).toContain('json_each(?)');
+      expect(tournamentId).toBe('tourney-1');
+      expect(JSON.parse(payload)).toEqual(expectedUpdates);
+    }
 
     it('should correctly calculate stats with round differential (BM/MR)', async () => {
       /* Player p1 played 3 matches: 1 win (3-1), 1 loss (1-3), 1 tie (2-2) */
@@ -375,13 +388,16 @@ describe('Score Report Helpers', () => {
           tournamentId: 'tourney-1',
           stage: 'qualification',
           completed: true,
-          OR: [{ player1Id: 'p1' }, { player2Id: 'p1' }],
+          OR: [
+            { player1Id: { in: ['p1'] } },
+            { player2Id: { in: ['p1'] } },
+          ],
         },
       });
 
-      expect(mockUpdateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 'tourney-1', playerId: 'p1' },
-        data: {
+      expectBulkUpdateWith('BMQualification', [
+        {
+          playerId: 'p1',
           mp: 3,
           wins: 1,
           ties: 1,
@@ -391,7 +407,7 @@ describe('Score Report Helpers', () => {
           points: 0,        // 6 - 6 = 0 differential
           score: 3,         // 1*2 + 1 = 3 match points
         },
-      });
+      ]);
     });
 
     it('should correctly calculate stats with absolute points (GP)', async () => {
@@ -403,9 +419,9 @@ describe('Score Report Helpers', () => {
 
       await recalculatePlayerStats(absoluteConfig, 'tourney-1', 'p1');
 
-      expect(mockUpdateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 'tourney-1', playerId: 'p1' },
-        data: {
+      expectBulkUpdateWith('GPQualification', [
+        {
+          playerId: 'p1',
           mp: 2,
           wins: 1,
           ties: 0,
@@ -413,7 +429,7 @@ describe('Score Report Helpers', () => {
           points: 24,       // 18 + 6 = total driver points
           score: 2,         // 1*2 + 0 = 2 match points
         },
-      });
+      ]);
     });
 
     it('should handle empty match list (no completed matches)', async () => {
@@ -421,13 +437,13 @@ describe('Score Report Helpers', () => {
 
       await recalculatePlayerStats(differentialConfig, 'tourney-1', 'p1');
 
-      expect(mockUpdateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 'tourney-1', playerId: 'p1' },
-        data: {
+      expectBulkUpdateWith('BMQualification', [
+        {
+          playerId: 'p1',
           mp: 0, wins: 0, ties: 0, losses: 0,
           winRounds: 0, lossRounds: 0, points: 0, score: 0,
         },
-      });
+      ]);
     });
 
     it('should correctly resolve player side when player is player2', async () => {
@@ -439,9 +455,9 @@ describe('Score Report Helpers', () => {
 
       await recalculatePlayerStats(differentialConfig, 'tourney-1', 'p1');
 
-      expect(mockUpdateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 'tourney-1', playerId: 'p1' },
-        data: {
+      expectBulkUpdateWith('BMQualification', [
+        {
+          playerId: 'p1',
           mp: 2,
           wins: 1,
           losses: 1,
@@ -451,7 +467,7 @@ describe('Score Report Helpers', () => {
           points: -2,       // 3 - 5 = -2
           score: 2,         // 1*2 + 0
         },
-      });
+      ]);
     });
 
     it('should support custom determineResult function (BM-style)', async () => {
@@ -474,13 +490,58 @@ describe('Score Report Helpers', () => {
 
       await recalculatePlayerStats(bmConfig, 'tourney-1', 'p1');
 
-      expect(mockUpdateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 'tourney-1', playerId: 'p1' },
-        data: {
+      expectBulkUpdateWith('BMQualification', [
+        {
+          playerId: 'p1',
           mp: 2, wins: 1, ties: 1, losses: 0,
           winRounds: 5, lossRounds: 3, points: 2, score: 3,
         },
+      ]);
+    });
+
+    it('should recalculate multiple players with one match query and one bulk update', async () => {
+      mockFindMany.mockResolvedValue([
+        createMockMatch('p1', 'p2', { score1: 3, score2: 1 }),
+        createMockMatch('p3', 'p2', { score1: 2, score2: 2 }),
+      ]);
+
+      await recalculatePlayersStats(differentialConfig, 'tourney-1', ['p1', 'p2', 'p1']);
+
+      expect(mockFindMany).toHaveBeenCalledWith({
+        where: {
+          tournamentId: 'tourney-1',
+          stage: 'qualification',
+          completed: true,
+          OR: [
+            { player1Id: { in: ['p1', 'p2'] } },
+            { player2Id: { in: ['p1', 'p2'] } },
+          ],
+        },
       });
+      expectBulkUpdateWith('BMQualification', [
+        {
+          playerId: 'p1',
+          mp: 1,
+          wins: 1,
+          ties: 0,
+          losses: 0,
+          winRounds: 3,
+          lossRounds: 1,
+          points: 2,
+          score: 2,
+        },
+        {
+          playerId: 'p2',
+          mp: 2,
+          wins: 0,
+          ties: 1,
+          losses: 1,
+          winRounds: 3,
+          lossRounds: 5,
+          points: -2,
+          score: 1,
+        },
+      ]);
     });
   });
 });

--- a/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/report/route.ts
@@ -40,7 +40,7 @@ import {
   createCharacterUsageLog,
   isDualReportEnabled,
   validateCharacter,
-  recalculatePlayerStats,
+  recalculatePlayersStats,
   type RecalculateStatsConfig,
 } from "@/lib/api-factories/score-report-helpers";
 
@@ -180,8 +180,10 @@ export async function POST(
           });
         });
 
-        await recalculatePlayerStats(BM_RECALC_CONFIG, tournamentId, correctedMatch.player1Id);
-        await recalculatePlayerStats(BM_RECALC_CONFIG, tournamentId, correctedMatch.player2Id);
+        await recalculatePlayersStats(BM_RECALC_CONFIG, tournamentId, [
+          correctedMatch.player1Id,
+          correctedMatch.player2Id,
+        ]);
 
         return createSuccessResponse({
           match: correctedMatch,
@@ -261,8 +263,10 @@ export async function POST(
             include: { player1: { select: PLAYER_AUTH_SELECT }, player2: { select: PLAYER_AUTH_SELECT } },
           });
         });
-        await recalculatePlayerStats(BM_RECALC_CONFIG, tournamentId, finalMatch.player1Id);
-        await recalculatePlayerStats(BM_RECALC_CONFIG, tournamentId, finalMatch.player2Id);
+        await recalculatePlayersStats(BM_RECALC_CONFIG, tournamentId, [
+          finalMatch.player1Id,
+          finalMatch.player2Id,
+        ]);
         return createSuccessResponse({ match: finalMatch, autoConfirmed: true },
           "Score confirmed (dual report disabled)");
       } catch (error) {
@@ -300,8 +304,10 @@ export async function POST(
           return finalResult;
         });
 
-        await recalculatePlayerStats(BM_RECALC_CONFIG, tournamentId, finalMatch.player1Id);
-        await recalculatePlayerStats(BM_RECALC_CONFIG, tournamentId, finalMatch.player2Id);
+        await recalculatePlayersStats(BM_RECALC_CONFIG, tournamentId, [
+          finalMatch.player1Id,
+          finalMatch.player2Id,
+        ]);
 
         return createSuccessResponse({
           match: finalMatch,

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -28,7 +28,7 @@ import {
   validateCharacter,
   checkScoreReportAuth,
   isDualReportEnabled,
-  recalculatePlayerStats,
+  recalculatePlayersStats,
   type RecalculateStatsConfig,
 } from "@/lib/api-factories/score-report-helpers";
 import { validateGPRacePosition } from "@/lib/score-validation";
@@ -254,8 +254,10 @@ export async function POST(
           });
         });
 
-        await recalculatePlayerStats(GP_RECALC_CONFIG, tournamentId, correctedMatch.player1Id);
-        await recalculatePlayerStats(GP_RECALC_CONFIG, tournamentId, correctedMatch.player2Id);
+        await recalculatePlayersStats(GP_RECALC_CONFIG, tournamentId, [
+          correctedMatch.player1Id,
+          correctedMatch.player2Id,
+        ]);
 
         return createSuccessResponse({
           match: correctedMatch,
@@ -384,8 +386,10 @@ export async function POST(
             include: { player1: { select: PLAYER_AUTH_SELECT }, player2: { select: PLAYER_AUTH_SELECT } },
           })
         );
-        await recalculatePlayerStats(GP_RECALC_CONFIG, tournamentId, finalMatch.player1Id);
-        await recalculatePlayerStats(GP_RECALC_CONFIG, tournamentId, finalMatch.player2Id);
+        await recalculatePlayersStats(GP_RECALC_CONFIG, tournamentId, [
+          finalMatch.player1Id,
+          finalMatch.player2Id,
+        ]);
         return createSuccessResponse({ match: finalMatch, autoConfirmed: true },
           "Score confirmed (dual report disabled)");
       } catch (error) {
@@ -462,8 +466,10 @@ export async function POST(
           return finalResult;
         });
 
-        await recalculatePlayerStats(GP_RECALC_CONFIG, tournamentId, confirmedMatch.player1Id);
-        await recalculatePlayerStats(GP_RECALC_CONFIG, tournamentId, confirmedMatch.player2Id);
+        await recalculatePlayersStats(GP_RECALC_CONFIG, tournamentId, [
+          confirmedMatch.player1Id,
+          confirmedMatch.player2Id,
+        ]);
 
         return createSuccessResponse({
           match: confirmedMatch,

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
@@ -29,7 +29,7 @@ import {
   createCharacterUsageLog,
   isDualReportEnabled,
   validateCharacter,
-  recalculatePlayerStats,
+  recalculatePlayersStats,
   type RecalculateStatsConfig,
 } from "@/lib/api-factories/score-report-helpers";
 import { validateMatchRaceScores } from "@/lib/score-validation";
@@ -166,8 +166,10 @@ export async function POST(
           });
         });
 
-        await recalculatePlayerStats(MR_RECALC_CONFIG, tournamentId, correctedMatch.player1Id);
-        await recalculatePlayerStats(MR_RECALC_CONFIG, tournamentId, correctedMatch.player2Id);
+        await recalculatePlayersStats(MR_RECALC_CONFIG, tournamentId, [
+          correctedMatch.player1Id,
+          correctedMatch.player2Id,
+        ]);
 
         return createSuccessResponse({
           match: correctedMatch,
@@ -287,8 +289,10 @@ export async function POST(
             include: { player1: { select: PLAYER_AUTH_SELECT }, player2: { select: PLAYER_AUTH_SELECT } },
           })
         );
-        await recalculatePlayerStats(MR_RECALC_CONFIG, tournamentId, finalMatch.player1Id);
-        await recalculatePlayerStats(MR_RECALC_CONFIG, tournamentId, finalMatch.player2Id);
+        await recalculatePlayersStats(MR_RECALC_CONFIG, tournamentId, [
+          finalMatch.player1Id,
+          finalMatch.player2Id,
+        ]);
         return createSuccessResponse({ match: finalMatch, autoConfirmed: true },
           "Score confirmed (dual report disabled)");
       } catch (error) {
@@ -345,8 +349,10 @@ export async function POST(
             return finalResult;
           });
 
-          await recalculatePlayerStats(MR_RECALC_CONFIG, tournamentId, completedMatch.player1Id);
-          await recalculatePlayerStats(MR_RECALC_CONFIG, tournamentId, completedMatch.player2Id);
+          await recalculatePlayersStats(MR_RECALC_CONFIG, tournamentId, [
+            completedMatch.player1Id,
+            completedMatch.player2Id,
+          ]);
 
           return createSuccessResponse({
             match: completedMatch,

--- a/smkc-score-app/src/lib/api-factories/match-detail-route.ts
+++ b/smkc-score-app/src/lib/api-factories/match-detail-route.ts
@@ -30,7 +30,7 @@ import { resolveTournamentId } from '@/lib/tournament-identifier';
 import { invalidate as invalidateStandingsCache } from '@/lib/standings-cache';
 import { invalidateOverallRankingsCache } from '@/lib/points/overall-ranking';
 import { retryDbRead } from '@/lib/db-read-retry';
-import { recalculatePlayerStats, type RecalculateStatsConfig } from './score-report-helpers';
+import { recalculatePlayersStats, type RecalculateStatsConfig } from './score-report-helpers';
 
 /**
  * Configuration for the match detail route factory.
@@ -281,10 +281,11 @@ export function createMatchDetailHandlers(config: MatchDetailConfig) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const um = updatedMatch as any;
         try {
-          await recalculatePlayerStats(config.recalcStatsConfig, matchMeta.tournamentId, um.player1Id);
-          if (um.player2Id) {
-            await recalculatePlayerStats(config.recalcStatsConfig, matchMeta.tournamentId, um.player2Id);
-          }
+          await recalculatePlayersStats(
+            config.recalcStatsConfig,
+            matchMeta.tournamentId,
+            [um.player1Id, um.player2Id].filter(Boolean),
+          );
         } catch (recalcErr) {
           logger.error('Failed to recalculate qualification stats after match update', {
             error: recalcErr,

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -26,6 +26,7 @@ import { checkQualificationConfirmed } from '@/lib/qualification-confirmed-check
 import { generateETag, invalidate } from '@/lib/standings-cache';
 import { invalidateOverallRankingsCache } from '@/lib/points/overall-ranking';
 import { computeQualificationRanks } from '@/lib/server-ranking';
+import { bulkUpdateQualificationStats } from '@/lib/api-factories/score-report-helpers';
 import {
   generateRoundRobinSchedule,
   getByeMatchData,
@@ -589,7 +590,7 @@ export function createQualificationHandlers(config: EventTypeConfig) {
           },
         });
 
-        await Promise.all(byeRecipientList.map(async (playerId) => {
+        const byeUpdates = byeRecipientList.map((playerId) => {
           const playerByeMatches = allByeMatches.filter(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (m: any) => m.player1Id === playerId || m.player2Id === playerId,
@@ -599,11 +600,9 @@ export function createQualificationHandlers(config: EventTypeConfig) {
             playerId,
             config.calculateMatchResult,
           );
-          await qualModel(prisma).updateMany({
-            where: { tournamentId, playerId },
-            data: stats.qualificationData,
-          });
-        }));
+          return { playerId, ...stats.qualificationData };
+        });
+        await bulkUpdateQualificationStats(config.qualificationModel, tournamentId, byeUpdates);
       }
 
       /* Audit logging if configured.
@@ -732,20 +731,12 @@ export function createQualificationHandlers(config: EventTypeConfig) {
         player2Matches, match.player2Id, config.calculateMatchResult,
       );
 
-      /* Update both players' qualification records in parallel (#707). */
-      const updates = [
-        qualModel(prisma).updateMany({
-          where: { tournamentId, playerId: match.player1Id },
-          data: p1.qualificationData,
-        }),
-      ];
+      /* Update both players' qualification records with one D1 round-trip. */
+      const updates = [{ playerId: match.player1Id, ...p1.qualificationData }];
       if (p2) {
-        updates.push(qualModel(prisma).updateMany({
-          where: { tournamentId, playerId: match.player2Id },
-          data: p2.qualificationData,
-        }));
+        updates.push({ playerId: match.player2Id, ...p2.qualificationData });
       }
-      await Promise.all(updates);
+      await bulkUpdateQualificationStats(config.qualificationModel, tournamentId, updates);
 
       /* Score updates change both per-mode standings and the cross-mode
        * overall ranking. Drop both caches so the next GET reflects the new

--- a/smkc-score-app/src/lib/api-factories/score-report-helpers.ts
+++ b/smkc-score-app/src/lib/api-factories/score-report-helpers.ts
@@ -283,6 +283,146 @@ export interface RecalculateStatsConfig {
   useRoundDifferential: boolean;
 }
 
+interface QualificationStatsUpdate {
+  playerId: string;
+  mp?: number;
+  wins?: number;
+  ties?: number;
+  losses?: number;
+  winRounds?: number;
+  lossRounds?: number;
+  points?: number;
+  score?: number;
+}
+
+const QUALIFICATION_STATS_UPDATE_SQL: Record<string, string> = {
+  bMQualification: `
+    WITH stats AS (
+      SELECT
+        json_extract(value, '$.playerId') AS playerId,
+        CAST(json_extract(value, '$.mp') AS INTEGER) AS mp,
+        CAST(json_extract(value, '$.wins') AS INTEGER) AS wins,
+        CAST(json_extract(value, '$.ties') AS INTEGER) AS ties,
+        CAST(json_extract(value, '$.losses') AS INTEGER) AS losses,
+        CAST(json_extract(value, '$.winRounds') AS INTEGER) AS winRounds,
+        CAST(json_extract(value, '$.lossRounds') AS INTEGER) AS lossRounds,
+        CAST(json_extract(value, '$.points') AS INTEGER) AS points,
+        CAST(json_extract(value, '$.score') AS INTEGER) AS score
+      FROM json_each(?)
+    )
+    UPDATE BMQualification
+    SET
+      mp = COALESCE((SELECT mp FROM stats WHERE stats.playerId = BMQualification.playerId), mp),
+      wins = COALESCE((SELECT wins FROM stats WHERE stats.playerId = BMQualification.playerId), wins),
+      ties = COALESCE((SELECT ties FROM stats WHERE stats.playerId = BMQualification.playerId), ties),
+      losses = COALESCE((SELECT losses FROM stats WHERE stats.playerId = BMQualification.playerId), losses),
+      winRounds = COALESCE((SELECT winRounds FROM stats WHERE stats.playerId = BMQualification.playerId), winRounds),
+      lossRounds = COALESCE((SELECT lossRounds FROM stats WHERE stats.playerId = BMQualification.playerId), lossRounds),
+      points = COALESCE((SELECT points FROM stats WHERE stats.playerId = BMQualification.playerId), points),
+      score = COALESCE((SELECT score FROM stats WHERE stats.playerId = BMQualification.playerId), score)
+    WHERE tournamentId = ? AND playerId IN (SELECT playerId FROM stats)
+  `,
+  mRQualification: `
+    WITH stats AS (
+      SELECT
+        json_extract(value, '$.playerId') AS playerId,
+        CAST(json_extract(value, '$.mp') AS INTEGER) AS mp,
+        CAST(json_extract(value, '$.wins') AS INTEGER) AS wins,
+        CAST(json_extract(value, '$.ties') AS INTEGER) AS ties,
+        CAST(json_extract(value, '$.losses') AS INTEGER) AS losses,
+        CAST(json_extract(value, '$.winRounds') AS INTEGER) AS winRounds,
+        CAST(json_extract(value, '$.lossRounds') AS INTEGER) AS lossRounds,
+        CAST(json_extract(value, '$.points') AS INTEGER) AS points,
+        CAST(json_extract(value, '$.score') AS INTEGER) AS score
+      FROM json_each(?)
+    )
+    UPDATE MRQualification
+    SET
+      mp = COALESCE((SELECT mp FROM stats WHERE stats.playerId = MRQualification.playerId), mp),
+      wins = COALESCE((SELECT wins FROM stats WHERE stats.playerId = MRQualification.playerId), wins),
+      ties = COALESCE((SELECT ties FROM stats WHERE stats.playerId = MRQualification.playerId), ties),
+      losses = COALESCE((SELECT losses FROM stats WHERE stats.playerId = MRQualification.playerId), losses),
+      winRounds = COALESCE((SELECT winRounds FROM stats WHERE stats.playerId = MRQualification.playerId), winRounds),
+      lossRounds = COALESCE((SELECT lossRounds FROM stats WHERE stats.playerId = MRQualification.playerId), lossRounds),
+      points = COALESCE((SELECT points FROM stats WHERE stats.playerId = MRQualification.playerId), points),
+      score = COALESCE((SELECT score FROM stats WHERE stats.playerId = MRQualification.playerId), score)
+    WHERE tournamentId = ? AND playerId IN (SELECT playerId FROM stats)
+  `,
+  gPQualification: `
+    WITH stats AS (
+      SELECT
+        json_extract(value, '$.playerId') AS playerId,
+        CAST(json_extract(value, '$.mp') AS INTEGER) AS mp,
+        CAST(json_extract(value, '$.wins') AS INTEGER) AS wins,
+        CAST(json_extract(value, '$.ties') AS INTEGER) AS ties,
+        CAST(json_extract(value, '$.losses') AS INTEGER) AS losses,
+        CAST(json_extract(value, '$.points') AS INTEGER) AS points,
+        CAST(json_extract(value, '$.score') AS INTEGER) AS score
+      FROM json_each(?)
+    )
+    UPDATE GPQualification
+    SET
+      mp = COALESCE((SELECT mp FROM stats WHERE stats.playerId = GPQualification.playerId), mp),
+      wins = COALESCE((SELECT wins FROM stats WHERE stats.playerId = GPQualification.playerId), wins),
+      ties = COALESCE((SELECT ties FROM stats WHERE stats.playerId = GPQualification.playerId), ties),
+      losses = COALESCE((SELECT losses FROM stats WHERE stats.playerId = GPQualification.playerId), losses),
+      points = COALESCE((SELECT points FROM stats WHERE stats.playerId = GPQualification.playerId), points),
+      score = COALESCE((SELECT score FROM stats WHERE stats.playerId = GPQualification.playerId), score)
+    WHERE tournamentId = ? AND playerId IN (SELECT playerId FROM stats)
+  `,
+};
+
+export async function bulkUpdateQualificationStats(
+  qualificationModel: RecalculateStatsConfig['qualificationModel'],
+  tournamentId: string,
+  updates: QualificationStatsUpdate[],
+): Promise<void> {
+  if (updates.length === 0) return;
+
+  const sql = QUALIFICATION_STATS_UPDATE_SQL[qualificationModel];
+  if (!sql) {
+    throw new Error(`Unsupported qualification stats bulk update model: ${qualificationModel}`);
+  }
+
+  await prisma.$executeRawUnsafe(sql, JSON.stringify(updates), tournamentId);
+}
+
+function calculateStatsForPlayer(
+  config: RecalculateStatsConfig,
+  matches: Array<Record<string, unknown>>,
+  playerId: string,
+): QualificationStatsUpdate {
+  let mp = 0, wins = 0, ties = 0, losses = 0;
+  let winRounds = 0, lossRounds = 0, totalPoints = 0;
+
+  for (const m of matches) {
+    const isPlayer1 = m.player1Id === playerId;
+    if (!isPlayer1 && m.player2Id !== playerId) continue;
+
+    const myScore = Number(isPlayer1 ? m[config.scoreFields.p1] : m[config.scoreFields.p2]);
+    const oppScore = Number(isPlayer1 ? m[config.scoreFields.p2] : m[config.scoreFields.p1]);
+
+    const result = config.determineResult(myScore, oppScore);
+    if (result === 'no_contest') continue;
+    mp++;
+    if (result === 'win') wins++;
+    else if (result === 'loss') losses++;
+    else ties++;
+
+    if (config.useRoundDifferential) {
+      winRounds += myScore;
+      lossRounds += oppScore;
+    } else {
+      totalPoints += myScore;
+    }
+  }
+
+  const score = wins * 2 + ties;
+  return config.useRoundDifferential
+    ? { playerId, mp, wins, ties, losses, winRounds, lossRounds, points: winRounds - lossRounds, score }
+    : { playerId, mp, wins, ties, losses, points: totalPoints, score };
+}
+
 /**
  * Recalculate qualification stats for a player from all completed matches.
  *
@@ -304,6 +444,21 @@ export async function recalculatePlayerStats(
   tournamentId: string,
   playerId: string,
 ): Promise<void> {
+  await recalculatePlayersStats(config, tournamentId, [playerId]);
+}
+
+/**
+ * Recalculate qualification stats for multiple players using one completed-match
+ * query and one JSON-backed qualification update.
+ */
+export async function recalculatePlayersStats(
+  config: RecalculateStatsConfig,
+  tournamentId: string,
+  playerIds: string[],
+): Promise<void> {
+  const uniquePlayerIds = [...new Set(playerIds.filter(Boolean))];
+  if (uniquePlayerIds.length === 0) return;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const matchDelegate = (prisma as any)[config.matchModel];
 
@@ -312,50 +467,13 @@ export async function recalculatePlayerStats(
       tournamentId,
       stage: 'qualification',
       completed: true,
-      OR: [{ player1Id: playerId }, { player2Id: playerId }],
+      OR: [
+        { player1Id: { in: uniquePlayerIds } },
+        { player2Id: { in: uniquePlayerIds } },
+      ],
     },
   });
 
-  let mp = 0, wins = 0, ties = 0, losses = 0;
-  let winRounds = 0, lossRounds = 0, totalPoints = 0;
-
-  for (const m of matches) {
-    const isPlayer1 = m.player1Id === playerId;
-    const myScore: number = isPlayer1
-      ? m[config.scoreFields.p1]
-      : m[config.scoreFields.p2];
-    const oppScore: number = isPlayer1
-      ? m[config.scoreFields.p2]
-      : m[config.scoreFields.p1];
-
-    const result = config.determineResult(myScore, oppScore);
-    // 'no_contest' matches (e.g., 0-0 cleared) should not be counted in stats
-    if (result === 'no_contest') continue;
-    mp++;
-    if (result === 'win') wins++;
-    else if (result === 'loss') losses++;
-    else ties++;
-
-    if (config.useRoundDifferential) {
-      winRounds += myScore;
-      lossRounds += oppScore;
-    } else {
-      totalPoints += myScore;
-    }
-  }
-
-  const score = wins * 2 + ties;
-
-  /* Build update data based on mode configuration */
-  const data = config.useRoundDifferential
-    ? { mp, wins, ties, losses, winRounds, lossRounds, points: winRounds - lossRounds, score }
-    : { mp, wins, ties, losses, points: totalPoints, score };
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const qualDelegate = (prisma as any)[config.qualificationModel];
-
-  await qualDelegate.updateMany({
-    where: { tournamentId, playerId },
-    data,
-  });
+  const updates = uniquePlayerIds.map((id) => calculateStatsForPlayer(config, matches, id));
+  await bulkUpdateQualificationStats(config.qualificationModel, tournamentId, updates);
 }


### PR DESCRIPTION
## Summary
- batch qualification stats recalculation into one match query and one JSON-backed qualification update
- update BM/MR/GP admin and participant score paths to use the batched recalculation
- preserve existing qualification fields during partial BYE/admin aggregate updates

## Validation
- npm test -- --runInBand
- npm run build:cf
