### PR TITLE
test: fail TC-823 on badge wait timeout

### DIFF
--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -464,12 +464,11 @@ async function main() {
             { href, shouldExist },
             { timeout: 10000 },
           );
-          return true;
         } catch (err) {
           const action = shouldExist ? 'appear' : 'disappear';
           const message = err instanceof Error ? err.message : String(err);
           console.warn(`[TC-823] Timed out waiting for ${label} badge to ${action}: ${message}`);
-          return false;
+          throw err;
         }
       };
 


### PR DESCRIPTION
## Summary
- Make TC-823 badge wait timeout warnings fail the scenario immediately by rethrowing after logging.
- Remove the unused boolean return path from waitForTabBadge.

## Issues
Closes #992

## Validation
- node --check e2e/tc-all.js
- git diff --check
