### PR TITLE
[codex] Disable performance logging

### DIFF
--- a/smkc-score-app/wrangler.toml
+++ b/smkc-score-app/wrangler.toml
@@ -26,8 +26,8 @@ AUTH_URL = "https://smkc.bluemoon.works"
 #                            posting LCP/INP/TTFB beacons.
 # Both are baked into the Worker bundle at deploy time; flip them off and
 # redeploy when measurement is no longer needed.
-PERF_LOG = "1"
-NEXT_PUBLIC_PERF_LOG = "1"
+PERF_LOG = "0"
+NEXT_PUBLIC_PERF_LOG = "0"
 
 [assets]
 directory = ".open-next/assets"


### PR DESCRIPTION
## Summary
- disable the performance logging flags in `wrangler.toml`
- stop Web Vitals beacons, Prisma/API timing instrumentation, and vitals ingestion logs from being enabled in the production Worker bundle

## Issues
- None

## Validation
- Confirmed `PERF_LOG = "0"` and `NEXT_PUBLIC_PERF_LOG = "0"` are present in `smkc-score-app/wrangler.toml`
