### PR TITLE
[codex] Fix TA pair-only self edit gating

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/entry-access.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/entry-access.test.ts
@@ -15,6 +15,20 @@ describe("TA entry access helper", () => {
     expect(canEditTaEntry(entry, { currentPlayerId: "player-1" })).toBe(true);
   });
 
+  it("rejects the owner when self-edit is disabled", () => {
+    expect(canEditTaEntry(entry, {
+      currentPlayerId: "player-1",
+      taPlayerSelfEdit: false,
+    })).toBe(false);
+  });
+
+  it("allows the assigned partner when self-edit is disabled", () => {
+    expect(canEditTaEntry(entry, {
+      currentPlayerId: "player-2",
+      taPlayerSelfEdit: false,
+    })).toBe(true);
+  });
+
   it("allows the assigned partner to edit the paired entry", () => {
     expect(canEditTaEntry(entry, { currentPlayerId: "player-2" })).toBe(true);
   });

--- a/smkc-score-app/__tests__/lib/ta/initial-data.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/initial-data.test.ts
@@ -46,7 +46,7 @@ describe('fetchTaInitialData', () => {
   });
 
   it('returns TaInitialData with qualificationRegistrationLocked=false when no knockout entries exist', async () => {
-    mockResolveTournament.mockResolvedValue({ id: 'tid-1', frozenStages: [] });
+    mockResolveTournament.mockResolvedValue({ id: 'tid-1', frozenStages: [], taPlayerSelfEdit: false });
 
     const mockEntries = [{ id: 'e1', stage: 'qualification' }];
     const mockPlayers = [{ id: 'p1', name: 'Alice', nickname: 'alice', country: null, noCamera: false }];
@@ -66,10 +66,11 @@ describe('fetchTaInitialData', () => {
     expect(result!.allPlayers).toEqual(mockPlayers);
     expect(result!.qualificationRegistrationLocked).toBe(false);
     expect(result!.frozenStages).toEqual([]);
+    expect(result!.taPlayerSelfEdit).toBe(false);
   });
 
   it('returns qualificationRegistrationLocked=true when a phase1 entry exists', async () => {
-    mockResolveTournament.mockResolvedValue({ id: 'tid-2', frozenStages: ['phase1'] });
+    mockResolveTournament.mockResolvedValue({ id: 'tid-2', frozenStages: ['phase1'], taPlayerSelfEdit: true });
 
     jest.mocked(prisma.tTEntry.findMany).mockResolvedValue([] as unknown as TTEntry[]);
     jest.mocked(prisma.tTEntry.findFirst).mockResolvedValue({ id: 'phase-entry' } as unknown as TTEntry);
@@ -80,5 +81,6 @@ describe('fetchTaInitialData', () => {
     expect(result).not.toBeNull();
     expect(result!.qualificationRegistrationLocked).toBe(true);
     expect(result!.frozenStages).toEqual(['phase1']);
+    expect(result!.taPlayerSelfEdit).toBe(true);
   });
 });

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
@@ -137,19 +137,6 @@ export default function TimeAttackPageClient({
    */
   const currentPlayerId = session?.user?.playerId;
 
-  /**
-   * Whether the current user can edit a specific entry's times.
-   * Returns false if the entry's stage is frozen (applies to both admins and players).
-   * Otherwise: admins can edit any entry; players can only edit their own.
-   */
-  const canEditEntry = (entry: TTEntry): boolean => {
-    return canEditTaEntry(entry, {
-      isAdmin,
-      currentPlayerId,
-      frozenStages,
-    });
-  };
-
   /** Whether the current user can edit any entries (admin or player with own entry).
    *  Controls whether editable time entry features are shown. */
   const canEditAnyEntry = isAdmin || !!currentPlayerId;
@@ -250,6 +237,7 @@ export default function TimeAttackPageClient({
       allPlayers: extractArrayData<Player>(playersJson),
       qualificationRegistrationLocked: taData.qualificationRegistrationLocked || false,
       frozenStages: taData.frozenStages || [],
+      taPlayerSelfEdit: taData.taPlayerSelfEdit ?? true,
     };
   }, [tournamentId]);
 
@@ -279,6 +267,21 @@ export default function TimeAttackPageClient({
   const qualificationRegistrationLocked: boolean = pollData?.qualificationRegistrationLocked ?? false;
   /** Frozen stages from the tournament - stages in this array cannot be edited */
   const frozenStages: string[] = pollData?.frozenStages ?? [];
+  const taPlayerSelfEdit: boolean = pollData?.taPlayerSelfEdit ?? true;
+  /**
+   * Whether the current user can edit a specific entry's times.
+   * Returns false if the entry's stage is frozen (applies to both admins and players).
+   * Otherwise: admins can edit any entry; players can edit partner entries,
+   * and can edit their own entry only when tournament self-edit is enabled.
+   */
+  const canEditEntry = (entry: TTEntry): boolean => {
+    return canEditTaEntry(entry, {
+      isAdmin,
+      currentPlayerId,
+      frozenStages,
+      taPlayerSelfEdit,
+    });
+  };
   const firstPlaceCounts = useMemo(
     () => calculateCourseFirstPlaceCounts(entries),
     [entries],
@@ -1284,11 +1287,11 @@ export default function TimeAttackPageClient({
                   {/* Quick-access button: lets logged-in players open their own
                    *  time entry dialog directly without scrolling the table.
                    *  Only shown when the player has an entry in this tournament. */}
-                    {currentPlayerId && entries.find((e) => e.playerId === currentPlayerId) && (
+                    {currentPlayerId && entries.find((e) => e.playerId === currentPlayerId && canEditEntry(e)) && (
                       <Button
                         size="sm"
                         onClick={() => {
-                          const myEntry = entries.find((e) => e.playerId === currentPlayerId);
+                          const myEntry = entries.find((e) => e.playerId === currentPlayerId && canEditEntry(e));
                           if (myEntry) openTimeEntryDialog(myEntry);
                         }}
                       >

--- a/smkc-score-app/src/lib/ta/entry-access.ts
+++ b/smkc-score-app/src/lib/ta/entry-access.ts
@@ -8,6 +8,7 @@ export interface TaEntryAccessContext {
   isAdmin?: boolean | null;
   currentPlayerId?: string | null;
   frozenStages?: readonly string[];
+  taPlayerSelfEdit?: boolean | null;
 }
 
 export function canEditTaEntry(
@@ -20,5 +21,7 @@ export function canEditTaEntry(
   const currentPlayerId = context.currentPlayerId;
   if (!currentPlayerId) return false;
 
-  return entry.playerId === currentPlayerId || entry.partnerId === currentPlayerId;
+  if (entry.partnerId === currentPlayerId) return true;
+
+  return entry.playerId === currentPlayerId && context.taPlayerSelfEdit !== false;
 }

--- a/smkc-score-app/src/lib/ta/initial-data.ts
+++ b/smkc-score-app/src/lib/ta/initial-data.ts
@@ -32,6 +32,7 @@ export interface TaInitialData {
   allPlayers: TaPlayer[];
   qualificationRegistrationLocked: boolean;
   frozenStages: string[];
+  taPlayerSelfEdit: boolean;
 }
 
 const KNOCKOUT_STAGES = ['phase1', 'phase2', 'phase3'] as const;
@@ -58,7 +59,7 @@ async function hasKnockoutStageStarted(tournamentId: string): Promise<boolean> {
  */
 export async function fetchTaInitialData(id: string): Promise<TaInitialData | null> {
   try {
-    const tournament = await resolveTournament(id, { id: true, frozenStages: true });
+    const tournament = await resolveTournament(id, { id: true, frozenStages: true, taPlayerSelfEdit: true });
     // Return null so the client falls back to its own first poll, same as qual-initial-data.ts.
     if (!tournament) return null;
     const tournamentId = tournament.id;
@@ -83,6 +84,7 @@ export async function fetchTaInitialData(id: string): Promise<TaInitialData | nu
       allPlayers,
       qualificationRegistrationLocked: knockoutStarted,
       frozenStages: (tournament.frozenStages as string[]) ?? [],
+      taPlayerSelfEdit: tournament.taPlayerSelfEdit ?? true,
     };
   } catch {
     // Intentionally swallowed: the client component handles data === null


### PR DESCRIPTION
## Summary
- Gate TA qualification edit access with `taPlayerSelfEdit`, so pair-only tournaments no longer expose the player self-edit modal.
- Carry `taPlayerSelfEdit` through the TA initial-data path so first paint and polling use the same permission state.
- Add focused regression coverage for self-edit disabled vs partner edit access.

## Root Cause
The TA qualification table reused `canEditTaEntry()` for the edit button, but that helper only checked owner/partner/frozen state. It did not receive the tournament-level `taPlayerSelfEdit` setting, so players could still open their own time entry dialog from the table or quick-access button in pair-only tournaments.

## Validation
- `npm test -- --runTestsByPath __tests__/lib/ta/entry-access.test.ts __tests__/lib/ta/initial-data.test.ts`
- `npx eslint 'src/app/tournaments/[id]/ta/page-client.tsx' src/lib/ta/entry-access.ts src/lib/ta/initial-data.ts`
- `git diff --check`
