### PR TITLE
Fix TA finals ranking to use elimination order

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2005,6 +2005,18 @@
   4. クリーンアップ
 - **期待結果**: チャンピオン決定時に Champion バナー/テキストがページに表示される
 
+## TC-TA-FLOW-24-RANK: TA Finals 総合ランキングが脱落順序で決定される
+- **URL**: /api/tournaments/[temp-id]/overall-ranking
+- **authRequired**: true (admin)
+- **背景**: TA Finals は life-based elimination で、最後まで生存したプレイヤーが優勝。総合ランキングの順位は脱落した順（最後に脱落した人ほど高順位）で決まらなければならない。過去のバグでは `totalTime` 累積で順位を判定していたため、早期脱落でも各コースで速かったプレイヤーが、後期脱落で遅かったプレイヤーより上に出る現象が発生していた（JSMKC 2026 で観測）
+- **手順**:
+  1. 24名の TA Phase 3 を実行し、ランク順 (`60_000 + rank*200ms`) で全ラウンドを進行（rank=1 が常勝、rank=24 が最初に脱落）
+  2. `/api/tournaments/[temp-id]/ta/phases?phase=phase3` でラウンド一覧を取得し、`eliminatedIds` を時系列で連結して脱落順序を抽出
+  3. POST `/api/tournaments/[temp-id]/overall-ranking` でランキングを再計算
+  4. champion (rank=1) の `taFinalsPoints` が 2000 (1位の点数) であることを確認
+  5. 最後に脱落したプレイヤーの `taFinalsPoints` が、最初に脱落したプレイヤーの `taFinalsPoints` より大きいことを確認
+- **期待結果**: 総合ランキングの TA Finals 配点が「最後まで生き残った順」を反映する。早期脱落者が後期脱落者を上回ることはない
+
 ## TC-809: TA Phase 1 で未提出ラウンドをキャンセルできる
 - **URL**: /tournaments/[temp-id]/ta/phase1
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
+++ b/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
@@ -72,6 +72,7 @@ function getMockGetFinalsPoints() {
 
 const mockPrisma = {
   tTEntry: { findMany: jest.fn() },
+  tTPhaseRound: { findMany: jest.fn() },
   bMQualification: { findMany: jest.fn() },
   mRQualification: { findMany: jest.fn() },
   gPQualification: { findMany: jest.fn() },
@@ -273,10 +274,20 @@ describe('Overall Ranking module', () => {
 
   // =========================================================================
   describe('getTAFinalsPositions', () => {
-    it('returns positions from phase3 entries', async () => {
+    it('returns positions from phase3 entries (single survivor)', async () => {
       mockPrisma.tTEntry.findMany.mockResolvedValueOnce([
         { playerId: 'p1', eliminated: false, lives: 2, totalTime: 90000 },
         { playerId: 'p2', eliminated: true, lives: 0, totalTime: 95000 },
+      ]);
+      mockPrisma.tTPhaseRound.findMany.mockResolvedValueOnce([
+        {
+          roundNumber: 1,
+          eliminatedIds: ['p2'],
+          results: [
+            { playerId: 'p1', timeMs: 60000, isRetry: false },
+            { playerId: 'p2', timeMs: 70000, isRetry: false },
+          ],
+        },
       ]);
 
       const positions = await getTAFinalsPositions(mockPrisma as any, TOURNAMENT_ID);
@@ -293,6 +304,7 @@ describe('Overall Ranking module', () => {
         .mockResolvedValueOnce([
           { playerId: 'p1', eliminated: false, lives: 1, totalTime: 80000 },
         ]);
+      mockPrisma.tTPhaseRound.findMany.mockResolvedValueOnce([]);
 
       const positions = await getTAFinalsPositions(mockPrisma as any, TOURNAMENT_ID);
 
@@ -302,10 +314,96 @@ describe('Overall Ranking module', () => {
 
     it('returns empty array when neither phase3 nor legacy finals exist', async () => {
       mockPrisma.tTEntry.findMany.mockResolvedValue([]);
+      mockPrisma.tTPhaseRound.findMany.mockResolvedValue([]);
 
       const positions = await getTAFinalsPositions(mockPrisma as any, TOURNAMENT_ID);
 
       expect(positions).toEqual([]);
+    });
+
+    /**
+     * Regression test for the production bug observed in JSMKC 2026 TA finals.
+     *
+     * In life-based elimination, ranking is determined by the order of
+     * elimination — the LAST player eliminated takes 2nd, the second-to-last
+     * takes 3rd, etc.  The previous implementation sorted eliminated players
+     * by `totalTime ASC` (sum of best times across courses played), which is
+     * unrelated to elimination order.  A player who recorded fast times
+     * before being eliminated early would incorrectly outrank a player who
+     * survived more rounds with slower times.
+     *
+     * Scenario: champion p1 (alive); p2 was the very last to be eliminated
+     * (round 5) and should take 2nd; p3 was eliminated in round 1 — earliest
+     * — but happens to have the lowest accumulated totalTime; under the old
+     * logic p3 would be incorrectly assigned 2nd place.
+     */
+    it('ranks eliminated players by elimination round (latest eliminated takes best position)', async () => {
+      // Mock order mirrors the legacy `eliminated ASC, lives DESC, totalTime ASC`
+      // ordering so this fails under the old logic.  Under the old sort, p3
+      // (lowest totalTime) would incorrectly land in 2nd place even though it
+      // was eliminated first.
+      mockPrisma.tTEntry.findMany.mockResolvedValueOnce([
+        { playerId: 'p1', eliminated: false, lives: 1, totalTime: 500000 },
+        { playerId: 'p3', eliminated: true, lives: 0, totalTime: 100000 },
+        { playerId: 'p4', eliminated: true, lives: 0, totalTime: 200000 },
+        { playerId: 'p2', eliminated: true, lives: 0, totalTime: 480000 },
+      ]);
+      mockPrisma.tTPhaseRound.findMany.mockResolvedValueOnce([
+        { roundNumber: 1, eliminatedIds: ['p3'], results: [{ playerId: 'p3', timeMs: 60000 }] },
+        { roundNumber: 3, eliminatedIds: ['p4'], results: [{ playerId: 'p4', timeMs: 70000 }] },
+        { roundNumber: 5, eliminatedIds: ['p2'], results: [{ playerId: 'p2', timeMs: 80000 }] },
+      ]);
+
+      const positions = await getTAFinalsPositions(mockPrisma as any, TOURNAMENT_ID);
+
+      expect(positions).toEqual([
+        { playerId: 'p1', position: 1 }, // last alive — champion
+        { playerId: 'p2', position: 2 }, // eliminated last (round 5)
+        { playerId: 'p4', position: 3 }, // eliminated in round 3
+        { playerId: 'p3', position: 4 }, // eliminated first (round 1)
+      ]);
+    });
+
+    /**
+     * When several players are eliminated in the same round (e.g., the bottom
+     * half are all knocked out at once after a lives reset), they are ordered
+     * by their time in that eliminating round — the faster runner gets the
+     * better position.  This preserves a strict ordering required by TA
+     * finals' per-position points table without giving identical points to
+     * runners with clearly different performance.
+     */
+    it('breaks same-round elimination ties by round time (faster = higher position)', async () => {
+      // Mock returns entries in the legacy `eliminated ASC, lives DESC, totalTime ASC`
+      // order so the test fails under the old logic (which would otherwise just map
+      // input array order to positions).  d would incorrectly take the best
+      // eliminated slot under the old logic because its totalTime is lowest.
+      mockPrisma.tTEntry.findMany.mockResolvedValueOnce([
+        { playerId: 'a', eliminated: false, lives: 1, totalTime: 600000 },
+        { playerId: 'd', eliminated: true, lives: 0, totalTime: 580000 },
+        { playerId: 'b', eliminated: true, lives: 0, totalTime: 590000 },
+        { playerId: 'c', eliminated: true, lives: 0, totalTime: 595000 },
+      ]);
+      mockPrisma.tTPhaseRound.findMany.mockResolvedValueOnce([
+        {
+          roundNumber: 4,
+          eliminatedIds: ['b', 'c', 'd'],
+          results: [
+            { playerId: 'a', timeMs: 60000, isRetry: false },
+            { playerId: 'b', timeMs: 62000, isRetry: false },
+            { playerId: 'c', timeMs: 63000, isRetry: false },
+            { playerId: 'd', timeMs: 65000, isRetry: false },
+          ],
+        },
+      ]);
+
+      const positions = await getTAFinalsPositions(mockPrisma as any, TOURNAMENT_ID);
+
+      expect(positions).toEqual([
+        { playerId: 'a', position: 1 },
+        { playerId: 'b', position: 2 }, // fastest of the three eliminated
+        { playerId: 'c', position: 3 },
+        { playerId: 'd', position: 4 }, // slowest — worst position
+      ]);
     });
   });
 
@@ -435,6 +533,8 @@ describe('Overall Ranking module', () => {
         .mockResolvedValueOnce([p1Entry, p2Entry])  // call 2: calculateTAQualificationPointsFromDB
         .mockResolvedValueOnce([])                   // call 3: getTAFinalsPositions phase3 (empty)
         .mockResolvedValueOnce([]);                  // call 4: getTAFinalsPositions legacy fallback
+      // No phase rounds in this scenario (no finals played)
+      mockPrisma.tTPhaseRound.findMany.mockResolvedValue([]);
 
       getMockCalculateAllCourseScores().mockReturnValue(
         new Map([

--- a/smkc-score-app/e2e/tc-ta-flow.js
+++ b/smkc-score-app/e2e/tc-ta-flow.js
@@ -148,6 +148,66 @@ async function runFullFlow(adminPage) {
 
     log('TC-TA-FLOW-24', championShown ? 'PASS' : 'FAIL',
       championShown ? '' : 'champion banner not found on TA finals page');
+
+    /* TC-TA-FLOW-24-RANK: confirm overall ranking honours elimination order.
+     *
+     * The phase round time formula (`60_000 + rank*200`) makes higher
+     * qualification ranks consistently faster, so the player with rank 1
+     * is the last surviving player and ranks 1..24 fall in roughly the
+     * order they were eliminated.  This pins the bug where finals positions
+     * were derived from `totalTime ASC` (sum of best times per player) —
+     * which inverted the order and could place an early-out player above
+     * the actual finalist.  After the fix, the player with rank 1 must
+     * appear at TA finals position 1, and the top finals positions must
+     * not be dominated by players who were eliminated earliest.
+     */
+    const eliminationOrder = [];
+    const phase3RoundsResp = await adminPage.evaluate(async (u) => {
+      const r = await fetch(u);
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, `/api/tournaments/${tournamentId}/ta/phases?phase=phase3`);
+    const phase3Rounds = phase3RoundsResp.b?.data?.rounds ?? [];
+    for (const round of phase3Rounds) {
+      for (const pid of (round.eliminatedIds ?? [])) {
+        eliminationOrder.push(pid);
+      }
+    }
+
+    const recRes = await adminPage.evaluate(async (u) => {
+      const r = await fetch(u, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, `/api/tournaments/${tournamentId}/overall-ranking`);
+    if (recRes.s < 200 || recRes.s >= 300) {
+      log('TC-TA-FLOW-24-RANK', 'FAIL', `recalculate failed: ${recRes.s}`);
+      return;
+    }
+    const ranked = (recRes.b?.data?.scores ?? recRes.b?.scores ?? []);
+
+    /* The player with qualification rank 1 (fastest under our formula)
+     * survives every round and must take TA finals points for 1st place. */
+    const champion = entries.find((e) => e.rank === 1);
+    const championScore = ranked.find((s) => s.playerId === champion?.playerId);
+    const championPoints = championScore?.taFinalsPoints ?? 0;
+
+    /* Identify the latest-eliminated player (the one in the last round to
+     * have a non-empty eliminatedIds list).  They must outrank earlier
+     * eliminations in TA finals points — which would not hold under the
+     * old `totalTime ASC` logic when an early-out player happened to have
+     * a low cumulative time from playing few rounds. */
+    const lastEliminatedId = eliminationOrder[eliminationOrder.length - 1];
+    const earliestEliminatedId = eliminationOrder[0];
+    const lastEliminatedPoints = ranked.find((s) => s.playerId === lastEliminatedId)?.taFinalsPoints ?? 0;
+    const earliestEliminatedPoints = ranked.find((s) => s.playerId === earliestEliminatedId)?.taFinalsPoints ?? 0;
+
+    if (championPoints !== 2000) {
+      log('TC-TA-FLOW-24-RANK', 'FAIL',
+        `champion (rank 1) expected 2000 TA finals points, got ${championPoints}`);
+    } else if (lastEliminatedPoints <= earliestEliminatedPoints) {
+      log('TC-TA-FLOW-24-RANK', 'FAIL',
+        `late-eliminated player (${lastEliminatedPoints} pts) should outrank earliest eliminated (${earliestEliminatedPoints} pts)`);
+    } else {
+      log('TC-TA-FLOW-24-RANK', 'PASS', '');
+    }
   } catch (err) {
     log('TC-TA-FLOW-24', 'FAIL', err instanceof Error ? err.message : 'TA flow failed');
   }

--- a/smkc-score-app/src/lib/points/overall-ranking.ts
+++ b/smkc-score-app/src/lib/points/overall-ranking.ts
@@ -297,15 +297,44 @@ export interface FinalsPosition {
 }
 
 /**
+ * A round result entry from TTPhaseRound.results JSON.
+ * Used to break ties when multiple players are eliminated in the same round.
+ */
+interface PhaseRoundResultRecord {
+  playerId: string;
+  timeMs: number;
+}
+
+/**
  * Determine TA finals positions from the phase3 (finals) stage data.
  *
- * TA finals use a life-based elimination system. Players are ordered by:
- * 1. Elimination status (non-eliminated players rank higher)
- * 2. Remaining lives (more lives = better)
- * 3. Total time (faster = better, as tiebreaker)
+ * TA finals use a life-based elimination system: every round, the bottom
+ * half lose a life, and players reaching 0 lives are eliminated. The last
+ * player standing is the champion.
+ *
+ * Ranking is therefore driven by elimination *order*, not accumulated time.
+ * The historical implementation sorted eliminated players by `totalTime ASC`
+ * (sum of best times across courses played), which is unrelated to when a
+ * player went out: a runner with very fast times in the few rounds they
+ * played would outrank a runner who survived more rounds with slower times.
+ * This produced visibly wrong results in JSMKC 2026 (e.g. a player
+ * eliminated in round 14 ended up with the runner-up points instead of the
+ * actual finalist eliminated in round 19).
+ *
+ * The corrected algorithm walks TTPhaseRound in chronological order to map
+ * each eliminated player to the round in which they went out, then sorts:
+ *   1. Non-eliminated players first  (still alive — best positions)
+ *      Tied alive players: more remaining lives wins; faster totalTime breaks
+ *      further ties.
+ *   2. Eliminated players in REVERSE elimination order  (latest out = best
+ *      remaining position). When several players were eliminated in the same
+ *      round (typical after a lives-reset cull), the faster time in that
+ *      round wins — this preserves a strict ordering required by TA's
+ *      per-position points table.
+ *   3. Stable tiebreaker: playerId ascending.
  *
  * Falls back to the legacy "finals" stage name for backwards compatibility
- * with older tournament data that used "finals" instead of "phase3".
+ * with older tournament data that predates the phase1/2/3 naming.
  *
  * @param prisma       - Prisma client instance
  * @param tournamentId - Tournament to look up
@@ -315,43 +344,84 @@ export async function getTAFinalsPositions(
   prisma: ExtendedPrismaClient,
   tournamentId: string
 ): Promise<FinalsPosition[]> {
-  // Query phase3 (current naming convention for TA finals stage)
-  // Ordering: non-eliminated first, then by lives descending, then by time ascending
-  const finalsEntries = await prisma.tTEntry.findMany({
-    where: {
-      tournamentId,
-      stage: "phase3",
-    },
-    orderBy: [
-      { eliminated: "asc" },   // Non-eliminated (false) sorts before eliminated (true)
-      { lives: "desc" },        // More remaining lives = better performance
-      { totalTime: "asc" },     // Faster total time breaks ties
-    ],
+  let finalsEntries = await prisma.tTEntry.findMany({
+    where: { tournamentId, stage: "phase3" },
   });
+  let phaseStage: "phase3" | "finals" = "phase3";
 
-  // Fallback: check for legacy "finals" stage name used in older tournaments
   if (finalsEntries.length === 0) {
-    const legacyFinalsEntries = await prisma.tTEntry.findMany({
-      where: {
-        tournamentId,
-        stage: "finals",
-      },
-      orderBy: [
-        { eliminated: "asc" },
-        { lives: "desc" },
-        { totalTime: "asc" },
-      ],
+    finalsEntries = await prisma.tTEntry.findMany({
+      where: { tournamentId, stage: "finals" },
     });
-
-    // Convert sorted array position to 1-based placement
-    return legacyFinalsEntries.map((entry: TTEntryRecord, index: number) => ({
-      playerId: entry.playerId,
-      position: index + 1,
-    }));
+    phaseStage = "finals";
   }
 
-  // Convert sorted array position to 1-based placement
-  return finalsEntries.map((entry: TTEntryRecord, index: number) => ({
+  if (finalsEntries.length === 0) return [];
+
+  // Walk all phase rounds chronologically and record the round in which
+  // each eliminated player went out, plus their time in that round (used
+  // to break ties when several players are eliminated in the same round).
+  // If a player somehow appears in multiple rounds' eliminatedIds (legacy
+  // data, manual override re-runs), the LATEST entry wins because it
+  // reflects the final on-record elimination.
+  const phaseRounds = await prisma.tTPhaseRound.findMany({
+    where: { tournamentId, phase: phaseStage },
+    orderBy: { roundNumber: "asc" },
+    select: { roundNumber: true, eliminatedIds: true, results: true },
+  });
+
+  const eliminationByPlayer = new Map<
+    string,
+    { round: number; timeMs: number }
+  >();
+  for (const round of phaseRounds) {
+    // results & eliminatedIds are Prisma JsonValue. Narrow defensively —
+    // schema-shape changes upstream should not silently corrupt rankings.
+    const eliminatedIds = Array.isArray(round.eliminatedIds)
+      ? (round.eliminatedIds as string[])
+      : [];
+    if (eliminatedIds.length === 0) continue;
+    const results: PhaseRoundResultRecord[] = Array.isArray(round.results)
+      ? (round.results as unknown as PhaseRoundResultRecord[])
+      : [];
+    const timeByPlayer = new Map(results.map((r) => [r.playerId, r.timeMs]));
+    for (const playerId of eliminatedIds) {
+      eliminationByPlayer.set(playerId, {
+        round: round.roundNumber,
+        // Missing round time (e.g. manual elimination) treated as worst time
+        // so manually-removed runners don't accidentally outrank players who
+        // actually skated the round.
+        timeMs: timeByPlayer.get(playerId) ?? Number.POSITIVE_INFINITY,
+      });
+    }
+  }
+
+  const sorted = [...finalsEntries].sort((a: TTEntryRecord, b: TTEntryRecord) => {
+    // Alive players always rank above eliminated ones.
+    if (a.eliminated !== b.eliminated) return a.eliminated ? 1 : -1;
+
+    if (!a.eliminated) {
+      // Both still alive — more lives wins; faster totalTime breaks ties.
+      if (a.lives !== b.lives) return b.lives - a.lives;
+      const at = a.totalTime ?? Number.POSITIVE_INFINITY;
+      const bt = b.totalTime ?? Number.POSITIVE_INFINITY;
+      if (at !== bt) return at - bt;
+      return a.playerId.localeCompare(b.playerId);
+    }
+
+    // Both eliminated — order by reverse elimination order.
+    const aData = eliminationByPlayer.get(a.playerId);
+    const bData = eliminationByPlayer.get(b.playerId);
+    if (!aData && !bData) return a.playerId.localeCompare(b.playerId);
+    if (!aData) return 1;
+    if (!bData) return -1;
+
+    if (aData.round !== bData.round) return bData.round - aData.round;
+    if (aData.timeMs !== bData.timeMs) return aData.timeMs - bData.timeMs;
+    return a.playerId.localeCompare(b.playerId);
+  });
+
+  return sorted.map((entry: TTEntryRecord, index: number) => ({
     playerId: entry.playerId,
     position: index + 1,
   }));


### PR DESCRIPTION
The overall ranking calculation for TA finals previously sorted eliminated
players by `totalTime ASC` (sum of best times across courses played), which
is unrelated to when a player was eliminated. A runner with fast times in
the few rounds they played would outrank a runner who survived more rounds
with slower times.

In JSMKC 2026 TA finals, this caused Lafungo (eliminated in round 14) to
take the runner-up points instead of KVD (the actual finalist eliminated
in round 19), and Takashi (eliminated in round 8 with 2 others) to claim
4th place instead of Antistar (eliminated in round 12).

The fix walks `TTPhaseRound` chronologically to build a playerId → round
map, then sorts eliminated players by reverse elimination order. Tied
eliminations within the same round are broken by their time in that round
(faster = better position) to preserve the strict ordering required by
TA's per-position points table.

Adds two regression tests that fail under the legacy logic, plus an E2E
assertion verifying the latest-eliminated player outranks the
earliest-eliminated player.

https://claude.ai/code/session_018L5sF1QsJnzgygEZ95gsAC