### PR TITLE
[codex] Preview Top 24 finals before barrage completion

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/finals/route.test.ts
@@ -223,6 +223,66 @@ describe('BM Finals API Route - /api/tournaments/[id]/bm/finals', () => {
       // All-null rounds must not be touched — no repair updateMany should fire
       expect(repairCall).toBeUndefined();
     });
+
+    it('should preview the Top-24 finals bracket with unresolved barrage seats as TBD', async () => {
+      const playoffMatches = [
+        { id: 'p1', matchNumber: 1, stage: 'playoff', round: 'playoff_r1', completed: false, score1: 0, score2: 0, player1Id: 'a8', player2Id: 'a7', player1: { id: 'a8' }, player2: { id: 'a7' }, startingCourseNumber: 1 },
+        { id: 'p2', matchNumber: 2, stage: 'playoff', round: 'playoff_r1', completed: false, score1: 0, score2: 0, player1Id: 'b8', player2Id: 'b7', player1: { id: 'b8' }, player2: { id: 'b7' }, startingCourseNumber: 1 },
+        { id: 'p3', matchNumber: 3, stage: 'playoff', round: 'playoff_r1', completed: false, score1: 0, score2: 0, player1Id: 'a9', player2Id: 'b9', player1: { id: 'a9' }, player2: { id: 'b9' }, startingCourseNumber: 1 },
+        { id: 'p4', matchNumber: 4, stage: 'playoff', round: 'playoff_r1', completed: false, score1: 0, score2: 0, player1Id: 'a10', player2Id: 'b10', player1: { id: 'a10' }, player2: { id: 'b10' }, startingCourseNumber: 1 },
+        { id: 'p5', matchNumber: 5, stage: 'playoff', round: 'playoff_r2', completed: true, score1: 3, score2: 1, player1Id: 'b8', player2Id: 'a8', player1: { id: 'b8', nickname: 'B8' }, player2: { id: 'a8', nickname: 'A8' }, startingCourseNumber: 2 },
+        { id: 'p6', matchNumber: 6, stage: 'playoff', round: 'playoff_r2', completed: false, score1: 0, score2: 0, player1Id: 'a11', player2Id: 'b11', player1: { id: 'a11' }, player2: { id: 'b11' }, startingCourseNumber: 2 },
+        { id: 'p7', matchNumber: 7, stage: 'playoff', round: 'playoff_r2', completed: false, score1: 0, score2: 0, player1Id: 'a12', player2Id: 'b12', player1: { id: 'a12' }, player2: { id: 'b12' }, startingCourseNumber: 2 },
+        { id: 'p8', matchNumber: 8, stage: 'playoff', round: 'playoff_r2', completed: false, score1: 0, score2: 0, player1Id: 'a10', player2Id: 'b10', player1: { id: 'a10' }, player2: { id: 'b10' }, startingCourseNumber: 2 },
+      ];
+      const qualifications = ['A', 'B'].flatMap((group) =>
+        Array.from({ length: 12 }, (_, index) => {
+          const rank = index + 1;
+          const id = `${group.toLowerCase()}${rank}`;
+          return {
+            id: `q-${id}`,
+            tournamentId: 't1',
+            playerId: id,
+            group,
+            score: 100 - rank,
+            points: 100 - rank,
+            winRounds: 12 - rank,
+            player: { id, nickname: `${group}${rank}` },
+          };
+        }),
+      );
+
+      (prisma.bMMatch.count as jest.Mock).mockResolvedValue(0);
+      (prisma.bMMatch.findMany as jest.Mock)
+        .mockResolvedValueOnce(playoffMatches)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      (prisma.bMQualification.findMany as jest.Mock).mockResolvedValue(qualifications);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/bm/finals');
+      const params = Promise.resolve({ id: 't1' });
+      const result = await GET(request, { params });
+
+      expect(result.status).toBe(200);
+      expect(result.data.phase).toBe('playoff');
+      expect(result.data.matches).toEqual([]);
+      expect(result.data.bracketSize).toBe(16);
+      expect(result.data.bracketStructure).toHaveLength(31);
+      expect(result.data.seededPlayers).toHaveLength(13);
+      expect(result.data.seededPlayers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ seed: 1, playerId: 'a1' }),
+          expect.objectContaining({ seed: 16, playerId: 'b8' }),
+        ]),
+      );
+      expect(result.data.seededPlayers).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ seed: 13 }),
+          expect.objectContaining({ seed: 14 }),
+          expect.objectContaining({ seed: 15 }),
+        ]),
+      );
+    });
   });
 
   describe('POST - Create finals tournament from qualification results', () => {

--- a/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
@@ -17,6 +17,7 @@
 
 import { render } from "@testing-library/react";
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
+import { generateBracketStructure } from "@/lib/double-elimination";
 
 /**
  * Build a minimal 8-player double-elimination bracket structure.
@@ -167,6 +168,44 @@ describe("DoubleEliminationBracket TBD rendering (issue #574)", () => {
     expect(winnersQF1).toBeDefined();
     expect(winnersQF1!.textContent).toContain(seed1.nickname);
     expect(winnersQF1!.textContent).toContain(seed8.nickname);
+  });
+
+  it("renders unresolved Top-24 barrage seats as TBD in a previewed 16-player bracket", () => {
+    const bracketStructure = generateBracketStructure(16);
+    const seededPreview = [
+      ...seededPlayers,
+      { seed: 9, playerId: "p9", player: { id: "p9", name: "Ivy I", nickname: "Ivy" } },
+      { seed: 10, playerId: "p10", player: { id: "p10", name: "Jules J", nickname: "Jules" } },
+      { seed: 11, playerId: "p11", player: { id: "p11", name: "Kai K", nickname: "Kai" } },
+      { seed: 12, playerId: "p12", player: { id: "p12", name: "Lee L", nickname: "Lee" } },
+      { seed: 16, playerId: "p16", player: { id: "p16", name: "Mika M", nickname: "Mika" } },
+    ];
+
+    const { container } = render(
+      <DoubleEliminationBracket
+        matches={[]}
+        bracketStructure={bracketStructure}
+        roundNames={{}}
+        seededPlayers={seededPreview}
+      />,
+    );
+
+    const winnersR1Cards = Array.from(
+      container.querySelectorAll<HTMLElement>("[role='button']"),
+    ).filter((el) => {
+      const label = el.querySelector("div.text-xs");
+      return label && ["M1", "M4", "M5", "M8"].includes(label.textContent || "");
+    });
+
+    expect(winnersR1Cards).toHaveLength(4);
+    expect(winnersR1Cards[0].textContent).toContain(seed1.nickname);
+    expect(winnersR1Cards[0].textContent).toContain("Mika");
+    expect(winnersR1Cards[1].textContent).toContain(seed4.nickname);
+    expect(winnersR1Cards[1].textContent).toContain("TBD");
+    expect(winnersR1Cards[2].textContent).toContain(seed3.nickname);
+    expect(winnersR1Cards[2].textContent).toContain("TBD");
+    expect(winnersR1Cards[3].textContent).toContain(seed2.nickname);
+    expect(winnersR1Cards[3].textContent).toContain("TBD");
   });
 });
 

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -735,7 +735,7 @@ export default function BattleModeFinals({
             </ul>
           </CardContent>
         </Card>
-      ) : playoffMatches.length > 0 && matches.length > 0 ? (
+      ) : playoffMatches.length > 0 && bracketStructure.length > 0 ? (
         /* Both playoff and finals exist — show tabs so the admin can review
          * the playoff (barrage) results after the Upper Bracket is created. */
         <Tabs defaultValue="finals" className="space-y-4">
@@ -764,6 +764,18 @@ export default function BattleModeFinals({
               onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
               getTargetWins={(match, bracketMatch) => getBmFinalsTargetWins({ stage: match?.stage ?? 'playoff', round: match?.round ?? bracketMatch.round })}
             />
+            {matches.length === 0 && playoffComplete && isAdmin && (
+              <Card className="mt-4 border-green-500/50 bg-green-500/10">
+                <CardContent className="py-4 text-center">
+                  <p className="text-sm text-muted-foreground mb-3">
+                    {tFinals('allPlayoffMatchesComplete')}
+                  </p>
+                  <Button onClick={handleCreateUpperBracket}>
+                    {tFinals('createUpperBracket')}
+                  </Button>
+                </CardContent>
+              </Card>
+            )}
           </TabsContent>
         </Tabs>
       ) : playoffMatches.length > 0 ? (

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -782,22 +782,22 @@ export default function GrandPrixFinals({
             </ul>
           </CardContent>
         </Card>
-      ) : playoffMatches.length > 0 && matches.length > 0 ? (
+      ) : playoffMatches.length > 0 && bracketStructure.length > 0 ? (
         <Tabs defaultValue="finals" className="space-y-4">
           <TabsList>
             <TabsTrigger value="finals">{tFinals('upperBracket')}</TabsTrigger>
             <TabsTrigger value="playoff">{tFinals('playoffBracket')}</TabsTrigger>
           </TabsList>
           <TabsContent value="finals">
-        <DoubleEliminationBracket
-          matches={gpBracketMatches}
-          bracketStructure={bracketStructure}
-          roundNames={roundNames}
-          seededPlayers={seededPlayers}
-          getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
-          onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
-          onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
-        />
+            <DoubleEliminationBracket
+              matches={gpBracketMatches}
+              bracketStructure={bracketStructure}
+              roundNames={roundNames}
+              seededPlayers={seededPlayers}
+              getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
+              onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
+              onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
+            />
           </TabsContent>
           <TabsContent value="playoff">
             <PlayoffBracket
@@ -809,6 +809,14 @@ export default function GrandPrixFinals({
               onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
               onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
             />
+            {matches.length === 0 && playoffComplete && isAdmin && (
+              <Card className="mt-4 border-green-500/50 bg-green-500/10">
+                <CardContent className="py-4 text-center">
+                  <p className="text-sm text-muted-foreground mb-3">{tFinals('allPlayoffMatchesComplete')}</p>
+                  <Button onClick={handleCreateUpperBracket}>{tFinals('createUpperBracket')}</Button>
+                </CardContent>
+              </Card>
+            )}
           </TabsContent>
         </Tabs>
       ) : playoffMatches.length > 0 ? (

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -711,7 +711,7 @@ export default function MatchRaceFinals({
             </ul>
           </CardContent>
         </Card>
-      ) : playoffMatches.length > 0 && matches.length > 0 ? (
+      ) : playoffMatches.length > 0 && bracketStructure.length > 0 ? (
         <Tabs defaultValue="finals" className="space-y-4">
           <TabsList>
             <TabsTrigger value="finals">{tFinals('upperBracket')}</TabsTrigger>
@@ -736,6 +736,14 @@ export default function MatchRaceFinals({
               onMatchClick={isAdmin ? openMatchDialog : undefined}
               onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
             />
+            {matches.length === 0 && playoffComplete && isAdmin && (
+              <Card className="mt-4 border-green-500/50 bg-green-500/10">
+                <CardContent className="py-4 text-center">
+                  <p className="text-sm text-muted-foreground mb-3">{tFinals('allPlayoffMatchesComplete')}</p>
+                  <Button onClick={handleCreateUpperBracket}>{tFinals('createUpperBracket')}</Button>
+                </CardContent>
+              </Card>
+            )}
           </TabsContent>
         </Tabs>
       ) : playoffMatches.length > 0 ? (

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -61,6 +61,12 @@ interface FinalsMatchResultError {
   field?: string;
 }
 
+interface SeededFinalsPlayer {
+  seed: number;
+  playerId: string;
+  player: unknown;
+}
+
 function fisherYatesShuffle<T>(arr: readonly T[]): T[] {
   const result = [...arr];
   for (let i = result.length - 1; i > 0; i--) {
@@ -615,6 +621,71 @@ export function createFinalsHandlers(config: FinalsConfig) {
     };
   }
 
+  async function buildTop24FinalsPreview(
+    tournamentId: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    playoffMatches: any[],
+  ): Promise<{
+    bracketStructure: ReturnType<typeof generateBracketStructure>;
+    seededPlayers: SeededFinalsPlayer[];
+  } | null> {
+    if (playoffMatches.length === 0) return null;
+
+    try {
+      const qualifications = await qualModel(prisma).findMany({
+        where: { tournamentId },
+        include: { player: { select: PLAYER_PUBLIC_SELECT } },
+        orderBy: config.qualificationOrderBy,
+      });
+
+      if (qualifications.length < 24) return null;
+
+      const rankedQualifications = await applyFinalsQualificationRanks(
+        model,
+        tournamentId,
+        qualifications,
+      );
+
+      const selection = selectFinalsEntrantsByGroup(
+        rankedQualifications as Array<{ playerId: string; player: unknown; group: string }>,
+      );
+
+      const seededPlayers: SeededFinalsPlayer[] = selection.direct.map((q, index) => ({
+        seed: index + 1,
+        playerId: q.playerId,
+        player: q.player,
+      }));
+
+      const playoffStructure = generatePlayoffStructure(PLAYOFF_ENTRANT_COUNT);
+      const r2Matches = playoffMatches.filter(
+        (m: { round?: string | null }) => m.round === 'playoff_r2',
+      );
+
+      for (const r2BracketMatch of playoffStructure.filter((m) => m.round === 'playoff_r2')) {
+        if (!r2BracketMatch.advancesToUpperSeed) continue;
+        const dbMatch = r2Matches.find(
+          (m: { matchNumber: number }) => m.matchNumber === r2BracketMatch.matchNumber,
+        );
+        if (!dbMatch?.completed) continue;
+
+        const winnerId = dbMatch.score1 >= dbMatch.score2 ? dbMatch.player1Id : dbMatch.player2Id;
+        const winnerPlayer = dbMatch.player1Id === winnerId ? dbMatch.player1 : dbMatch.player2;
+        seededPlayers.push({
+          seed: r2BracketMatch.advancesToUpperSeed,
+          playerId: winnerId,
+          player: winnerPlayer,
+        });
+      }
+
+      return {
+        bracketStructure: generateBracketStructure(16),
+        seededPlayers,
+      };
+    } catch {
+      return null;
+    }
+  }
+
   /**
    * GET handler: Fetch finals bracket data for a tournament.
    * Response shape depends on config.getStyle.
@@ -788,6 +859,9 @@ export function createFinalsHandlers(config: FinalsConfig) {
       const phase = hasFinals > 0 ? 'finals' as const
         : playoffMatches.length > 0 ? 'playoff' as const
         : 'finals' as const;
+      const top24FinalsPreview = hasFinals === 0
+        ? await buildTop24FinalsPreview(tournamentId, playoffMatches)
+        : null;
 
       /* Normalize cups-per-round for legacy finals rows before paginating or
        * simple/grouped fetches, so every branch sees the repaired state.
@@ -860,11 +934,15 @@ export function createFinalsHandlers(config: FinalsConfig) {
          * 8-player bracket = 17 matches, 16-player bracket = 31 matches.
          * Use count > 20 as threshold to distinguish.
          * Use result.meta.total from paginate() to avoid an extra count query. */
-        const bracketSize = (result.meta.total ?? 0) > BRACKET_SIZE_THRESHOLD ? 16 : 8;
+        const bracketSize = (result.meta.total ?? 0) > BRACKET_SIZE_THRESHOLD
+          ? 16
+          : top24FinalsPreview
+            ? 16
+            : 8;
 
         const bracketStructure = result.data.length > 0
           ? generateBracketStructure(bracketSize)
-          : [];
+          : top24FinalsPreview?.bracketStructure ?? [];
 
         return createSuccessResponse({
           ...result,
@@ -877,6 +955,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
           playoffStructure,
           playoffSeededPlayers,
           playoffComplete,
+          ...(top24FinalsPreview ? { seededPlayers: top24FinalsPreview.seededPlayers } : {}),
         });
       }
 
@@ -887,11 +966,16 @@ export function createFinalsHandlers(config: FinalsConfig) {
         orderBy: { matchNumber: 'asc' },
       });
 
-      const bracketSize = matches.length > BRACKET_SIZE_THRESHOLD ? 16 : 8;
+      const bracketSize = matches.length > BRACKET_SIZE_THRESHOLD
+        ? 16
+        : top24FinalsPreview
+          ? 16
+          : 8;
 
       const bracketStructure = matches.length > 0
         ? generateBracketStructure(bracketSize)
-        : [];
+        : top24FinalsPreview?.bracketStructure ?? [];
+      const seededPlayers = top24FinalsPreview?.seededPlayers ?? [];
 
       if (config.getStyle === 'grouped') {
         const winnersMatches = matches.filter(
@@ -918,6 +1002,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
           playoffSeededPlayers,
           playoffComplete,
           phase,
+          ...(top24FinalsPreview ? { seededPlayers } : {}),
         });
       }
 
@@ -933,6 +1018,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
         playoffStructure,
         playoffSeededPlayers,
         playoffComplete,
+        ...(top24FinalsPreview ? { seededPlayers } : {}),
       });
     } catch (error) {
       logger.error(config.getErrorMessage, { error, tournamentId });


### PR DESCRIPTION
## Summary
- Preview the Top 24 finals bracket while barrage/playoff results are still in progress.
- Keep unresolved barrage winners as TBD while showing direct qualifiers and any resolved R2 winners.
- Show the finals/playoff tabs for BM, MR, and GP during the barrage phase, preserving the create-upper-bracket action after barrage completion.
- Keep existing playoff-only GET responses resilient when Top 24 qualification data is unavailable.

## Validation
- npm test -- --runInBand --runTestsByPath __tests__/lib/api-factories/finals-route.test.ts __tests__/app/api/tournaments/[id]/bm/finals/route.test.ts __tests__/app/api/tournaments/[id]/mr/finals/route.test.ts __tests__/app/api/tournaments/[id]/gp/finals/route.test.ts __tests__/components/tournament/double-elimination-bracket.test.tsx
- npm run build
- git diff --check
- npx eslint src/lib/api-factories/finals-route.ts src/app/tournaments/[id]/bm/finals/page.tsx src/app/tournaments/[id]/mr/finals/page.tsx src/app/tournaments/[id]/gp/finals/page.tsx __tests__/components/tournament/double-elimination-bracket.test.tsx __tests__/app/api/tournaments/[id]/bm/finals/route.test.ts (warnings only: pre-existing unused-variable warnings)
