### PR TITLE
[codex] Fix TA finals bonus placements

### DIFF
--- a/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
+++ b/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
@@ -80,6 +80,7 @@ const mockPrisma = {
   bMMatch: { findMany: jest.fn() },
   mRMatch: { findMany: jest.fn() },
   gPMatch: { findMany: jest.fn() },
+  tTPhaseRound: { findMany: jest.fn() },
   player: { findMany: jest.fn() },
   tournamentPlayerScore: {
     findMany: jest.fn(),
@@ -276,11 +277,12 @@ describe('Overall Ranking module', () => {
   describe('getTAFinalsPositions', () => {
     it('returns positions from phase3 entries (single survivor)', async () => {
       mockPrisma.tTEntry.findMany.mockResolvedValueOnce([
-        { playerId: 'p1', eliminated: false, lives: 2, totalTime: 90000 },
-        { playerId: 'p2', eliminated: true, lives: 0, totalTime: 95000 },
+        { playerId: 'p1', stage: 'phase3', eliminated: false, lives: 2, totalTime: 90000 },
+        { playerId: 'p2', stage: 'phase3', eliminated: true, lives: 0, totalTime: 95000 },
       ]);
       mockPrisma.tTPhaseRound.findMany.mockResolvedValueOnce([
         {
+          phase: 'phase3',
           roundNumber: 1,
           eliminatedIds: ['p2'],
           results: [
@@ -300,7 +302,7 @@ describe('Overall Ranking module', () => {
 
     it('falls back to legacy "finals" stage when phase3 is empty', async () => {
       mockPrisma.tTEntry.findMany
-        .mockResolvedValueOnce([]) // phase3 returns nothing
+        .mockResolvedValueOnce([]) // phase stages return nothing
         .mockResolvedValueOnce([
           { playerId: 'p1', eliminated: false, lives: 1, totalTime: 80000 },
         ]);
@@ -321,70 +323,39 @@ describe('Overall Ranking module', () => {
       expect(positions).toEqual([]);
     });
 
-    /**
-     * Regression test for the production bug observed in JSMKC 2026 TA finals.
-     *
-     * In life-based elimination, ranking is determined by the order of
-     * elimination — the LAST player eliminated takes 2nd, the second-to-last
-     * takes 3rd, etc.  The previous implementation sorted eliminated players
-     * by `totalTime ASC` (sum of best times across courses played), which is
-     * unrelated to elimination order.  A player who recorded fast times
-     * before being eliminated early would incorrectly outrank a player who
-     * survived more rounds with slower times.
-     *
-     * Scenario: champion p1 (alive); p2 was the very last to be eliminated
-     * (round 5) and should take 2nd; p3 was eliminated in round 1 — earliest
-     * — but happens to have the lowest accumulated totalTime; under the old
-     * logic p3 would be incorrectly assigned 2nd place.
-     */
-    it('ranks eliminated players by elimination round (latest eliminated takes best position)', async () => {
-      // Mock order mirrors the legacy `eliminated ASC, lives DESC, totalTime ASC`
-      // ordering so this fails under the old logic.  Under the old sort, p3
-      // (lowest totalTime) would incorrectly land in 2nd place even though it
-      // was eliminated first.
+    it('ranks phase3 eliminated players by elimination round (latest eliminated takes best position)', async () => {
       mockPrisma.tTEntry.findMany.mockResolvedValueOnce([
-        { playerId: 'p1', eliminated: false, lives: 1, totalTime: 500000 },
-        { playerId: 'p3', eliminated: true, lives: 0, totalTime: 100000 },
-        { playerId: 'p4', eliminated: true, lives: 0, totalTime: 200000 },
-        { playerId: 'p2', eliminated: true, lives: 0, totalTime: 480000 },
+        { playerId: 'p1', stage: 'phase3', eliminated: false, lives: 1, totalTime: 500000 },
+        { playerId: 'p3', stage: 'phase3', eliminated: true, lives: 0, totalTime: 100000 },
+        { playerId: 'p4', stage: 'phase3', eliminated: true, lives: 0, totalTime: 200000 },
+        { playerId: 'p2', stage: 'phase3', eliminated: true, lives: 0, totalTime: 480000 },
       ]);
       mockPrisma.tTPhaseRound.findMany.mockResolvedValueOnce([
-        { roundNumber: 1, eliminatedIds: ['p3'], results: [{ playerId: 'p3', timeMs: 60000 }] },
-        { roundNumber: 3, eliminatedIds: ['p4'], results: [{ playerId: 'p4', timeMs: 70000 }] },
-        { roundNumber: 5, eliminatedIds: ['p2'], results: [{ playerId: 'p2', timeMs: 80000 }] },
+        { phase: 'phase3', roundNumber: 1, eliminatedIds: ['p3'], results: [{ playerId: 'p3', timeMs: 60000 }] },
+        { phase: 'phase3', roundNumber: 3, eliminatedIds: ['p4'], results: [{ playerId: 'p4', timeMs: 70000 }] },
+        { phase: 'phase3', roundNumber: 5, eliminatedIds: ['p2'], results: [{ playerId: 'p2', timeMs: 80000 }] },
       ]);
 
       const positions = await getTAFinalsPositions(mockPrisma as any, TOURNAMENT_ID);
 
       expect(positions).toEqual([
-        { playerId: 'p1', position: 1 }, // last alive — champion
-        { playerId: 'p2', position: 2 }, // eliminated last (round 5)
-        { playerId: 'p4', position: 3 }, // eliminated in round 3
-        { playerId: 'p3', position: 4 }, // eliminated first (round 1)
+        { playerId: 'p1', position: 1 },
+        { playerId: 'p2', position: 2 },
+        { playerId: 'p4', position: 3 },
+        { playerId: 'p3', position: 4 },
       ]);
     });
 
-    /**
-     * When several players are eliminated in the same round (e.g., the bottom
-     * half are all knocked out at once after a lives reset), they are ordered
-     * by their time in that eliminating round — the faster runner gets the
-     * better position.  This preserves a strict ordering required by TA
-     * finals' per-position points table without giving identical points to
-     * runners with clearly different performance.
-     */
-    it('breaks same-round elimination ties by round time (faster = higher position)', async () => {
-      // Mock returns entries in the legacy `eliminated ASC, lives DESC, totalTime ASC`
-      // order so the test fails under the old logic (which would otherwise just map
-      // input array order to positions).  d would incorrectly take the best
-      // eliminated slot under the old logic because its totalTime is lowest.
+    it('breaks same-round phase3 eliminations by round time (faster = higher position)', async () => {
       mockPrisma.tTEntry.findMany.mockResolvedValueOnce([
-        { playerId: 'a', eliminated: false, lives: 1, totalTime: 600000 },
-        { playerId: 'd', eliminated: true, lives: 0, totalTime: 580000 },
-        { playerId: 'b', eliminated: true, lives: 0, totalTime: 590000 },
-        { playerId: 'c', eliminated: true, lives: 0, totalTime: 595000 },
+        { playerId: 'a', stage: 'phase3', eliminated: false, lives: 1, totalTime: 600000 },
+        { playerId: 'd', stage: 'phase3', eliminated: true, lives: 0, totalTime: 580000 },
+        { playerId: 'b', stage: 'phase3', eliminated: true, lives: 0, totalTime: 590000 },
+        { playerId: 'c', stage: 'phase3', eliminated: true, lives: 0, totalTime: 595000 },
       ]);
       mockPrisma.tTPhaseRound.findMany.mockResolvedValueOnce([
         {
+          phase: 'phase3',
           roundNumber: 4,
           eliminatedIds: ['b', 'c', 'd'],
           results: [
@@ -400,10 +371,55 @@ describe('Overall Ranking module', () => {
 
       expect(positions).toEqual([
         { playerId: 'a', position: 1 },
-        { playerId: 'b', position: 2 }, // fastest of the three eliminated
+        { playerId: 'b', position: 2 },
         { playerId: 'c', position: 3 },
-        { playerId: 'd', position: 4 }, // slowest — worst position
+        { playerId: 'd', position: 4 },
       ]);
+    });
+
+    it('assigns TA finals bonus positions through 24th from phase eliminations', async () => {
+      mockPrisma.tTEntry.findMany.mockResolvedValueOnce([
+        { playerId: 'p1', stage: 'phase3', eliminated: false, lives: 1, totalTime: 90000 },
+        { playerId: 'p2', stage: 'phase3', eliminated: true, lives: 0, totalTime: 92000 },
+        ...Array.from({ length: 4 }, (_, i) => ({
+          playerId: `p${17 + i}`,
+          stage: 'phase2',
+          eliminated: true,
+          lives: 0,
+          totalTime: 100000 + i,
+        })),
+        ...Array.from({ length: 4 }, (_, i) => ({
+          playerId: `p${21 + i}`,
+          stage: 'phase1',
+          eliminated: true,
+          lives: 0,
+          totalTime: 110000 + i,
+        })),
+      ]);
+      mockPrisma.tTPhaseRound.findMany.mockResolvedValueOnce([
+        { phase: 'phase1', roundNumber: 1, results: [{ playerId: 'p24', timeMs: 120000 }], eliminatedIds: ['p24'] },
+        { phase: 'phase1', roundNumber: 2, results: [{ playerId: 'p23', timeMs: 119000 }], eliminatedIds: ['p23'] },
+        { phase: 'phase1', roundNumber: 3, results: [{ playerId: 'p22', timeMs: 118000 }], eliminatedIds: ['p22'] },
+        { phase: 'phase1', roundNumber: 4, results: [{ playerId: 'p21', timeMs: 117000 }], eliminatedIds: ['p21'] },
+        { phase: 'phase2', roundNumber: 1, results: [{ playerId: 'p20', timeMs: 116000 }], eliminatedIds: ['p20'] },
+        { phase: 'phase2', roundNumber: 2, results: [{ playerId: 'p19', timeMs: 115000 }], eliminatedIds: ['p19'] },
+        { phase: 'phase2', roundNumber: 3, results: [{ playerId: 'p18', timeMs: 114000 }], eliminatedIds: ['p18'] },
+        { phase: 'phase2', roundNumber: 4, results: [{ playerId: 'p17', timeMs: 113000 }], eliminatedIds: ['p17'] },
+        { phase: 'phase3', roundNumber: 1, results: [{ playerId: 'p2', timeMs: 112000 }], eliminatedIds: ['p2'] },
+      ]);
+
+      const positions = await getTAFinalsPositions(mockPrisma as any, TOURNAMENT_ID);
+
+      expect(positions).toEqual(
+        expect.arrayContaining([
+          { playerId: 'p1', position: 1 },
+          { playerId: 'p2', position: 2 },
+          { playerId: 'p17', position: 17 },
+          { playerId: 'p20', position: 20 },
+          { playerId: 'p21', position: 21 },
+          { playerId: 'p24', position: 24 },
+        ])
+      );
     });
   });
 
@@ -551,6 +567,7 @@ describe('Overall Ranking module', () => {
       mockPrisma.bMMatch.findMany.mockResolvedValue([]);
       mockPrisma.mRMatch.findMany.mockResolvedValue([]);
       mockPrisma.gPMatch.findMany.mockResolvedValue([]);
+      mockPrisma.tTPhaseRound.findMany.mockResolvedValue([]);
       mockPrisma.player.findMany.mockResolvedValue([PLAYER_P1, PLAYER_P2]);
       getMockGetFinalsPoints().mockReturnValue(0);
     }

--- a/smkc-score-app/src/lib/points/overall-ranking.ts
+++ b/smkc-score-app/src/lib/points/overall-ranking.ts
@@ -133,6 +133,14 @@ interface TTEntryRecord {
   eliminated: boolean;
   lives: number;
   totalTime: number | null;
+  stage?: string;
+}
+
+interface TTPhaseRoundRecord {
+  phase: string;
+  roundNumber: number;
+  results: unknown;
+  eliminatedIds: unknown;
 }
 
 /**
@@ -344,87 +352,140 @@ export async function getTAFinalsPositions(
   prisma: ExtendedPrismaClient,
   tournamentId: string
 ): Promise<FinalsPosition[]> {
-  let finalsEntries = await prisma.tTEntry.findMany({
-    where: { tournamentId, stage: "phase3" },
+  let phaseEntries = await prisma.tTEntry.findMany({
+    where: { tournamentId, stage: { in: ["phase1", "phase2", "phase3"] } },
+    orderBy: [
+      { stage: "asc" },
+      { eliminated: "asc" },
+      { lives: "desc" },
+      { totalTime: "asc" },
+    ],
   });
-  let phaseStage: "phase3" | "finals" = "phase3";
+  let phaseFilter: "finals" | { in: string[] } = { in: ["phase1", "phase2", "phase3"] };
 
-  if (finalsEntries.length === 0) {
-    finalsEntries = await prisma.tTEntry.findMany({
+  if (phaseEntries.length === 0) {
+    phaseEntries = await prisma.tTEntry.findMany({
       where: { tournamentId, stage: "finals" },
+      orderBy: [
+        { eliminated: "asc" },
+        { lives: "desc" },
+        { totalTime: "asc" },
+      ],
     });
-    phaseStage = "finals";
+    phaseFilter = "finals";
   }
 
-  if (finalsEntries.length === 0) return [];
+  if (phaseEntries.length === 0) return [];
 
-  // Walk all phase rounds chronologically and record the round in which
-  // each eliminated player went out, plus their time in that round (used
-  // to break ties when several players are eliminated in the same round).
-  // If a player somehow appears in multiple rounds' eliminatedIds (legacy
-  // data, manual override re-runs), the LATEST entry wins because it
-  // reflects the final on-record elimination.
+  // Walk all submitted phase rounds chronologically and record the round in
+  // which each eliminated player went out, plus their time in that round.
   const phaseRounds = await prisma.tTPhaseRound.findMany({
-    where: { tournamentId, phase: phaseStage },
-    orderBy: { roundNumber: "asc" },
-    select: { roundNumber: true, eliminatedIds: true, results: true },
+    where: { tournamentId, phase: phaseFilter },
+    orderBy: [
+      { phase: "asc" },
+      { roundNumber: "asc" },
+    ],
+    select: { phase: true, roundNumber: true, eliminatedIds: true, results: true },
   });
 
-  const eliminationByPlayer = new Map<
+  const eliminationByPhase = new Map<
     string,
-    { round: number; timeMs: number }
+    Map<string, { round: number; timeMs: number }>
   >();
-  for (const round of phaseRounds) {
-    // results & eliminatedIds are Prisma JsonValue. Narrow defensively —
-    // schema-shape changes upstream should not silently corrupt rankings.
+  const getPhaseEliminations = (phase: string) => {
+    const existing = eliminationByPhase.get(phase);
+    if (existing) return existing;
+    const created = new Map<string, { round: number; timeMs: number }>();
+    eliminationByPhase.set(phase, created);
+    return created;
+  };
+
+  for (const round of phaseRounds as TTPhaseRoundRecord[]) {
     const eliminatedIds = Array.isArray(round.eliminatedIds)
-      ? (round.eliminatedIds as string[])
+      ? round.eliminatedIds.filter((id): id is string => typeof id === "string")
       : [];
     if (eliminatedIds.length === 0) continue;
+
     const results: PhaseRoundResultRecord[] = Array.isArray(round.results)
       ? (round.results as unknown as PhaseRoundResultRecord[])
       : [];
-    const timeByPlayer = new Map(results.map((r) => [r.playerId, r.timeMs]));
+    const timeByPlayer = new Map(results.map((result) => [result.playerId, result.timeMs]));
+    const phaseEliminations = getPhaseEliminations(round.phase);
+
     for (const playerId of eliminatedIds) {
-      eliminationByPlayer.set(playerId, {
+      phaseEliminations.set(playerId, {
         round: round.roundNumber,
-        // Missing round time (e.g. manual elimination) treated as worst time
-        // so manually-removed runners don't accidentally outrank players who
-        // actually skated the round.
+        // Missing round time (e.g. manual elimination) is treated as the
+        // worst time so it does not outrank submitted results accidentally.
         timeMs: timeByPlayer.get(playerId) ?? Number.POSITIVE_INFINITY,
       });
     }
   }
 
-  const sorted = [...finalsEntries].sort((a: TTEntryRecord, b: TTEntryRecord) => {
-    // Alive players always rank above eliminated ones.
-    if (a.eliminated !== b.eliminated) return a.eliminated ? 1 : -1;
+  const positions: FinalsPosition[] = [];
+  const assignedPlayerIds = new Set<string>();
+  const currentPhaseEntries = phaseEntries as TTEntryRecord[];
 
-    if (!a.eliminated) {
-      // Both still alive — more lives wins; faster totalTime breaks ties.
-      if (a.lives !== b.lives) return b.lives - a.lives;
-      const at = a.totalTime ?? Number.POSITIVE_INFINITY;
-      const bt = b.totalTime ?? Number.POSITIVE_INFINITY;
-      if (at !== bt) return at - bt;
+  const sortPhase3Entries = (entries: TTEntryRecord[]) => {
+    const phase3Eliminations = getPhaseEliminations(phaseFilter === "finals" ? "finals" : "phase3");
+    return [...entries].sort((a, b) => {
+      if (a.eliminated !== b.eliminated) return a.eliminated ? 1 : -1;
+
+      if (!a.eliminated) {
+        if (a.lives !== b.lives) return b.lives - a.lives;
+        const at = a.totalTime ?? Number.POSITIVE_INFINITY;
+        const bt = b.totalTime ?? Number.POSITIVE_INFINITY;
+        if (at !== bt) return at - bt;
+        return a.playerId.localeCompare(b.playerId);
+      }
+
+      const aData = phase3Eliminations.get(a.playerId);
+      const bData = phase3Eliminations.get(b.playerId);
+      if (!aData && !bData) return a.playerId.localeCompare(b.playerId);
+      if (!aData) return 1;
+      if (!bData) return -1;
+
+      if (aData.round !== bData.round) return bData.round - aData.round;
+      if (aData.timeMs !== bData.timeMs) return aData.timeMs - bData.timeMs;
       return a.playerId.localeCompare(b.playerId);
+    });
+  };
+
+  const assignPhaseEliminations = (phase: string, startingPosition: number) => {
+    let position = startingPosition;
+    const eliminations = [...getPhaseEliminations(phase).entries()].sort(([, a], [, b]) => {
+      if (a.round !== b.round) return a.round - b.round;
+      if (a.timeMs !== b.timeMs) return b.timeMs - a.timeMs;
+      return 0;
+    });
+
+    for (const [playerId] of eliminations) {
+      if (assignedPlayerIds.has(playerId)) continue;
+      positions.push({ playerId, position });
+      assignedPlayerIds.add(playerId);
+      position -= 1;
     }
+  };
 
-    // Both eliminated — order by reverse elimination order.
-    const aData = eliminationByPlayer.get(a.playerId);
-    const bData = eliminationByPlayer.get(b.playerId);
-    if (!aData && !bData) return a.playerId.localeCompare(b.playerId);
-    if (!aData) return 1;
-    if (!bData) return -1;
+  if (phaseFilter === "finals") {
+    return sortPhase3Entries(currentPhaseEntries).map((entry, index) => ({
+      playerId: entry.playerId,
+      position: index + 1,
+    }));
+  }
 
-    if (aData.round !== bData.round) return bData.round - aData.round;
-    if (aData.timeMs !== bData.timeMs) return aData.timeMs - bData.timeMs;
-    return a.playerId.localeCompare(b.playerId);
+  const phase3Entries = currentPhaseEntries.filter((entry) => entry.stage === "phase3");
+  sortPhase3Entries(phase3Entries).forEach((entry, index) => {
+    positions.push({ playerId: entry.playerId, position: index + 1 });
+    assignedPlayerIds.add(entry.playerId);
   });
 
-  return sorted.map((entry: TTEntryRecord, index: number) => ({
-    playerId: entry.playerId,
-    position: index + 1,
-  }));
+  // TA finals are staged from the bottom up: Phase 1 eliminations decide
+  // 24th through 21st, and Phase 2 eliminations decide 20th through 17th.
+  assignPhaseEliminations("phase2", 20);
+  assignPhaseEliminations("phase1", 24);
+
+  return positions.sort((a, b) => a.position - b.position || a.playerId.localeCompare(b.playerId));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix TA finals bonus placement calculation so Phase 1 and Phase 2 eliminations receive 21st-24th and 17th-20th bonus points
- Keep the existing fixed bonus point tables unchanged and feed the corrected TA placements into overall ranking totals
- Add regression coverage for TA bonus positions through 24th

## Root Cause
TA overall ranking only derived finals placements from `phase3` entries. Players eliminated in Phase 1 or Phase 2 were not assigned finals positions, so their 17th-24th bonus points were omitted from the overall ranking.

## Validation
- `npm test -- --runTestsByPath __tests__/lib/points/overall-ranking.test.ts __tests__/lib/points/finals-points.test.ts`
- `npm run lint -- src/lib/points/overall-ranking.ts __tests__/lib/points/overall-ranking.test.ts`
- `git diff --check`
