### PR TITLE
[codex] Fix 2P playoff broadcast footer label

### DIFF
--- a/smkc-score-app/__tests__/components/tournament/qualification-playoff-manager.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/qualification-playoff-manager.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QualificationPlayoffManager } from "@/components/tournament/qualification-playoff-manager";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string, values?: Record<string, unknown>) => {
+    if (key === "playoffGroupTitle") return `Playoff rank ${values?.rank}`;
+    if (key === "broadcastReflect") return "Broadcast";
+    if (key === "saving") return "Saving";
+    if (key === "recordPlayoffResult") return "Record result";
+    return key;
+  },
+}));
+
+describe("QualificationPlayoffManager broadcast", () => {
+  it("updates the lower-frame label when broadcasting a 2P qualification playoff", async () => {
+    const onBroadcast = jest.fn().mockResolvedValue(true);
+
+    render(
+      <QualificationPlayoffManager
+        groups={[
+          {
+            id: "group-a-rank-3",
+            rank: 3,
+            players: [
+              { id: "q1", nickname: "Mario", _autoRank: 3, rankOverride: null },
+              { id: "q2", nickname: "Luigi", _autoRank: 3, rankOverride: null },
+            ],
+          },
+        ]}
+        isAdmin
+        onSave={jest.fn()}
+        onBroadcast={onBroadcast}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Broadcast" }));
+
+    await waitFor(() => expect(onBroadcast).toHaveBeenCalledTimes(1));
+    expect(onBroadcast).toHaveBeenCalledWith("Mario", "Luigi", {
+      matchLabel: "Qualification Playoff Rank 3",
+      player1Wins: null,
+      player2Wins: null,
+      matchFt: null,
+    });
+  });
+});

--- a/smkc-score-app/src/components/tournament/qualification-playoff-manager.tsx
+++ b/smkc-score-app/src/components/tournament/qualification-playoff-manager.tsx
@@ -31,7 +31,16 @@ interface QualificationPlayoffManagerProps {
   isAdmin: boolean;
   onSave: (entries: PlayoffEntry[]) => Promise<boolean>;
   /** Broadcast first two players in the group to the overlay. */
-  onBroadcast?: (player1Name: string, player2Name: string) => Promise<boolean>;
+  onBroadcast?: (
+    player1Name: string,
+    player2Name: string,
+    matchInfo?: {
+      matchLabel?: string;
+      player1Wins?: number | null;
+      player2Wins?: number | null;
+      matchFt?: number | null;
+    },
+  ) => Promise<boolean>;
 }
 
 function moveEntry<T>(entries: T[], from: number, to: number): T[] {
@@ -100,7 +109,12 @@ export function QualificationPlayoffManager({
                     disabled={broadcastingGroupId === group.id}
                     onClick={async () => {
                       setBroadcastingGroupId(group.id);
-                      await onBroadcast(group.players[0].nickname, group.players[1].nickname);
+                      await onBroadcast(group.players[0].nickname, group.players[1].nickname, {
+                        matchLabel: `Qualification Playoff Rank ${group.rank}`,
+                        player1Wins: null,
+                        player2Wins: null,
+                        matchFt: null,
+                      });
                       setBroadcastingGroupId(null);
                     }}
                   >


### PR DESCRIPTION
## Summary
- Update 2P qualification playoff broadcast reflection to set the dashboard lower-frame label.
- Clear stale score/FT fields when reflecting a qualification playoff.
- Add a regression test for the playoff broadcast payload.

## Root Cause
The qualification playoff broadcast button only sent player names to the broadcast endpoint. Because it omitted `matchLabel`, the OBS dashboard footer kept showing the previous lower-frame label in 2P mode.

## Validation
- `npm test -- __tests__/components/tournament/qualification-playoff-manager.test.tsx --runInBand`
- `npx eslint src/components/tournament/qualification-playoff-manager.tsx __tests__/components/tournament/qualification-playoff-manager.test.tsx`
- `git diff --cached --check`
