### PR TITLE
[codex] Fix TA finals standings order

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
@@ -365,6 +365,89 @@ describe('GET /api/tournaments/[id]/ta/phases', () => {
       );
     });
 
+    it('should order phase standings by current finals placement instead of stored qualification time', async () => {
+      (prisma.tTEntry.findMany as jest.Mock).mockResolvedValue([
+        {
+          ...mockEntries[0],
+          id: 'entry-eliminated-early',
+          playerId: 'player-eliminated-early',
+          lives: 0,
+          eliminated: true,
+          totalTime: 50000,
+          rank: 1,
+          player: { ...mockEntries[0].player, id: 'player-eliminated-early', nickname: 'early-out' },
+        },
+        {
+          ...mockEntries[0],
+          id: 'entry-eliminated-late',
+          playerId: 'player-eliminated-late',
+          lives: 0,
+          eliminated: true,
+          totalTime: 90000,
+          rank: 4,
+          player: { ...mockEntries[0].player, id: 'player-eliminated-late', nickname: 'late-out' },
+        },
+        {
+          ...mockEntries[0],
+          id: 'entry-active-low-rank',
+          playerId: 'player-active-low-rank',
+          lives: 2,
+          eliminated: false,
+          totalTime: 80000,
+          rank: 3,
+          player: { ...mockEntries[0].player, id: 'player-active-low-rank', nickname: 'active-3' },
+        },
+        {
+          ...mockEntries[0],
+          id: 'entry-active-high-rank',
+          playerId: 'player-active-high-rank',
+          lives: 2,
+          eliminated: false,
+          totalTime: 100000,
+          rank: 2,
+          player: { ...mockEntries[0].player, id: 'player-active-high-rank', nickname: 'active-2' },
+        },
+      ]);
+      (prisma.tTPhaseRound.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'round-1',
+          phase: 'phase3',
+          roundNumber: 1,
+          course: 'MC1',
+          results: [
+            { playerId: 'player-eliminated-early', timeMs: 95000, isRetry: false },
+            { playerId: 'player-eliminated-late', timeMs: 85000, isRetry: false },
+          ],
+          eliminatedIds: ['player-eliminated-early'],
+          livesReset: false,
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+        {
+          id: 'round-2',
+          phase: 'phase3',
+          roundNumber: 2,
+          course: 'DP1',
+          results: [
+            { playerId: 'player-eliminated-early', timeMs: 75000, isRetry: false },
+            { playerId: 'player-eliminated-late', timeMs: 96000, isRetry: false },
+          ],
+          eliminatedIds: ['player-eliminated-late'],
+          livesReset: false,
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+      ]);
+
+      await phasesRoute.GET(createRequest('?phase=phase3'), { params: mockParams });
+
+      const call = NextResponse.json.mock.calls[0][0];
+      expect(call.data.entries.map((entry: { playerId: string }) => entry.playerId)).toEqual([
+        'player-active-high-rank',
+        'player-active-low-rank',
+        'player-eliminated-late',
+        'player-eliminated-early',
+      ]);
+    });
+
     it('should query rounds with correct phase filter', async () => {
       await phasesRoute.GET(createRequest('?phase=phase3'), { params: mockParams });
 

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
@@ -60,6 +60,71 @@ function normalizePhaseRound<T extends { results: unknown; eliminatedIds?: unkno
   };
 }
 
+type PhaseEntryForDisplay = {
+  playerId: string;
+  eliminated: boolean;
+  lives: number;
+  rank: number | null;
+  totalTime: number | null;
+};
+
+type PhaseRoundForDisplay = {
+  roundNumber: number;
+  results: Array<{ playerId: string; timeMs: number }>;
+  eliminatedIds: string[];
+};
+
+function compareNullableNumber(a: number | null, b: number | null) {
+  if (a === null && b === null) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  return a - b;
+}
+
+function sortPhaseEntriesForDisplay<T extends PhaseEntryForDisplay>(
+  entries: T[],
+  rounds: PhaseRoundForDisplay[]
+): T[] {
+  const eliminationMeta = new Map<string, { roundNumber: number; timeMs: number; index: number }>();
+
+  for (const round of rounds) {
+    const timeByPlayer = new Map(round.results.map((result) => [result.playerId, result.timeMs]));
+    round.eliminatedIds.forEach((playerId, index) => {
+      eliminationMeta.set(playerId, {
+        roundNumber: round.roundNumber,
+        timeMs: timeByPlayer.get(playerId) ?? Number.POSITIVE_INFINITY,
+        index,
+      });
+    });
+  }
+
+  return [...entries].sort((a, b) => {
+    if (a.eliminated !== b.eliminated) return a.eliminated ? 1 : -1;
+
+    if (!a.eliminated && !b.eliminated) {
+      if (a.lives !== b.lives) return b.lives - a.lives;
+      const rankCompare = compareNullableNumber(a.rank, b.rank);
+      if (rankCompare !== 0) return rankCompare;
+      return compareNullableNumber(a.totalTime, b.totalTime);
+    }
+
+    const aMeta = eliminationMeta.get(a.playerId);
+    const bMeta = eliminationMeta.get(b.playerId);
+    const aRound = aMeta?.roundNumber ?? -1;
+    const bRound = bMeta?.roundNumber ?? -1;
+    if (aRound !== bRound) return bRound - aRound;
+    if ((aMeta?.timeMs ?? Number.POSITIVE_INFINITY) !== (bMeta?.timeMs ?? Number.POSITIVE_INFINITY)) {
+      return (aMeta?.timeMs ?? Number.POSITIVE_INFINITY) - (bMeta?.timeMs ?? Number.POSITIVE_INFINITY);
+    }
+    if ((aMeta?.index ?? Number.POSITIVE_INFINITY) !== (bMeta?.index ?? Number.POSITIVE_INFINITY)) {
+      return (aMeta?.index ?? Number.POSITIVE_INFINITY) - (bMeta?.index ?? Number.POSITIVE_INFINITY);
+    }
+    const rankCompare = compareNullableNumber(a.rank, b.rank);
+    if (rankCompare !== 0) return rankCompare;
+    return compareNullableNumber(a.totalTime, b.totalTime);
+  });
+}
+
 /**
  * Admin authentication helper that returns the session.
  * Returns { error } if user is not authenticated or not admin.
@@ -274,8 +339,10 @@ export async function GET(
         },
       );
 
-      response.entries = entries;
-      response.rounds = rounds.map(normalizePhaseRound);
+      const normalizedRounds = rounds.map(normalizePhaseRound);
+
+      response.entries = sortPhaseEntriesForDisplay(entries, normalizedRounds);
+      response.rounds = normalizedRounds;
       response.availableCourses = getAvailableCourses(playedCourses);
       response.playedCourses = playedCourses;
     }


### PR DESCRIPTION
## Summary
- Sort TA phase entries for display using finals state instead of qualification total time
- Keep active players above eliminated players, then order eliminated players by later elimination round
- Add an API regression test for finals standings order

## Root cause
The TA phases API returned entries ordered by `eliminated`, `lives`, and `totalTime`. The UI labels rows using that API order, so eliminated players could appear in the wrong finals placement when their qualification total time was faster than players eliminated later.

## Validation
- `npm test -- --runTestsByPath __tests__/app/api/tournaments/[id]/ta/phases/route.test.ts`
- `npx eslint src/app/api/tournaments/[id]/ta/phases/route.ts __tests__/app/api/tournaments/[id]/ta/phases/route.test.ts`
- `npx tsc --noEmit --pretty false` stops on existing `__tests__/e2e/*.test.ts` `.ts` extension import errors (`TS5097`) before this diff
