### PR TITLE
[codex] Allow null broadcast playoff scores

### DIFF
--- a/smkc-score-app/src/lib/hooks/useQualificationActions.ts
+++ b/smkc-score-app/src/lib/hooks/useQualificationActions.ts
@@ -116,8 +116,8 @@ export function useQualificationActions({ tournamentId, mode, refetch }: UseQual
       player1NoCamera?: boolean;
       player2NoCamera?: boolean;
       matchLabel?: string;
-      player1Wins?: number;
-      player2Wins?: number;
+      player1Wins?: number | null;
+      player2Wins?: number | null;
       matchFt?: number | null;
     },
   ): Promise<boolean> => {


### PR DESCRIPTION
## Summary
- Allow qualification playoff broadcast payloads to pass `null` wins values.
- Unblocks the production OpenNext/Cloudflare build after the combined standings merge.

## Validation
- npm run build:cf
- npm run deploy:cf

## Deployment
- Deployed manually to Cloudflare Workers after confirming no D1 migrations were pending.
- Current Worker version: 3654b539-3ae0-4b39-9b9b-4524859f0f1a
