### PR TITLE
Fix BM losers round 2 order

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -188,10 +188,10 @@ describe('Finals Route Factory', () => {
       { matchNumber: 6, round: 'winners_r1', bracket: 'winners', player1Seed: 6, player2Seed: 11, winnerGoesTo: 11, loserGoesTo: 18 },
       { matchNumber: 7, round: 'winners_r1', bracket: 'winners', player1Seed: 7, player2Seed: 10, winnerGoesTo: 12, loserGoesTo: 19 },
       { matchNumber: 8, round: 'winners_r1', bracket: 'winners', player1Seed: 2, player2Seed: 15, winnerGoesTo: 12, loserGoesTo: 19 },
-      { matchNumber: 9, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 13, loserGoesTo: 20 },
-      { matchNumber: 10, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 13, loserGoesTo: 21 },
-      { matchNumber: 11, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 14, loserGoesTo: 22 },
-      { matchNumber: 12, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 14, loserGoesTo: 23 },
+      { matchNumber: 9, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 13, loserGoesTo: 23 },
+      { matchNumber: 10, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 13, loserGoesTo: 22 },
+      { matchNumber: 11, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 14, loserGoesTo: 21 },
+      { matchNumber: 12, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 14, loserGoesTo: 20 },
       ...Array.from({ length: 19 }, (_, i) => ({
         matchNumber: i + 13,
         round: i < 2 ? 'winners_sf' : i === 2 ? 'winners_final' : 'losers_r1',
@@ -1438,20 +1438,24 @@ describe('Finals Route Factory', () => {
       expect(mockGenerateBracketStructure).toHaveBeenCalledWith(16);
     });
 
-    it('should route 16-player QF loser to player2Id (loserPosition=2)', async () => {
-      // In 16-player bracket, QF losers enter L_R2 at position 2
+    it('should route 16-player QF loser to reversed L_R2 slot and player2Id', async () => {
+      // In 16-player bracket, QF losers enter L_R2 at position 2.
+      // M9 routes to M23 so the two-group LR2 order is B3/A4/A3/B4.
       const requestBody = createMockRequestBody();
       const mockMatch = createMockMatch({
         matchNumber: 9, // winners_qf in 16-player bracket
         player1Id: 'player-1',
         player2Id: 'player-2',
       });
-      const nextLoserMatch = createMockMatch({ matchNumber: 20 }); // L_R2 in 16-player
+      const nextLoserMatch = createMockMatch({ matchNumber: 23 }); // L_R2 in 16-player
 
       (prisma.bMMatch as any).count.mockResolvedValue(31); // 16-player bracket
       (prisma.bMMatch as any).findUnique.mockResolvedValue(mockMatch);
       (prisma.bMMatch as any).update.mockResolvedValue(createMockMatch({ completed: true }));
-      (prisma.bMMatch as any).findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce(nextLoserMatch);
+      (prisma.bMMatch as any).findFirst.mockImplementation((args: any) => {
+        if (args?.where?.matchNumber === 23) return Promise.resolve(nextLoserMatch);
+        return Promise.resolve(null);
+      });
 
       const config = createMockConfig();
       const { PUT } = createFinalsHandlers(config);

--- a/smkc-score-app/__tests__/lib/double-elimination.test.ts
+++ b/smkc-score-app/__tests__/lib/double-elimination.test.ts
@@ -519,6 +519,51 @@ describe('Double Elimination Bracket Structure', () => {
         });
       });
     });
+
+    it('should route Winners QF losers into reversed Losers R2 slots', () => {
+      const matches16 = generateBracketStructure(16);
+
+      [
+        [9, 23],
+        [10, 22],
+        [11, 21],
+        [12, 20],
+      ].forEach(([matchNumber, nextMatchNumber]) => {
+        expect(getNextMatchInfo(matches16, matchNumber, false)).toEqual({
+          nextMatchNumber,
+          position: 2,
+        });
+      });
+    });
+
+    it('should pair two-group LR2 matches in the requested top-to-bottom order', () => {
+      const matches16 = generateBracketStructure(16);
+      const qfLoserLabelsByMatch = new Map([
+        [9, 'B4'],
+        [10, 'A3'],
+        [11, 'A4'],
+        [12, 'B3'],
+      ]);
+
+      const lr2PairLabels = matches16
+        .filter((m) => m.round === 'losers_r2')
+        .map((lr2Match) => {
+          const lr1Source = matches16.find(
+            (m) => m.round === 'losers_r1' && m.winnerGoesTo === lr2Match.matchNumber,
+          );
+          const qfSource = matches16.find(
+            (m) => m.round === 'winners_qf' && m.loserGoesTo === lr2Match.matchNumber,
+          );
+          return [`W${lr1Source?.matchNumber}`, qfLoserLabelsByMatch.get(qfSource?.matchNumber ?? 0)];
+        });
+
+      expect(lr2PairLabels).toEqual([
+        ['W16', 'B3'],
+        ['W17', 'A4'],
+        ['W18', 'A3'],
+        ['W19', 'B4'],
+      ]);
+    });
   });
 
   describe('roundNames', () => {

--- a/smkc-score-app/src/lib/double-elimination.ts
+++ b/smkc-score-app/src/lib/double-elimination.ts
@@ -255,8 +255,10 @@ function generate16PlayerBracket(): BracketMatch[] {
       round: "winners_qf",
       bracket: "winners",
       winnerGoesTo: 13 + Math.floor(i / 2),
-      /* QF losers → Losers R2 (20-23) */
-      loserGoesTo: 20 + i,
+      /* QF losers → Losers R2 in reverse visual order.
+       * With the two-group paper layout this pairs LR1 winners top-to-bottom
+       * against B3, A4, A3, B4 instead of B4, A3, A4, B3. */
+      loserGoesTo: 23 - i,
       position: ((i % 2) + 1) as 1 | 2,
     });
     mn++;
@@ -503,7 +505,7 @@ export function getNextMatchInfo(
       };
     } else if (match.round === "winners_qf") {
       /* QF losers enter Losers R2 as position 2 (L_R1 winners enter as position 1).
-       * In 16-player bracket, QF is matches 9-12 → each goes to L_R2 match 20-23.
+       * In 16-player bracket, QF matches 9-12 route to L_R2 matches 23-20.
        * In 8-player bracket, QF is matches 1-4 → position based on parity. */
       const is16Player = matches.length > 17;
       return {


### PR DESCRIPTION
Summary
- Reverse the 16-player winners QF loser routes so LR2 pairs M16/M17/M18/M19 winners against the intended opposite-side opponents.
- Add regression coverage for the M20/M23 and M21/M22 swap order, and update finals route tests.

Deployment
- Deployed to https://smkc.bluemoon.works with Worker version c3b85913-f5f8-43c0-b956-35a09ca21661.
- Corrected existing jsmkc2026 BM finals rows in production D1: M20 Antistar-Kasmo, M21 GAS-Matt, M22 はな-onwa, M23 Tif-KVD.

Validation
- npm test -- --runTestsByPath __tests__/lib/double-elimination.test.ts __tests__/lib/api-factories/finals-route.test.ts
- npm test -- --runTestsByPath __tests__/app/api/tournaments/[id]/bm/finals/route.test.ts
- npm run deploy
- Verified production API bracketStructure: M9→M23, M10→M22, M11→M21, M12→M20.
- Verified production API M20-M23 pairings after D1 correction.