### PR TITLE
[codex] Make MR losers semi final FT9

### DIFF
--- a/docs/operation-mr.md
+++ b/docs/operation-mr.md
@@ -138,7 +138,7 @@ VSMR 決勝では、MC1 から RR までの 20 コースをランダムな順番
 | バラッジ | 先に 3 勝、後半は先に 4 勝 |
 | 決勝序盤 | 先に 5 勝 |
 | 中盤 | 先に 7 勝 |
-| Winners Final / Losers Final / Grand Final | 先に 9 勝 |
+| Losers Semi Final / Winners Final / Losers Final / Grand Final | 先に 9 勝 |
 
 画面上の入力欄に従って、必要な勝利数に達した結果を保存してください。
 

--- a/smkc-score-app/__tests__/lib/finals-target-wins.test.ts
+++ b/smkc-score-app/__tests__/lib/finals-target-wins.test.ts
@@ -19,6 +19,7 @@ describe('finals-target-wins', () => {
     expect(getMrFinalsTargetWins({ stage: 'playoff', round: 'playoff_r2' })).toBe(4);
     expect(getMrFinalsTargetWins({ round: 'winners_r1' })).toBe(5);
     expect(getMrFinalsTargetWins({ round: 'winners_sf' })).toBe(7);
+    expect(getMrFinalsTargetWins({ round: 'losers_sf' })).toBe(9);
     expect(getMrFinalsTargetWins({ round: 'grand_final' })).toBe(9);
     expect(getMrFinalsTargetWins({ round: 'grand_final_reset' })).toBe(9);
   });
@@ -33,6 +34,7 @@ describe('finals-target-wins', () => {
     expect(getMrFinalsMaxRounds({ stage: 'playoff', round: 'playoff_r1' })).toBe(5);
     expect(getMrFinalsMaxRounds({ stage: 'playoff', round: 'playoff_r2' })).toBe(7);
     expect(getMrFinalsMaxRounds({ round: 'winners_sf' })).toBe(13);
+    expect(getMrFinalsMaxRounds({ round: 'losers_sf' })).toBe(17);
     expect(getMrFinalsMaxRounds({ round: 'grand_final' })).toBe(17);
   });
 });

--- a/smkc-score-app/src/lib/finals-target-wins.ts
+++ b/smkc-score-app/src/lib/finals-target-wins.ts
@@ -12,11 +12,12 @@ function isEarlyLowerRound(round?: string | null): boolean {
 }
 
 function isMidLowerRound(round?: string | null): boolean {
-  return round === 'losers_r3' || round === 'losers_r4' || round === 'losers_sf';
+  return round === 'losers_r3' || round === 'losers_r4';
 }
 
 function isFinalRound(round?: string | null): boolean {
   return round === 'winners_final'
+    || round === 'losers_sf'
     || round === 'losers_final'
     || round === 'grand_final'
     || round === 'grand_final_reset';


### PR DESCRIPTION
## Summary
- Treat MR `losers_sf` as FT9 instead of FT7.
- Add regression coverage for MR Losers Semi Final target wins and max-round count.
- Update the MR operation manual table to list Losers Semi Final under the FT9 stages.

## Validation
- `npm test -- __tests__/lib/finals-target-wins.test.ts --runInBand`
- Deployed production worker after applying the live M28 course extension.

## Live data note
- `jsmkc2026` MR finals M28 was updated directly in remote D1 to keep the existing 13-course order and append 4 additional courses for FT9.