### PR TITLE
[codex] Fix GP BREAK-only overall points

### DIFF
--- a/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
+++ b/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
@@ -105,6 +105,9 @@ describe('Overall Ranking module', () => {
     // The Phase-2 in-memory cache for calculateOverallRankings persists across
     // tests via module scope, so clear it here to keep each test independent.
     clearOverallRankingsCache();
+    mockPrisma.bMMatch.findMany.mockResolvedValue([]);
+    mockPrisma.mRMatch.findMany.mockResolvedValue([]);
+    mockPrisma.gPMatch.findMany.mockResolvedValue([]);
   });
 
   // =========================================================================
@@ -170,6 +173,9 @@ describe('Overall Ranking module', () => {
     });
 
     it('maps results by player ID', async () => {
+      mockPrisma.bMMatch.findMany.mockResolvedValueOnce([
+        { id: 'bm-real-1' },
+      ]);
       mockPrisma.bMQualification.findMany.mockResolvedValue([
         { playerId: 'p1', wins: 5, ties: 1, losses: 2, mp: 8, player: PLAYER_P1 },
       ]);
@@ -186,6 +192,9 @@ describe('Overall Ranking module', () => {
     });
 
     it('normalizes by each player actual match count instead of total participants', async () => {
+      mockPrisma.bMMatch.findMany.mockResolvedValueOnce([
+        { id: 'bm-real-1' },
+      ]);
       mockPrisma.bMQualification.findMany.mockResolvedValue([
         ...Array.from({ length: 12 }, (_, i) => ({
           playerId: `a${i + 1}`,
@@ -235,6 +244,9 @@ describe('Overall Ranking module', () => {
   // =========================================================================
   describe('calculateMRQualificationPointsFromDB', () => {
     it('delegates to calculateQualificationPoints with MR data', async () => {
+      mockPrisma.mRMatch.findMany.mockResolvedValueOnce([
+        { id: 'mr-real-1' },
+      ]);
       mockPrisma.mRQualification.findMany.mockResolvedValue([
         { playerId: 'p2', wins: 3, ties: 0, losses: 4, mp: 7, player: PLAYER_P2 },
       ]);
@@ -257,6 +269,9 @@ describe('Overall Ranking module', () => {
   // =========================================================================
   describe('calculateGPQualificationPointsFromDB', () => {
     it('delegates to calculateQualificationPoints with GP data', async () => {
+      mockPrisma.gPMatch.findMany.mockResolvedValueOnce([
+        { id: 'gp-real-1' },
+      ]);
       mockPrisma.gPQualification.findMany.mockResolvedValue([
         { playerId: 'p1', wins: 8, ties: 0, losses: 0, mp: 8, player: PLAYER_P1 },
       ]);
@@ -270,6 +285,30 @@ describe('Overall Ranking module', () => {
       );
 
       expect(result.get('p1')?.normalizedPoints).toBe(1000);
+    });
+
+    it('does not award GP qualification points when only BREAK matches are completed', async () => {
+      mockPrisma.gPMatch.findMany.mockResolvedValueOnce([]);
+      mockPrisma.gPQualification.findMany.mockResolvedValue([
+        { playerId: 'p1', wins: 1, ties: 0, losses: 0, mp: 1, points: 45, player: PLAYER_P1 },
+      ]);
+
+      const result = await calculateGPQualificationPointsFromDB(
+        mockPrisma as any,
+        TOURNAMENT_ID
+      );
+
+      expect(result.size).toBe(0);
+      expect(mockPrisma.gPMatch.findMany).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          tournamentId: TOURNAMENT_ID,
+          stage: 'qualification',
+          completed: true,
+          isBye: false,
+        }),
+      }));
+      expect(mockPrisma.gPQualification.findMany).not.toHaveBeenCalled();
+      expect(getMockCalculateQualificationPointsFromMatches()).not.toHaveBeenCalled();
     });
   });
 

--- a/smkc-score-app/src/lib/points/overall-ranking.ts
+++ b/smkc-score-app/src/lib/points/overall-ranking.ts
@@ -124,6 +124,8 @@ interface QualificationEntry {
   mp?: number;
 }
 
+type MatchQualificationModel = "bMMatch" | "mRMatch" | "gPMatch";
+
 /**
  * Shape of a TTEntry record from the database, used for determining
  * TA finals positions based on elimination status and lives remaining.
@@ -245,6 +247,10 @@ export async function calculateBMQualificationPointsFromDB(
   prisma: ExtendedPrismaClient,
   tournamentId: string
 ): Promise<Map<string, QualificationPointsResult>> {
+  if (!await hasCompletedRealQualificationMatch(prisma, tournamentId, "bMMatch")) {
+    return new Map();
+  }
+
   const qualifications = await prisma.bMQualification.findMany({
     where: { tournamentId },
     include: { player: { select: PLAYER_PUBLIC_SELECT } },
@@ -266,6 +272,10 @@ export async function calculateMRQualificationPointsFromDB(
   prisma: ExtendedPrismaClient,
   tournamentId: string
 ): Promise<Map<string, QualificationPointsResult>> {
+  if (!await hasCompletedRealQualificationMatch(prisma, tournamentId, "mRMatch")) {
+    return new Map();
+  }
+
   const qualifications = await prisma.mRQualification.findMany({
     where: { tournamentId },
     include: { player: { select: PLAYER_PUBLIC_SELECT } },
@@ -287,6 +297,10 @@ export async function calculateGPQualificationPointsFromDB(
   prisma: ExtendedPrismaClient,
   tournamentId: string
 ): Promise<Map<string, QualificationPointsResult>> {
+  if (!await hasCompletedRealQualificationMatch(prisma, tournamentId, "gPMatch")) {
+    return new Map();
+  }
+
   const qualifications = await prisma.gPQualification.findMany({
     where: { tournamentId },
     include: { player: { select: PLAYER_PUBLIC_SELECT } },
@@ -527,6 +541,30 @@ function toMatchRecord(q: QualificationEntry): MatchRecord & { matchesPlayed: nu
     losses: q.losses,
     matchesPlayed: q.mp ?? q.wins + q.ties + q.losses,
   };
+}
+
+async function hasCompletedRealQualificationMatch(
+  prisma: ExtendedPrismaClient,
+  tournamentId: string,
+  matchModel: MatchQualificationModel,
+): Promise<boolean> {
+  const where = {
+    tournamentId,
+    stage: "qualification",
+    completed: true,
+    isBye: false,
+    deletedAt: null,
+  };
+  const select = { id: true };
+  const take = 1;
+
+  const matches = matchModel === "bMMatch"
+    ? await prisma.bMMatch.findMany({ where, select, take })
+    : matchModel === "mRMatch"
+      ? await prisma.mRMatch.findMany({ where, select, take })
+      : await prisma.gPMatch.findMany({ where, select, take });
+
+  return matches.length > 0;
 }
 
 function qualificationResultsByPlayer(


### PR DESCRIPTION
## Summary
- Gate BM/MR/GP qualification points in overall ranking until at least one real non-BREAK qualification match is completed.
- Add regression coverage for GP where only BREAK auto-completed matches exist.

## Root cause
BREAK matches are auto-completed during qualification setup and immediately update qualification stats, so overall ranking could treat a BREAK-only GP state as scored.

## Validation
- npm test -- --runTestsByPath __tests__/lib/points/overall-ranking.test.ts
- npm run lint -- src/lib/points/overall-ranking.ts __tests__/lib/points/overall-ranking.test.ts
- npm run build
