### PR TITLE
[codex] Simplify GP participant score entry

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -336,11 +336,11 @@
   1. 管理者セッションで一時トーナメントと対戦用プレイヤーを作成する
   2. 一時トーナメントで GP 予選をセットアップし、対象プレイヤーに pending match を作る
   3. 別の一時ブラウザコンテキストで対象プレイヤーとしてログインする
-  4. `/gp/participant` を開き、カップ割当済みの5コースが自動表示されていることを確認する
-  5. 各レースの順位を入力して送信する（コース選択は不要 — 自動入力済み）
+  4. `/gp/participant` を開き、ドライバーズポイントの合計入力欄が表示されていることを確認する
+  5. 両プレイヤーのドライバーズポイント合計を入力して送信する
   6. participant ページで pending match が消えることと、管理者 API 側で match が `completed` になり合計点が保存されていることを確認する
   7. 一時トーナメントと一時プレイヤーを削除する
-- **期待結果**: GP の participant 入力フォームでコースが自動入力され、順位のみ入力でスコア送信・永続化される
+- **期待結果**: GP の participant 入力フォームでコースごとのリザルトなしにドライバーズポイント合計を送信・永続化できる
 
 ## TC-312: TA ノックアウト開始後はプレイヤーが予選タイムを編集できない
 - **URL**: /auth/signin -> /tournaments/[temp-id]/ta/participant
@@ -1543,18 +1543,18 @@
   6. クリーンアップ
 - **期待結果**: 28名4グループのGP予選がシード・自動振り分け・driver points換算で正しく集計される
 
-## TC-702: GPプレイヤーログインから 5-race 送信
+## TC-702: GPプレイヤーログインからドライバーズポイント合計送信
 - **URL**: /auth/signin -> /tournaments/[temp-id]/gp/participant
 - **authRequired**: true (player)
 - **手順**:
   1. 管理者セッションで一時トーナメントとプレイヤー2名を作成（`dualReportEnabled=false`）
   2. GP予選グループ設定で2名のpendingマッチを生成（カップ自動割当付き）
   3. 別の一時ブラウザでP1としてログインし `/api/.../gp/match/:id/report` に
-     `{ reportingPlayer: 1, races: [...5 entries with position1=1, position2=5...] }` を POST
+     `{ reportingPlayer: 1, points1: 45, points2: 0 }` を POST
   4. レスポンスに `autoConfirmed: true` が含まれること（`dualReportEnabled=false` のため即時確定）
   5. 管理者APIでマッチが completed、`points1=45, points2=0` で保存されていること
   6. クリーンアップ
-- **期待結果**: GP participant 入力で5レース順位送信→driver points換算→永続化が動作
+- **期待結果**: GP participant 入力でdriver points合計送信→永続化が動作
 
 ## TC-703: GP予選28名フル + 決勝ブラケット生成・1試合スコア入力
 - **URL**: /tournaments/[temp-id]/gp/finals

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
@@ -186,6 +186,65 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
       expect(createSuccessResponse).toHaveBeenCalledWith({ match: updatedMatch, waitingFor: 'player2' }, 'Score reported successfully');
     });
 
+    it('should accept direct driver-point totals from participant score entry', async () => {
+      const mockMatch = {
+        id: 'm1',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        player1: { userId: null },
+        player2: { userId: null },
+        completed: false,
+        player1ReportedPoints1: null,
+        player1ReportedPoints2: null,
+        player2ReportedPoints1: null,
+        player2ReportedPoints2: null,
+      };
+
+      const updatedMatch = {
+        ...mockMatch,
+        player1ReportedPoints1: 37,
+        player1ReportedPoints2: 24,
+        player1ReportedRaces: null,
+        version: 1,
+      };
+
+      (prisma.gPMatch.findUnique as jest.Mock)
+        .mockResolvedValueOnce(mockMatch)
+        .mockResolvedValueOnce({ version: 0 });
+      (prisma.scoreEntryLog.create as jest.Mock).mockResolvedValue({ id: 'log1' });
+      (prisma.gPMatch.update as jest.Mock).mockResolvedValue(updatedMatch);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/match/m1/report', {
+        reportingPlayer: 1,
+        points1: 37,
+        points2: 24,
+      });
+      const params = Promise.resolve({ id: 't1', matchId: 'm1' });
+      const result = await POST(request, { params });
+
+      expect(result).toEqual({
+        data: { match: updatedMatch, waitingFor: 'player2' },
+        message: 'Score reported successfully',
+        status: 200
+      });
+      expect(prisma.gPMatch.update).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({
+          player1ReportedPoints1: 37,
+          player1ReportedPoints2: 24,
+          player1ReportedRaces: expect.any(Object),
+        }),
+      }));
+      expect(prisma.scoreEntryLog.create).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({
+          reportedData: expect.objectContaining({
+            totalPoints1: 37,
+            totalPoints2: 24,
+            races: [],
+          }),
+        }),
+      }));
+    });
+
     // Success case - Reports score from player 2
     it('should report score from player 2 and wait for player 1', async () => {
       const mockMatch = {

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -3,7 +3,7 @@
  *
  * Coverage:
  *   TC-701  28-player full qualification (shared fixture, verify standings/matches)
- *   TC-702  GP player login + participant 5-race submission (2 players)
+ *   TC-702  GP player login + participant driver-points submission (2 players)
  *   TC-703  28-player full + finals bracket gen + first race score (routing)
  *   TC-704  GP finals bracket reset
  *   TC-705  GP Grand Final → champion
@@ -182,7 +182,7 @@ async function runTc702(adminPage) {
 
     const ctx = await loginSharedPlayer(adminPage, p1);
     playerBrowser = ctx.browser;
-    /* Submit 5 race positions via API from the player browser session. */
+    /* Submit driver-point totals via API from the player browser session. */
     const reportRes = await ctx.page.evaluate(async ([u, body]) => {
       const r = await fetch(u, {
         method: 'POST',
@@ -192,7 +192,7 @@ async function runTc702(adminPage) {
       return { s: r.status, b: await r.json().catch(() => ({})) };
     }, [
       `/api/tournaments/${tournamentId}/gp/match/${match.id}/report`,
-      { reportingPlayer: 1, races: makeRacesP1Wins(match.cup) },
+      { reportingPlayer: 1, points1: 45, points2: 0 },
     ]);
 
     /* dualReportEnabled=false → autoConfirmed on first report. */
@@ -201,7 +201,7 @@ async function runTc702(adminPage) {
 
     const after = await apiFetchGp(adminPage, tournamentId);
     const updated = (after.matches || []).find((m) => m.id === match.id);
-    /* P1 wins all 5 races at 1st = 45 points, P2 at 5th = 0 points. */
+    /* P1/P2 driver-point totals are persisted directly. */
     const persisted = updated?.completed === true && updated.points1 === 45 && updated.points2 === 0;
 
     log('TC-702', confirmed && persisted ? 'PASS' : 'FAIL',

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -448,6 +448,8 @@
     "p1Position": "P1 Position",
     "p2Position": "P2 Position",
     "driverPoints": "Driver's Points: 1st = 9pts, 2nd = 6pts, 3rd = 3pts, 4th = 1pt, 5th-8th = 0pts",
+    "driverPointsEntry": "Driver's Points Entry",
+    "driverPointsValidation": "Driver's points must be integers from 0 to 45.",
     "enterMatchResult": "Enter Match Result",
     "manualTotalScore": "Manual Total Score",
     "manualTotalScoreDesc": "Use this when you only need to correct the cup total after play ends.",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -448,6 +448,8 @@
     "p1Position": "P1 順位",
     "p2Position": "P2 順位",
     "driverPoints": "ドライバーズポイント: 1位 = 9pts, 2位 = 6pts, 3位 = 3pts, 4位 = 1pt, 5位〜8位 = 0pt",
+    "driverPointsEntry": "ドライバーズポイント入力",
+    "driverPointsValidation": "ドライバーズポイントは 0〜45 の整数で入力してください。",
     "enterMatchResult": "試合結果入力",
     "manualTotalScore": "合計ポイントを手動修正",
     "manualTotalScoreDesc": "カップ終了後に合計点だけを修正したい場合はこちらを使用します。",

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -6,8 +6,8 @@
  * When both reports match, the match is auto-confirmed.
  * If reports differ, the match is flagged for admin review.
  *
- * GP-specific: Reports include race-by-race positions and driver points
- * (9 for 1st, 6 for 2nd, 3 for 3rd, 1 for 4th, 0 for 5th-8th).
+ * GP-specific: Participant reports may include driver-point totals directly.
+ * Legacy race-by-race reports are still accepted and converted to driver points.
  *
  * Features:
  * - Score entry logging for audit trail
@@ -17,7 +17,8 @@
  */
 
 import { NextRequest } from "next/server";
-import { PLAYER_PUBLIC_SELECT, PLAYER_AUTH_SELECT } from '@/lib/prisma-selects';
+import { Prisma } from "@prisma/client";
+import { PLAYER_AUTH_SELECT } from '@/lib/prisma-selects';
 import prisma from "@/lib/prisma";
 import { getUserAgent, getClientIdentifier } from "@/lib/request-utils";
 import { sanitizeInput } from "@/lib/sanitize";
@@ -46,6 +47,20 @@ import { checkRateLimit } from "@/lib/rate-limit";
 import { updateWithRetry, OptimisticLockError } from "@/lib/optimistic-locking";
 import { resolveTournamentId } from "@/lib/tournament-identifier";
 import { checkQualificationConfirmed } from "@/lib/qualification-confirmed-check";
+
+const MAX_GP_DRIVER_POINTS = 45;
+
+type ProcessedRace = {
+  course: string;
+  position1: number;
+  position2: number;
+  points1: number;
+  points2: number;
+};
+
+type ProcessedReport =
+  | { ok: true; totalPoints1: number; totalPoints2: number; processedRaces: ProcessedRace[] | null }
+  | { ok: false; message: string; field: string };
 
 /**
  * GP-specific stats recalculation config.
@@ -103,6 +118,102 @@ function validateSubmittedCup(
   return !!submittedCup && isValidCupChoice(assignedCup, submittedCup);
 }
 
+function validateDirectDriverPoints(points1: unknown, points2: unknown): ProcessedReport {
+  const p1 = Number(points1);
+  const p2 = Number(points2);
+  if (
+    !Number.isInteger(p1) ||
+    !Number.isInteger(p2) ||
+    p1 < 0 ||
+    p2 < 0 ||
+    p1 > MAX_GP_DRIVER_POINTS ||
+    p2 > MAX_GP_DRIVER_POINTS
+  ) {
+    return {
+      ok: false,
+      message: `points1 and points2 must be integers between 0 and ${MAX_GP_DRIVER_POINTS}`,
+      field: "points",
+    };
+  }
+
+  return {
+    ok: true,
+    totalPoints1: p1,
+    totalPoints2: p2,
+    processedRaces: null,
+  };
+}
+
+function toReportedRacesJson(races: ProcessedRace[] | null): Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput {
+  return races ?? Prisma.JsonNull;
+}
+
+function processRaceReport(assignedCup: string | null | undefined, races: unknown): ProcessedReport {
+  if (!Array.isArray(races) || races.length !== TOTAL_GP_RACES) {
+    return {
+      ok: false,
+      message: `races must be an array of ${TOTAL_GP_RACES} entries`,
+      field: "races",
+    };
+  }
+
+  if (!validateSubmittedCup(assignedCup, races)) {
+    return {
+      ok: false,
+      message: "Submitted races do not match the assigned cup for this match",
+      field: "races",
+    };
+  }
+
+  let totalPoints1 = 0;
+  let totalPoints2 = 0;
+
+  const processedRaces: ProcessedRace[] = [];
+  for (let i = 0; i < races.length; i++) {
+    const race = races[i] as { position1: number; position2: number; course: string };
+    const pos1Result = validateGPRacePosition(race.position1);
+    if (!pos1Result.isValid) {
+      return { ok: false, message: pos1Result.error!, field: "position1" };
+    }
+    const pos2Result = validateGPRacePosition(race.position2);
+    if (!pos2Result.isValid) {
+      return { ok: false, message: pos2Result.error!, field: "position2" };
+    }
+    if (race.position1 === race.position2 && race.position1 !== 0) {
+      return {
+        ok: false,
+        message: `Race ${i + 1}: both players cannot finish in the same position (${race.position1})`,
+        field: "position",
+      };
+    }
+
+    const points1 = getDriverPoints(race.position1);
+    const points2 = getDriverPoints(race.position2);
+    totalPoints1 += points1;
+    totalPoints2 += points2;
+    processedRaces.push({
+      course: race.course,
+      position1: race.position1,
+      position2: race.position2,
+      points1,
+      points2,
+    });
+  }
+
+  return { ok: true, totalPoints1, totalPoints2, processedRaces };
+}
+
+function processGpParticipantReport(
+  assignedCup: string | null | undefined,
+  body: { points1?: unknown; points2?: unknown; races?: unknown },
+): ProcessedReport {
+  if (body.points1 !== undefined || body.points2 !== undefined) {
+    return validateDirectDriverPoints(body.points1, body.points2);
+  }
+
+  return processRaceReport(assignedCup, body.races);
+}
+
 
 /**
  * POST /api/tournaments/[id]/gp/match/[matchId]/report
@@ -136,7 +247,7 @@ export async function POST(
     const userAgent = getUserAgent(request);
 
     const body = sanitizeInput(await request.json());
-    const { reportingPlayer, races, character } = body;
+    const { reportingPlayer, character } = body;
 
     /* Fetch match with player userId for auth check */
     const match = await prisma.gPMatch.findUnique({
@@ -173,12 +284,13 @@ export async function POST(
       return handleValidationError("Invalid character", "character");
     }
 
-    if (!Array.isArray(races) || races.length !== TOTAL_GP_RACES) {
-      return handleValidationError(`races must be an array of ${TOTAL_GP_RACES} entries`, "races");
+    const processedReport = processGpParticipantReport(match.cup, body);
+    if (!processedReport.ok) {
+      return handleValidationError(processedReport.message, processedReport.field);
     }
-    if (!validateSubmittedCup(match.cup, races)) {
-      return handleValidationError("Submitted races do not match the assigned cup for this match", "races");
-    }
+
+    const { totalPoints1, totalPoints2, processedRaces } = processedReport;
+    const reportedRacesJson = toReportedRacesJson(processedRaces);
 
     /*
      * Correction path: let a participant fix a GP score after the match has
@@ -186,45 +298,6 @@ export async function POST(
      * and the reporting player's stored report, then recalculate standings.
      */
     if (match.completed) {
-      /* Validate GP race positions are in legal range (0-8) before processing */
-      for (let i = 0; i < races.length; i++) {
-        const race = races[i] as { position1: number; position2: number; course: string };
-        const pos1Result = validateGPRacePosition(race.position1);
-        if (!pos1Result.isValid) return handleValidationError(pos1Result.error!, "position1");
-        const pos2Result = validateGPRacePosition(race.position2);
-        if (!pos2Result.isValid) return handleValidationError(pos2Result.error!, "position2");
-        /* Two players cannot finish in the same position (except both game-over at 0 per §7.2) */
-        if (race.position1 === race.position2 && race.position1 !== 0) {
-          return handleValidationError(
-            `Race ${i + 1}: both players cannot finish in the same position (${race.position1})`,
-            "position",
-          );
-        }
-      }
-
-      const submittedCup = getSubmittedCup(races);
-      if (!submittedCup || !isValidCupChoice(match.cup, submittedCup)) {
-        return handleValidationError("Submitted races do not match the assigned cup for this match", "races");
-      }
-
-      /* Process races: convert finishing positions to driver points (same as normal flow) */
-      let totalPoints1 = 0;
-      let totalPoints2 = 0;
-
-      const processedRaces = races.map((race: { position1: number; position2: number; course: string }) => {
-        const pts1 = getDriverPoints(race.position1);
-        const pts2 = getDriverPoints(race.position2);
-        totalPoints1 += pts1;
-        totalPoints2 += pts2;
-        return {
-          course: race.course,
-          position1: race.position1,
-          position2: race.position2,
-          points1: pts1,
-          points2: pts2,
-        };
-      });
-
       try {
         const correctedMatch = await updateWithRetry(prisma, async (tx) => {
           const currentMatch = await tx.gPMatch.findUnique({
@@ -238,8 +311,8 @@ export async function POST(
 
           const reportData =
             reportingPlayer === 1
-              ? { player1ReportedPoints1: totalPoints1, player1ReportedPoints2: totalPoints2, player1ReportedRaces: processedRaces }
-              : { player2ReportedPoints1: totalPoints1, player2ReportedPoints2: totalPoints2, player2ReportedRaces: processedRaces };
+              ? { player1ReportedPoints1: totalPoints1, player1ReportedPoints2: totalPoints2, player1ReportedRaces: reportedRacesJson }
+              : { player2ReportedPoints1: totalPoints1, player2ReportedPoints2: totalPoints2, player2ReportedRaces: reportedRacesJson };
 
           return tx.gPMatch.update({
             where: { id: matchId, version: currentMatch.version },
@@ -276,49 +349,10 @@ export async function POST(
 
     const reportingPlayerId = reportingPlayer === 1 ? match.player1Id : match.player2Id;
 
-    /* Validate GP race positions are in legal range (0-8) before processing */
-    for (let i = 0; i < races.length; i++) {
-      const race = races[i] as { position1: number; position2: number; course: string };
-      const pos1Result = validateGPRacePosition(race.position1);
-      if (!pos1Result.isValid) return handleValidationError(pos1Result.error!, "position1");
-      const pos2Result = validateGPRacePosition(race.position2);
-      if (!pos2Result.isValid) return handleValidationError(pos2Result.error!, "position2");
-      /* Two players cannot finish in the same position (except both game-over at 0 per §7.2) */
-      if (race.position1 === race.position2 && race.position1 !== 0) {
-        return handleValidationError(
-          `Race ${i + 1}: both players cannot finish in the same position (${race.position1})`,
-          "position",
-        );
-      }
-    }
-
-    const submittedCup = getSubmittedCup(races);
-    if (!submittedCup || !isValidCupChoice(match.cup, submittedCup)) {
-      return handleValidationError("Submitted races do not match the assigned cup for this match", "races");
-    }
-
-    /* Process races: convert finishing positions to driver points */
-    let totalPoints1 = 0;
-    let totalPoints2 = 0;
-
-    const processedRaces = races.map((race: { position1: number; position2: number; course: string }) => {
-      const points1 = getDriverPoints(race.position1);
-      const points2 = getDriverPoints(race.position2);
-      totalPoints1 += points1;
-      totalPoints2 += points2;
-      return {
-        course: race.course,
-        position1: race.position1,
-        position2: race.position2,
-        points1,
-        points2,
-      };
-    });
-
     /* Audit logging via shared helpers */
     await createScoreEntryLog(logger, {
       tournamentId, matchId, matchType: 'GP', playerId: reportingPlayerId,
-      reportedData: { reportingPlayer, races: processedRaces, totalPoints1, totalPoints2 },
+      reportedData: { reportingPlayer, races: processedRaces || [], totalPoints1, totalPoints2 },
       clientIp, userAgent,
     });
 
@@ -346,8 +380,8 @@ export async function POST(
 
         const updateData =
           reportingPlayer === 1
-            ? { player1ReportedPoints1: totalPoints1, player1ReportedPoints2: totalPoints2, player1ReportedRaces: processedRaces, version: { increment: 1 } }
-            : { player2ReportedPoints1: totalPoints1, player2ReportedPoints2: totalPoints2, player2ReportedRaces: processedRaces, version: { increment: 1 } };
+            ? { player1ReportedPoints1: totalPoints1, player1ReportedPoints2: totalPoints2, player1ReportedRaces: reportedRacesJson, version: { increment: 1 } }
+            : { player2ReportedPoints1: totalPoints1, player2ReportedPoints2: totalPoints2, player2ReportedRaces: reportedRacesJson, version: { increment: 1 } };
 
         const updateResult = await tx.gPMatch.update({
           where: { id: matchId, version: currentMatch.version },

--- a/smkc-score-app/src/app/tournaments/[id]/gp/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/participant/page.tsx
@@ -1,23 +1,16 @@
 /**
  * Grand Prix Participant Score Entry Page
  *
- * Player-facing page for reporting GP match results with race-by-race entry.
+ * Player-facing page for reporting GP match results with driver-point totals.
  * Uses shared useParticipantMatches hook and ParticipantPageLayout.
- *
- * GP-specific: race results with cup-filtered courses, auto-calculated driver points,
- * and cup substitution (§7.1: Star→Mushroom, Special→Flower).
- *
- * Driver points: 1st=9, 2nd=6, 3rd=3, 4th=1, 5th-8th=0
  */
 "use client";
 
-import { useState, useMemo, useEffect, use } from "react";
-import { useLocale, useTranslations } from "next-intl";
+import { useState, use } from "react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
 import { Star } from "lucide-react";
-import { COURSE_INFO, CUP_SUBSTITUTIONS, GP_POSITION_OPTIONS, TOTAL_GP_RACES, getDriverPoints } from "@/lib/constants";
-import { formatGpPosition } from "@/lib/gp-utils";
 import { useParticipantMatches, type BaseMatch } from "@/lib/hooks/useParticipantMatches";
 import { ParticipantPageLayout } from "@/components/tournament/participant-page-layout";
 import { getMatchReportSuccessMessage } from "@/lib/participant-report-message";
@@ -34,13 +27,17 @@ interface GPMatch extends BaseMatch {
   player2ReportedPoints2?: number;
 }
 
-/** Individual race result with auto-calculated driver points */
-interface RaceResult {
-  course: string;
-  position1: number | null;
-  position2: number | null;
-  points1: number;
-  points2: number;
+interface DriverPointInput {
+  points1: string;
+  points2: string;
+}
+
+const MAX_GP_DRIVER_POINTS = 45;
+
+function isValidDriverPointInput(value: string): boolean {
+  if (!/^\d+$/.test(value)) return false;
+  const points = Number(value);
+  return Number.isInteger(points) && points >= 0 && points <= MAX_GP_DRIVER_POINTS;
 }
 
 export default function GrandPrixParticipantPage({
@@ -52,121 +49,41 @@ export default function GrandPrixParticipantPage({
   const tPart = useTranslations("participant");
   const tMatch = useTranslations("match");
   const tGp = useTranslations("gp");
-  const tCommon = useTranslations("common");
-  const locale = useLocale();
-  // Bind locale and gameOver label into the shared formatGpPosition utility
-  const fmtPos = (position: number) => formatGpPosition(position, locale, tCommon("gameOver"));
 
   const ctx = useParticipantMatches<GPMatch>({ tournamentId, mode: "gp" });
 
-  /* GP-specific state */
-  const [raceResults, setRaceResults] = useState<Record<string, RaceResult[]>>({});
-  /** §7.1 cup substitution: derive default cups from match data, allow user overrides */
-  const matchCups = useMemo(() => {
-    const cups: Record<string, string> = {};
-    ctx.myMatches.forEach((match) => {
-      if (match.cup) cups[match.id] = match.cup;
-    });
-    return cups;
-  }, [ctx.myMatches]);
-  const [cupOverrides, setCupOverrides] = useState<Record<string, string>>({});
-  /* Merge: user overrides take precedence over match-derived defaults */
-  const activeCups = useMemo(() => ({ ...matchCups, ...cupOverrides }), [matchCups, cupOverrides]);
+  const [driverPoints, setDriverPoints] = useState<Record<string, DriverPointInput>>({});
 
-  /* Auto-initialize 5 races from cup's fixed course order when matches load.
-   * setState inside useEffect is intentional here: the functional updater
-   * only commits when matches first load (checked by the `changed` flag),
-   * so no cascading renders occur. */
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    if (ctx.myMatches.length === 0) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setRaceResults((prev) => {
-      const next = { ...prev };
-      let changed = false;
-      for (const match of ctx.myMatches) {
-        const cup = cupOverrides[match.id] || match.cup;
-        if (cup && (!next[match.id] || next[match.id].length === 0)) {
-          const cupCourses = COURSE_INFO.filter((c) => c.cup === cup).map((c) => c.abbr);
-          next[match.id] = cupCourses.map((course) => ({ course, position1: null, position2: null, points1: 0, points2: 0 }));
-          changed = true;
-        }
-      }
-      return changed ? next : prev;
-    });
-  }, [ctx.myMatches, cupOverrides]);
+  const getPointsInput = (matchId: string): DriverPointInput =>
+    driverPoints[matchId] ?? { points1: "", points2: "" };
 
-  const addRaceResult = (matchId: string) => {
-    setRaceResults((prev) => ({
+  const updatePointsInput = (matchId: string, field: keyof DriverPointInput, value: string) => {
+    if (value !== "" && !/^\d+$/.test(value)) return;
+    setDriverPoints((prev) => ({
       ...prev,
-      [matchId]: [...(prev[matchId] || []), { course: "", position1: null, position2: null, points1: 0, points2: 0 }],
+      [matchId]: { ...getPointsInput(matchId), [field]: value },
     }));
   };
 
-  /** Update race result field — auto-calculates driver points on position change */
-  const updateRaceResult = (matchId: string, index: number, field: keyof RaceResult, value: string | number | null) => {
-    setRaceResults((prev) => ({
-      ...prev,
-      [matchId]: (prev[matchId] || []).map((r, i) => {
-        if (i !== index) return r;
-        const updated = { ...r, [field]: value };
-        if (field === "position1" || field === "position2") {
-          const pos1 = field === "position1" ? (value as number | null) : r.position1;
-          const pos2 = field === "position2" ? (value as number | null) : r.position2;
-          updated.points1 = pos1 ? getDriverPoints(pos1) : 0;
-          updated.points2 = pos2 ? getDriverPoints(pos2) : 0;
-        }
-        return updated;
-      }),
-    }));
-  };
-
-  const removeRaceResult = (matchId: string, index: number) => {
-    setRaceResults((prev) => ({
-      ...prev,
-      [matchId]: (prev[matchId] || []).filter((_, i) => i !== index),
-    }));
-  };
-
-  const calculateTotalPoints = (results: RaceResult[]) => {
-    let points1 = 0, points2 = 0;
-    results.forEach((r) => { points1 += r.points1; points2 += r.points2; });
-    return { points1, points2 };
-  };
-
-  /** Check if all races are complete and valid for submission.
-   * Same-position is blocked except both at 0 (game over, §7.2). */
-  const canSubmitRaces = (races: RaceResult[]) =>
-    races.length === TOTAL_GP_RACES &&
-    races.every((race) =>
-      race.course &&
-      race.position1 !== null &&
-      race.position2 !== null &&
-      (race.position1 !== race.position2 || race.position1 === 0)
-    );
+  const canSubmitPoints = ({ points1, points2 }: DriverPointInput) =>
+    isValidDriverPointInput(points1) && isValidDriverPointInput(points2);
 
   const handleSubmitMatch = async (match: GPMatch) => {
-    const races = raceResults[match.id] || [];
-    if (races.length === 0) { ctx.setError(tPart("addAtLeastOneRace")); return; }
+    const points = getPointsInput(match.id);
+    if (!canSubmitPoints(points)) {
+      ctx.setError(tGp("driverPointsValidation"));
+      return;
+    }
     const reportingPlayer = match.player1.id === ctx.playerId ? 1 : 2;
 
-    for (const r of races) {
-      if (!r.course || r.position1 === null || r.position2 === null) {
-        ctx.setError(tPart("completeAllRaceFields")); return;
-      }
-      /* Two players cannot finish in same position, except both game-over (0) per §7.2 */
-      if (r.position1 === r.position2 && r.position1 !== 0) {
-        ctx.setError(tPart("racePositionsCannotBeEqual")); return;
-      }
-    }
-
-    const { points1, points2 } = calculateTotalPoints(races);
     const data = await ctx.submitReport(match.id, {
-      reportingPlayer, points1, points2, races,
+      reportingPlayer,
+      points1: Number(points.points1),
+      points2: Number(points.points2),
     });
 
     if (data) {
-      setRaceResults((prev) => ({ ...prev, [match.id]: [] }));
+      setDriverPoints((prev) => ({ ...prev, [match.id]: { points1: "", points2: "" } }));
       alert(getMatchReportSuccessMessage(data, {
         matchReportedSuccess: tPart("matchReportedSuccess"),
         matchConfirmedSuccess: tPart("matchConfirmedSuccess"),
@@ -195,111 +112,54 @@ export default function GrandPrixParticipantPage({
       qualificationConfirmed={ctx.qualificationConfirmed}
       renderCardHeaderExtra={(match) => (
         <>
-          {match.cup && ` • ${tGp("cupLabel", { cup: activeCups[match.id] || match.cup })}`}
-          {match.cup && CUP_SUBSTITUTIONS[match.cup] && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-xs h-5 ml-1 px-1"
-              onClick={() => {
-                if (!match.cup) return;
-                const current = activeCups[match.id] || match.cup;
-                const next = current === match.cup ? CUP_SUBSTITUTIONS[match.cup] : match.cup;
-                setCupOverrides((prev) => ({ ...prev, [match.id]: next }));
-                /* Clear races so useEffect re-initializes with new cup's courses */
-                setRaceResults((prev) => ({ ...prev, [match.id]: [] }));
-              }}
-            >
-              {(activeCups[match.id] || match.cup) === match.cup
-                ? tGp("switchToSubstitute", { cup: CUP_SUBSTITUTIONS[match.cup] })
-                : tGp("switchBackToAssigned", { cup: match.cup })}
-            </Button>
-          )}
+          {match.cup && ` • ${tGp("cupLabel", { cup: match.cup })}`}
         </>
       )}
       renderMatchForm={(match) => {
-        /* Races are auto-initialized by useEffect when matches load */
-        const races = raceResults[match.id] || [];
-        const { points1, points2 } = calculateTotalPoints(races);
+        const points = getPointsInput(match.id);
+        const points1 = points.points1 === "" ? 0 : Number(points.points1);
+        const points2 = points.points2 === "" ? 0 : Number(points.points2);
 
         return (
           <div className="border-t pt-4">
             <div className="mb-3 flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-              <h4 className="font-medium">{tPart("raceResults")}</h4>
+              <h4 className="font-medium">{tGp("driverPointsEntry")}</h4>
               <div className="text-sm font-medium text-muted-foreground">
                 {tMatch("totalPoints", { points1, points2 })}
               </div>
             </div>
 
-            {races.length === 0 ? (
-              <div className="text-center py-8 text-muted-foreground">
-                <Star className="h-8 w-8 mx-auto mb-2" />
-                <p>{tPart("noRacesYet")}</p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{match.player1.nickname}</p>
+                <Input
+                  inputMode="numeric"
+                  min={0}
+                  max={MAX_GP_DRIVER_POINTS}
+                  value={points.points1}
+                  onChange={(event) => updatePointsInput(match.id, "points1", event.target.value)}
+                  placeholder="0"
+                />
               </div>
-            ) : (
-              <div className="space-y-3">
-                {races.map((result, index) => (
-                  <div key={index} className="grid gap-3 rounded-md border p-3 lg:grid-cols-[4rem_minmax(12rem,1fr)_minmax(8rem,0.7fr)_4rem_minmax(8rem,0.7fr)_4rem] lg:items-end">
-                    <div className="text-sm font-medium lg:pb-2">
-                      {tMatch("raceN", { n: index + 1 })}
-                    </div>
-                    <div className="space-y-1">
-                      <p className="text-xs text-muted-foreground">{tCommon("course")}</p>
-                      {/* Course is auto-determined by cup + race order (SMK fixed sequence) */}
-                      <p className="text-sm font-medium py-2">
-                        {COURSE_INFO.find((c) => c.abbr === result.course)?.name || result.course}
-                      </p>
-                    </div>
-                    <div className="space-y-1">
-                      <p className="text-xs text-muted-foreground">{match.player1.nickname}</p>
-                      <Select
-                        value={result.position1?.toString() ?? ""}
-                        onValueChange={(v) => updateRaceResult(match.id, index, "position1", v === "" ? null : parseInt(v, 10))}
-                      >
-                        <SelectTrigger><SelectValue placeholder={tCommon("position")} /></SelectTrigger>
-                        <SelectContent>
-                          {GP_POSITION_OPTIONS.map((pos) => (
-                            <SelectItem key={`p1-${index}-${pos}`} value={pos.toString()}>
-                              {fmtPos(pos)}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="rounded-md bg-muted px-2 py-2 text-center font-mono text-sm">
-                      {tMatch("pts", { points: result.points1 })}
-                    </div>
-                    <div className="space-y-1">
-                      <p className="text-xs text-muted-foreground">{match.player2.nickname}</p>
-                      <Select
-                        value={result.position2?.toString() ?? ""}
-                        onValueChange={(v) => updateRaceResult(match.id, index, "position2", v === "" ? null : parseInt(v, 10))}
-                      >
-                        <SelectTrigger><SelectValue placeholder={tCommon("position")} /></SelectTrigger>
-                        <SelectContent>
-                          {GP_POSITION_OPTIONS.map((pos) => (
-                            <SelectItem key={`p2-${index}-${pos}`} value={pos.toString()}>
-                              {fmtPos(pos)}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div className="rounded-md bg-muted px-2 py-2 text-center font-mono text-sm">
-                      {tMatch("pts", { points: result.points2 })}
-                    </div>
-                    {/* Race removal removed: 5 races are fixed per cup */}
-                  </div>
-                ))}
-                <div className="mt-4 p-3 bg-gray-50 rounded-lg">
-                  <div className="font-medium text-center">{tMatch("totalPoints", { points1, points2 })}</div>
-                </div>
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">{match.player2.nickname}</p>
+                <Input
+                  inputMode="numeric"
+                  min={0}
+                  max={MAX_GP_DRIVER_POINTS}
+                  value={points.points2}
+                  onChange={(event) => updatePointsInput(match.id, "points2", event.target.value)}
+                  placeholder="0"
+                />
               </div>
-            )}
+            </div>
+            <div className="mt-4 rounded-lg bg-gray-50 p-3">
+              <div className="text-center font-medium">{tMatch("totalPoints", { points1, points2 })}</div>
+            </div>
 
             <Button
               onClick={() => handleSubmitMatch(match)}
-              disabled={ctx.submitting === match.id || !canSubmitRaces(races)}
+              disabled={ctx.submitting === match.id || !canSubmitPoints(points)}
               className="mt-4 h-12 w-full text-base"
             >
               {ctx.submitting === match.id ? tMatch("submitting") : tPart("submitMatchResult")}


### PR DESCRIPTION
## Summary
- simplify the GP participant score-entry page to accept only driver-point totals
- allow the GP participant report API to accept direct `points1` / `points2` totals while preserving legacy race-based reports
- update GP participant test coverage and E2E scenario wording for total-point submission

## Validation
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts'`
- `npm run lint -- 'src/app/tournaments/[id]/gp/participant/page.tsx' 'src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts'`
- `npm run build`
