### PR TITLE
[codex] Use numeric keyboard for GP driver points

### DIFF
--- a/smkc-score-app/__tests__/lib/gp-driver-points-input.test.ts
+++ b/smkc-score-app/__tests__/lib/gp-driver-points-input.test.ts
@@ -1,0 +1,12 @@
+import { GP_DRIVER_POINTS_INPUT_PROPS } from "@/lib/gp-driver-points-input";
+
+describe("GP driver points input", () => {
+  it("uses mobile numeric keyboard hints for driver-point fields", () => {
+    expect(GP_DRIVER_POINTS_INPUT_PROPS).toEqual({
+      type: "text",
+      inputMode: "numeric",
+      pattern: "[0-9]*",
+      autoComplete: "off",
+    });
+  });
+});

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -84,6 +84,7 @@ import type { Player } from "@/lib/types";
 import { buildMatchLabel } from "@/lib/overlay/phase";
 import { getGpFinalsTargetWins } from "@/lib/finals-target-wins";
 import { getCupForFormIndex, isRemovableCupForm, removeCupFormAt } from "@/lib/gp-finals-score-form";
+import { GP_DRIVER_POINTS_INPUT_PROPS } from "@/lib/gp-driver-points-input";
 
 /** Client-side logger for error tracking */
 const logger = createLogger({ serviceName: 'tournaments-gp-finals' });
@@ -970,10 +971,7 @@ export default function GrandPrixFinals({
                           <Label>{selectedMatch.player1.nickname}</Label>
                           <Input
                             data-testid={`gp-finals-cup-${cupIndex}-manual-p1`}
-                            type="number"
-                            min="0"
-                            step="1"
-                            inputMode="numeric"
+                            {...GP_DRIVER_POINTS_INPUT_PROPS}
                             value={cup.manualPoints1}
                             onChange={(e) => {
                               const next = [...cupForms];
@@ -986,10 +984,7 @@ export default function GrandPrixFinals({
                           <Label>{selectedMatch.player2.nickname}</Label>
                           <Input
                             data-testid={`gp-finals-cup-${cupIndex}-manual-p2`}
-                            type="number"
-                            min="0"
-                            step="1"
-                            inputMode="numeric"
+                            {...GP_DRIVER_POINTS_INPUT_PROPS}
                             value={cup.manualPoints2}
                             onChange={(e) => {
                               const next = [...cupForms];

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
@@ -87,6 +87,7 @@ import {
   canResetFinalsFromQualification,
 } from "@/lib/finals-action-availability";
 import { calculateMaxMatchPoints, normalizePoints } from "@/lib/points/qualification-points";
+import { GP_DRIVER_POINTS_INPUT_PROPS } from "@/lib/gp-driver-points-input";
 
 import type { Player } from "@/lib/types";
 
@@ -1230,10 +1231,7 @@ export default function GrandPrixPageClient({
                     <Label htmlFor="manual-points1">{selectedMatch.player1.nickname}</Label>
                     <Input
                       id="manual-points1"
-                      type="number"
-                      min="0"
-                      step="1"
-                      inputMode="numeric"
+                      {...GP_DRIVER_POINTS_INPUT_PROPS}
                       value={manualPoints1}
                       onChange={(e) => setManualPoints1(e.target.value)}
                     />
@@ -1242,10 +1240,7 @@ export default function GrandPrixPageClient({
                     <Label htmlFor="manual-points2">{selectedMatch.player2.nickname}</Label>
                     <Input
                       id="manual-points2"
-                      type="number"
-                      min="0"
-                      step="1"
-                      inputMode="numeric"
+                      {...GP_DRIVER_POINTS_INPUT_PROPS}
                       value={manualPoints2}
                       onChange={(e) => setManualPoints2(e.target.value)}
                     />

--- a/smkc-score-app/src/app/tournaments/[id]/gp/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/participant/page.tsx
@@ -14,6 +14,7 @@ import { Star } from "lucide-react";
 import { useParticipantMatches, type BaseMatch } from "@/lib/hooks/useParticipantMatches";
 import { ParticipantPageLayout } from "@/components/tournament/participant-page-layout";
 import { getMatchReportSuccessMessage } from "@/lib/participant-report-message";
+import { GP_DRIVER_POINTS_INPUT_PROPS } from "@/lib/gp-driver-points-input";
 
 /** GP Match extends BaseMatch with GP-specific fields */
 interface GPMatch extends BaseMatch {
@@ -133,9 +134,7 @@ export default function GrandPrixParticipantPage({
               <div className="space-y-1">
                 <p className="text-xs text-muted-foreground">{match.player1.nickname}</p>
                 <Input
-                  inputMode="numeric"
-                  min={0}
-                  max={MAX_GP_DRIVER_POINTS}
+                  {...GP_DRIVER_POINTS_INPUT_PROPS}
                   value={points.points1}
                   onChange={(event) => updatePointsInput(match.id, "points1", event.target.value)}
                   placeholder="0"
@@ -144,9 +143,7 @@ export default function GrandPrixParticipantPage({
               <div className="space-y-1">
                 <p className="text-xs text-muted-foreground">{match.player2.nickname}</p>
                 <Input
-                  inputMode="numeric"
-                  min={0}
-                  max={MAX_GP_DRIVER_POINTS}
+                  {...GP_DRIVER_POINTS_INPUT_PROPS}
                   value={points.points2}
                   onChange={(event) => updatePointsInput(match.id, "points2", event.target.value)}
                   placeholder="0"

--- a/smkc-score-app/src/lib/gp-driver-points-input.ts
+++ b/smkc-score-app/src/lib/gp-driver-points-input.ts
@@ -1,0 +1,6 @@
+export const GP_DRIVER_POINTS_INPUT_PROPS = {
+  type: "text",
+  inputMode: "numeric",
+  pattern: "[0-9]*",
+  autoComplete: "off",
+} as const;


### PR DESCRIPTION
## Summary
- Add a shared GP driver-points input prop set that uses mobile numeric keyboard hints.
- Apply it to GP participant score entry, GP qualification manual score override, and GP finals manual driver-point entry.
- Add a focused regression test for the shared input attributes.

## Validation
- npm ci
- npm test -- --runTestsByPath __tests__/lib/gp-driver-points-input.test.ts
- npx eslint 'src/app/tournaments/[id]/gp/participant/page.tsx' 'src/app/tournaments/[id]/gp/page-client.tsx' 'src/app/tournaments/[id]/gp/finals/page.tsx' src/lib/gp-driver-points-input.ts __tests__/lib/gp-driver-points-input.test.ts
