### PR TITLE
[codex] Fix GP finals mobile score entry scroll

### DIFF
--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3856,7 +3856,9 @@ async function main() {
   {
     let tc356TournamentId = null;
     const tc356PlayerIds = [];
+    const previousViewport356 = page.viewportSize();
     try {
+      await page.setViewportSize({ width: 390, height: 844 });
       const ts356 = Date.now();
       const players356 = [];
       for (let i = 1; i <= 8; i++) {
@@ -3879,13 +3881,20 @@ async function main() {
       await page.locator('[role="dialog"]').waitFor({ state: 'visible', timeout: 40000 });
       const hasScrollWrapper = await page.evaluate(() => {
         const dialog = document.querySelector('[role="dialog"]');
-        const scrollDivs = dialog ? dialog.querySelectorAll('div.overflow-x-auto') : [];
-        return Array.from(scrollDivs).some((div) => div.querySelector('table, [role="table"]'));
+        const table = dialog?.querySelector('table, [role="table"]');
+        const scrollDiv = table?.closest('[data-slot="table-container"], div.overflow-x-auto');
+        if (!(scrollDiv instanceof HTMLElement)) return false;
+        const originalLeft = scrollDiv.scrollLeft;
+        scrollDiv.scrollLeft = scrollDiv.scrollWidth;
+        const canScroll = scrollDiv.scrollWidth > scrollDiv.clientWidth && scrollDiv.scrollLeft > originalLeft;
+        scrollDiv.scrollLeft = originalLeft;
+        return canScroll;
       });
-      log('TC-356', hasScrollWrapper ? 'PASS' : 'FAIL', 'overflow-x-auto wrapper containing a table in GP finals score dialog');
+      log('TC-356', hasScrollWrapper ? 'PASS' : 'FAIL', 'GP finals score table can scroll horizontally at mobile width');
     } catch (e) {
       log('TC-356', 'FAIL', e instanceof Error ? e.message : String(e));
     } finally {
+      if (previousViewport356) await page.setViewportSize(previousViewport356);
       if (tc356TournamentId) await deleteTournament(page, tc356TournamentId);
       for (const playerId of tc356PlayerIds) await deletePlayer(page, playerId);
     }

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -1001,7 +1001,7 @@ export default function GrandPrixFinals({
                       </div>
                     ) : (
                       <div className="overflow-x-auto">
-                        <Table>
+                        <Table className="min-w-[560px]">
                           <TableHeader>
                             <TableRow>
                               <TableHead className="w-16">{tCommon('race')}</TableHead>


### PR DESCRIPTION
## Summary
- Keep the GP finals race-entry table wide enough to require horizontal scrolling on mobile instead of compressing the P2 position column out of reach.
- Strengthen TC-356 so it verifies real horizontal scroll behavior at a 390px mobile viewport.

## Root Cause
The dialog had an overflow wrapper, but the table itself could shrink to the narrow mobile viewport. That meant the scroll container did not always expose a reachable horizontal scroll area for the right-side input column.

## Validation
- npx eslint 'src/app/tournaments/[id]/gp/finals/page.tsx'
- git diff --check
- npm run build


## Issues
Closes #1113
