### PR TITLE
[codex] Document GP finals score table width

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -1008,6 +1008,8 @@ export default function GrandPrixFinals({
                       </div>
                     ) : (
                       <div className="overflow-x-auto">
+                        {/* Keep enough intrinsic width for race, course, and two position selects:
+                            64 + ~220 + 136 * 2 = ~556px. */}
                         <Table className="min-w-[560px]">
                           <TableHeader>
                             <TableRow>


### PR DESCRIPTION
## Summary
- Document the rationale for the GP finals score-entry table minimum width added in #1112.

## Root Cause
Claude review asked for the 560px value to be explained so future changes to the table columns can update the width intentionally.

## Validation
- npx eslint 'src/app/tournaments/[id]/gp/finals/page.tsx'

## Issues
Closes #1113
