### PR TITLE
[codex] Use stacked GP finals score inputs on mobile

### DIFF
--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3849,10 +3849,9 @@ async function main() {
     log('TC-355', 'SKIP', 'TID not available');
   }
 
-  // TC-356: GP finals score dialog table is horizontally scrollable on mobile
-  // Verifies that the race-entry table inside the score dialog has an
-  // overflow-x-auto wrapper so the P2 position column is reachable on narrow
-  // viewports (issue #810).
+  // TC-356: GP finals score dialog is usable on mobile without horizontal scroll
+  // Verifies that the race-entry form switches to stacked mobile rows so both
+  // P1/P2 position controls are reachable on narrow viewports (issue #810).
   {
     let tc356TournamentId = null;
     const tc356PlayerIds = [];
@@ -3879,18 +3878,17 @@ async function main() {
       await firstMatch.waitFor({ state: 'visible', timeout: 40000 });
       await firstMatch.click({ timeout: 40000 });
       await page.locator('[role="dialog"]').waitFor({ state: 'visible', timeout: 40000 });
-      const hasScrollWrapper = await page.evaluate(() => {
+      const mobileLayoutUsable = await page.evaluate(() => {
         const dialog = document.querySelector('[role="dialog"]');
-        const table = dialog?.querySelector('table, [role="table"]');
-        const scrollDiv = table?.closest('[data-slot="table-container"], div.overflow-x-auto');
-        if (!(scrollDiv instanceof HTMLElement)) return false;
-        const originalLeft = scrollDiv.scrollLeft;
-        scrollDiv.scrollLeft = scrollDiv.scrollWidth;
-        const canScroll = scrollDiv.scrollWidth > scrollDiv.clientWidth && scrollDiv.scrollLeft > originalLeft;
-        scrollDiv.scrollLeft = originalLeft;
-        return canScroll;
+        if (!(dialog instanceof HTMLElement)) return false;
+        const firstRace = dialog.querySelector('[data-testid="gp-finals-mobile-race-entry"]');
+        if (!(firstRace instanceof HTMLElement)) return false;
+        const controls = firstRace.querySelectorAll('[role="combobox"]');
+        const rect = firstRace.getBoundingClientRect();
+        const viewportWidth = document.documentElement.clientWidth;
+        return controls.length === 2 && rect.left >= 0 && rect.right <= viewportWidth;
       });
-      log('TC-356', hasScrollWrapper ? 'PASS' : 'FAIL', 'GP finals score table can scroll horizontally at mobile width');
+      log('TC-356', mobileLayoutUsable ? 'PASS' : 'FAIL', 'GP finals score dialog shows stacked P1/P2 inputs at mobile width');
     } catch (e) {
       log('TC-356', 'FAIL', e instanceof Error ? e.message : String(e));
     } finally {

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -930,6 +930,20 @@ export default function GrandPrixFinals({
             <div className="space-y-4">
               {cupForms.map((cup, cupIndex) => {
                 const points = calculateCupPoints(cup);
+                const setRacePosition = (
+                  raceIndex: number,
+                  field: "position1" | "position2",
+                  value: string,
+                ) => {
+                  const next = [...cupForms];
+                  const races = [...cup.races];
+                  races[raceIndex] = {
+                    ...races[raceIndex],
+                    [field]: value === "" ? null : parseInt(value, 10),
+                  };
+                  next[cupIndex] = { ...cup, races };
+                  setCupForms(next);
+                };
                 return (
                   <div
                     key={`cup-${cupIndex}`}
@@ -1007,7 +1021,64 @@ export default function GrandPrixFinals({
                         </div>
                       </div>
                     ) : (
-                      <div className="overflow-x-auto">
+                      <>
+                      <div className="space-y-3 sm:hidden" data-testid={`gp-finals-mobile-race-list-${cupIndex}`}>
+                        {cup.races.map((race, raceIndex) => (
+                          <div
+                            key={`mobile-race-${selectedMatch?.id}-${cupIndex}-${raceIndex}`}
+                            className="space-y-3 border-t border-foreground/10 pt-3 first:border-t-0 first:pt-0"
+                            data-testid="gp-finals-mobile-race-entry"
+                          >
+                            <div className="space-y-1">
+                              <div className="text-xs font-semibold uppercase text-muted-foreground">
+                                {tCommon('race')} {raceIndex + 1}
+                              </div>
+                              <div className="text-sm font-medium break-words">
+                                {COURSE_INFO.find((c) => c.abbr === race.course)?.name || race.course}
+                              </div>
+                            </div>
+                            <div className="grid gap-3">
+                              <div className="space-y-1.5">
+                                <Label className="text-xs text-muted-foreground">{tGp('p1Position')}</Label>
+                                <Select
+                                  value={race.position1?.toString() || ""}
+                                  onValueChange={(value) => setRacePosition(raceIndex, "position1", value)}
+                                >
+                                  <SelectTrigger className="w-full">
+                                    <SelectValue placeholder={tCommon('position')} />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {GP_POSITION_OPTIONS.map((position) => (
+                                      <SelectItem key={`mobile-admin-p1-${cupIndex}-${raceIndex}-${position}`} value={position.toString()}>
+                                        {fmtPos(position)}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              </div>
+                              <div className="space-y-1.5">
+                                <Label className="text-xs text-muted-foreground">{tGp('p2Position')}</Label>
+                                <Select
+                                  value={race.position2?.toString() || ""}
+                                  onValueChange={(value) => setRacePosition(raceIndex, "position2", value)}
+                                >
+                                  <SelectTrigger className="w-full">
+                                    <SelectValue placeholder={tCommon('position')} />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {GP_POSITION_OPTIONS.map((position) => (
+                                      <SelectItem key={`mobile-admin-p2-${cupIndex}-${raceIndex}-${position}`} value={position.toString()}>
+                                        {fmtPos(position)}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                      <div className="hidden overflow-x-auto sm:block">
                         {/* Keep enough intrinsic width for race, course, and two position selects:
                             64 + ~220 + 136 * 2 = ~556px. */}
                         <Table className="min-w-[560px]">
@@ -1029,13 +1100,7 @@ export default function GrandPrixFinals({
                                 <TableCell>
                                   <Select
                                     value={race.position1?.toString() || ""}
-                                    onValueChange={(value) => {
-                                      const next = [...cupForms];
-                                      const races = [...cup.races];
-                                      races[raceIndex] = { ...races[raceIndex], position1: value === "" ? null : parseInt(value, 10) };
-                                      next[cupIndex] = { ...cup, races };
-                                      setCupForms(next);
-                                    }}
+                                    onValueChange={(value) => setRacePosition(raceIndex, "position1", value)}
                                   >
                                     <SelectTrigger>
                                       <SelectValue placeholder={tCommon('position')} />
@@ -1052,13 +1117,7 @@ export default function GrandPrixFinals({
                                 <TableCell>
                                   <Select
                                     value={race.position2?.toString() || ""}
-                                    onValueChange={(value) => {
-                                      const next = [...cupForms];
-                                      const races = [...cup.races];
-                                      races[raceIndex] = { ...races[raceIndex], position2: value === "" ? null : parseInt(value, 10) };
-                                      next[cupIndex] = { ...cup, races };
-                                      setCupForms(next);
-                                    }}
+                                    onValueChange={(value) => setRacePosition(raceIndex, "position2", value)}
                                   >
                                     <SelectTrigger>
                                       <SelectValue placeholder={tCommon('position')} />
@@ -1077,6 +1136,7 @@ export default function GrandPrixFinals({
                           </TableBody>
                         </Table>
                       </div>
+                      </>
                     )}
                   </div>
                 );


### PR DESCRIPTION
## Summary
- Replace the mobile GP finals race-entry table with stacked per-race controls so P1/P2 positions are reachable without horizontal scrolling.
- Keep the desktop/tablet table layout for wider screens.
- Update TC-356 to verify the stacked mobile layout at 390px width.

## Root Cause
The previous fix made the table horizontally scrollable, but mobile score entry still depended on horizontal gesture behavior inside a scrollable dialog. On real phones that left the P2 column unreachable.

## Validation
- npx eslint 'src/app/tournaments/[id]/gp/finals/page.tsx'
- git diff --check
- npm run build
