### PR TITLE
[codex] Show GP qualification rank labels in brackets

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -569,6 +569,14 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const result = await POST(request, { params });
 
       expect(result.status).toBe(201);
+      expect(result.data.playoffSeededPlayers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ playerId: 'p20', qualificationRankLabel: 'B8' }),
+          expect.objectContaining({ playerId: 'p8', qualificationRankLabel: 'A8' }),
+          expect.objectContaining({ playerId: 'p21', qualificationRankLabel: 'B9' }),
+          expect.objectContaining({ playerId: 'p11', qualificationRankLabel: 'A11' }),
+        ]),
+      );
       const createManyData = (prisma.gPMatch.createMany as jest.Mock).mock.calls[0][0].data as Array<Record<string, unknown>>;
       expect(createManyData).toHaveLength(3);
       for (const match of createManyData) {

--- a/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
@@ -170,6 +170,30 @@ describe("DoubleEliminationBracket TBD rendering (issue #574)", () => {
     expect(winnersQF1!.textContent).toContain(seed8.nickname);
   });
 
+  it("shows qualification group-rank labels when seeded players include them", () => {
+    const { container } = render(
+      <DoubleEliminationBracket
+        matches={buildInitialMatches()}
+        bracketStructure={build8PlayerStructure()}
+        roundNames={{}}
+        seededPlayers={seededPlayers.map((entry, index) => ({
+          ...entry,
+          qualificationRankLabel: index % 2 === 0 ? `A${index + 1}` : `B${index + 1}`,
+        }))}
+      />,
+    );
+
+    const winnersQF1 = Array.from(
+      container.querySelectorAll<HTMLElement>("[role='button']"),
+    ).find((el) => el.querySelector("div.text-xs")?.textContent === "M1");
+
+    expect(winnersQF1).toBeDefined();
+    expect(winnersQF1!.textContent).toContain("[A1]");
+    expect(winnersQF1!.textContent).toContain("[B8]");
+    expect(winnersQF1!.textContent).not.toContain("[1]");
+    expect(winnersQF1!.textContent).not.toContain("[8]");
+  });
+
   it("renders unresolved Top-24 barrage seats as TBD in a previewed 16-player bracket", () => {
     const bracketStructure = generateBracketStructure(16);
     const seededPreview = [

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -71,8 +71,8 @@ interface DoubleEliminationBracketProps {
   roundNames: Record<string, string>;
   /** Optional callback when a match card is clicked (for score entry) */
   onMatchClick?: (match: BMMatch) => void;
-  /** Optional seeded player data for displaying seed numbers */
-  seededPlayers?: { seed: number; playerId: string; player: Player }[];
+  /** Optional seeded player data for displaying qualification labels */
+  seededPlayers?: { seed: number; playerId: string; player: Player; qualificationRankLabel?: string }[];
   /** Number of wins required to highlight a completed match winner. */
   getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
   /**
@@ -86,12 +86,12 @@ interface DoubleEliminationBracketProps {
 
 /**
  * Individual match card within the bracket.
- * Displays two player rows with their nicknames, seed numbers, and scores.
+ * Displays two player rows with their nicknames, qualification labels, and scores.
  * Completed matches show a green border; winners have highlighted rows.
  *
  * @param match - Actual match data (may be undefined for unfilled bracket positions)
  * @param bracketMatch - Bracket structure definition for this position
- * @param seededPlayers - Seeded player data for seed number display
+ * @param seededPlayers - Seeded player data for name and qualification-label display
  * @param onClick - Click handler for score entry
  * @param isTBD - Per-slot TBD flags: whether player1/player2 slots are undetermined
  */
@@ -106,24 +106,26 @@ function MatchCard({
 }: {
   match?: BMMatch;
   bracketMatch: BracketMatch;
-  seededPlayers?: { seed: number; playerId: string; player: Player }[];
+  seededPlayers?: { seed: number; playerId: string; player: Player; qualificationRankLabel?: string }[];
   onClick?: () => void;
   isTBD: { player1: boolean; player2: boolean };
   getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
   onTvNumberChange?: (match: BMMatch, tvNumber: number | null) => void;
 }) {
   const tc = useTranslations("common");
-  /* Look up seeded players for displaying seed numbers in first-round matches */
-  const seededPlayer1 = bracketMatch.player1Seed
-    ? seededPlayers?.find((p) => p.seed === bracketMatch.player1Seed)?.player
+  /* Look up seeded players for displaying names and qualification rank labels. */
+  const seededEntry1 = bracketMatch.player1Seed
+    ? seededPlayers?.find((p) => p.seed === bracketMatch.player1Seed)
     : undefined;
-  const seededPlayer2 = bracketMatch.player2Seed
-    ? seededPlayers?.find((p) => p.seed === bracketMatch.player2Seed)?.player
+  const seededEntry2 = bracketMatch.player2Seed
+    ? seededPlayers?.find((p) => p.seed === bracketMatch.player2Seed)
     : undefined;
+  const seedLabel1 = seededEntry1?.qualificationRankLabel ?? bracketMatch.player1Seed;
+  const seedLabel2 = seededEntry2?.qualificationRankLabel ?? bracketMatch.player2Seed;
 
   /* Use actual match players if available, fall back to seeded player data */
-  const player1: Player | undefined = match?.player1 || seededPlayer1;
-  const player2: Player | undefined = match?.player2 || seededPlayer2;
+  const player1: Player | undefined = match?.player1 || seededEntry1?.player;
+  const player2: Player | undefined = match?.player2 || seededEntry2?.player;
 
   const targetWins = getTargetWins?.(match, bracketMatch) ?? 3;
   const isWinner1 = !!match?.completed && match.score1 >= targetWins && match.score1 > match.score2;
@@ -203,7 +205,7 @@ function MatchCard({
         <span className="flex items-center gap-1">
           {bracketMatch.player1Seed && (
             <span className="text-xs text-muted-foreground">
-              [{bracketMatch.player1Seed}]
+              [{seedLabel1}]
             </span>
           )}
           <span className={showTBD1 ? "text-muted-foreground" : ""}>
@@ -225,7 +227,7 @@ function MatchCard({
         <span className="flex items-center gap-1">
           {bracketMatch.player2Seed && (
             <span className="text-xs text-muted-foreground">
-              [{bracketMatch.player2Seed}]
+              [{seedLabel2}]
             </span>
           )}
           <span className={showTBD2 ? "text-muted-foreground" : ""}>

--- a/smkc-score-app/src/components/tournament/playoff-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/playoff-bracket.tsx
@@ -65,8 +65,8 @@ interface PlayoffBracketProps {
   roundNames: Record<string, string>;
   /** Optional callback when a match card is clicked (for score entry) */
   onMatchClick?: (match: BMMatch) => void;
-  /** Seeded player data for displaying seed numbers */
-  seededPlayers?: { seed: number; playerId: string; player: Player }[];
+  /** Seeded player data for displaying qualification labels */
+  seededPlayers?: { seed: number; playerId: string; player: Player; qualificationRankLabel?: string }[];
   /** Number of wins required to highlight a completed match winner */
   getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
   /** See `DoubleEliminationBracket.onTvNumberChange` — same select-to-save UX. */
@@ -90,7 +90,7 @@ function PlayoffMatchCard({
 }: {
   match?: BMMatch;
   bracketMatch: BracketMatch;
-  seededPlayers?: { seed: number; playerId: string; player: Player }[];
+  seededPlayers?: { seed: number; playerId: string; player: Player; qualificationRankLabel?: string }[];
   onClick?: () => void;
   isPlayer1TBD: boolean;
   isPlayer2TBD: boolean;
@@ -99,15 +99,17 @@ function PlayoffMatchCard({
 }) {
   const tc = useTranslations("common");
   const tf = useTranslations("finals");
-  const seededPlayer1 = bracketMatch.player1Seed
-    ? seededPlayers?.find((p) => p.seed === bracketMatch.player1Seed)?.player
+  const seededEntry1 = bracketMatch.player1Seed
+    ? seededPlayers?.find((p) => p.seed === bracketMatch.player1Seed)
     : undefined;
-  const seededPlayer2 = bracketMatch.player2Seed
-    ? seededPlayers?.find((p) => p.seed === bracketMatch.player2Seed)?.player
+  const seededEntry2 = bracketMatch.player2Seed
+    ? seededPlayers?.find((p) => p.seed === bracketMatch.player2Seed)
     : undefined;
+  const seedLabel1 = seededEntry1?.qualificationRankLabel ?? bracketMatch.player1Seed;
+  const seedLabel2 = seededEntry2?.qualificationRankLabel ?? bracketMatch.player2Seed;
 
-  const player1: Player | undefined = match?.player1 || seededPlayer1;
-  const player2: Player | undefined = match?.player2 || seededPlayer2;
+  const player1: Player | undefined = match?.player1 || seededEntry1?.player;
+  const player2: Player | undefined = match?.player2 || seededEntry2?.player;
 
   const targetWins = getTargetWins?.(match, bracketMatch) ?? 3;
   const isWinner1 = !!match?.completed && match.score1 >= targetWins && match.score1 > match.score2;
@@ -178,7 +180,7 @@ function PlayoffMatchCard({
         <span className="flex items-center gap-1">
           {bracketMatch.player1Seed && (
             <span className="text-xs text-muted-foreground">
-              [{bracketMatch.player1Seed}]
+              [{seedLabel1}]
             </span>
           )}
           <span className={isPlayer1TBD ? "text-muted-foreground" : ""}>
@@ -200,7 +202,7 @@ function PlayoffMatchCard({
         <span className="flex items-center gap-1">
           {bracketMatch.player2Seed !== undefined && bracketMatch.player2Seed > 0 && (
             <span className="text-xs text-muted-foreground">
-              [{bracketMatch.player2Seed}]
+              [{seedLabel2}]
             </span>
           )}
           <span className={isPlayer2TBD ? "text-muted-foreground" : ""}>

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -64,6 +64,7 @@ interface SeededFinalsPlayer {
   seed: number;
   playerId: string;
   player: unknown;
+  qualificationRankLabel?: string;
 }
 
 function fisherYatesShuffle<T>(arr: readonly T[]): T[] {
@@ -638,6 +639,22 @@ export function createFinalsHandlers(config: FinalsConfig) {
     );
   }
 
+  function buildQualificationRankLabelMap(
+    qualifications: Array<{ playerId: string; group?: string | null }>,
+  ): Map<string, string> {
+    const rankByPlayerId = new Map<string, string>();
+    const groupCounts = new Map<string, number>();
+
+    for (const q of qualifications) {
+      const group = q.group ?? '';
+      const rank = (groupCounts.get(group) ?? 0) + 1;
+      groupCounts.set(group, rank);
+      rankByPlayerId.set(q.playerId, group ? `${group}${rank}` : `${rank}`);
+    }
+
+    return rankByPlayerId;
+  }
+
   function getRoundAssignmentData(
     round: string,
     mrAssignments?: Map<string, string[]>,
@@ -676,6 +693,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
         tournamentId,
         qualifications,
       );
+      const qualificationRankLabels = buildQualificationRankLabelMap(rankedQualifications);
 
       const selection = selectFinalsEntrantsByGroup(
         rankedQualifications as Array<{ playerId: string; player: unknown; group: string }>,
@@ -685,6 +703,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
         seed,
         playerId: qualification.playerId,
         player: qualification.player,
+        qualificationRankLabel: qualificationRankLabels.get(qualification.playerId),
       }));
 
       const playoffStructure = generatePlayoffStructure(PLAYOFF_ENTRANT_COUNT);
@@ -705,6 +724,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
           seed: r2BracketMatch.advancesToUpperSeed,
           playerId: winnerId,
           player: winnerPlayer,
+          qualificationRankLabel: qualificationRankLabels.get(winnerId),
         });
       }
 
@@ -1127,6 +1147,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
         qualifications,
       );
       const selectedQualifications = rankedQualifications.slice(0, topN);
+      const qualificationRankLabels = buildQualificationRankLabelMap(rankedQualifications);
 
       if (selectedQualifications.length < topN) {
         return handleValidationError(
@@ -1150,6 +1171,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
           seed: index + 1,
           playerId: q.playerId,
           player: q.player,
+          qualificationRankLabel: qualificationRankLabels.get(q.playerId),
         }),
       );
 
@@ -1300,6 +1322,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
         tournamentId,
         qualifications,
       );
+      const qualificationRankLabels = buildQualificationRankLabelMap(rankedQualifications);
 
       /* Per-group Top-N selection with bracket seed assignment (#454).
        * For 2 groups, finals-group-selection applies the handwritten CDM
@@ -1359,6 +1382,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
           seed: index + 1,
           playerId: q.playerId,
           player: q.player,
+          qualificationRankLabel: qualificationRankLabels.get(q.playerId),
         }));
 
         /*
@@ -1467,6 +1491,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
         seed,
         playerId: qualification.playerId,
         player: qualification.player,
+        qualificationRankLabel: qualificationRankLabels.get(qualification.playerId),
       }));
       const playoffUpperSeeds = playoffStructure
         .filter((m) => m.round === 'playoff_r2' && m.advancesToUpperSeed)
@@ -1476,7 +1501,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
         if (!winner) {
           throw new Error(`Playoff winner for Upper seed ${upperSeed} not resolved`);
         }
-        return { seed: upperSeed, playerId: winner.playerId, player: winner.player };
+        return {
+          seed: upperSeed,
+          playerId: winner.playerId,
+          player: winner.player,
+          qualificationRankLabel: qualificationRankLabels.get(winner.playerId),
+        };
       });
       const seededPlayers = [...directPlayers, ...playoffWinnerSeeds];
 


### PR DESCRIPTION
## Summary
- add qualification group-rank labels (for example `A1`, `B8`) to finals seeded-player payloads
- render qualification labels in finals and playoff bracket cards when available, while keeping bracket seed slots as the internal placement key
- add regression coverage for GP Top-24 playoff payload labels and bracket-card label rendering

## Root Cause
The bracket UI displayed `player1Seed` / `player2Seed` directly. Those numbers are bracket placement slots, not qualification ranks, so GP Top-24 operators could read them as seed-style/global numbers instead of group-scoped qualification ranks.

## Validation
- `npm ci`
- `npm test -- --runTestsByPath __tests__/components/tournament/double-elimination-bracket.test.tsx '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts' --runInBand`
- `npx eslint src/lib/api-factories/finals-route.ts src/components/tournament/double-elimination-bracket.tsx src/components/tournament/playoff-bracket.tsx __tests__/components/tournament/double-elimination-bracket.test.tsx '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts'` (passes with existing warnings)
