### PR TITLE
[codex] Fix GP qualification ranks per group

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/route.test.ts
@@ -120,7 +120,7 @@ describe('GP API Route - /api/tournaments/[id]/gp', () => {
       expect(prisma.gPQualification.findMany).toHaveBeenCalledWith({
         where: { tournamentId: 't1' },
         include: { player: { select: PLAYER_PUBLIC_SELECT } },
-        orderBy: [{ points: 'desc' }, { score: 'desc' }],
+        orderBy: [{ group: 'asc' }, { points: 'desc' }, { score: 'desc' }],
       });
       expect(prisma.gPMatch.findMany).toHaveBeenCalledWith({
         where: { tournamentId: 't1', stage: 'qualification' },
@@ -140,6 +140,29 @@ describe('GP API Route - /api/tournaments/[id]/gp', () => {
 
       expect(result.data).toEqual({ qualifications: [], matches: [], qualificationConfirmed: false });
       expect(result.status).toBe(200);
+    });
+
+    it('should compute GP qualification ranks independently inside each group', async () => {
+      const mockQualifications = [
+        { id: 'qa1', tournamentId: 't1', playerId: 'pa1', group: 'A', score: 6, points: 90, rankOverride: null, player: { id: 'pa1', name: 'A1' } },
+        { id: 'qa2', tournamentId: 't1', playerId: 'pa2', group: 'A', score: 4, points: 70, rankOverride: null, player: { id: 'pa2', name: 'A2' } },
+        { id: 'qb1', tournamentId: 't1', playerId: 'pb1', group: 'B', score: 6, points: 95, rankOverride: null, player: { id: 'pb1', name: 'B1' } },
+        { id: 'qb2', tournamentId: 't1', playerId: 'pb2', group: 'B', score: 4, points: 65, rankOverride: null, player: { id: 'pb2', name: 'B2' } },
+      ];
+      (prisma.gPQualification.findMany as jest.Mock).mockResolvedValue(mockQualifications);
+      (prisma.gPMatch.findMany as jest.Mock).mockResolvedValue([]);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp');
+      const params = Promise.resolve({ id: 't1' });
+      const result = await GET(request, { params });
+
+      expect(result.status).toBe(200);
+      expect(result.data.qualifications.map((q: any) => [q.group, q.playerId, q._rank])).toEqual([
+        ['A', 'pa1', 1],
+        ['A', 'pa2', 2],
+        ['B', 'pb1', 1],
+        ['B', 'pb2', 2],
+      ]);
     });
 
     // Error case - Returns 500 when database query fails
@@ -719,4 +742,5 @@ describe('GP API Route - /api/tournaments/[id]/gp', () => {
       );
     });
   });
+
 });

--- a/smkc-score-app/src/lib/event-types/gp-config.ts
+++ b/smkc-score-app/src/lib/event-types/gp-config.ts
@@ -8,7 +8,6 @@
  * At qualification setup, the full cup list is shuffled 5 separate times,
  * concatenated, then assigned 1 cup per round in sequence. Deck boundaries
  * are adjusted so the same cup is not selected in consecutive rounds.
- * Unlike BM/MR, GP has no group-based ordering in qualifications.
  */
 
 import { EventTypeConfig, MatchResult } from './types';
@@ -68,8 +67,8 @@ export const gpConfig: EventTypeConfig = {
   matchScoreFields: { p1: 'points1', p2: 'points2' },
   loggerName: 'gp-api',
   eventDisplayName: 'grand prix',
-  // Per requirements.md §4.1: GP uses driver points as primary ranking criterion
-  qualificationOrderBy: [{ points: 'desc' }, { score: 'desc' }],
+  // Per requirements.md §4.1: GP uses driver points as primary ranking criterion within each group.
+  qualificationOrderBy: [{ group: 'asc' }, { points: 'desc' }, { score: 'desc' }],
   // §7.4: Pre-assign a cup to each qualification round at setup time.
   // Cups are shuffled 5 times and assigned sequentially without adjacent repeats.
   assignCupRandomly: true,


### PR DESCRIPTION
## Summary
- make GP qualification ordering group-aware before driver-points ranking
- remove the stale comment saying GP has no group-based qualification ordering
- add regression coverage that GP `_rank` resets inside each group

## Root Cause
`jsmkc2026` GP qualification API returned server `_rank` values computed across all GP groups because `gpConfig.qualificationOrderBy` did not start with `group`. The GP page renders separate group tables and trusts server `_rank`, so Group A/B displayed skipped rank numbers like `1,2,6,9...` and `3,4,5,7...`.

## Live Evidence
Before the fix, `https://smkc.bluemoon.works/api/tournaments/jsmkc2026/gp` returned:
- Group A ranks: `1, 2, 6, 9, 10, 11, 13, 17, 18, 19, 20, 22`
- Group B ranks: `3, 4, 5, 7, 8, 12, 14, 15, 16, 21, 23, 24`

## Validation
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/route.test.ts' '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts' --runInBand`
- `npx eslint src/lib/event-types/gp-config.ts '__tests__/app/api/tournaments/[id]/gp/route.test.ts'` (passes with existing unused-import warning)
