### PR TITLE
Show GP match points in standings

### DIFF
--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -462,6 +462,8 @@
     "w": "W",
     "t": "T",
     "l": "L",
+    "matchPointsShort": "Match Pts",
+    "driverPointsShort": "Driver Pts",
     "pts": "Pts",
     "finalsTitle": "Grand Prix Finals",
     "matchTitle": "Grand Prix - Match #{number}",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -462,6 +462,8 @@
     "w": "勝",
     "t": "引",
     "l": "敗",
+    "matchPointsShort": "勝点",
+    "driverPointsShort": "ドライバー点",
     "pts": "得点",
     "finalsTitle": "グランプリ 決勝",
     "matchTitle": "グランプリ - 試合 #{number}",

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
@@ -829,7 +829,8 @@ export default function GrandPrixPageClient({
                                 <TableHead className="text-center">{t('w')}</TableHead>
                                 <TableHead className="text-center">{t('t')}</TableHead>
                                 <TableHead className="text-center">{t('l')}</TableHead>
-                                <TableHead className="text-center">{t('pts')}</TableHead>
+                                <TableHead className="text-center">{t('matchPointsShort')}</TableHead>
+                                <TableHead className="text-center">{t('driverPointsShort')}</TableHead>
                                 <TableHead className="text-center">{tc('qualificationPointsShort')}</TableHead>
                               </TableRow>
                             </TableHeader>
@@ -855,6 +856,9 @@ export default function GrandPrixPageClient({
                                   <TableCell className="text-center">{q.wins}</TableCell>
                                   <TableCell className="text-center">{q.ties}</TableCell>
                                   <TableCell className="text-center">{q.losses}</TableCell>
+                                  <TableCell className="text-center font-bold">
+                                    {q.score}
+                                  </TableCell>
                                   <TableCell className="text-center font-bold">
                                     {q.points}
                                   </TableCell>
@@ -900,7 +904,8 @@ export default function GrandPrixPageClient({
                           <TableHead className="text-center">{t('w')}</TableHead>
                           <TableHead className="text-center">{t('t')}</TableHead>
                           <TableHead className="text-center">{t('l')}</TableHead>
-                          <TableHead className="text-center">{t('pts')}</TableHead>
+                          <TableHead className="text-center">{t('matchPointsShort')}</TableHead>
+                          <TableHead className="text-center">{t('driverPointsShort')}</TableHead>
                           <TableHead className="text-center">{tc('qualificationPointsShort')}</TableHead>
                         </TableRow>
                       </TableHeader>
@@ -914,6 +919,7 @@ export default function GrandPrixPageClient({
                             <TableCell className="text-center">{q.wins}</TableCell>
                             <TableCell className="text-center">{q.ties}</TableCell>
                             <TableCell className="text-center">{q.losses}</TableCell>
+                            <TableCell className="text-center font-bold">{q.score}</TableCell>
                             <TableCell className="text-center font-bold">{q.points}</TableCell>
                             <TableCell className="text-center font-bold">
                               {getQualificationPoints(q)}


### PR DESCRIPTION
## Summary
- Add GP match-point score columns to both group standings and combined standings
- Split the visible columns into Match Pts and Driver Pts so the score-first ranking rule is visible
- Add Japanese and English labels for the new GP standings columns

## Validation
- npx eslint 'src/app/tournaments/[id]/gp/page-client.tsx'
- node -e "JSON.parse(require('fs').readFileSync('messages/ja.json','utf8')); JSON.parse(require('fs').readFileSync('messages/en.json','utf8')); console.log('messages ok')"