### PR TITLE
[codex] fix GP playoff winners entering Upper bracket

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1265,6 +1265,58 @@ describe('Finals Route Factory', () => {
         ['player-14', 'player-5'],  /* B3 vs A6 */
       ]);
     });
+
+    it('Phase 2: derives playoff winners from configured score fields for GP-style routes', async () => {
+      (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(24));
+      const playoffRows = [
+        ...Array.from({ length: 4 }, (_, i) => ({
+          id: `p-r1-${i}`,
+          matchNumber: i + 1,
+          round: 'playoff_r1',
+          stage: 'playoff',
+          completed: true,
+          points1: 1,
+          points2: 0,
+          score1: 0,
+          score2: 9,
+          player1Id: ['player-8', 'player-21', 'player-20', 'player-9'][i],
+          player2Id: ['player-23', 'player-10', 'player-11', 'player-22'][i],
+          player1: { id: ['player-8', 'player-21', 'player-20', 'player-9'][i] },
+          player2: { id: ['player-23', 'player-10', 'player-11', 'player-22'][i] },
+        })),
+        { id: 'p-r2-5', matchNumber: 5, round: 'playoff_r2', stage: 'playoff', completed: true, points1: 0, points2: 4, score1: 9, score2: 0, player1Id: 'loser-16', player2Id: 'winner-16', player1: { id: 'loser-16' }, player2: { id: 'winner-16' } },
+        { id: 'p-r2-6', matchNumber: 6, round: 'playoff_r2', stage: 'playoff', completed: true, points1: 4, points2: 0, score1: 0, score2: 9, player1Id: 'winner-12', player2Id: 'loser-12', player1: { id: 'winner-12' }, player2: { id: 'loser-12' } },
+        { id: 'p-r2-7', matchNumber: 7, round: 'playoff_r2', stage: 'playoff', completed: true, points1: 0, points2: 4, score1: 9, score2: 0, player1Id: 'loser-14', player2Id: 'winner-14', player1: { id: 'loser-14' }, player2: { id: 'winner-14' } },
+        { id: 'p-r2-8', matchNumber: 8, round: 'playoff_r2', stage: 'playoff', completed: true, points1: 4, points2: 0, score1: 0, score2: 9, player1Id: 'winner-10', player2Id: 'loser-10', player1: { id: 'winner-10' }, player2: { id: 'loser-10' } },
+      ];
+      (prisma.bMMatch as any).findMany.mockImplementation((args: any) => {
+        if (args?.where?.stage === 'finals') return Promise.resolve([]);
+        return Promise.resolve(playoffRows);
+      });
+      (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 31 });
+
+      const config = createMockConfig({
+        putScoreFields: { dbField1: 'points1', dbField2: 'points2' },
+      });
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 24 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(201);
+      const json = await response.json();
+      const seedMap = new Map(json.data.seededPlayers.map((p: { seed: number; playerId: string }) => [p.seed, p.playerId]));
+      expect(seedMap.get(16)).toBe('winner-16');
+      expect(seedMap.get(12)).toBe('winner-12');
+      expect(seedMap.get(14)).toBe('winner-14');
+      expect(seedMap.get(10)).toBe('winner-10');
+    });
   });
 
   // ============================================================

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -82,7 +82,7 @@ import { canResetFinalsFromQualification } from "@/lib/finals-action-availabilit
 import { parseManualScore } from "@/lib/parse-manual-score";
 import type { Player } from "@/lib/types";
 import { buildMatchLabel } from "@/lib/overlay/phase";
-import { getGpFinalsTargetWins } from "@/lib/finals-target-wins";
+import { getGpFinalsMaxCups, getGpFinalsTargetWins } from "@/lib/finals-target-wins";
 import { getCupForFormIndex, isRemovableCupForm, removeCupFormAt } from "@/lib/gp-finals-score-form";
 import { GP_DRIVER_POINTS_INPUT_PROPS } from "@/lib/gp-driver-points-input";
 
@@ -440,7 +440,7 @@ export default function GrandPrixFinals({
     getGpFinalsTargetWins({ round: match?.round, stage: match?.stage ?? "finals" });
 
   const getLockedCupCountForMatch = (match?: Pick<GPMatch, "round"> & { stage?: string | null } | null) =>
-    getTargetWinsForMatch(match);
+    getGpFinalsMaxCups({ round: match?.round, stage: match?.stage ?? "finals" });
 
   const usesCupWinScoreOnly = (match?: Pick<GPMatch, "stage"> | null) =>
     match?.stage !== "playoff";

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -571,6 +571,26 @@ export function createFinalsHandlers(config: FinalsConfig) {
       : { p1: 'score1', p2: 'score2' };
   }
 
+  function getCompletedMatchWinner(
+    match: Record<string, unknown>,
+  ): { winnerId: string; winnerPlayer: unknown } | null {
+    const score1 = Number(match[config.putScoreFields.dbField1]);
+    const score2 = Number(match[config.putScoreFields.dbField2]);
+    if (!Number.isFinite(score1) || !Number.isFinite(score2) || score1 === score2) {
+      return null;
+    }
+
+    const winnerId = score1 > score2 ? match.player1Id : match.player2Id;
+    if (typeof winnerId !== 'string' || winnerId.length === 0) {
+      return null;
+    }
+
+    return {
+      winnerId,
+      winnerPlayer: match.player1Id === winnerId ? match.player1 : match.player2,
+    };
+  }
+
   function hasAutomaticRankTies(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     qualifications: any[],
@@ -718,13 +738,13 @@ export function createFinalsHandlers(config: FinalsConfig) {
         );
         if (!dbMatch?.completed) continue;
 
-        const winnerId = dbMatch.score1 >= dbMatch.score2 ? dbMatch.player1Id : dbMatch.player2Id;
-        const winnerPlayer = dbMatch.player1Id === winnerId ? dbMatch.player1 : dbMatch.player2;
+        const winner = getCompletedMatchWinner(dbMatch);
+        if (!winner) continue;
         seededPlayers.push({
           seed: r2BracketMatch.advancesToUpperSeed,
-          playerId: winnerId,
-          player: winnerPlayer,
-          qualificationRankLabel: qualificationRankLabels.get(winnerId),
+          playerId: winner.winnerId,
+          player: winner.winnerPlayer,
+          qualificationRankLabel: qualificationRankLabels.get(winner.winnerId),
         });
       }
 
@@ -1476,11 +1496,13 @@ export function createFinalsHandlers(config: FinalsConfig) {
           (m: { matchNumber: number }) => m.matchNumber === r2BracketMatch.matchNumber,
         );
         if (!dbMatch || !r2BracketMatch.advancesToUpperSeed) continue;
-        const winnerId = dbMatch.score1 >= dbMatch.score2 ? dbMatch.player1Id : dbMatch.player2Id;
-        const winnerPlayer = dbMatch.player1Id === winnerId ? dbMatch.player1 : dbMatch.player2;
+        const winner = getCompletedMatchWinner(dbMatch);
+        if (!winner) {
+          throw new Error(`Playoff winner for match ${r2BracketMatch.matchNumber} not resolved`);
+        }
         upperSeedToPlayer.set(r2BracketMatch.advancesToUpperSeed, {
-          playerId: winnerId,
-          player: winnerPlayer,
+          playerId: winner.winnerId,
+          player: winner.winnerPlayer,
         });
       }
 


### PR DESCRIPTION
## Summary
- Fix Top-24 Phase 2 winner resolution to use the configured match score fields instead of hard-coded score1/score2.
- Add regression coverage for GP-style points1/points2 playoff winners when filling Upper bracket barrage slots.
- Show the full seeded GP cup form count up front: FT1 = 1 cup, FT2 = 3 cups, FT3 = 5 cups.

## Root Cause
GP playoff rows store resolved cup wins in points1/points2, but the Top-24 Upper bracket creation path was reading score1/score2. That could place the playoff loser into the Upper bracket. The score dialog also locked only the FT target count instead of the maximum number of cups needed to decide that FT, so FT2 opened with too few cup forms.

## Validation
- npm test -- --runTestsByPath __tests__/lib/api-factories/finals-route.test.ts --runInBand
- npm test -- --runTestsByPath __tests__/lib/gp-finals-score-form.test.ts __tests__/lib/finals-target-wins.test.ts --runInBand
- npx eslint src/app/tournaments/[id]/gp/finals/page.tsx src/lib/finals-target-wins.ts src/lib/gp-finals-score-form.ts
- Production hotfix deployed to smkc.bluemoon.works and jsmkc2026 Upper bracket data was corrected separately after D1 backup.