### PR TITLE
[codex] Restore GP finals assigned cup display

### DIFF
--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -456,6 +456,7 @@
     "manualScoreValidation": "Manual total scores must be non-negative integers.",
     "manualScoreSaveFailed": "Failed to save the manual total score.",
     "cupWinsScore": "Cups won",
+    "assignedCups": "Assigned cups",
     "createGroupsAndMatches": "Create Groups & Matches",
     "noGroupsYet": "No groups set up yet. Click \"Setup Groups\" to begin.",
     "noGroupsYetViewer": "No groups set up yet. Please wait until the setup is complete.",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -456,6 +456,7 @@
     "manualScoreValidation": "手動入力の合計ポイントは 0 以上の整数で入力してください。",
     "manualScoreSaveFailed": "合計ポイントの手動保存に失敗しました。",
     "cupWinsScore": "取得カップ数",
+    "assignedCups": "選ばれたカップ",
     "createGroupsAndMatches": "グループ＆試合作成",
     "noGroupsYet": "グループがまだ設定されていません。「グループ設定」をクリックして開始してください。",
     "noGroupsYetViewer": "グループがまだ設定されていません。セットアップが完了するまでお待ちください。",

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -445,6 +445,12 @@ export default function GrandPrixFinals({
   const usesCupWinScoreOnly = (match?: Pick<GPMatch, "stage"> | null) =>
     match?.stage !== "playoff";
 
+  const getAssignedCupLabelsForMatch = (match: GPMatch): string[] => {
+    const assigned = Array.isArray(match.assignedCups) ? match.assignedCups.filter(Boolean) : [];
+    if (assigned.length > 0) return assigned;
+    return match.cup ? [match.cup] : [];
+  };
+
   const calculateCupPoints = (cup: CupScoreForm) => {
     if (cup.manualEnabled) {
       const p1 = parseManualScore(cup.manualPoints1);
@@ -946,6 +952,18 @@ export default function GrandPrixFinals({
                   </div>
                   <Badge variant="outline">FT{selectedMatchTargetWins}</Badge>
                 </div>
+                {getAssignedCupLabelsForMatch(selectedMatch).length > 0 && (
+                  <div className="space-y-2">
+                    <div className="text-xs font-medium text-muted-foreground">{tGp('assignedCups')}</div>
+                    <div className="flex flex-wrap gap-2">
+                      {getAssignedCupLabelsForMatch(selectedMatch).map((cup, index) => (
+                        <Badge key={`${selectedMatch.id}-assigned-cup-${index}-${cup}`} variant="secondary">
+                          {index + 1}. {tGp('cupLabel', { cup })}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
                 <div className="grid gap-4 md:grid-cols-[1fr_auto_1fr] md:items-end">
                   <div className="space-y-2">
                     <Label htmlFor="gp-finals-simple-score1">{selectedMatch.player1.nickname}</Label>


### PR DESCRIPTION
## Summary
- restore the selected/assigned cup sequence in the GP upper-bracket score dialog
- keep the simplified cup-win score input (`2-0`, `2-1`, etc.) unchanged
- add English/Japanese labels for the assigned-cup display

## Validation
- `npx eslint 'src/app/tournaments/[id]/gp/finals/page.tsx'`
- `npm test -- --runInBand --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts'`
- `npx eslint 'src/app/tournaments/[id]/gp/finals/page.tsx' 'src/app/api/tournaments/[id]/gp/finals/route.ts' '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts'`
- `npm run deploy` deployed Cloudflare Worker version `90c909c8-66b4-4b61-acc6-ca9e3066c4a1`
- `curl -I https://smkc.bluemoon.works/tournaments` returned HTTP 200
