### PR TITLE
Add R2 tournament archives

### DIFF
--- a/smkc-score-app/__tests__/lib/tournament-archive.test.ts
+++ b/smkc-score-app/__tests__/lib/tournament-archive.test.ts
@@ -1,0 +1,99 @@
+import {
+  getTournamentArchiveKeys,
+  readTournamentArchive,
+  TOURNAMENT_ARCHIVE_SCHEMA_VERSION,
+  type TournamentArchiveBundle,
+} from "@/lib/tournament-archive";
+
+const objects = new Map<string, unknown>();
+
+jest.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: () => ({
+    env: {
+      ARCHIVE_BUCKET: {
+        get: jest.fn(async (key: string) => {
+          if (!objects.has(key)) return null;
+          return { json: async () => objects.get(key) };
+        }),
+        put: jest.fn(async (key: string, value: string) => {
+          objects.set(key, JSON.parse(value));
+        }),
+      },
+    },
+  }),
+}));
+
+function makeArchive(overrides: Partial<TournamentArchiveBundle> = {}): TournamentArchiveBundle {
+  return {
+    schemaVersion: TOURNAMENT_ARCHIVE_SCHEMA_VERSION,
+    generatedAt: "2026-05-07T00:00:00.000Z",
+    tournament: {
+      id: "tournament-1",
+      slug: "jsmkc2026",
+      name: "JSMKC 2026",
+      date: "2026-05-07T00:00:00.000Z",
+      status: "completed",
+      publicModes: ["ta", "bm", "mr", "gp", "overall"],
+      frozenStages: [],
+      taPlayerSelfEdit: true,
+      bmQualificationConfirmed: true,
+      mrQualificationConfirmed: true,
+      gpQualificationConfirmed: true,
+      createdAt: "2026-05-07T00:00:00.000Z",
+      updatedAt: "2026-05-07T00:00:00.000Z",
+    },
+    allPlayers: [],
+    modes: {
+      ta: {
+        entries: [],
+        phaseRounds: [],
+        courses: [],
+        qualificationRegistrationLocked: true,
+        qualificationEditingLockedForPlayers: true,
+        frozenStages: [],
+        taPlayerSelfEdit: true,
+      },
+      bm: { qualifications: [], matches: [], qualificationConfirmed: true },
+      mr: { qualifications: [], matches: [], qualificationConfirmed: true },
+      gp: { qualifications: [], matches: [], qualificationConfirmed: true },
+    },
+    overallRanking: {
+      tournamentId: "tournament-1",
+      tournamentName: "JSMKC 2026",
+      lastUpdated: "2026-05-07T00:00:00.000Z",
+      rankings: [],
+    },
+    archived: true,
+    ...overrides,
+  };
+}
+
+describe("tournament archive", () => {
+  beforeEach(() => {
+    objects.clear();
+  });
+
+  it("stores latest archive keys by id and slug", () => {
+    expect(getTournamentArchiveKeys({ id: "tournament-1", slug: "jsmkc2026" })).toEqual([
+      "archives/by-id/tournament-1/latest.json",
+      "archives/by-slug/jsmkc2026/latest.json",
+    ]);
+  });
+
+  it("can read an archive by slug when the schema version is supported", async () => {
+    const archive = makeArchive();
+    objects.set("archives/by-slug/jsmkc2026/latest.json", archive);
+
+    await expect(readTournamentArchive("jsmkc2026")).resolves.toEqual(archive);
+  });
+
+  it("ignores unsupported archive shapes", async () => {
+    objects.set("archives/by-id/tournament-1/latest.json", {
+      schemaVersion: 999,
+      tournament: {},
+      modes: {},
+    });
+
+    await expect(readTournamentArchive("tournament-1")).resolves.toBeNull();
+  });
+});

--- a/smkc-score-app/src/app/api/tournaments/[id]/archive/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/archive/route.ts
@@ -1,0 +1,57 @@
+/**
+ * Tournament Archive API Route
+ *
+ * GET  /api/tournaments/[id]/archive - Read the immutable R2 archive bundle.
+ * POST /api/tournaments/[id]/archive - Regenerate the archive for a completed tournament.
+ */
+import { NextRequest } from "next/server";
+import { auth } from "@/lib/auth";
+import { createErrorResponse, createSuccessResponse, handleAuthError, handleAuthzError } from "@/lib/error-handling";
+import { persistTournamentArchive, readTournamentArchive } from "@/lib/tournament-archive";
+import { resolveTournament } from "@/lib/tournament-identifier";
+import { createLogger } from "@/lib/logger";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const archive = await readTournamentArchive(id);
+  if (!archive) {
+    return createErrorResponse("Tournament archive not found", 404, "NOT_FOUND");
+  }
+
+  const publicModes = archive.tournament.publicModes as string[] || [];
+  if (publicModes.length === 0) {
+    return handleAuthzError("This archived tournament has no visible modes");
+  }
+
+  return createSuccessResponse(archive);
+}
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const logger = createLogger("tournament-archive-api");
+  const session = await auth();
+  if (!session?.user) return handleAuthError("Authentication required");
+  if (session.user.role !== "admin") return handleAuthzError();
+
+  const { id } = await params;
+  const tournament = await resolveTournament(id, { id: true, status: true });
+  if (!tournament) {
+    return createErrorResponse("Tournament not found", 404, "NOT_FOUND");
+  }
+  if (tournament.status !== "completed") {
+    return createErrorResponse("Only completed tournaments can be archived", 409, "CONFLICT");
+  }
+
+  try {
+    const archive = await persistTournamentArchive(tournament.id);
+    return createSuccessResponse(archive);
+  } catch (error) {
+    logger.error("Failed to persist tournament archive", { error, tournamentId: tournament.id });
+    return createErrorResponse("Failed to persist tournament archive", 500, "INTERNAL_ERROR");
+  }
+}

--- a/smkc-score-app/src/app/api/tournaments/[id]/overall-ranking/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/overall-ranking/route.ts
@@ -34,6 +34,7 @@ import {
 } from "@/lib/error-handling";
 import { resolveTournament } from "@/lib/tournament-identifier";
 import { withApiTiming } from "@/lib/perf/api-timing";
+import { readTournamentArchive } from "@/lib/tournament-archive";
 
 /**
  * GET /api/tournaments/[id]/overall-ranking
@@ -61,6 +62,10 @@ async function handleGET(
     });
 
     if (!tournament) {
+      const archived = await readTournamentArchive(id);
+      if (archived) {
+        return createSuccessResponse({ ...archived.overallRanking, archived: true });
+      }
       return createErrorResponse("Tournament not found", 404);
     }
     const session = await auth();
@@ -92,6 +97,10 @@ async function handleGET(
     });
   } catch (error) {
     logger.error("Failed to fetch overall rankings", { error, tournamentId: id });
+    const archived = await readTournamentArchive(id);
+    if (archived) {
+      return createSuccessResponse({ ...archived.overallRanking, archived: true });
+    }
     return createErrorResponse("Failed to fetch overall rankings", 500);
   }
 }

--- a/smkc-score-app/src/app/api/tournaments/[id]/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/route.ts
@@ -29,6 +29,11 @@ import {
   handleValidationError,
 } from "@/lib/error-handling";
 import { isValidPublicModes } from "@/lib/public-modes";
+import {
+  getArchivedTournamentSummary,
+  persistTournamentArchive,
+  readTournamentArchive,
+} from "@/lib/tournament-archive";
 
 /**
  * GET /api/tournaments/:id
@@ -132,6 +137,10 @@ export async function GET(
     );
 
     if (!tournament) {
+      const archived = await readTournamentArchive(identifier);
+      if (archived) {
+        return createSuccessResponse(getArchivedTournamentSummary(archived, isSummary));
+      }
       return createErrorResponse("Tournament not found", 404);
     }
 
@@ -163,6 +172,12 @@ export async function GET(
   } catch (error) {
     // Log with tournament ID for easy filtering in log aggregation
     logger.error("Failed to fetch tournament", { error, id: resolvedId });
+    const archived = await readTournamentArchive(identifier);
+    if (archived) {
+      return createSuccessResponse(
+        getArchivedTournamentSummary(archived, new URL(request.url).searchParams.get('fields') === 'summary')
+      );
+    }
     return createErrorResponse("Failed to fetch tournament", 500);
   }
 }
@@ -276,6 +291,17 @@ export async function PUT(
         ...(debugMode !== undefined && { debugMode: debugMode === true }),
       },
     });
+
+    if (status === "completed") {
+      try {
+        await persistTournamentArchive(resolvedId);
+      } catch (archiveError) {
+        logger.warn("Failed to persist tournament archive", {
+          error: archiveError,
+          id: resolvedId,
+        });
+      }
+    }
 
     // Audit log for the update operation — fire-and-forget via .catch()
     try {

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
@@ -51,6 +51,7 @@ import { RETRY_PENALTY_MS } from "@/lib/constants";
 import { resolveTournamentId } from "@/lib/tournament-identifier";
 import { resolveAuditUserId } from "@/lib/audit-log";
 import type { Session } from "next-auth";
+import { readTournamentArchive } from "@/lib/tournament-archive";
 
 function normalizePhaseRound<T extends { results: unknown; eliminatedIds?: unknown }>(round: T) {
   return {
@@ -145,6 +146,56 @@ async function requireAdminAndGetSession(): Promise<{
 
 /** Valid phase names for URL query parameters and request bodies */
 const PhaseSchema = z.enum(["phase1", "phase2", "phase3"]);
+type PhaseName = z.infer<typeof PhaseSchema>;
+
+function summarizeArchivedPhase(entries: unknown[], phase: PhaseName) {
+  const phaseEntries = entries.filter((entry) => (entry as { stage?: unknown }).stage === phase);
+  if (phaseEntries.length === 0) return null;
+  const activeEntry = phaseEntries.find((entry) => (entry as { eliminated?: unknown }).eliminated !== true);
+  const active = phaseEntries.filter((entry) => (entry as { eliminated?: unknown }).eliminated !== true).length;
+  const winner = phase === "phase3" && active === 1
+    ? ((activeEntry as { player?: { nickname?: string } } | undefined)?.player?.nickname ?? null)
+    : null;
+  return {
+    total: phaseEntries.length,
+    active,
+    eliminated: phaseEntries.length - active,
+    ...(phase === "phase3" ? { winner } : {}),
+  };
+}
+
+async function getArchivedPhaseResponse(id: string, phase?: PhaseName) {
+  const archive = await readTournamentArchive(id);
+  if (!archive) return null;
+
+  const entries = archive.modes.ta.entries ?? [];
+  const rounds = archive.modes.ta.phaseRounds ?? [];
+  const response: Record<string, unknown> = {
+    phaseStatus: {
+      phase1: summarizeArchivedPhase(entries, "phase1"),
+      phase2: summarizeArchivedPhase(entries, "phase2"),
+      phase3: summarizeArchivedPhase(entries, "phase3"),
+      currentPhase: "completed",
+    },
+    archived: true,
+  };
+
+  if (phase) {
+    const phaseEntries = entries.filter((entry) => (entry as { stage?: unknown }).stage === phase);
+    const phaseRounds = rounds
+      .filter((round) => (round as { phase?: unknown }).phase === phase)
+      .map((round) => normalizePhaseRound(round as { results: unknown; eliminatedIds?: unknown }));
+    const playedCourses = phaseRounds
+      .map((round) => (round as { course?: unknown }).course)
+      .filter((course): course is string => typeof course === "string");
+    response.entries = sortPhaseEntriesForDisplay(phaseEntries as never[], phaseRounds as never[]);
+    response.rounds = phaseRounds;
+    response.availableCourses = getAvailableCourses(playedCourses);
+    response.playedCourses = playedCourses;
+  }
+
+  return response;
+}
 
 /**
  * POST request body schema.
@@ -270,6 +321,10 @@ export async function GET(
     );
 
     if (!tournament) {
+      const archived = await getArchivedPhaseResponse(id, phase?.success ? phase.data : undefined);
+      if (archived) {
+        return createSuccessResponse(archived);
+      }
       return createErrorResponse("Tournament not found", 404);
     }
 
@@ -354,6 +409,12 @@ export async function GET(
       stack: err instanceof Error ? err.stack : undefined,
       tournamentId,
     });
+    const { searchParams } = new URL(request.url);
+    const phase = PhaseSchema.safeParse(searchParams.get("phase"));
+    const archived = await getArchivedPhaseResponse(id, phase.success ? phase.data : undefined);
+    if (archived) {
+      return createSuccessResponse(archived);
+    }
     return createErrorResponse("Internal server error", 500);
   }
 }

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
@@ -38,6 +38,7 @@ import { checkStageFrozen } from "@/lib/ta/freeze-check";
 import { createErrorResponse, createSuccessResponse } from "@/lib/error-handling";
 import { resolveTournamentId, resolveTournament } from "@/lib/tournament-identifier";
 import { withApiTiming } from "@/lib/perf/api-timing";
+import { getArchivedModePayload, readTournamentArchive } from "@/lib/tournament-archive";
 
 const KNOCKOUT_STAGES = ["phase1", "phase2", "phase3"] as const;
 
@@ -205,6 +206,10 @@ async function handleGET(
   } catch (error) {
     // Use structured logging for error tracking and debugging
     logger.error("Failed to fetch TA data", { error, tournamentId: id });
+    const archived = await readTournamentArchive(id);
+    if (archived) {
+      return createSuccessResponse(getArchivedModePayload(archived, "ta"));
+    }
     return createErrorResponse("Failed to fetch time attack data", 500, "INTERNAL_ERROR");
   }
 }

--- a/smkc-score-app/src/app/api/tournaments/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/route.ts
@@ -20,6 +20,7 @@ import { sanitizeInput } from "@/lib/sanitize";
 import { paginate } from "@/lib/pagination";
 import { createLogger } from "@/lib/logger";
 import { isValidTournamentSlug, normalizeTournamentSlug } from "@/lib/tournament-identifier";
+import { readTournamentArchiveIndex } from "@/lib/tournament-archive";
 import {
   createSuccessResponse,
   createErrorResponse,
@@ -77,6 +78,19 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     // Log error with structured metadata for monitoring
     logger.error("Failed to fetch tournaments", { error });
+    const archived = await readTournamentArchiveIndex();
+    if (archived.length > 0) {
+      return createSuccessResponse({
+        data: archived,
+        meta: {
+          page: 1,
+          limit: archived.length,
+          total: archived.length,
+          totalPages: 1,
+        },
+        archived: true,
+      });
+    }
     return createErrorResponse("Failed to fetch tournaments", 500);
   }
 }

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page-client.tsx
@@ -180,28 +180,30 @@ export default function BattleModePageClient({
    * This is the polling function called at the standard interval for live updates.
    */
   const fetchTournamentData = useCallback(async () => {
-    const [bmResponse, playersResponse] = await Promise.all([
-      fetchWithRetry(`/api/tournaments/${tournamentId}/bm`),
-      /* limit=100 (API cap) avoids truncating the Setup dialog player list — see ta/page.tsx for rationale. */
-      fetchWithRetry("/api/players?limit=100"),
-    ]);
+    const bmResponse = await fetchWithRetry(`/api/tournaments/${tournamentId}/bm`);
 
     if (!bmResponse.ok) {
       throw new Error(`Failed to fetch BM data: ${bmResponse.status}`);
     }
 
-    if (!playersResponse.ok) {
-      throw new Error(`Failed to fetch players: ${playersResponse.status}`);
-    }
-
     const bmJson = await bmResponse.json();
     const bmData = bmJson.data ?? bmJson;
-    const playersJson = await playersResponse.json();
+    let allPlayers = bmData.allPlayers || [];
+    try {
+      /* limit=100 (API cap) avoids truncating the Setup dialog player list — see ta/page.tsx for rationale. */
+      const playersResponse = await fetchWithRetry("/api/players?limit=100");
+      if (playersResponse.ok) {
+        const playersJson = await playersResponse.json();
+        allPlayers = extractArrayData<Player>(playersJson);
+      }
+    } catch {
+      // Archived mode payloads carry the tournament players, so read-only pages can survive DB outages.
+    }
 
     return {
       qualifications: bmData.qualifications || [],
       matches: bmData.matches || [],
-      allPlayers: extractArrayData<Player>(playersJson),
+      allPlayers,
       qualificationConfirmed: bmData.qualificationConfirmed ?? false,
     };
   }, [tournamentId]);

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
@@ -205,28 +205,30 @@ export default function GrandPrixPageClient({
    * Returns qualification standings, matches, and all registered players.
    */
   const fetchTournamentData = useCallback(async () => {
-    const [gpResponse, playersResponse] = await Promise.all([
-      fetchWithRetry(`/api/tournaments/${tournamentId}/gp`),
-      /* limit=100 (API cap) avoids truncating the Setup dialog player list — see ta/page.tsx for rationale. */
-      fetchWithRetry("/api/players?limit=100"),
-    ]);
+    const gpResponse = await fetchWithRetry(`/api/tournaments/${tournamentId}/gp`);
 
     if (!gpResponse.ok) {
       throw new Error(`Failed to fetch GP data: ${gpResponse.status}`);
     }
 
-    if (!playersResponse.ok) {
-      throw new Error(`Failed to fetch players: ${playersResponse.status}`);
-    }
-
     const gpJson = await gpResponse.json();
     const gpData = gpJson.data ?? gpJson;
-    const playersJson = await playersResponse.json();
+    let allPlayers = gpData.allPlayers || [];
+    try {
+      /* limit=100 (API cap) avoids truncating the Setup dialog player list — see ta/page.tsx for rationale. */
+      const playersResponse = await fetchWithRetry("/api/players?limit=100");
+      if (playersResponse.ok) {
+        const playersJson = await playersResponse.json();
+        allPlayers = extractArrayData<Player>(playersJson);
+      }
+    } catch {
+      // Archived mode payloads carry the tournament players, so read-only pages can survive DB outages.
+    }
 
     return {
       qualifications: gpData.qualifications || [],
       matches: gpData.matches || [],
-      allPlayers: extractArrayData<Player>(playersJson),
+      allPlayers,
       qualificationConfirmed: gpData.qualificationConfirmed ?? false,
     };
   }, [tournamentId]);

--- a/smkc-score-app/src/app/tournaments/[id]/mr/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/page-client.tsx
@@ -178,28 +178,30 @@ export default function MatchRacePageClient({
    * Called by the polling hook for real-time updates.
    */
   const fetchTournamentData = useCallback(async () => {
-    const [mrResponse, playersResponse] = await Promise.all([
-      fetchWithRetry(`/api/tournaments/${tournamentId}/mr`),
-      /* limit=100 (API cap) avoids truncating the Setup dialog player list — see ta/page.tsx for rationale. */
-      fetchWithRetry("/api/players?limit=100"),
-    ]);
+    const mrResponse = await fetchWithRetry(`/api/tournaments/${tournamentId}/mr`);
 
     if (!mrResponse.ok) {
       throw new Error(`Failed to fetch MR data: ${mrResponse.status}`);
     }
 
-    if (!playersResponse.ok) {
-      throw new Error(`Failed to fetch players: ${playersResponse.status}`);
-    }
-
     const mrJson = await mrResponse.json();
     const mrData = mrJson.data ?? mrJson;
-    const playersJson = await playersResponse.json();
+    let allPlayers = mrData.allPlayers || [];
+    try {
+      /* limit=100 (API cap) avoids truncating the Setup dialog player list — see ta/page.tsx for rationale. */
+      const playersResponse = await fetchWithRetry("/api/players?limit=100");
+      if (playersResponse.ok) {
+        const playersJson = await playersResponse.json();
+        allPlayers = extractArrayData<Player>(playersJson);
+      }
+    } catch {
+      // Archived mode payloads carry the tournament players, so read-only pages can survive DB outages.
+    }
 
     return {
       qualifications: mrData.qualifications || [],
       matches: mrData.matches || [],
-      allPlayers: extractArrayData<Player>(playersJson),
+      allPlayers,
       qualificationConfirmed: mrData.qualificationConfirmed ?? false,
     };
   }, [tournamentId]);

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
@@ -206,35 +206,36 @@ export default function TimeAttackPageClient({
   // === Data Fetching ===
   // Fetch tournament data and player list in parallel
   const fetchTournamentData = useCallback(async () => {
-    const [taResponse, playersResponse] = await Promise.all([
-      fetchWithRetry(`/api/tournaments/${tournamentId}/ta?stage=qualification`),
-      /* limit=100 is the API's hard cap (src/lib/pagination.ts). The default of 50
-       * silently truncates the Setup Players search once the roster grows past
-       * that — newly-created players end up paginated out and can no longer be
-       * added from the dialog. Request the max in one hop; if a deployment
-       * ever needs >100, the dialog must switch to server-side search instead. */
-      fetchWithRetry("/api/players?limit=100"),
-    ]);
+    const taResponse = await fetchWithRetry(`/api/tournaments/${tournamentId}/ta?stage=qualification`);
 
     if (!taResponse.ok) {
       const errorData = await taResponse.json().catch(() => ({}));
       throw new Error(errorData.error || `Failed to fetch TA data: ${taResponse.status}`);
     }
 
-    if (!playersResponse.ok) {
-      const errorData = await playersResponse.json().catch(() => ({}));
-      throw new Error(errorData.error || `Failed to fetch players: ${playersResponse.status}`);
-    }
-
     const taJson = await taResponse.json();
-    const playersJson = await playersResponse.json();
 
     // Unwrap createSuccessResponse wrapper: { success, data: { entries, ... } }
     const taData = taJson.data ?? taJson;
+    let allPlayers = taData.allPlayers || [];
+    try {
+      /* limit=100 is the API's hard cap (src/lib/pagination.ts). The default of 50
+       * silently truncates the Setup Players search once the roster grows past
+       * that — newly-created players end up paginated out and can no longer be
+       * added from the dialog. Request the max in one hop; if a deployment
+       * ever needs >100, the dialog must switch to server-side search instead. */
+      const playersResponse = await fetchWithRetry("/api/players?limit=100");
+      if (playersResponse.ok) {
+        const playersJson = await playersResponse.json();
+        allPlayers = extractArrayData<Player>(playersJson);
+      }
+    } catch {
+      // Archived mode payloads carry the tournament players, so read-only pages can survive DB outages.
+    }
 
     return {
       entries: taData.entries || [],
-      allPlayers: extractArrayData<Player>(playersJson),
+      allPlayers,
       qualificationRegistrationLocked: taData.qualificationRegistrationLocked || false,
       frozenStages: taData.frozenStages || [],
       taPlayerSelfEdit: taData.taPlayerSelfEdit ?? true,

--- a/smkc-score-app/src/env.d.ts
+++ b/smkc-score-app/src/env.d.ts
@@ -7,11 +7,12 @@
  * rather than adding it to tsconfig types[], which would globally override
  * DOM types (Response, Request, etc.) and break existing API route code.
  */
-import type { D1Database } from '@cloudflare/workers-types';
+import type { D1Database, R2Bucket } from '@cloudflare/workers-types';
 
 declare global {
   interface CloudflareEnv {
     DB: D1Database;
+    ARCHIVE_BUCKET?: R2Bucket;
   }
 }
 

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -33,6 +33,7 @@ import { checkQualificationConfirmed } from '@/lib/qualification-confirmed-check
 import { computeQualificationRanks } from '@/lib/server-ranking';
 import { invalidateOverallRankingsCache } from '@/lib/points/overall-ranking';
 import { COURSES, CUPS, MAX_TV_NUMBER } from '@/lib/constants';
+import { getArchivedFinalsPayload, readTournamentArchive } from '@/lib/tournament-archive';
 
 /**
  * Bracket size inference thresholds.
@@ -777,13 +778,31 @@ export function createFinalsHandlers(config: FinalsConfig) {
       | 'mrQualificationConfirmed'
       | 'gpQualificationConfirmed';
     // Select all three flags explicitly to avoid computed-key type inference issues with Prisma generics.
-    const tournament = await resolveTournament(id, {
-      id: true,
-      bmQualificationConfirmed: true,
-      mrQualificationConfirmed: true,
-      gpQualificationConfirmed: true,
-    });
+    let tournament;
+    try {
+      tournament = await resolveTournament(id, {
+        id: true,
+        bmQualificationConfirmed: true,
+        mrQualificationConfirmed: true,
+        gpQualificationConfirmed: true,
+      });
+    } catch (error) {
+      logger.error(config.getErrorMessage, { error, tournamentId: id });
+      const archived = await readTournamentArchive(id);
+      if (archived) {
+        return createSuccessResponse(
+          getArchivedFinalsPayload(archived, config.eventTypeCode, config.getStyle)
+        );
+      }
+      return createErrorResponse(config.getErrorMessage, 500, 'INTERNAL_ERROR');
+    }
     if (!tournament) {
+      const archived = await readTournamentArchive(id);
+      if (archived) {
+        return createSuccessResponse(
+          getArchivedFinalsPayload(archived, config.eventTypeCode, config.getStyle)
+        );
+      }
       return createErrorResponse('Tournament not found', 404, 'NOT_FOUND');
     }
     const tournamentId = tournament.id;
@@ -1087,6 +1106,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
       });
     } catch (error) {
       logger.error(config.getErrorMessage, { error, tournamentId });
+      const archived = await readTournamentArchive(id);
+      if (archived) {
+        return createSuccessResponse(
+          getArchivedFinalsPayload(archived, config.eventTypeCode, config.getStyle)
+        );
+      }
       return createErrorResponse(config.getErrorMessage, 500, 'INTERNAL_ERROR');
     }
   }

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -26,6 +26,7 @@ import { checkQualificationConfirmed } from '@/lib/qualification-confirmed-check
 import { generateETag, invalidate } from '@/lib/standings-cache';
 import { invalidateOverallRankingsCache } from '@/lib/points/overall-ranking';
 import { computeQualificationRanks } from '@/lib/server-ranking';
+import { getArchivedModePayload, readTournamentArchive } from '@/lib/tournament-archive';
 import { bulkUpdateQualificationStats } from '@/lib/api-factories/score-report-helpers';
 import {
   generateRoundRobinSchedule,
@@ -302,6 +303,10 @@ export function createQualificationHandlers(config: EventTypeConfig) {
         gpQualificationConfirmed: true,
       });
       if (!tournament) {
+        const archived = await readTournamentArchive(id);
+        if (archived) {
+          return createSuccessResponse(getArchivedModePayload(archived, config.eventTypeCode));
+        }
         return createErrorResponse(`${config.eventDisplayName} tournament not found`, 404, 'NOT_FOUND');
       }
       tournamentId = tournament.id;
@@ -361,6 +366,10 @@ export function createQualificationHandlers(config: EventTypeConfig) {
       return response;
     } catch (error) {
       logger.error(`Failed to fetch ${config.eventDisplayName} data`, { error, tournamentId });
+      const archived = await readTournamentArchive(id);
+      if (archived) {
+        return createSuccessResponse(getArchivedModePayload(archived, config.eventTypeCode));
+      }
       return createErrorResponse(`Failed to fetch ${config.eventDisplayName} data`, 500, 'INTERNAL_ERROR');
     }
   }

--- a/smkc-score-app/src/lib/tournament-archive.ts
+++ b/smkc-score-app/src/lib/tournament-archive.ts
@@ -1,0 +1,421 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import type { R2Bucket } from "@cloudflare/workers-types";
+import prisma from "@/lib/prisma";
+import { PLAYER_PUBLIC_SELECT } from "@/lib/prisma-selects";
+import { computeQualificationRanks } from "@/lib/server-ranking";
+import { getOverallRankings } from "@/lib/points/overall-ranking";
+import { COURSES } from "@/lib/constants";
+import { generateBracketStructure, generatePlayoffStructure, roundNames } from "@/lib/double-elimination";
+
+export const TOURNAMENT_ARCHIVE_SCHEMA_VERSION = 1;
+const twoPlayerQualificationOrder = () => [{ group: "asc" }, { score: "desc" }, { points: "desc" }] as const;
+const GP_MATCH_SCORE_FIELDS = { p1: "points1", p2: "points2" };
+
+export type TournamentArchiveModePayload = {
+  qualifications?: unknown[];
+  matches?: unknown[];
+  entries?: unknown[];
+  phaseRounds?: unknown[];
+  qualificationConfirmed?: boolean;
+};
+
+export type TournamentArchiveBundle = {
+  schemaVersion: 1;
+  generatedAt: string;
+  tournament: {
+    id: string;
+    slug: string | null;
+    name: string;
+    date: string | Date;
+    status: string;
+    publicModes: unknown;
+    frozenStages: unknown;
+    taPlayerSelfEdit: boolean;
+    bmQualificationConfirmed: boolean;
+    mrQualificationConfirmed: boolean;
+    gpQualificationConfirmed: boolean;
+    createdAt: string | Date;
+    updatedAt: string | Date;
+  };
+  allPlayers: unknown[];
+  modes: {
+    ta: TournamentArchiveModePayload & {
+      courses: typeof COURSES;
+      qualificationRegistrationLocked: boolean;
+      qualificationEditingLockedForPlayers: boolean;
+      frozenStages: unknown;
+      taPlayerSelfEdit: boolean;
+    };
+    bm: TournamentArchiveModePayload;
+    mr: TournamentArchiveModePayload;
+    gp: TournamentArchiveModePayload;
+  };
+  overallRanking: {
+    tournamentId: string;
+    tournamentName: string;
+    lastUpdated: string;
+    rankings: unknown[];
+  };
+  archived: true;
+};
+
+export type TournamentArchiveIndexItem = {
+  id: string;
+  slug: string | null;
+  name: string;
+  date: string | Date;
+  status: "completed";
+  publicModes: unknown;
+  createdAt: string | Date;
+  archivedAt: string;
+};
+
+type ArchiveBucketEnv = CloudflareEnv & { ARCHIVE_BUCKET?: R2Bucket };
+
+function getArchiveBucket(): R2Bucket | null {
+  try {
+    const { env } = getCloudflareContext();
+    return (env as ArchiveBucketEnv).ARCHIVE_BUCKET ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function getTournamentArchiveKeys(tournament: { id: string; slug?: string | null }) {
+  const keys = [`archives/by-id/${tournament.id}/latest.json`];
+  if (tournament.slug) {
+    keys.push(`archives/by-slug/${tournament.slug}/latest.json`);
+  }
+  return keys;
+}
+
+function archiveLookupKeys(identifier: string) {
+  return [
+    `archives/by-id/${identifier}/latest.json`,
+    `archives/by-slug/${identifier}/latest.json`,
+  ];
+}
+
+function isArchiveBundle(value: unknown): value is TournamentArchiveBundle {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    (value as { schemaVersion?: unknown }).schemaVersion === TOURNAMENT_ARCHIVE_SCHEMA_VERSION &&
+    (value as { tournament?: unknown }).tournament &&
+    (value as { modes?: unknown }).modes,
+  );
+}
+
+async function readJsonFromR2<T>(key: string): Promise<T | null> {
+  const bucket = getArchiveBucket();
+  if (!bucket) return null;
+  const object = await bucket.get(key);
+  if (!object) return null;
+  return object.json<T>();
+}
+
+async function putJsonToR2(key: string, value: unknown): Promise<void> {
+  const bucket = getArchiveBucket();
+  if (!bucket) {
+    throw new Error("ARCHIVE_BUCKET binding is not configured");
+  }
+  await bucket.put(key, JSON.stringify(value), {
+    httpMetadata: { contentType: "application/json; charset=utf-8" },
+  });
+}
+
+export async function readTournamentArchive(identifier: string): Promise<TournamentArchiveBundle | null> {
+  for (const key of archiveLookupKeys(identifier)) {
+    const bundle = await readJsonFromR2<unknown>(key);
+    if (isArchiveBundle(bundle)) return bundle;
+  }
+  return null;
+}
+
+function uniquePlayersFromArchive(bundle: Pick<TournamentArchiveBundle, "modes">): unknown[] {
+  const byId = new Map<string, unknown>();
+  const remember = (player: unknown) => {
+    const id = player && typeof player === "object" ? (player as { id?: unknown }).id : null;
+    if (typeof id === "string") byId.set(id, player);
+  };
+
+  for (const entry of bundle.modes.ta.entries ?? []) {
+    remember((entry as { player?: unknown }).player);
+  }
+  for (const mode of [bundle.modes.bm, bundle.modes.mr, bundle.modes.gp]) {
+    for (const qualification of mode.qualifications ?? []) {
+      remember((qualification as { player?: unknown }).player);
+    }
+    for (const match of mode.matches ?? []) {
+      remember((match as { player1?: unknown; player2?: unknown }).player1);
+      remember((match as { player1?: unknown; player2?: unknown }).player2);
+    }
+  }
+  return [...byId.values()];
+}
+
+export function getArchivedModePayload(
+  bundle: TournamentArchiveBundle,
+  mode: "ta" | "bm" | "mr" | "gp",
+) {
+  if (mode === "ta") {
+    return {
+      ...bundle.modes.ta,
+      allPlayers: bundle.allPlayers,
+      archived: true,
+    };
+  }
+  return {
+    qualifications: bundle.modes[mode].qualifications ?? [],
+    matches: (bundle.modes[mode].matches ?? []).filter((match) =>
+      (match as { stage?: unknown }).stage === "qualification"
+    ),
+    allPlayers: bundle.allPlayers,
+    qualificationConfirmed: bundle.modes[mode].qualificationConfirmed ?? true,
+    archived: true,
+  };
+}
+
+export function getArchivedFinalsPayload(
+  bundle: TournamentArchiveBundle,
+  mode: "bm" | "mr" | "gp",
+  style: "grouped" | "simple" | "paginated",
+) {
+  const allMatches = bundle.modes[mode].matches ?? [];
+  const matches = allMatches.filter((match) => (match as { stage?: unknown }).stage === "finals");
+  const playoffMatches = allMatches.filter((match) => (match as { stage?: unknown }).stage === "playoff");
+  const bracketSize = matches.length > 20 ? 16 : 8;
+  const bracketStructure = matches.length > 0 ? generateBracketStructure(bracketSize) : [];
+  const playoffStructure = playoffMatches.length > 0 ? generatePlayoffStructure(12) : [];
+  const playoffComplete = playoffMatches
+    .filter((match) => (match as { round?: unknown }).round === "playoff_r2")
+    .every((match) => (match as { completed?: unknown }).completed === true);
+  const phase = matches.length > 0 ? "finals" : playoffMatches.length > 0 ? "playoff" : "finals";
+  const qualificationConfirmed = bundle.modes[mode].qualificationConfirmed ?? true;
+  const common = {
+    bracketStructure,
+    bracketSize,
+    roundNames,
+    qualificationConfirmed,
+    phase,
+    playoffMatches,
+    playoffStructure,
+    playoffSeededPlayers: [],
+    playoffComplete,
+    archived: true,
+  };
+
+  if (style === "paginated") {
+    return {
+      data: matches,
+      meta: { page: 1, limit: matches.length, total: matches.length, totalPages: 1 },
+      ...common,
+    };
+  }
+
+  if (style === "grouped") {
+    return {
+      matches,
+      winnersMatches: matches.filter((match) =>
+        ((match as { round?: string | null }).round ?? "").startsWith("winners_")
+      ),
+      losersMatches: matches.filter((match) =>
+        ((match as { round?: string | null }).round ?? "").startsWith("losers_")
+      ),
+      grandFinalMatches: matches.filter((match) =>
+        ((match as { round?: string | null }).round ?? "").startsWith("grand_final")
+      ),
+      ...common,
+    };
+  }
+
+  return {
+    matches,
+    ...common,
+  };
+}
+
+export function getArchivedTournamentSummary(bundle: TournamentArchiveBundle, isSummary: boolean) {
+  const base = {
+    ...bundle.tournament,
+    archived: true,
+  };
+  if (isSummary) return base;
+  return {
+    ...base,
+    bmQualifications: bundle.modes.bm.qualifications ?? [],
+    bmMatches: bundle.modes.bm.matches ?? [],
+  };
+}
+
+export async function readTournamentArchiveIndex(): Promise<TournamentArchiveIndexItem[]> {
+  const index = await readJsonFromR2<unknown>("archives/index.json");
+  if (!index || !Array.isArray(index)) return [];
+  return index as TournamentArchiveIndexItem[];
+}
+
+async function updateTournamentArchiveIndex(bundle: TournamentArchiveBundle) {
+  const existing = await readTournamentArchiveIndex();
+  const item: TournamentArchiveIndexItem = {
+    id: bundle.tournament.id,
+    slug: bundle.tournament.slug,
+    name: bundle.tournament.name,
+    date: bundle.tournament.date,
+    status: "completed",
+    publicModes: bundle.tournament.publicModes,
+    createdAt: bundle.tournament.createdAt,
+    archivedAt: bundle.generatedAt,
+  };
+  const next = [
+    item,
+    ...existing.filter((entry) => entry.id !== item.id && entry.slug !== item.slug),
+  ].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  await putJsonToR2("archives/index.json", next);
+}
+
+export async function buildTournamentArchiveBundle(tournamentId: string): Promise<TournamentArchiveBundle> {
+  const tournament = await prisma.tournament.findUnique({
+    where: { id: tournamentId },
+    select: {
+      id: true,
+      slug: true,
+      name: true,
+      date: true,
+      status: true,
+      publicModes: true,
+      frozenStages: true,
+      taPlayerSelfEdit: true,
+      bmQualificationConfirmed: true,
+      mrQualificationConfirmed: true,
+      gpQualificationConfirmed: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+  if (!tournament) {
+    throw new Error(`Tournament not found: ${tournamentId}`);
+  }
+
+  const [
+    ttEntries,
+    ttPhaseRounds,
+    bmQualifications,
+    mrQualifications,
+    gpQualifications,
+    bmMatches,
+    mrMatches,
+    gpMatches,
+    overallRankings,
+  ] = await Promise.all([
+    prisma.tTEntry.findMany({
+      where: { tournamentId },
+      include: { player: { select: PLAYER_PUBLIC_SELECT } },
+      orderBy: [{ stage: "asc" }, { rank: "asc" }, { totalTime: "asc" }],
+    }),
+    prisma.tTPhaseRound.findMany({
+      where: { tournamentId },
+      orderBy: [{ phase: "asc" }, { roundNumber: "asc" }],
+    }),
+    prisma.bMQualification.findMany({
+      where: { tournamentId },
+      include: { player: { select: PLAYER_PUBLIC_SELECT } },
+      orderBy: [...twoPlayerQualificationOrder()],
+    }),
+    prisma.mRQualification.findMany({
+      where: { tournamentId },
+      include: { player: { select: PLAYER_PUBLIC_SELECT } },
+      orderBy: [...twoPlayerQualificationOrder()],
+    }),
+    prisma.gPQualification.findMany({
+      where: { tournamentId },
+      include: { player: { select: PLAYER_PUBLIC_SELECT } },
+      orderBy: [...twoPlayerQualificationOrder()],
+    }),
+    prisma.bMMatch.findMany({
+      where: { tournamentId },
+      include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } },
+      orderBy: { matchNumber: "asc" },
+    }),
+    prisma.mRMatch.findMany({
+      where: { tournamentId },
+      include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } },
+      orderBy: { matchNumber: "asc" },
+    }),
+    prisma.gPMatch.findMany({
+      where: { tournamentId },
+      include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } },
+      orderBy: { matchNumber: "asc" },
+    }),
+    getOverallRankings(prisma, tournamentId),
+  ]);
+
+  const modes = {
+    ta: {
+      entries: ttEntries,
+      phaseRounds: ttPhaseRounds,
+      courses: COURSES,
+      qualificationRegistrationLocked: true,
+      qualificationEditingLockedForPlayers: true,
+      frozenStages: tournament.frozenStages,
+      taPlayerSelfEdit: tournament.taPlayerSelfEdit,
+    },
+    bm: {
+      qualifications: computeQualificationRanks(
+        bmQualifications,
+        [...twoPlayerQualificationOrder()],
+        bmMatches.filter((match) => match.stage === "qualification"),
+        { matchScoreFields: { p1: "score1", p2: "score2" } },
+      ),
+      matches: bmMatches,
+      qualificationConfirmed: tournament.bmQualificationConfirmed,
+    },
+    mr: {
+      qualifications: computeQualificationRanks(
+        mrQualifications,
+        [...twoPlayerQualificationOrder()],
+        mrMatches.filter((match) => match.stage === "qualification"),
+        { matchScoreFields: { p1: "score1", p2: "score2" } },
+      ),
+      matches: mrMatches,
+      qualificationConfirmed: tournament.mrQualificationConfirmed,
+    },
+    gp: {
+      qualifications: computeQualificationRanks(
+        gpQualifications,
+        [...twoPlayerQualificationOrder()],
+        gpMatches.filter((match) => match.stage === "qualification"),
+        { matchScoreFields: GP_MATCH_SCORE_FIELDS },
+      ),
+      matches: gpMatches,
+      qualificationConfirmed: tournament.gpQualificationConfirmed,
+    },
+  };
+
+  const bundle: TournamentArchiveBundle = {
+    schemaVersion: TOURNAMENT_ARCHIVE_SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    tournament,
+    allPlayers: [],
+    modes,
+    overallRanking: {
+      tournamentId,
+      tournamentName: tournament.name,
+      lastUpdated: overallRankings.length > 0
+        ? new Date(Math.max(...overallRankings.map((ranking) =>
+            new Date((ranking as { updatedAt?: unknown }).updatedAt as string | Date | undefined ?? new Date()).getTime()
+          ))).toISOString()
+        : new Date().toISOString(),
+      rankings: overallRankings,
+    },
+    archived: true,
+  };
+  bundle.allPlayers = uniquePlayersFromArchive(bundle);
+  return bundle;
+}
+
+export async function persistTournamentArchive(tournamentId: string): Promise<TournamentArchiveBundle> {
+  const bundle = await buildTournamentArchiveBundle(tournamentId);
+  await Promise.all(getTournamentArchiveKeys(bundle.tournament).map((key) => putJsonToR2(key, bundle)));
+  await updateTournamentArchiveIndex(bundle);
+  return bundle;
+}

--- a/smkc-score-app/wrangler.toml
+++ b/smkc-score-app/wrangler.toml
@@ -38,3 +38,7 @@ binding = "DB"
 database_name = "smkc-db"
 database_id = "3132bf8c-d0f5-46a6-bc33-713480687d76"
 migrations_dir = "migrations"
+
+[[r2_buckets]]
+binding = "ARCHIVE_BUCKET"
+bucket_name = "smkc-archives"


### PR DESCRIPTION
## Summary
- add R2-backed tournament archive bundles for completed tournaments
- persist archive JSON when a tournament is marked `completed`, plus admin `GET/POST /api/tournaments/[id]/archive`
- fall back to archived data for tournament list/detail, TA/BM/MR/GP, finals, TA phases, and overall ranking when DB reads fail
- keep archived mode pages viewable even if `/api/players` is unavailable

## Ops note
- The Cloudflare environment needs an R2 bucket named `smkc-archives` bound as `ARCHIVE_BUCKET` before deploy.
- Existing tournaments can be backfilled after deploy with `POST /api/tournaments/<id-or-slug>/archive` as an admin.

## jsmkc2026 backup
- Built a live JSON backup outside the repo at `/private/tmp/jsmkc2026-r2-archive-bundle.json`.
- Also kept the raw endpoint dump at `/private/tmp/jsmkc2026-archive-backup.json`.

## Validation
- `npm run build`
- `npm test -- __tests__/lib/tournament-archive.test.ts`
