### PR TITLE
Support IPv6 preview DNS fallback

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -209,7 +209,8 @@
   1. `smkc-score-app/` で `npm run e2e:preview` を実行する
   2. runner が `https://preview.smkc.bluemoon.works` と `/tmp/playwright-smkc-preview-profile` を選ぶことを確認する
   3. preview host が通常 DNS または public DNS fallback で解決できることを確認する
-  4. macOS では Chrome for Testing の Crashpad path に依存せず、installed Chrome channel で起動することを確認する
+  4. public DNS fallback は IPv4 A レコードがない host でも IPv6 AAAA レコードを解決できることを確認する
+  5. macOS では Chrome for Testing の Crashpad path に依存せず、installed Chrome channel で起動することを確認する
 - **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / Crashpad permission failure で停止しない
 
 ## TC-359: CDM Export 失敗時の原因ヒント表示

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -110,6 +110,30 @@ describe('preview E2E runner', () => {
     ).resolves.toBe('104.21.41.48');
   });
 
+  it('falls back to public IPv6 DNS when local resolution and IPv4 public DNS fail', async () => {
+    lookupMock.mockRejectedValue(new Error('getaddrinfo ENOTFOUND ipv6-preview.example.com'));
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: '', stderr: '' })
+      .mockReturnValueOnce({ status: 0, stdout: '2606:4700:3037::6815:2930\n', stderr: '' });
+
+    await expect(
+      runner.assertBaseUrlResolvable('https://ipv6-preview.example.com'),
+    ).resolves.toBe('2606:4700:3037::6815:2930');
+
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      1,
+      'dig',
+      ['+short', 'A', 'ipv6-preview.example.com', '@1.1.1.1'],
+      { encoding: 'utf8' },
+    );
+    expect(spawnSyncMock).toHaveBeenNthCalledWith(
+      2,
+      'dig',
+      ['+short', 'AAAA', 'ipv6-preview.example.com', '@1.1.1.1'],
+      { encoding: 'utf8' },
+    );
+  });
+
   it('throws a helpful error when the preview host does not resolve', async () => {
     lookupMock.mockRejectedValue(new Error('getaddrinfo ENOTFOUND preview.smkc.bluemoon.works'));
 

--- a/smkc-score-app/e2e/run-preview.js
+++ b/smkc-score-app/e2e/run-preview.js
@@ -52,17 +52,26 @@ async function assertBaseUrlResolvable(baseUrl) {
 }
 
 function resolveHostViaPublicDns(hostname) {
-  const result = spawnSync('dig', ['+short', hostname, '@1.1.1.1'], {
-    encoding: 'utf8',
-  });
-  if (result.status !== 0) return null;
+  const records = [
+    { type: 'A', pattern: /^\d{1,3}(\.\d{1,3}){3}$/ },
+    { type: 'AAAA', pattern: /^[0-9a-f:]+$/i },
+  ];
 
-  const addresses = (result.stdout || '')
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => /^\d{1,3}(\.\d{1,3}){3}$/.test(line));
+  for (const record of records) {
+    const result = spawnSync('dig', ['+short', record.type, hostname, '@1.1.1.1'], {
+      encoding: 'utf8',
+    });
+    if (result.status !== 0) continue;
 
-  return addresses[0] || null;
+    const addresses = (result.stdout || '')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => record.pattern.test(line));
+
+    if (addresses[0]) return addresses[0];
+  }
+
+  return null;
 }
 
 async function runTargetScript(targetScript, env = buildPreviewRuntimeEnv()) {
@@ -112,5 +121,6 @@ if (require.main === module) {
 module.exports = {
   assertBaseUrlResolvable,
   buildPreviewRuntimeEnv,
+  resolveHostViaPublicDns,
   runTargetScript,
 };


### PR DESCRIPTION
Summary
- Extend preview E2E public DNS fallback to query IPv4 A records first and IPv6 AAAA records when A records are unavailable.
- Document the IPv6-only preview host case in TC-109 and add focused Jest coverage for the fallback sequence.

Issues: Closes #1154

Validation
- npm test -- --runTestsByPath __tests__/e2e/run-preview.test.ts
- node --check e2e/run-preview.js
- npx eslint e2e/run-preview.js __tests__/e2e/run-preview.test.ts (exit 0; e2e/run-preview.js is ignored by repo eslint config and reports the existing ignored-file warning)
- git diff --check
