### PR TITLE
Keep TA phase status currentPhase required

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/phase-controls.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/phase-controls.test.ts
@@ -25,6 +25,7 @@ describe("TA phase control visibility", () => {
         phase1: { total: 8, active: 8, eliminated: 0 },
         phase2: null,
         phase3: null,
+        currentPhase: "phase1",
       },
     })).toBe(true);
   });

--- a/smkc-score-app/src/lib/ta/phase-controls.ts
+++ b/smkc-score-app/src/lib/ta/phase-controls.ts
@@ -2,7 +2,7 @@ export type TaPhaseStatus = {
   phase1: { total: number; active: number; eliminated: number } | null;
   phase2: { total: number; active: number; eliminated: number } | null;
   phase3: { total: number; active: number; eliminated: number; winner: string | null } | null;
-  currentPhase?: string;
+  currentPhase: string;
 } | null;
 
 export function hasStartedTaPhase(phaseStatus: TaPhaseStatus): boolean {


### PR DESCRIPTION
## Summary
- keep `TaPhaseStatus.currentPhase` required to match the TA phases API and `getPhaseStatus` contract
- update phase control unit coverage to include the required `currentPhase` field

Issues: Closes #1163

## Validation
- `npm test -- --runTestsByPath __tests__/lib/ta/phase-controls.test.ts`
- `npx eslint src/lib/ta/phase-controls.ts __tests__/lib/ta/phase-controls.test.ts 'src/app/tournaments/[id]/ta/page-client.tsx'`
- `git diff --check`
