### PR TITLE
Tighten preview DNS address filtering

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -210,7 +210,8 @@
   2. runner が `https://preview.smkc.bluemoon.works` と `/tmp/playwright-smkc-preview-profile` を選ぶことを確認する
   3. preview host が通常 DNS または public DNS fallback で解決できることを確認する
   4. public DNS fallback は IPv4 A レコードがない host でも IPv6 AAAA レコードを解決できることを確認する
-  5. macOS では Chrome for Testing の Crashpad path に依存せず、installed Chrome channel で起動することを確認する
+  5. public DNS fallback は `dig +short` の説明行や不正な IPv4/IPv6 風文字列を host resolver rules に採用しないことを確認する
+  6. macOS では Chrome for Testing の Crashpad path に依存せず、installed Chrome channel で起動することを確認する
 - **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / Crashpad permission failure で停止しない
 
 ## TC-359: CDM Export 失敗時の原因ヒント表示

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -134,6 +134,34 @@ describe('preview E2E runner', () => {
     );
   });
 
+  it('ignores invalid public IPv4 DNS lines before using a valid A record', async () => {
+    lookupMock.mockRejectedValue(new Error('getaddrinfo ENOTFOUND preview.smkc.bluemoon.works'));
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: '999.999.999.999\n104.21.41.48\n',
+      stderr: '',
+    });
+
+    await expect(
+      runner.assertBaseUrlResolvable('https://preview.smkc.bluemoon.works'),
+    ).resolves.toBe('104.21.41.48');
+  });
+
+  it('ignores invalid public IPv6 DNS lines before using a valid AAAA record', async () => {
+    lookupMock.mockRejectedValue(new Error('getaddrinfo ENOTFOUND ipv6-preview.example.com'));
+    spawnSyncMock
+      .mockReturnValueOnce({ status: 0, stdout: '', stderr: '' })
+      .mockReturnValueOnce({
+        status: 0,
+        stdout: 'feed\n2606:4700:3037::6815:2930\n',
+        stderr: '',
+      });
+
+    await expect(
+      runner.assertBaseUrlResolvable('https://ipv6-preview.example.com'),
+    ).resolves.toBe('2606:4700:3037::6815:2930');
+  });
+
   it('throws a helpful error when the preview host does not resolve', async () => {
     lookupMock.mockRejectedValue(new Error('getaddrinfo ENOTFOUND preview.smkc.bluemoon.works'));
 

--- a/smkc-score-app/e2e/run-preview.js
+++ b/smkc-score-app/e2e/run-preview.js
@@ -2,6 +2,7 @@ const { spawn } = require('child_process');
 const { spawnSync } = require('child_process');
 const dns = require('dns').promises;
 const fs = require('fs');
+const net = require('net');
 const path = require('path');
 
 const {
@@ -53,8 +54,8 @@ async function assertBaseUrlResolvable(baseUrl) {
 
 function resolveHostViaPublicDns(hostname) {
   const records = [
-    { type: 'A', pattern: /^\d{1,3}(\.\d{1,3}){3}$/ },
-    { type: 'AAAA', pattern: /^[0-9a-f:]+$/i },
+    { type: 'A', family: 4 },
+    { type: 'AAAA', family: 6 },
   ];
 
   for (const record of records) {
@@ -66,7 +67,7 @@ function resolveHostViaPublicDns(hostname) {
     const addresses = (result.stdout || '')
       .split(/\r?\n/)
       .map((line) => line.trim())
-      .filter((line) => record.pattern.test(line));
+      .filter((line) => net.isIP(line) === record.family);
 
     if (addresses[0]) return addresses[0];
   }


### PR DESCRIPTION
Summary
- Add TC-109 scenario coverage for rejecting invalid public DNS fallback lines.
- Use Node's net.isIP family check for preview public DNS A/AAAA filtering.
- Add Jest regression coverage for invalid IPv4 and IPv6-looking dig output.

Issues: Closes #1158

Validation
- npm test -- --runTestsByPath __tests__/e2e/run-preview.test.ts
- npm run lint (exit 0; existing warnings only)
