### PR TITLE
Register GP TC-1103 E2E coverage

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -696,6 +696,20 @@
 - **期待結果**: BM のみロック、MR は編集可能
 - **スクリプト**: tc-all.js TC-351
 
+## TC-352: Tournament PUT — debugMode フラグを後から有効化できる
+- **URL**: /api/tournaments/[temp-id]
+- **authRequired**: true (admin)
+- **背景**: debug tournament は preview E2E のセットアップや debug-fill 検証で使うため、作成後の Tournament PUT でも `debugMode` が永続化される必要がある。
+- **手順**:
+  1. `debugMode=false` の一時トーナメントを作成する
+  2. `PUT /api/tournaments/:id` に `{ debugMode: true }` を送信する
+  3. PUT レスポンスの `debugMode` が `true` であることを確認する
+  4. `GET /api/tournaments/:id?fields=summary` で再取得する
+  5. 再取得した summary の `debugMode` が `true` で永続化されていることを確認する
+  6. 一時トーナメントを削除する
+- **期待結果**: Tournament PUT で `debugMode=true` が保存され、GET summary でも同じ値が返る
+- **スクリプト**: tc-all.js TC-352
+
 ## TC-353: BM/MR 予選セットアップ — 8人グループで createMany が D1 パラメータ制限内に収まること (issue #736)
 - **authRequired**: true (admin)
 - **背景**: D1 は SQL ステートメントあたり ~100 バインドパラメータ制限がある。8人グループのラウンドロビンは 28 試合を生成し、各試合に 9～12 カラムあると 252+ パラメータになる。`createMany` をチャンク分割（MATCH_CHUNK=8）することで制限を超えないようにし、D1 ネットワークリトライによる 6 秒外れ値を抑制する。
@@ -749,6 +763,16 @@
   - 横スクロール可能なテーブルラッパーが存在する
   - ラッパー未検出時は SKIP ではなく FAIL
 - **スクリプト**: tc-all.js TC-356
+
+## TC-357: Suspense fallback — 4モード予選ページの見出しが即時描画される
+- **authRequired**: true (admin)
+- **背景**: RSC streaming / PPR の待機中でも E2E セレクタと利用者の初期表示が安定するよう、BM/MR/GP/TA の qualification fallback はモード名見出しを先に描画する必要がある。
+- **手順**:
+  1. 共有トーナメント ID を使って BM/MR/GP/TA の各予選ページへ順に遷移する
+  2. 各ページで `h1` / `h2` / `h3` のいずれかを即時確認する
+  3. BM は `バトルモード` または `Battle Mode`、MR は `マッチレース` または `Match Race`、GP は `グランプリ` または `Grand Prix`、TA は `タイムアタック` または `Time Attack` を含む見出しがあることを確認する
+- **期待結果**: 4モードすべてで fallback 期間中もモード名見出しが存在し、遅いデータ取得でも見出しセレクタが安定する
+- **スクリプト**: tc-all.js TC-357
 
 ## TC-401: 全モードトーナメント — TA/BM/MR/GP の予選データが正しく存在する
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -617,7 +617,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
     });
 
     // Success case - Updates match and advances winner
-    it('should update match and advance winner to next round', async () => {
+    it('should update score-only upper bracket match with null cupResults and advance winner', async () => {
       const mockMatch = {
         id: 'm1',
         tournamentId: 't1',
@@ -628,6 +628,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         player2Id: 'p2',
         points1: 2,
         points2: 0,
+        cupResults: [{ cup: 'Mushroom', points1: 45, points2: 0 }],
         completed: false,
         player1: { id: 'p1', name: 'Player 1' },
         player2: { id: 'p2', name: 'Player 2' },

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -14,6 +14,7 @@
  *   TC-713  GP qualification tie resolution (tie warning → resolveAllTies)
  *   TC-717  GP finals same-cup-per-round enforcement (PR #585 normalizer)
  *   TC-718  GP finals admin manual total-score override (PR #585 manual form)
+ *   TC-1103 GP finals upper bracket score-only cup-win save
  *   TC-719  GP tied cup extends non-grand-final bracket match
  *   TC-831  GP finals added cup form can be removed without stale scores
  *   TC-723  GP qualification standings show 0-1000 qualification points
@@ -662,6 +663,47 @@ async function runTc718(adminPage) {
       : '');
   } catch (err) {
     log('TC-718', 'FAIL', err instanceof Error ? err.message : 'GP 718 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-1103: GP finals upper bracket score-only cup-win save ─────────
+ * Upper-bracket GP finals can be saved with just cup-win totals. This keeps
+ * cupResults null when operators do not need per-cup driver-point detail. */
+async function runTc1103(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedGpFinalsSetup(adminPage);
+
+    const gen = await apiGenerateGpFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    const before = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const m1 = before.find((m) => m.matchNumber === 1 && m.round === 'winners_qf');
+    if (!m1) throw new Error('Upper-bracket Match 1 missing');
+
+    const scoreOnly = await apiSetGpFinalsScore(adminPage, setup.tournamentId, m1.id, 2, 0);
+    if (scoreOnly.s !== 200) throw new Error(`Score-only PUT failed (${scoreOnly.s})`);
+
+    const after = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const updated = after.find((m) => m.id === m1.id);
+    const winnerTarget = after.find((m) => m.matchNumber === 5);
+    const loserTarget = after.find((m) => m.matchNumber === 8);
+    const savedScoreOnly = updated?.completed === true &&
+      updated.points1 === 2 &&
+      updated.points2 === 0 &&
+      updated.cupResults === null;
+    const routed = [winnerTarget?.player1Id, winnerTarget?.player2Id].includes(m1.player1Id) &&
+      [loserTarget?.player1Id, loserTarget?.player2Id].includes(m1.player2Id);
+
+    log('TC-1103', savedScoreOnly && routed ? 'PASS' : 'FAIL',
+      !savedScoreOnly
+        ? `completed=${updated?.completed} points=${updated?.points1}-${updated?.points2} cupResults=${JSON.stringify(updated?.cupResults)}`
+        : !routed ? 'routing mismatch after score-only save'
+        : '');
+  } catch (err) {
+    log('TC-1103', 'FAIL', err instanceof Error ? err.message : 'GP 1103 failed');
   } finally {
     if (setup) await setup.cleanup();
   }
@@ -1494,6 +1536,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-709', fn: runTc709 },
       { name: 'TC-717', fn: runTc717 },
       { name: 'TC-718', fn: runTc718 },
+      { name: 'TC-1103', fn: runTc1103 },
       { name: 'TC-715', fn: runTc715 },
       { name: 'TC-716', fn: runTc716 },
       { name: 'TC-710', fn: runTc710 },
@@ -1513,7 +1556,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 module.exports = {
   runTc701, runTc702, runTc703, runTc704, runTc705, runTc706,
   runTc707, runTc708, runTc709, runTc710, runTc712, runTc713,
-  runTc715, runTc716, runTc717, runTc718, runTc719,
+  runTc715, runTc716, runTc717, runTc718, runTc1103, runTc719,
   runTc720, runTc721, runTc722, runTc724, runTc821, runTc831, runTc832,
   getSuite,
   results,


### PR DESCRIPTION
## Summary
- Add `TC-1103` to the GP E2E suite so the score-only upper-bracket finals path runs through the `tc-all.js` composed GP suite.
- Document existing `TC-352` and `TC-357` runner coverage in `E2E_TEST_CASES.md` to reduce the doc-vs-runner drift tracked by #1146.
- Tighten the GP finals route unit test to prove score-only upper-bracket saves clear stale `cupResults` to `null` while advancing the winner.

## Issues
Closes #1130

## Validation
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts'`
- `node --check smkc-score-app/e2e/tc-gp.js`
- `git diff --check`
- Focused doc/runner reference check for `TC-352`, `TC-357`, and `TC-1103`
