### PR TITLE
Delegate preview all E2E alias

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -207,11 +207,12 @@
 - **背景**: preview 環境移行後、自動化手順は `npm run e2e:preview` を公式入口として扱う。runner は preview URL/profile を設定し、Chromium 起動前に host 解決と macOS Chrome channel fallback を行う。
 - **手順**:
   1. `smkc-score-app/` で `npm run e2e:preview` を実行する
-  2. runner が `https://preview.smkc.bluemoon.works` と `/tmp/playwright-smkc-preview-profile` を選ぶことを確認する
-  3. preview host が通常 DNS または public DNS fallback で解決できることを確認する
-  4. public DNS fallback は IPv4 A レコードがない host でも IPv6 AAAA レコードを解決できることを確認する
-  5. public DNS fallback は `dig +short` の説明行や不正な IPv4/IPv6 風文字列を host resolver rules に採用しないことを確認する
-  6. macOS では Chrome for Testing の Crashpad path に依存せず、installed Chrome channel で起動することを確認する
+  2. 互換 alias の `npm run e2e:preview:all` は同じ runner コマンドを重複定義せず、`npm run e2e:preview --` に委譲していることを確認する
+  3. runner が `https://preview.smkc.bluemoon.works` と `/tmp/playwright-smkc-preview-profile` を選ぶことを確認する
+  4. preview host が通常 DNS または public DNS fallback で解決できることを確認する
+  5. public DNS fallback は IPv4 A レコードがない host でも IPv6 AAAA レコードを解決できることを確認する
+  6. public DNS fallback は `dig +short` の説明行や不正な IPv4/IPv6 風文字列を host resolver rules に採用しないことを確認する
+  7. macOS では Chrome for Testing の Crashpad path に依存せず、installed Chrome channel で起動することを確認する
 - **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / Crashpad permission failure で停止しない
 
 ## TC-359: CDM Export 失敗時の原因ヒント表示

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -64,7 +64,11 @@ describe('preview E2E runner', () => {
 
   it('exposes npm run e2e:preview as the official all-suite preview alias', () => {
     expect(packageJson.scripts['e2e:preview']).toBe('node e2e/run-preview.js tc-all.js');
-    expect(packageJson.scripts['e2e:preview:all']).toBe(packageJson.scripts['e2e:preview']);
+  });
+
+  it('keeps e2e:preview:all as a delegated compatibility alias', () => {
+    expect(packageJson.scripts['e2e:preview:all']).toBe('npm run e2e:preview --');
+    expect(packageJson.scripts['e2e:preview:all']).not.toBe(packageJson.scripts['e2e:preview']);
   });
 
   it('defaults to the installed Chrome channel on macOS preview runs', () => {

--- a/smkc-score-app/package.json
+++ b/smkc-score-app/package.json
@@ -19,7 +19,7 @@
     "e2e:ta": "node e2e/tc-ta.js",
     "e2e:ta-flow": "node e2e/tc-ta-flow.js",
     "e2e:preview": "node e2e/run-preview.js tc-all.js",
-    "e2e:preview:all": "node e2e/run-preview.js tc-all.js",
+    "e2e:preview:all": "npm run e2e:preview --",
     "e2e:preview:login": "node e2e/login-preview-admin.js",
     "e2e:preview:cleanup": "node e2e/run-preview.js cleanup.js",
     "e2e:preview:bm": "node e2e/run-preview.js tc-bm.js",


### PR DESCRIPTION
## Summary

- Delegate `e2e:preview:all` to the official `e2e:preview` command instead of duplicating the runner command.
- Update TC-109 so the E2E scenario explicitly covers the compatibility alias delegation.
- Add focused Jest coverage for the delegated alias contract.

## Issues

Closes #1152

## Validation

- npm test -- __tests__/e2e/run-preview.test.ts
- git diff --check
- npm run lint
