### PR TITLE
Remove redundant preview alias assertion

### DIFF
--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -68,7 +68,6 @@ describe('preview E2E runner', () => {
 
   it('keeps e2e:preview:all as a delegated compatibility alias', () => {
     expect(packageJson.scripts['e2e:preview:all']).toBe('npm run e2e:preview --');
-    expect(packageJson.scripts['e2e:preview:all']).not.toBe(packageJson.scripts['e2e:preview']);
   });
 
   it('defaults to the installed Chrome channel on macOS preview runs', () => {


### PR DESCRIPTION
## Summary

- Remove the redundant negative assertion from the preview alias contract test.
- Keep the delegated `e2e:preview:all` expectation as the single source of truth for the compatibility alias.

## Issues

Closes #1171

## Validation

- npm test -- __tests__/e2e/run-preview.test.ts
- git diff --check
- npm run lint
