### PR TITLE
Address GP standings header review follow-ups

### DIFF
--- a/smkc-score-app/__tests__/e2e/standings-assertions.test.ts
+++ b/smkc-score-app/__tests__/e2e/standings-assertions.test.ts
@@ -50,4 +50,20 @@ describe('GP combined standings E2E assertions', () => {
       ]);
     }).toThrow('GP combined standings missing driver points header');
   });
+
+  it('fails when the match points header is missing', () => {
+    expect(() => {
+      assertGpCombinedStandingsHeaders([
+        '#',
+        'Group',
+        'Player',
+        'MP',
+        'W',
+        'T',
+        'L',
+        'Driver Pts',
+        'Qual Pts',
+      ]);
+    }).toThrow('GP combined standings missing match points header');
+  });
 });

--- a/smkc-score-app/e2e/lib/standings-assertions.js
+++ b/smkc-score-app/e2e/lib/standings-assertions.js
@@ -3,9 +3,8 @@ function normalizeHeaderText(value) {
 }
 
 function hasAnyHeader(headers, labels) {
-  const normalized = headers.map(normalizeHeaderText);
   return labels.some((label) =>
-    normalized.some((header) => header.includes(label))
+    headers.some((header) => header.includes(label))
   );
 }
 


### PR DESCRIPTION
## Summary
- Remove duplicate header normalization in the GP combined standings assertion helper.
- Add the missing negative Jest case for a missing Match Pts/勝点 header.

## Issues
Closes #1174
Closes #1175

## Validation
- node --check smkc-score-app/e2e/lib/standings-assertions.js && node --check smkc-score-app/e2e/lib/common.js && node --check smkc-score-app/e2e/tc-gp.js && git diff --check
- npm test -- __tests__/e2e/standings-assertions.test.ts
- npm run lint (passes with existing warnings)