### PR TITLE
Replace preview login fixed wait

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -215,6 +215,18 @@
   7. macOS では Chrome for Testing の Crashpad path に依存せず、installed Chrome channel で起動することを確認する
 - **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / Crashpad permission failure で停止しない
 
+## TC-110: Preview 管理者ログイン補助スクリプトの要素待機
+- **URL**: /auth/signin
+- **authRequired**: false (ログイン準備)
+- **背景**: preview E2E は永続プロファイルの Discord 管理者セッションを前提にする。`npm run e2e:preview:login` は手動ログイン用にサインイン画面を開くため、ページロード後の固定 sleep ではなく、実際の Admin タブと Discord ログインボタンの表示を待つ必要がある。
+- **手順**:
+  1. `smkc-score-app/` で `npm run e2e:preview:login` を実行する
+  2. script が `/auth/signin` を開くことを確認する
+  3. Admin タブが表示されるまで待ち、Admin タブを選択することを確認する
+  4. Discord ログインボタンが表示されるまで待つことを確認する
+  5. 固定の `waitForTimeout(1500)` に依存しないことを確認する
+- **期待結果**: preview ログイン補助はページ描画速度に左右されず、Discord 管理者ログイン操作を開始できる
+
 ## TC-359: CDM Export 失敗時の原因ヒント表示
 - **URL**: /tournaments/[id]
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/e2e/login-preview-admin.test.ts
+++ b/smkc-score-app/__tests__/e2e/login-preview-admin.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+type LoginPreviewAdmin = typeof import('../../e2e/login-preview-admin');
+
+jest.mock('../../e2e/lib/common', () => ({
+  launchPersistentChromiumContext: jest.fn(),
+  resolveE2EProfileDir: jest.fn(() => '/tmp/playwright-smkc-preview-profile'),
+}));
+
+jest.mock('../../e2e/run-preview', () => ({
+  buildPreviewRuntimeEnv: jest.fn(() => ({
+    E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
+    E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
+  })),
+  assertBaseUrlResolvable: jest.fn(),
+}));
+
+function loadLoginPreviewAdmin() {
+  let loaded: LoginPreviewAdmin | undefined;
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    loaded = require('../../e2e/login-preview-admin') as LoginPreviewAdmin;
+  });
+  if (!loaded) throw new Error('Failed to load preview login helper');
+  return loaded;
+}
+
+describe('preview admin login helper', () => {
+  it('waits for the admin tab and Discord button instead of a fixed sleep', async () => {
+    const adminTab = {
+      waitFor: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      click: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    };
+    const discordButton = {
+      waitFor: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    };
+    const page = {
+      getByRole: jest.fn((role: string, options: { name: RegExp }) => {
+        if (role === 'tab' && options.name.test('Admin')) return adminTab;
+        if (role === 'button' && options.name.test('Discord')) return discordButton;
+        throw new Error(`unexpected role lookup: ${role}`);
+      }),
+      waitForTimeout: jest.fn(),
+    };
+
+    const helper = loadLoginPreviewAdmin();
+    await helper.waitForPreviewAdminLoginReady(page);
+
+    expect(page.getByRole).toHaveBeenCalledWith('tab', { name: /管理者|Admin/ });
+    expect(adminTab.waitFor).toHaveBeenCalledWith({ state: 'visible', timeout: 15000 });
+    expect(adminTab.click).toHaveBeenCalledTimes(1);
+    expect(page.getByRole).toHaveBeenCalledWith('button', { name: /Discord/ });
+    expect(discordButton.waitFor).toHaveBeenCalledWith({ state: 'visible', timeout: 15000 });
+    expect(page.waitForTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -70,6 +70,10 @@ describe('preview E2E runner', () => {
     expect(packageJson.scripts['e2e:preview:all']).toBe('npm run e2e:preview --');
   });
 
+  it('exposes the preview admin login helper as a selector-driven E2E setup script', () => {
+    expect(packageJson.scripts['e2e:preview:login']).toBe('node e2e/login-preview-admin.js');
+  });
+
   it('defaults to the installed Chrome channel on macOS preview runs', () => {
     const platform = Object.getOwnPropertyDescriptor(process, 'platform');
     Object.defineProperty(process, 'platform', { value: 'darwin' });

--- a/smkc-score-app/e2e/login-preview-admin.js
+++ b/smkc-score-app/e2e/login-preview-admin.js
@@ -14,6 +14,13 @@ async function isAuthenticated(page) {
   return result;
 }
 
+async function waitForPreviewAdminLoginReady(page) {
+  const adminTab = page.getByRole('tab', { name: /管理者|Admin/ });
+  await adminTab.waitFor({ state: 'visible', timeout: 15000 });
+  await adminTab.click();
+  await page.getByRole('button', { name: /Discord/ }).waitFor({ state: 'visible', timeout: 15000 });
+}
+
 async function main() {
   const env = buildPreviewRuntimeEnv(process.env);
   const { hostname } = new URL(env.E2E_BASE_URL);
@@ -35,7 +42,7 @@ async function main() {
   try {
     const page = browser.pages()[0] || await browser.newPage();
     await page.goto(`${env.E2E_BASE_URL}/auth/signin`, { waitUntil: 'domcontentloaded', timeout: 30000 });
-    await page.waitForTimeout(1500);
+    await waitForPreviewAdminLoginReady(page);
 
     let session = await isAuthenticated(page);
     if (session.authenticated) {
@@ -63,7 +70,15 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.stack || error.message : error);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.stack || error.message : error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  isAuthenticated,
+  waitForPreviewAdminLoginReady,
+  main,
+};


### PR DESCRIPTION
Summary
- Document TC-110 for the preview admin login setup script.
- Replace login-preview-admin.js fixed page-load sleep with Admin tab and Discord button selector waits.
- Add focused Jest coverage for the selector-driven helper and npm preview-login script.

Issues: Closes #1153

Validation
- node --check smkc-score-app/e2e/login-preview-admin.js
- npm test -- __tests__/e2e/login-preview-admin.test.ts __tests__/e2e/run-preview.test.ts
- git diff --check
- git diff --cached --check
- npm run lint (exit 0; existing warnings only)