### PR TITLE
Remove preview login user fallback

### DIFF
--- a/smkc-score-app/e2e/login-preview-admin.js
+++ b/smkc-score-app/e2e/login-preview-admin.js
@@ -8,7 +8,7 @@ async function isAuthenticated(page) {
       const body = await response.json().catch(() => null);
       return {
         status: response.status,
-        authenticated: body?.data?.authenticated === true || Boolean(body?.user),
+        authenticated: body?.data?.authenticated === true,
         body,
       };
     } catch (error) {


### PR DESCRIPTION
Summary
- Remove the unneeded body?.user fallback from login-preview-admin isAuthenticated.
- Keep the helper aligned with /api/auth/session-status data.authenticated contract.

Issues: Closes #1180

Validation
- node --check smkc-score-app/e2e/login-preview-admin.js
- npm test -- __tests__/e2e/login-preview-admin.test.ts __tests__/e2e/run-preview.test.ts
- git diff --check
- npm run lint (exit 0; existing warnings only)