### PR TITLE
Address archive debug E2E follow-ups

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2373,9 +2373,11 @@
   見せてはいけない。
 - **手順**:
   1. admin で tournament を作成し `status: completed`, `publicModes: []` に更新
-  2. `/api/tournaments/:id/archive` を GET
-  3. レスポンス status と error code を確認
+  2. `/api/tournaments/:id/archive` に POST して private archive bundle を生成
+  3. 同じ URL を GET
+  4. レスポンス status と error code を確認
 - **期待結果**:
+  - POST は HTTP 200
   - HTTP 403
   - `error.code === 'FORBIDDEN'`
 - **スクリプト**: tc-archive.js TC-ARC-04 (`npm run e2e:archive`, preview: `npm run e2e:preview:archive`)

--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -1,0 +1,14 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('tc-all focused suite registration', () => {
+  const sourcePath = path.join(process.cwd(), 'e2e', 'tc-all.js');
+  const source = fs.readFileSync(sourcePath, 'utf8');
+
+  it('runs archive and debug-fill focused suites from npm run e2e:all', () => {
+    expect(source).toContain("require('./tc-archive')");
+    expect(source).toContain("require('./tc-debug-fill')");
+    expect(source).toContain('runArchiveTests');
+    expect(source).toContain('runDebugFillTests');
+  });
+});

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -153,6 +153,23 @@ async function apiCreateTournament(page, name, opts = {}) {
   return id;
 }
 
+async function apiJson(page, path, options = {}) {
+  return page.evaluate(async ([url, init]) => {
+    const response = await fetch(url, {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(init.headers || {}),
+      },
+      body: init.body === undefined ? undefined : JSON.stringify(init.body),
+    });
+    return {
+      status: response.status,
+      body: await response.json().catch(() => ({})),
+    };
+  }, [path, options]);
+}
+
 async function apiDeletePlayer(page, id) {
   if (!id) return;
   await page.evaluate(async (u) => { await fetch(u, { method: 'DELETE' }); },
@@ -2592,6 +2609,7 @@ module.exports = {
   /* CRUD */
   apiCreatePlayer,
   apiCreateTournament,
+  apiJson,
   apiDeletePlayer,
   apiDeleteTournament,
   /* UI helpers */

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -55,6 +55,8 @@ const mrModule = require('./tc-mr');
 const gpModule = require('./tc-gp');
 const taModule = require('./tc-ta');
 const overlayModule = require('./tc-overlay');
+const archiveModule = require('./tc-archive');
+const debugFillModule = require('./tc-debug-fill');
 
 /* TID is set at runtime from a dedicated test tournament we create in main().
  * We deliberately do NOT target a pre-existing remote tournament (previously
@@ -3963,6 +3965,8 @@ async function main() {
   }
 
   const suites = [
+    { label: 'Archive Tests', mod: archiveModule, run: archiveModule.runArchiveTests },
+    { label: 'Debug-fill Tests', mod: debugFillModule, run: debugFillModule.runDebugFillTests },
     { label: 'BM Tests', mod: bmModule },
     { label: 'MR Tests', mod: mrModule },
     { label: 'GP Tests', mod: gpModule },
@@ -3975,6 +3979,11 @@ async function main() {
   const suiteFailures = {};
   for (const { label, mod } of suites) {
     console.log(`\n========== Running ${label} (in-process) ==========`);
+    if (typeof mod.runArchiveTests === 'function' || typeof mod.runDebugFillTests === 'function') {
+      const { failed } = await (mod.runArchiveTests ?? mod.runDebugFillTests)(page);
+      suiteFailures[label] = failed;
+      continue;
+    }
     const spec = mod.getSuite({ sharedFixture });
     try {
       const { failed } = await runSuiteInBrowser({ ...spec, page });

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -12,7 +12,9 @@
 const {
   makeResults,
   makeLog,
+  apiCreatePlayer,
   apiCreateTournament,
+  apiJson,
   apiDeletePlayer,
   apiDeleteTournament,
   apiSetupBmGroup,
@@ -26,39 +28,13 @@ const { closeBrowser, envMs, exitAfterCleanup } = require('./lib/runner');
 const results = makeResults();
 const log = makeLog(results);
 
-async function apiJson(page, path, options = {}) {
-  return page.evaluate(async ([url, init]) => {
-    const response = await fetch(url, {
-      ...init,
-      headers: {
-        'Content-Type': 'application/json',
-        ...(init.headers || {}),
-      },
-      body: init.body === undefined ? undefined : JSON.stringify(init.body),
-    });
-    return {
-      status: response.status,
-      body: await response.json().catch(() => ({})),
-    };
-  }, [path, options]);
-}
-
 async function createPlayers(page, prefix, count) {
   const stamp = Date.now();
   const players = [];
   for (let index = 1; index <= count; index++) {
     const nickname = `${prefix.toLowerCase()}_${stamp}_${index}`;
-    const player = await apiJson(page, '/api/players', {
-      method: 'POST',
-      body: {
-        name: `${prefix} Player ${index}`,
-        nickname,
-        country: 'JP',
-      },
-    });
-    const id = player.body?.data?.player?.id;
-    if (player.status !== 201 || !id) throw new Error(`player create failed (${player.status})`);
-    players.push({ id, name: `${prefix} Player ${index}`, nickname });
+    const player = await apiCreatePlayer(page, `${prefix} Player ${index}`, nickname);
+    players.push({ ...player, name: `${prefix} Player ${index}` });
   }
   return players;
 }
@@ -150,16 +126,28 @@ async function tcArc04(page) {
     });
     if (completed.s !== 200) throw new Error(`completion update failed (${completed.s})`);
 
+    const post = await apiJson(page, `/api/tournaments/${tournamentId}/archive`, { method: 'POST' });
     const response = await apiJson(page, `/api/tournaments/${tournamentId}/archive`);
     log('TC-ARC-04',
-      response.status === 403 && response.body?.code === 'FORBIDDEN' ? 'PASS' : 'FAIL',
-      `status=${response.status} code=${response.body?.code}`,
+      post.status === 200 && response.status === 403 && response.body?.code === 'FORBIDDEN' ? 'PASS' : 'FAIL',
+      `post=${post.status} get=${response.status} code=${response.body?.code}`,
     );
   } catch (error) {
     log('TC-ARC-04', 'FAIL', error instanceof Error ? error.message : String(error));
   } finally {
     await apiDeleteTournament(page, tournamentId);
   }
+}
+
+async function runArchiveTests(page) {
+  await tcArc01(page);
+  await tcArc02(page);
+  await tcArc03(page);
+  await tcArc04(page);
+
+  const failed = results.filter((result) => result.s === 'FAIL');
+  console.log(`\nTC-ARC summary: ${results.length - failed.length}/${results.length} passed`);
+  return { failed: failed.length > 0 };
 }
 
 async function main() {
@@ -180,18 +168,12 @@ async function main() {
     page.setDefaultNavigationTimeout(envMs('E2E_NAV_TIMEOUT_MS', 30 * 1000));
     await page.goto(BASE + '/', { waitUntil: 'domcontentloaded' });
 
-    await tcArc01(page);
-    await tcArc02(page);
-    await tcArc03(page);
-    await tcArc04(page);
+    const { failed } = await runArchiveTests(page);
+    process.exitCode = failed ? 1 : 0;
   } finally {
     clearTimeout(suiteTimer);
     await closeBrowser(browser);
   }
-
-  const failed = results.filter((result) => result.s === 'FAIL');
-  console.log(`\nTC-ARC summary: ${results.length - failed.length}/${results.length} passed`);
-  process.exit(failed.length ? 1 : 0);
 }
 
 if (require.main === module) {
@@ -200,3 +182,7 @@ if (require.main === module) {
     process.exit(1);
   });
 }
+
+module.exports = {
+  runArchiveTests,
+};

--- a/smkc-score-app/e2e/tc-debug-fill.js
+++ b/smkc-score-app/e2e/tc-debug-fill.js
@@ -15,6 +15,7 @@ const {
   nav,
   apiCreatePlayer,
   apiCreateTournament,
+  apiJson,
   apiDeletePlayer,
   apiDeleteTournament,
   apiSetupBmGroup,
@@ -42,23 +43,6 @@ function playerAssignments(players) {
     group: index < players.length / 2 ? 'A' : 'B',
     seeding: index + 1,
   }));
-}
-
-async function apiJson(page, path, options = {}) {
-  return page.evaluate(async ([url, init]) => {
-    const response = await fetch(url, {
-      ...init,
-      headers: {
-        'Content-Type': 'application/json',
-        ...(init.headers || {}),
-      },
-      body: init.body === undefined ? undefined : JSON.stringify(init.body),
-    });
-    return {
-      status: response.status,
-      body: await response.json().catch(() => ({})),
-    };
-  }, [path, options]);
 }
 
 async function createPlayers(page, prefix, count) {
@@ -274,6 +258,17 @@ async function tcDbg04(page) {
   }
 }
 
+async function runDebugFillTests(page) {
+  await tcDbg01(page);
+  await tcDbg02(page);
+  await tcDbg03(page);
+  await tcDbg04(page);
+
+  const failed = results.filter((result) => result.s === 'FAIL');
+  console.log(`\nTC-DBG summary: ${results.length - failed.length}/${results.length} passed`);
+  return { failed: failed.length > 0 };
+}
+
 async function main() {
   let browser = null;
   const suiteTimeoutMs = envMs('E2E_DEBUG_FILL_TIMEOUT_MS', envMs('E2E_SUITE_TIMEOUT_MS', 20 * 60 * 1000));
@@ -292,18 +287,12 @@ async function main() {
     page.setDefaultNavigationTimeout(envMs('E2E_NAV_TIMEOUT_MS', 30 * 1000));
     await page.goto(BASE + '/', { waitUntil: 'domcontentloaded' });
 
-    await tcDbg01(page);
-    await tcDbg02(page);
-    await tcDbg03(page);
-    await tcDbg04(page);
+    const { failed } = await runDebugFillTests(page);
+    process.exitCode = failed ? 1 : 0;
   } finally {
     clearTimeout(suiteTimer);
     await closeBrowser(browser);
   }
-
-  const failed = results.filter((result) => result.s === 'FAIL');
-  console.log(`\nTC-DBG summary: ${results.length - failed.length}/${results.length} passed`);
-  process.exit(failed.length ? 1 : 0);
 }
 
 if (require.main === module) {
@@ -312,3 +301,7 @@ if (require.main === module) {
     process.exit(1);
   });
 }
+
+module.exports = {
+  runDebugFillTests,
+};


### PR DESCRIPTION
## Summary

- Move the focused E2E JSON fetch helper into e2e/lib/common.js and make archive player setup use the shared apiCreatePlayer helper.
- Generate the private archive bundle before TC-ARC-04 verifies the public GET returns 403.
- Register archive and debug-fill focused suites inside tc-all.js and add a Jest guard for that registration.

## Issues

Closes #1183
Closes #1184
Closes #1185

## Validation

- `node --check smkc-score-app/e2e/tc-archive.js && node --check smkc-score-app/e2e/tc-debug-fill.js && node --check smkc-score-app/e2e/tc-all.js`
- `npm test -- __tests__/e2e/run-preview.test.ts __tests__/e2e/tc-all-registration.test.ts __tests__/docs/e2e-debug-fill-cases.test.ts __tests__/docs/e2e-archive-cases.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)

## PR Body Diff Check

- [x] Summary only describes changes that are present in this PR diff.
