### PR TITLE
Tighten focused E2E suite dispatch

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -4,11 +4,32 @@ import path from 'path';
 describe('tc-all focused suite registration', () => {
   const sourcePath = path.join(process.cwd(), 'e2e', 'tc-all.js');
   const source = fs.readFileSync(sourcePath, 'utf8');
+  const debugFillPath = path.join(process.cwd(), 'e2e', 'tc-debug-fill.js');
+  const debugFillSource = fs.readFileSync(debugFillPath, 'utf8');
 
   it('runs archive and debug-fill focused suites from npm run e2e:all', () => {
     expect(source).toContain("require('./tc-archive')");
     expect(source).toContain("require('./tc-debug-fill')");
     expect(source).toContain('runArchiveTests');
     expect(source).toContain('runDebugFillTests');
+    expect(source).toContain('for (const { label, mod, run } of suites)');
+    expect(source).toContain('const { failed } = await run(page)');
+  });
+
+  it('keeps debug-fill player creation on the shared helper', () => {
+    const createPlayersStart = debugFillSource.indexOf('async function createPlayers');
+    const createPlayersEnd = debugFillSource.indexOf('\n}\n\nasync function setupAllModes', createPlayersStart);
+    const createPlayersSource = debugFillSource.slice(createPlayersStart, createPlayersEnd);
+
+    expect(createPlayersSource).toContain('apiCreatePlayer');
+    expect(createPlayersSource).not.toContain('apiJson');
+  });
+
+  it('keeps focused suite failure counts numeric', () => {
+    for (const script of ['tc-archive.js', 'tc-debug-fill.js']) {
+      const scriptSource = fs.readFileSync(path.join(process.cwd(), 'e2e', script), 'utf8');
+      expect(scriptSource).toContain('return { failed: failed.length }');
+      expect(scriptSource).not.toContain('return { failed: failed.length > 0 }');
+    }
   });
 });

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3977,10 +3977,10 @@ async function main() {
   ];
 
   const suiteFailures = {};
-  for (const { label, mod } of suites) {
+  for (const { label, mod, run } of suites) {
     console.log(`\n========== Running ${label} (in-process) ==========`);
-    if (typeof mod.runArchiveTests === 'function' || typeof mod.runDebugFillTests === 'function') {
-      const { failed } = await (mod.runArchiveTests ?? mod.runDebugFillTests)(page);
+    if (run) {
+      const { failed } = await run(page);
       suiteFailures[label] = failed;
       continue;
     }

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -147,7 +147,7 @@ async function runArchiveTests(page) {
 
   const failed = results.filter((result) => result.s === 'FAIL');
   console.log(`\nTC-ARC summary: ${results.length - failed.length}/${results.length} passed`);
-  return { failed: failed.length > 0 };
+  return { failed: failed.length };
 }
 
 async function main() {

--- a/smkc-score-app/e2e/tc-debug-fill.js
+++ b/smkc-score-app/e2e/tc-debug-fill.js
@@ -266,7 +266,7 @@ async function runDebugFillTests(page) {
 
   const failed = results.filter((result) => result.s === 'FAIL');
   console.log(`\nTC-DBG summary: ${results.length - failed.length}/${results.length} passed`);
-  return { failed: failed.length > 0 };
+  return { failed: failed.length };
 }
 
 async function main() {


### PR DESCRIPTION
## Summary

- Use the explicit `run` property in tc-all.js focused suite dispatch instead of function-name probing.
- Keep archive/debug-fill focused suite failures as numeric counts.
- Add Jest guards for focused suite dispatch, numeric failure counts, and debug-fill player creation through apiCreatePlayer.

## Issues

Closes #1187
Closes #1188
Closes #1189

## Validation

- `node --check smkc-score-app/e2e/tc-archive.js && node --check smkc-score-app/e2e/tc-debug-fill.js && node --check smkc-score-app/e2e/tc-all.js`
- `npm test -- __tests__/e2e/tc-all-registration.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)

## PR Body Diff Check

- [x] Summary only describes changes that are present in this PR diff.
