### PR TITLE
Harden tc-all registration test scope

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -17,9 +17,9 @@ describe('tc-all focused suite registration', () => {
   });
 
   it('keeps debug-fill player creation on the shared helper', () => {
-    const createPlayersStart = debugFillSource.indexOf('async function createPlayers');
-    const createPlayersEnd = debugFillSource.indexOf('\n}\n\nasync function setupAllModes', createPlayersStart);
-    const createPlayersSource = debugFillSource.slice(createPlayersStart, createPlayersEnd);
+    const createPlayersMatch = debugFillSource.match(/async function createPlayers[\s\S]*?^}/m);
+    if (!createPlayersMatch) throw new Error('createPlayers function not found');
+    const createPlayersSource = createPlayersMatch[0];
 
     expect(createPlayersSource).toContain('apiCreatePlayer');
     expect(createPlayersSource).not.toContain('apiJson');


### PR DESCRIPTION
## Summary

- Harden tc-all-registration.test.ts so createPlayers extraction does not depend on the following function name.
- Fail explicitly if the createPlayers function cannot be found before asserting helper usage.

## Issues

Closes #1191

## Validation

- `npm test -- __tests__/e2e/tc-all-registration.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)

## PR Body Diff Check

- [x] Summary only describes changes that are present in this PR diff.
