### PR TITLE
Document tc registration regex assumption

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -17,6 +17,8 @@ describe('tc-all focused suite registration', () => {
   });
 
   it('keeps debug-fill player creation on the shared helper', () => {
+    // Match through the first unindented closing brace, which marks the end
+    // of a top-level async function in the repo's standard JS formatting.
     const createPlayersMatch = debugFillSource.match(/async function createPlayers[\s\S]*?^}/m);
     if (!createPlayersMatch) throw new Error('createPlayers function not found');
     const createPlayersSource = createPlayersMatch[0];


### PR DESCRIPTION
## Summary

- Add a concise comment documenting that the createPlayers extraction regex relies on a top-level, unindented closing brace.

## Issues

Closes #1193

## Validation

- `npm test -- __tests__/e2e/tc-all-registration.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)

## PR Body Diff Check

- [x] Summary only describes changes that are present in this PR diff.
