### PR TITLE
Guard E2E case documentation drift

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -214,6 +214,8 @@
   6. public DNS fallback は `dig +short` の説明行や不正な IPv4/IPv6 風文字列を host resolver rules に採用しないことを確認する
   7. macOS では Chrome for Testing の Crashpad path に依存せず、installed Chrome channel で起動することを確認する
 - **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / Crashpad permission failure で停止しない
+- **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
+- **補助検証**: `smkc-score-app/__tests__/e2e/run-preview.test.ts`
 
 ## TC-110: Preview 管理者ログイン補助スクリプトの要素待機
 - **URL**: /auth/signin
@@ -1815,6 +1817,7 @@
   4. M1 が `completed=true`、`points1=2`、`points2=0`、`cupResults=null` で保存されていることを確認
   5. クリーンアップ
 - **期待結果**: アッパーブラケットは `2-0` のような取得カップ数だけで保存・進行でき、不要なカップ別明細を作らない
+- **スクリプト**: tc-gp.js TC-1103 (`npm run e2e:gp`, preview: `npm run e2e:preview:gp`)
 
 ## TC-710: GP カップ不一致修正の拒否
 - **URL**: /api/tournaments/[temp-id]/gp (PATCH with correction)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1,0 +1,71 @@
+import fs from 'fs';
+import path from 'path';
+
+const root = path.join(process.cwd(), '..');
+const casesPath = path.join(root, 'E2E_TEST_CASES.md');
+const cases = fs.readFileSync(casesPath, 'utf8');
+
+function readE2eScript(script: string) {
+  return fs.readFileSync(path.join(process.cwd(), 'e2e', script), 'utf8');
+}
+
+function sectionFor(tc: string) {
+  const heading = new RegExp(`^#{2,3} ${tc}:`, 'm');
+  const match = heading.exec(cases);
+  const start = match?.index ?? -1;
+  if (start === -1) throw new Error(`${tc} section not found`);
+  const next = cases.slice(start + 1).search(/\n#{2,3} TC-/);
+  const end = next === -1 ? cases.length : start + 1 + next;
+  return cases.slice(start, end);
+}
+
+describe('E2E case drift coverage', () => {
+  const tcAll = readE2eScript('tc-all.js');
+  const tcGp = readE2eScript('tc-gp.js');
+  const tcDebugFill = readE2eScript('tc-debug-fill.js');
+
+  it.each([
+    ['TC-352', tcAll],
+    ['TC-357', tcAll],
+    ['TC-1103', tcGp],
+  ])('keeps %s documented and registered in its runnable E2E script', (tc, scriptSource) => {
+    const section = sectionFor(tc);
+
+    expect(section).toContain('**手順**');
+    expect(section).toContain('**期待結果**');
+    expect(section).toContain(`**スクリプト**:`);
+    expect(scriptSource).toContain(`log('${tc}'`);
+  });
+
+  it.each(['TC-DBG-01', 'TC-DBG-02', 'TC-DBG-03', 'TC-DBG-04'])(
+    'keeps %s documented as runnable focused debug-fill coverage',
+    (tc) => {
+      const section = sectionFor(tc);
+
+      expect(section).toContain(`tc-debug-fill.js ${tc}`);
+      expect(section).toContain('npm run e2e:preview:debug-fill');
+      expect(tcDebugFill).toContain(`log('${tc}'`);
+    },
+  );
+
+  it('keeps debug-fill wired into the all-suite dispatcher', () => {
+    expect(tcAll).toContain("require('./tc-debug-fill')");
+    expect(tcAll).toContain('runDebugFillTests');
+    expect(tcAll).toContain('for (const { label, mod, run } of suites)');
+  });
+
+  it.each([
+    ['TC-109', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/run-preview.test.ts'],
+    ['TC-803', 'TC-318 でカバー済み', 'TC-318'],
+    ['TC-943', '.github/pull_request_template.md', '__tests__/docs/pr-template.test.ts'],
+  ])('keeps %s explicitly classified outside standalone browser runner registration', (tc, marker, coverage) => {
+    const section = sectionFor(tc);
+
+    expect(section).toContain(marker);
+    expect(section).toContain(coverage);
+  });
+
+  it('does not leave retired TC identifiers in runnable E2E scripts as false drift signals', () => {
+    expect(tcAll).not.toContain('TC-403');
+  });
+});

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -1483,7 +1483,7 @@ async function main() {
   }
   log('TC-307', tc307 ? 'PASS' : 'FAIL');
 
-  // 旧 TC-403/404 (軽量フルワークフローと GP ダイアログUI checks) は廃止。
+  // Legacy lightweight full-workflow and GP dialog UI checks were retired.
   // TC-401/402 は上の共有4モード大会と総合ランキング検証に再利用。
 
   // TC-316: Tiebreaker warning suppressed at group setup (mp=0), shown after tie match


### PR DESCRIPTION
## Summary
- Add a focused Jest guard that keeps the #1146 E2E documentation/runner drift cases aligned.
- Document the command-level TC-109 validation hook and the runnable TC-1103 GP E2E script.
- Remove the retired TC-403 identifier from `tc-all.js` comments so it no longer appears as a false runner drift signal.

## Issues
Closes #1146

## Validation
- `npm test -- __tests__/docs/e2e-cases-drift.test.ts __tests__/docs/e2e-debug-fill-cases.test.ts __tests__/e2e/tc-all-registration.test.ts`
- `node --check smkc-score-app/e2e/tc-all.js`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
