### PR TITLE
Unify tc-all retired comment language

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -34,4 +34,10 @@ describe('tc-all focused suite registration', () => {
       expect(scriptSource).not.toContain('return { failed: failed.length > 0 }');
     }
   });
+
+  it('keeps retired TC-401/TC-402 comments in one language', () => {
+    expect(source).toContain('// 旧軽量フルワークフローとGPダイアログUI確認は廃止済み。');
+    expect(source).toContain('// TC-401/402 は上の共有4モード大会と総合ランキング検証に再利用。');
+    expect(source).not.toContain('Legacy lightweight full-workflow and GP dialog UI checks were retired.');
+  });
 });

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -1483,7 +1483,7 @@ async function main() {
   }
   log('TC-307', tc307 ? 'PASS' : 'FAIL');
 
-  // Legacy lightweight full-workflow and GP dialog UI checks were retired.
+  // 旧軽量フルワークフローとGPダイアログUI確認は廃止済み。
   // TC-401/402 は上の共有4モード大会と総合ランキング検証に再利用。
 
   // TC-316: Tiebreaker warning suppressed at group setup (mp=0), shown after tie match


### PR DESCRIPTION
## Summary
- Unify the retired TC-401/TC-402 comment in `tc-all.js` to Japanese.
- Add focused Jest coverage so the mixed-language comment does not regress.

## Issues
Closes #1196

## Validation
- `node --check smkc-score-app/e2e/tc-all.js`
- `npm test -- __tests__/e2e/tc-all-registration.test.ts`
- `git diff --check`
