### PR TITLE
Refactor GP finals assigned cup validator

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1796,6 +1796,7 @@
 - **URL**: /api/tournaments/[temp-id]/gp/finals (GET)
 - **authRequired**: true (admin)
 - **背景**: GP Knockout / Finals では、各ラウンドに使用するカップの組み合わせをランダムに決め、同じラウンド内の全試合で同じ順番を使う。FT1 は 1 カップ、FT2 は最大 3 カップ、FT3 は最大 5 カップ。キノコ、フラワー、スター、スペシャルの4カップ内では重複しないため、同じラウンドでカップが重複し得るのは FT3 の 5 カップ目だけ。
+- **補足**: `assignedCups` の検証は E2E runner と単体テストで共有する validator を使い、E2E スクリプト内部をテスト目的だけで export しない。
 - **手順**:
   1. 28名予選 + 決勝ブラケット生成（17試合）
   2. `GET /api/.../gp/finals` で全マッチ取得

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -9,6 +9,10 @@ function readE2eScript(script: string) {
   return fs.readFileSync(path.join(process.cwd(), 'e2e', script), 'utf8');
 }
 
+function readE2eLib(script: string) {
+  return fs.readFileSync(path.join(process.cwd(), 'e2e', 'lib', script), 'utf8');
+}
+
 function sectionFor(tc: string) {
   const heading = new RegExp(`^#{2,3} ${tc}:`, 'm');
   const match = heading.exec(cases);
@@ -23,6 +27,7 @@ describe('E2E case drift coverage', () => {
   const tcAll = readE2eScript('tc-all.js');
   const tcGp = readE2eScript('tc-gp.js');
   const tcDebugFill = readE2eScript('tc-debug-fill.js');
+  const gpFinalsValidators = readE2eLib('gp-finals-validators.js');
 
   it.each([
     ['TC-352', tcAll],
@@ -46,8 +51,8 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('FT2 相当');
     expect(section).toContain('FT3 相当');
     expect(tcGp).toContain('validateGpFinalsAssignedCupSequences');
-    expect(tcGp).toContain('match.cup !== assignedCups[0]');
-    expect(tcGp).toContain('assignedCups.slice(0, 4)');
+    expect(gpFinalsValidators).toContain('validateGpFinalsAssignedCupSequences');
+    expect(gpFinalsValidators).toContain('module.exports');
   });
 
   it.each(['TC-DBG-01', 'TC-DBG-02', 'TC-DBG-03', 'TC-DBG-04'])(

--- a/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
@@ -1,4 +1,4 @@
-import { validateGpFinalsAssignedCupSequences } from '../../e2e/tc-gp';
+import { validateGpFinalsAssignedCupSequences } from '../../e2e/lib/gp-finals-validators';
 
 describe('TC-717 assigned cup sequence validation', () => {
   it('accepts shared FT2 and FT3 assignedCups sequences', () => {

--- a/smkc-score-app/e2e/lib/gp-finals-validators.js
+++ b/smkc-score-app/e2e/lib/gp-finals-validators.js
@@ -1,0 +1,55 @@
+function isGpFinalsFt3Round(round) {
+  return ['winners_final', 'losers_sf', 'losers_final', 'grand_final', 'grand_final_reset'].includes(round);
+}
+
+function validateGpFinalsAssignedCupSequences(matches) {
+  const errors = [];
+  const sequencesByRound = new Map();
+
+  for (const match of matches) {
+    const round = match.round;
+    const assignedCups = Array.isArray(match.assignedCups) ? match.assignedCups : [];
+
+    if (!round) continue;
+    if (assignedCups.length === 0) {
+      errors.push(`M${match.matchNumber || match.id}: assignedCups is empty`);
+      continue;
+    }
+    if (match.cup !== assignedCups[0]) {
+      errors.push(`M${match.matchNumber || match.id}: cup=${match.cup} first=${assignedCups[0]}`);
+    }
+
+    const key = JSON.stringify(assignedCups);
+    if (!sequencesByRound.has(round)) sequencesByRound.set(round, new Set());
+    sequencesByRound.get(round).add(key);
+
+    if (isGpFinalsFt3Round(round)) {
+      if (assignedCups.length !== 5) {
+        errors.push(`M${match.matchNumber || match.id}: ${round} expected 5 assigned cups, got ${assignedCups.length}`);
+      }
+      if (new Set(assignedCups.slice(0, 4)).size !== Math.min(4, assignedCups.length)) {
+        errors.push(`M${match.matchNumber || match.id}: ${round} repeats within first 4 assigned cups`);
+      }
+    } else {
+      if (assignedCups.length > 3) {
+        errors.push(`M${match.matchNumber || match.id}: ${round} expected <=3 assigned cups, got ${assignedCups.length}`);
+      }
+      if (new Set(assignedCups).size !== assignedCups.length) {
+        errors.push(`M${match.matchNumber || match.id}: ${round} repeats assigned cups`);
+      }
+    }
+  }
+
+  for (const [round, sequences] of sequencesByRound.entries()) {
+    if (sequences.size !== 1) {
+      errors.push(`${round}: divergent assignedCups sequences`);
+    }
+  }
+
+  return errors;
+}
+
+module.exports = {
+  isGpFinalsFt3Round,
+  validateGpFinalsAssignedCupSequences,
+};

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -48,6 +48,7 @@ const {
 } = require('./lib/common');
 const { createSharedE2eFixture, setupModePlayersViaUi, ensurePlayerPassword } = require('./lib/fixtures');
 const { runSuite } = require('./lib/runner');
+const { validateGpFinalsAssignedCupSequences } = require('./lib/gp-finals-validators');
 
 const results = makeResults();
 const log = makeLog(results);
@@ -615,57 +616,6 @@ async function runTc709(adminPage) {
     if (setup) await setup.cleanup();
     if (extraChallengerId) await apiDeletePlayer(adminPage, extraChallengerId);
   }
-}
-
-function isGpFinalsFt3Round(round) {
-  return ['winners_final', 'losers_sf', 'losers_final', 'grand_final', 'grand_final_reset'].includes(round);
-}
-
-function validateGpFinalsAssignedCupSequences(matches) {
-  const errors = [];
-  const sequencesByRound = new Map();
-
-  for (const match of matches) {
-    const round = match.round;
-    const assignedCups = Array.isArray(match.assignedCups) ? match.assignedCups : [];
-
-    if (!round) continue;
-    if (assignedCups.length === 0) {
-      errors.push(`M${match.matchNumber || match.id}: assignedCups is empty`);
-      continue;
-    }
-    if (match.cup !== assignedCups[0]) {
-      errors.push(`M${match.matchNumber || match.id}: cup=${match.cup} first=${assignedCups[0]}`);
-    }
-
-    const key = JSON.stringify(assignedCups);
-    if (!sequencesByRound.has(round)) sequencesByRound.set(round, new Set());
-    sequencesByRound.get(round).add(key);
-
-    if (isGpFinalsFt3Round(round)) {
-      if (assignedCups.length !== 5) {
-        errors.push(`M${match.matchNumber || match.id}: ${round} expected 5 assigned cups, got ${assignedCups.length}`);
-      }
-      if (new Set(assignedCups.slice(0, 4)).size !== Math.min(4, assignedCups.length)) {
-        errors.push(`M${match.matchNumber || match.id}: ${round} repeats within first 4 assigned cups`);
-      }
-    } else {
-      if (assignedCups.length > 3) {
-        errors.push(`M${match.matchNumber || match.id}: ${round} expected <=3 assigned cups, got ${assignedCups.length}`);
-      }
-      if (new Set(assignedCups).size !== assignedCups.length) {
-        errors.push(`M${match.matchNumber || match.id}: ${round} repeats assigned cups`);
-      }
-    }
-  }
-
-  for (const [round, sequences] of sequencesByRound.entries()) {
-    if (sequences.size !== 1) {
-      errors.push(`${round}: divergent assignedCups sequences`);
-    }
-  }
-
-  return errors;
 }
 
 /* ───────── TC-717: GP finals assigned-cup sequence enforcement ─────────
@@ -1637,7 +1587,6 @@ module.exports = {
   runTc707, runTc708, runTc709, runTc710, runTc712, runTc713,
   runTc715, runTc716, runTc717, runTc718, runTc1103, runTc719,
   runTc720, runTc721, runTc722, runTc724, runTc725, runTc821, runTc831, runTc832,
-  validateGpFinalsAssignedCupSequences,
   getSuite,
   results,
 };


### PR DESCRIPTION
Summary
- Move GP finals assignedCups validation into a shared E2E validator module
- Keep TC-717 runner coverage wired through the shared validator
- Update drift coverage so it checks documented/runnable coverage without hard-coding validator implementation strings

Issues: Closes #1204, Closes #1203

Validation
- npm test -- --runTestsByPath __tests__/e2e/tc-gp-assigned-cups.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint
- git diff --check
