### PR TITLE
Tighten GP validator drift assertions

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import * as gpFinalsValidatorExports from '../../e2e/lib/gp-finals-validators';
 
 const root = path.join(process.cwd(), '..');
 const casesPath = path.join(root, 'E2E_TEST_CASES.md');
@@ -50,9 +51,14 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('assignedCups');
     expect(section).toContain('FT2 相当');
     expect(section).toContain('FT3 相当');
+    expect(tcGp).toContain("require('./lib/gp-finals-validators')");
     expect(tcGp).toContain('validateGpFinalsAssignedCupSequences');
     expect(gpFinalsValidators).toContain('validateGpFinalsAssignedCupSequences');
-    expect(gpFinalsValidators).toContain('module.exports');
+    expect(gpFinalsValidators).toContain('isGpFinalsFt3Round');
+    expect(gpFinalsValidatorExports).toEqual(expect.objectContaining({
+      isGpFinalsFt3Round: expect.any(Function),
+      validateGpFinalsAssignedCupSequences: expect.any(Function),
+    }));
   });
 
   it.each(['TC-DBG-01', 'TC-DBG-02', 'TC-DBG-03', 'TC-DBG-04'])(

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -52,6 +52,7 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('FT2 相当');
     expect(section).toContain('FT3 相当');
     expect(tcGp).toContain("require('./lib/gp-finals-validators')");
+    expect(tcGp).toContain('isGpFinalsFt3Round, validateGpFinalsAssignedCupSequences');
     expect(tcGp).toContain('validateGpFinalsAssignedCupSequences');
     expect(gpFinalsValidators).toContain('validateGpFinalsAssignedCupSequences');
     expect(gpFinalsValidators).toContain('isGpFinalsFt3Round');

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -48,7 +48,7 @@ const {
 } = require('./lib/common');
 const { createSharedE2eFixture, setupModePlayersViaUi, ensurePlayerPassword } = require('./lib/fixtures');
 const { runSuite } = require('./lib/runner');
-const { validateGpFinalsAssignedCupSequences } = require('./lib/gp-finals-validators');
+const { isGpFinalsFt3Round, validateGpFinalsAssignedCupSequences } = require('./lib/gp-finals-validators');
 
 const results = makeResults();
 const log = makeLog(results);


### PR DESCRIPTION
Summary
- Make the TC-717 drift guard verify the shared validator module more specifically
- Assert the GP E2E runner imports the validator helper instead of relying on generic CommonJS text
- Check the validator exports expose the expected functions

Issues: Closes #1206

Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/tc-gp-assigned-cups.test.ts
- npm run lint
- git diff --check
