### PR TITLE
Make TC-717 drift import checks format-stable

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -52,7 +52,7 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('FT2 相当');
     expect(section).toContain('FT3 相当');
     expect(tcGp).toContain("require('./lib/gp-finals-validators')");
-    expect(tcGp).toContain('isGpFinalsFt3Round, validateGpFinalsAssignedCupSequences');
+    expect(tcGp).toContain('isGpFinalsFt3Round');
     expect(tcGp).toContain('validateGpFinalsAssignedCupSequences');
     expect(gpFinalsValidators).toContain('validateGpFinalsAssignedCupSequences');
     expect(gpFinalsValidators).toContain('isGpFinalsFt3Round');


### PR DESCRIPTION
Summary
- Split the TC-717 drift import assertion into independent helper-name checks
- Avoid coupling the drift guard to exact destructuring order or spacing

Issues: Closes #1208

Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/tc-gp-assigned-cups.test.ts
- npm run lint
- git diff --check
