### PR TITLE
Avoid GP E2E target wins duplication

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1747,9 +1747,10 @@
 - **背景**: GPのWinners Semi FinalはFT2で完了する。Winners Final / Losers Semi Final / Losers Final / Grand Final はFT3で、2カップ勝利では未完了、3カップ先取が必要。ベスト4以前のダブルイリミネーション試合もFT2、BarragesはFT1。
 - **手順**:
   1. 28名予選 + Top-8 GP決勝ブラケット生成
-  2. Winners Semi Final に2カップ分のP1勝利をPUTし、`points1=2, completed=true` であることを確認する
-  3. Grand Final に2カップ分のP1勝利をPUTし、`points1=2, completed=false` であることを確認する
-  4. Grand Final に3カップ目P1勝利を追加してPUTし、`points1=3, completed=true` になることを確認する
+  2. M1-M15 は E2E 側でFT数を再計算せず、`assignedCups` を1件ずつ追加PUTしてAPIレスポンス上の `completed=true` を確認できた時点で次試合へ進める
+  3. Winners Final (M16) に2カップ分のP1勝利をPUTし、`points1=2, completed=false` であることを確認する
+  4. Winners Final (M16) に3カップ目P1勝利を追加してPUTし、`points1=3, completed=true` になることを確認する
+  5. Winners Semi Final 群は `points1=2, completed=true` で完了済みであることを確認する
 - **期待結果**: GP Winners Semi Final はFT2として完了し、Winners Final / Losers Semi Final / Losers Final / Grand Final はFT3として動作する
 - **スクリプト**: tc-gp.js TC-722
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -34,6 +34,7 @@ describe('E2E case drift coverage', () => {
     ['TC-352', tcAll],
     ['TC-357', tcAll],
     ['TC-717', tcGp],
+    ['TC-722', tcGp],
     ['TC-1103', tcGp],
     ['TC-725', tcGp],
   ])('keeps %s documented and registered in its runnable E2E script', (tc, scriptSource) => {
@@ -52,7 +53,6 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('FT2 相当');
     expect(section).toContain('FT3 相当');
     expect(tcGp).toContain("require('./lib/gp-finals-validators')");
-    expect(tcGp).toContain('isGpFinalsFt3Round');
     expect(tcGp).toContain('validateGpFinalsAssignedCupSequences');
     expect(gpFinalsValidators).toContain('validateGpFinalsAssignedCupSequences');
     expect(gpFinalsValidators).toContain('isGpFinalsFt3Round');
@@ -60,6 +60,16 @@ describe('E2E case drift coverage', () => {
       isGpFinalsFt3Round: expect.any(Function),
       validateGpFinalsAssignedCupSequences: expect.any(Function),
     }));
+  });
+
+  it('keeps TC-722 from duplicating GP finals target-wins logic in E2E', () => {
+    const section = sectionFor('TC-722');
+
+    expect(section).toContain('completed=true');
+    expect(section).toContain('FT数を再計算せず');
+    expect(tcGp).toContain('completeGpFinalsMatchByCompletedFlag');
+    expect(tcGp).toContain('updated?.completed === true');
+    expect(tcGp).not.toContain('gpFinalsTargetWinsForRound');
   });
 
   it.each(['TC-DBG-01', 'TC-DBG-02', 'TC-DBG-03', 'TC-DBG-04'])(

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -48,7 +48,7 @@ const {
 } = require('./lib/common');
 const { createSharedE2eFixture, setupModePlayersViaUi, ensurePlayerPassword } = require('./lib/fixtures');
 const { runSuite } = require('./lib/runner');
-const { isGpFinalsFt3Round, validateGpFinalsAssignedCupSequences } = require('./lib/gp-finals-validators');
+const { validateGpFinalsAssignedCupSequences } = require('./lib/gp-finals-validators');
 
 const results = makeResults();
 const log = makeLog(results);
@@ -1452,17 +1452,39 @@ async function runTc721(adminPage) {
   }
 }
 
-function gpFinalsTargetWinsForRound(round) {
-  if (isGpFinalsFt3Round(round)) {
-    return 3;
+function gpAssignedCupSequence(match) {
+  if (Array.isArray(match.assignedCups) && match.assignedCups.length > 0) {
+    return match.assignedCups;
   }
-  return 2;
+  return [match.cup || 'Mushroom', 'Flower', 'Star', 'Special', 'Mushroom'];
 }
 
-function gpWinningCupResults(match, targetWins) {
-  const fallbackCups = ['Flower', 'Star', 'Special'];
-  return Array.from({ length: targetWins }, (_, index) => {
-    const cup = index === 0 ? match.cup || 'Mushroom' : fallbackCups[index - 1] || 'Mushroom';
+function gpWinningCupResultsForCups(cups) {
+  return cups.map((cup) => gpCupResult(cup, 45, 0));
+}
+
+async function completeGpFinalsMatchByCompletedFlag(adminPage, tournamentId, match) {
+  const cups = gpAssignedCupSequence(match);
+  for (let count = 1; count <= cups.length; count++) {
+    const res = await apiSetGpFinalsCupResults(
+      adminPage,
+      tournamentId,
+      match.id,
+      gpWinningCupResultsForCups(cups.slice(0, count)),
+    );
+    if (res.s !== 200) throw new Error(`Match ${match.matchNumber} put failed (${res.s})`);
+
+    const matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+    const updated = matches.find((m) => m.id === match.id);
+    if (updated?.completed === true) return updated;
+  }
+  throw new Error(`Match ${match.matchNumber} did not complete after ${cups.length} cups`);
+}
+
+function gpWinningCupResults(match, count) {
+  const cups = gpAssignedCupSequence(match);
+  return Array.from({ length: count }, (_, index) => {
+    const cup = cups[index] || 'Mushroom';
     return gpCupResult(cup, 45, 0);
   });
 }
@@ -1483,33 +1505,20 @@ async function runTc722(adminPage) {
       if (!match || !match.player1Id || !match.player2Id || match.player1Id === match.player2Id) {
         throw new Error(`Match ${mn} not ready`);
       }
-      const res = await apiSetGpFinalsCupResults(
-        adminPage,
-        tournamentId,
-        match.id,
-        gpWinningCupResults(match, gpFinalsTargetWinsForRound(match.round)),
-      );
-      if (res.s !== 200) throw new Error(`Match ${mn} put failed (${res.s})`);
+      await completeGpFinalsMatchByCompletedFlag(adminPage, tournamentId, match);
     }
 
     let matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
     const m16 = matches.find((m) => m.matchNumber === 16);
     if (!m16 || !m16.player1Id || !m16.player2Id) throw new Error('M16 not ready');
 
-    const twoCup = await apiSetGpFinalsCupResults(adminPage, tournamentId, m16.id, [
-      gpCupResult(m16.cup || 'Mushroom', 45, 0),
-      gpCupResult('Flower', 45, 0),
-    ]);
+    const twoCup = await apiSetGpFinalsCupResults(adminPage, tournamentId, m16.id, gpWinningCupResults(m16, 2));
     if (twoCup.s !== 200) throw new Error(`M16 2-cup PUT failed (${twoCup.s})`);
     matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
     const afterTwo = matches.find((m) => m.id === m16.id);
     const stillOpen = afterTwo?.completed === false && afterTwo?.points1 === 2 && afterTwo?.points2 === 0;
 
-    const threeCup = await apiSetGpFinalsCupResults(adminPage, tournamentId, m16.id, [
-      gpCupResult(m16.cup || 'Mushroom', 45, 0),
-      gpCupResult('Flower', 45, 0),
-      gpCupResult('Star', 45, 0),
-    ]);
+    const threeCup = await apiSetGpFinalsCupResults(adminPage, tournamentId, m16.id, gpWinningCupResults(m16, 3));
     if (threeCup.s !== 200) throw new Error(`M16 3-cup PUT failed (${threeCup.s})`);
     matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
     const afterThree = matches.find((m) => m.id === m16.id);


### PR DESCRIPTION
Summary
- Remove duplicated GP finals target-win calculation from TC-722 E2E flow.
- Advance setup matches by adding assigned cups until the API reports `completed=true`.
- Document and guard the no-duplicated-target-wins expectation in E2E drift coverage.

Issues: Closes #1135

Validation
- `node --check smkc-score-app/e2e/tc-gp.js`
- `npm test -- __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/tc-gp-assigned-cups.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
