### PR TITLE
Limit GP E2E fallback cup sequence

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1748,6 +1748,7 @@
 - **手順**:
   1. 28名予選 + Top-8 GP決勝ブラケット生成
   2. M1-M15 は E2E 側でFT数を再計算せず、`assignedCups` を1件ずつ追加PUTしてAPIレスポンス上の `completed=true` を確認できた時点で次試合へ進める
+     - レガシーデータなどで `assignedCups` がない場合のE2Eフォールバックは、FT3の最大3勝に対応する3カップまでに限定する
   3. Winners Final (M16) に2カップ分のP1勝利をPUTし、`points1=2, completed=false` であることを確認する
   4. Winners Final (M16) に3カップ目P1勝利を追加してPUTし、`points1=3, completed=true` になることを確認する
   5. Winners Semi Final 群は `points1=2, completed=true` で完了済みであることを確認する

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -67,6 +67,7 @@ describe('E2E case drift coverage', () => {
 
     expect(section).toContain('completed=true');
     expect(section).toContain('FT数を再計算せず');
+    expect(section).toContain('FT3の最大3勝に対応する3カップ');
     expect(tcGp).toContain('completeGpFinalsMatchByCompletedFlag');
     expect(tcGp).toContain('updated?.completed === true');
     expect(tcGp).not.toContain('gpFinalsTargetWinsForRound');

--- a/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
@@ -1,4 +1,8 @@
 import { validateGpFinalsAssignedCupSequences } from '../../e2e/lib/gp-finals-validators';
+import fs from 'fs';
+import path from 'path';
+
+const tcGpSource = fs.readFileSync(path.join(process.cwd(), 'e2e', 'tc-gp.js'), 'utf8');
 
 describe('TC-717 assigned cup sequence validation', () => {
   it('accepts shared FT2 and FT3 assignedCups sequences', () => {
@@ -24,5 +28,11 @@ describe('TC-717 assigned cup sequence validation', () => {
       'M13: losers_sf expected 5 assigned cups, got 3',
       'M13: losers_sf repeats within first 4 assigned cups',
     ]));
+  });
+
+  it('keeps the legacy TC-722 fallback to the maximum FT3 cup count', () => {
+    expect(tcGpSource).toContain('FT3 maximum');
+    expect(tcGpSource).toContain("return [match.cup || 'Mushroom', 'Flower', 'Star'];");
+    expect(tcGpSource).not.toContain("'Special', 'Mushroom']");
   });
 });

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -1456,7 +1456,8 @@ function gpAssignedCupSequence(match) {
   if (Array.isArray(match.assignedCups) && match.assignedCups.length > 0) {
     return match.assignedCups;
   }
-  return [match.cup || 'Mushroom', 'Flower', 'Star', 'Special', 'Mushroom'];
+  // TC-722 only needs enough fallback cups to reach the GP FT3 maximum.
+  return [match.cup || 'Mushroom', 'Flower', 'Star'];
 }
 
 function gpWinningCupResultsForCups(cups) {


### PR DESCRIPTION
Summary
- Document TC-722's legacy fallback cup limit for GP finals E2E coverage.
- Add drift/static tests that keep the fallback aligned to the FT3 maximum.
- Trim gpAssignedCupSequence's legacy fallback from five cups to three cups.

Issues: Closes #1212

Validation
- `node --check e2e/tc-gp.js`
- `npm test -- __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/tc-gp-assigned-cups.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
