### PR TITLE
Test GP fallback cups by behavior

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
@@ -1,8 +1,5 @@
 import { validateGpFinalsAssignedCupSequences } from '../../e2e/lib/gp-finals-validators';
-import fs from 'fs';
-import path from 'path';
-
-const tcGpSource = fs.readFileSync(path.join(process.cwd(), 'e2e', 'tc-gp.js'), 'utf8');
+import { gpAssignedCupSequence } from '../../e2e/tc-gp';
 
 describe('TC-717 assigned cup sequence validation', () => {
   it('accepts shared FT2 and FT3 assignedCups sequences', () => {
@@ -31,8 +28,15 @@ describe('TC-717 assigned cup sequence validation', () => {
   });
 
   it('keeps the legacy TC-722 fallback to the maximum FT3 cup count', () => {
-    expect(tcGpSource).toContain('FT3 maximum');
-    expect(tcGpSource).toContain("return [match.cup || 'Mushroom', 'Flower', 'Star'];");
-    expect(tcGpSource).not.toContain("'Special', 'Mushroom']");
+    expect(gpAssignedCupSequence({ cup: 'Special' })).toEqual(['Special', 'Flower', 'Star']);
+    expect(gpAssignedCupSequence({})).toEqual(['Mushroom', 'Flower', 'Star']);
+    expect(gpAssignedCupSequence({ cup: 'Special' })).toHaveLength(3);
+  });
+
+  it('uses assignedCups before the legacy fallback', () => {
+    expect(gpAssignedCupSequence({
+      cup: 'Flower',
+      assignedCups: ['Flower', 'Special', 'Mushroom', 'Star'],
+    })).toEqual(['Flower', 'Special', 'Mushroom', 'Star']);
   });
 });

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -1597,6 +1597,7 @@ module.exports = {
   runTc707, runTc708, runTc709, runTc710, runTc712, runTc713,
   runTc715, runTc716, runTc717, runTc718, runTc1103, runTc719,
   runTc720, runTc721, runTc722, runTc724, runTc725, runTc821, runTc831, runTc832,
+  gpAssignedCupSequence,
   getSuite,
   results,
 };


### PR DESCRIPTION
Summary
- Export the GP E2E fallback cup helper for behavior-level test coverage.
- Replace brittle source-string assertions with argument/result assertions.
- Remove the module-top-level readFileSync from the assigned-cup E2E test.

Issues: Closes #1215, Closes #1216

Validation
- `node --check e2e/tc-gp.js`
- `npm test -- __tests__/e2e/tc-gp-assigned-cups.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
