### PR TITLE
Remove redundant GP fallback assertion

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
@@ -30,7 +30,6 @@ describe('TC-717 assigned cup sequence validation', () => {
   it('keeps the legacy TC-722 fallback to the maximum FT3 cup count', () => {
     expect(gpAssignedCupSequence({ cup: 'Special' })).toEqual(['Special', 'Flower', 'Star']);
     expect(gpAssignedCupSequence({})).toEqual(['Mushroom', 'Flower', 'Star']);
-    expect(gpAssignedCupSequence({ cup: 'Special' })).toHaveLength(3);
   });
 
   it('uses assignedCups before the legacy fallback', () => {


### PR DESCRIPTION
Summary
- Remove the redundant `toHaveLength(3)` assertion from the GP fallback cup test.
- Keep the existing `toEqual` assertions as the behavior and length guarantee.

Issues: Closes #1218

Validation
- `npm test -- __tests__/e2e/tc-gp-assigned-cups.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
