### PR TITLE
Optimize GP TC-722 completed flag polling

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1747,7 +1747,7 @@
 - **背景**: GPのWinners Semi FinalはFT2で完了する。Winners Final / Losers Semi Final / Losers Final / Grand Final はFT3で、2カップ勝利では未完了、3カップ先取が必要。ベスト4以前のダブルイリミネーション試合もFT2、BarragesはFT1。
 - **手順**:
   1. 28名予選 + Top-8 GP決勝ブラケット生成
-  2. M1-M15 は E2E 側でFT数を再計算せず、`assignedCups` を1件ずつ追加PUTしてAPIレスポンス上の `completed=true` を確認できた時点で次試合へ進める
+  2. M1-M15 は E2E 側でFT数を再計算せず、`assignedCups` を1件ずつ追加PUTし、PUTレスポンスの更新済みmatchで `completed=true` を確認できた時点で次試合へ進める
      - レガシーデータなどで `assignedCups` がない場合のE2Eフォールバックは、FT3の最大3勝に対応する3カップまでに限定する
   3. Winners Final (M16) に2カップ分のP1勝利をPUTし、`points1=2, completed=false` であることを確認する
   4. Winners Final (M16) に3カップ目P1勝利を追加してPUTし、`points1=3, completed=true` になることを確認する

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -67,8 +67,10 @@ describe('E2E case drift coverage', () => {
 
     expect(section).toContain('completed=true');
     expect(section).toContain('FT数を再計算せず');
+    expect(section).toContain('PUTレスポンスの更新済みmatch');
     expect(section).toContain('FT3の最大3勝に対応する3カップ');
     expect(tcGp).toContain('completeGpFinalsMatchByCompletedFlag');
+    expect(tcGp).toContain('gpFinalsUpdatedMatchFromPutResult');
     expect(tcGp).toContain('updated?.completed === true');
     expect(tcGp).not.toContain('gpFinalsTargetWinsForRound');
   });

--- a/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
@@ -1,5 +1,5 @@
 import { validateGpFinalsAssignedCupSequences } from '../../e2e/lib/gp-finals-validators';
-import { gpAssignedCupSequence } from '../../e2e/tc-gp';
+import { gpAssignedCupSequence, gpFinalsUpdatedMatchFromPutResult } from '../../e2e/tc-gp';
 
 describe('TC-717 assigned cup sequence validation', () => {
   it('accepts shared FT2 and FT3 assignedCups sequences', () => {
@@ -37,5 +37,19 @@ describe('TC-717 assigned cup sequence validation', () => {
       cup: 'Flower',
       assignedCups: ['Flower', 'Special', 'Mushroom', 'Star'],
     })).toEqual(['Flower', 'Special', 'Mushroom', 'Star']);
+  });
+
+  it('reads the updated GP finals match from PUT responses before fetch fallback', () => {
+    const updatedMatch = { id: 'm16', matchNumber: 16, completed: true };
+
+    expect(gpFinalsUpdatedMatchFromPutResult({
+      b: { data: { match: updatedMatch } },
+    }, 'm16')).toBe(updatedMatch);
+    expect(gpFinalsUpdatedMatchFromPutResult({
+      b: { match: updatedMatch },
+    }, 'm16')).toBe(updatedMatch);
+    expect(gpFinalsUpdatedMatchFromPutResult({
+      b: { data: { match: { id: 'm15', completed: true } } },
+    }, 'm16')).toBeNull();
   });
 });

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -1464,6 +1464,11 @@ function gpWinningCupResultsForCups(cups) {
   return cups.map((cup) => gpCupResult(cup, 45, 0));
 }
 
+function gpFinalsUpdatedMatchFromPutResult(putResult, matchId) {
+  const match = putResult?.b?.data?.match || putResult?.b?.match;
+  return match?.id === matchId ? match : null;
+}
+
 async function completeGpFinalsMatchByCompletedFlag(adminPage, tournamentId, match) {
   const cups = gpAssignedCupSequence(match);
   for (let count = 1; count <= cups.length; count++) {
@@ -1475,8 +1480,11 @@ async function completeGpFinalsMatchByCompletedFlag(adminPage, tournamentId, mat
     );
     if (res.s !== 200) throw new Error(`Match ${match.matchNumber} put failed (${res.s})`);
 
-    const matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
-    const updated = matches.find((m) => m.id === match.id);
+    let updated = gpFinalsUpdatedMatchFromPutResult(res, match.id);
+    if (!updated) {
+      const matches = await apiFetchGpFinalsMatches(adminPage, tournamentId);
+      updated = matches.find((m) => m.id === match.id);
+    }
     if (updated?.completed === true) return updated;
   }
   throw new Error(`Match ${match.matchNumber} did not complete after ${cups.length} cups`);
@@ -1597,7 +1605,7 @@ module.exports = {
   runTc707, runTc708, runTc709, runTc710, runTc712, runTc713,
   runTc715, runTc716, runTc717, runTc718, runTc1103, runTc719,
   runTc720, runTc721, runTc722, runTc724, runTc725, runTc821, runTc831, runTc832,
-  gpAssignedCupSequence,
+  gpAssignedCupSequence, gpFinalsUpdatedMatchFromPutResult,
   getSuite,
   results,
 };


### PR DESCRIPTION
## Summary
- Update TC-722 documentation to state that GP finals completion advances from the updated match in the PUT response.
- Make completeGpFinalsMatchByCompletedFlag use the PUT response match first, falling back to all-match fetch only for older/missing response payloads.
- Add focused drift/unit coverage for the PUT-response helper and TC-722 contract.

## Issues
Closes #1213

## Validation
- node --check smkc-score-app/e2e/tc-gp.js
- npm test -- __tests__/e2e/tc-gp-assigned-cups.test.ts __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
- npm run lint (exit 0; existing warnings only)
