### PR TITLE
Clarify GP PUT result helper

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
@@ -42,6 +42,8 @@ describe('TC-717 assigned cup sequence validation', () => {
   it('reads the updated GP finals match from PUT responses before fetch fallback', () => {
     const updatedMatch = { id: 'm16', matchNumber: 16, completed: true };
 
+    expect(gpFinalsUpdatedMatchFromPutResult(null, 'm16')).toBeNull();
+    expect(gpFinalsUpdatedMatchFromPutResult(undefined, 'm16')).toBeNull();
     expect(gpFinalsUpdatedMatchFromPutResult({
       b: { data: { match: updatedMatch } },
     }, 'm16')).toBe(updatedMatch);

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -1465,6 +1465,7 @@ function gpWinningCupResultsForCups(cups) {
 }
 
 function gpFinalsUpdatedMatchFromPutResult(putResult, matchId) {
+  // Current createSuccessResponse shape is b.data.match; keep b.match for legacy E2E payloads.
   const match = putResult?.b?.data?.match || putResult?.b?.match;
   return match?.id === matchId ? match : null;
 }


### PR DESCRIPTION
## Summary
- Add explicit null/undefined coverage for gpFinalsUpdatedMatchFromPutResult.
- Document why the helper accepts both b.data.match and legacy b.match response shapes.

## Issues
Closes #1221
Closes #1222

## Validation
- node --check smkc-score-app/e2e/tc-gp.js
- npm test -- __tests__/e2e/tc-gp-assigned-cups.test.ts __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
- npm run lint (exit 0; existing warnings only)
