### PR TITLE
Clarify GP PUT result fallback

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-gp-assigned-cups.test.ts
@@ -51,6 +51,9 @@ describe('TC-717 assigned cup sequence validation', () => {
       b: { match: updatedMatch },
     }, 'm16')).toBe(updatedMatch);
     expect(gpFinalsUpdatedMatchFromPutResult({
+      b: { data: { match: false }, match: updatedMatch },
+    }, 'm16')).toBeNull();
+    expect(gpFinalsUpdatedMatchFromPutResult({
       b: { data: { match: { id: 'm15', completed: true } } },
     }, 'm16')).toBeNull();
   });

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -1466,7 +1466,7 @@ function gpWinningCupResultsForCups(cups) {
 
 function gpFinalsUpdatedMatchFromPutResult(putResult, matchId) {
   // Current createSuccessResponse shape is b.data.match; keep b.match for legacy E2E payloads.
-  const match = putResult?.b?.data?.match || putResult?.b?.match;
+  const match = putResult?.b?.data?.match ?? putResult?.b?.match;
   return match?.id === matchId ? match : null;
 }
 


### PR DESCRIPTION
## Summary
- Use nullish coalescing when reading the updated GP finals match from PUT responses so legacy fallback is only used for null/undefined current-shape payloads.
- Add focused coverage for the fallback guard so falsey non-null current-shape values do not incorrectly fall through to legacy b.match.

## Issues
Closes #1224

## Validation
- node --check smkc-score-app/e2e/tc-gp.js
- npm test -- __tests__/e2e/tc-gp-assigned-cups.test.ts
- git diff --check
- npm run lint (passes with existing warnings)
