### PR TITLE
Avoid auto Chrome fallback for preview E2E

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -204,7 +204,7 @@
 ## TC-109: Preview E2E 公式 alias と起動前 preflight
 - **URL**: n/a (runner command)
 - **authRequired**: true (admin profile)
-- **背景**: preview 環境移行後、自動化手順は `npm run e2e:preview` を公式入口として扱う。runner は preview URL/profile を設定し、Chromium 起動前に host 解決と macOS Chrome channel fallback を行う。
+- **背景**: preview 環境移行後、自動化手順は `npm run e2e:preview` を公式入口として扱う。runner は preview URL/profile を設定し、Chromium 起動前に host 解決を行う。macOS の installed Chrome は Crashpad がユーザーホーム配下を参照して abort することがあるため、自動 fallback ではなく明示指定時のみ使用する。
 - **手順**:
   1. `smkc-score-app/` で `npm run e2e:preview` を実行する
   2. 互換 alias の `npm run e2e:preview:all` は同じ runner コマンドを重複定義せず、`npm run e2e:preview --` に委譲していることを確認する
@@ -212,7 +212,8 @@
   4. preview host が通常 DNS または public DNS fallback で解決できることを確認する
   5. public DNS fallback は IPv4 A レコードがない host でも IPv6 AAAA レコードを解決できることを確認する
   6. public DNS fallback は `dig +short` の説明行や不正な IPv4/IPv6 風文字列を host resolver rules に採用しないことを確認する
-  7. macOS では Chrome for Testing の Crashpad path に依存せず、installed Chrome channel で起動することを確認する
+  7. macOS で `/Applications/Google Chrome.app` が存在しても、runner が自動で `E2E_BROWSER_CHANNEL=chrome` を設定しないことを確認する
+  8. `E2E_BROWSER_CHANNEL=chrome` または `E2E_EXECUTABLE_PATH=...` を明示した場合だけ、その指定が子プロセスへ渡ることを確認する
 - **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / Crashpad permission failure で停止しない
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
 - **補助検証**: `smkc-score-app/__tests__/e2e/run-preview.test.ts`

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -2,17 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals
 import packageJson from '../../package.json';
 
 const lookupMock = jest.fn();
-const existsSyncMock = jest.fn();
 const spawnSyncMock = jest.fn();
 
 jest.mock('dns', () => ({
   promises: {
     lookup: (...args: unknown[]) => lookupMock(...args),
   },
-}));
-
-jest.mock('fs', () => ({
-  existsSync: (...args: unknown[]) => existsSyncMock(...args),
 }));
 
 jest.mock('child_process', () => ({
@@ -44,9 +39,7 @@ describe('preview E2E runner', () => {
     delete process.env.E2E_BROWSER_CHANNEL;
     delete process.env.E2E_EXECUTABLE_PATH;
     lookupMock.mockReset();
-    existsSyncMock.mockReset();
     spawnSyncMock.mockReset();
-    existsSyncMock.mockReturnValue(false);
     spawnSyncMock.mockReturnValue({ status: 1, stdout: '', stderr: '' });
     runner = loadRunner();
   });
@@ -84,18 +77,25 @@ describe('preview E2E runner', () => {
     expect(packageJson.scripts['e2e:preview:archive']).toBe('node e2e/run-preview.js tc-archive.js');
   });
 
-  it('defaults to the installed Chrome channel on macOS preview runs', () => {
+  it('does not auto-select installed Chrome on macOS preview runs', () => {
     const platform = Object.getOwnPropertyDescriptor(process, 'platform');
     Object.defineProperty(process, 'platform', { value: 'darwin' });
-    existsSyncMock.mockReturnValue(true);
 
     const env = runner.buildPreviewRuntimeEnv({});
 
-    expect(env.E2E_BROWSER_CHANNEL).toBe('chrome');
+    expect(env.E2E_BROWSER_CHANNEL).toBeUndefined();
 
     if (platform) {
       Object.defineProperty(process, 'platform', platform);
     }
+  });
+
+  it('preserves caller-provided browser channel override', () => {
+    const env = runner.buildPreviewRuntimeEnv({
+      E2E_BROWSER_CHANNEL: 'chrome',
+    });
+
+    expect(env.E2E_BROWSER_CHANNEL).toBe('chrome');
   });
 
   it('preserves caller-provided non-production base url override', () => {

--- a/smkc-score-app/e2e/run-preview.js
+++ b/smkc-score-app/e2e/run-preview.js
@@ -1,7 +1,6 @@
 const { spawn } = require('child_process');
 const { spawnSync } = require('child_process');
 const dns = require('dns').promises;
-const fs = require('fs');
 const net = require('net');
 const path = require('path');
 
@@ -16,15 +15,6 @@ function buildPreviewRuntimeEnv(env = process.env) {
     E2E_BASE_URL: resolveE2EBaseUrl(env),
     E2E_PROFILE_DIR: resolveE2EProfileDir(env),
   };
-
-  if (
-    process.platform === 'darwin' &&
-    !runtimeEnv.E2E_EXECUTABLE_PATH &&
-    !runtimeEnv.E2E_BROWSER_CHANNEL &&
-    fs.existsSync('/Applications/Google Chrome.app')
-  ) {
-    runtimeEnv.E2E_BROWSER_CHANNEL = 'chrome';
-  }
 
   return runtimeEnv;
 }


### PR DESCRIPTION
## Summary
- Stop preview E2E from automatically selecting the installed macOS Chrome channel.
- Keep installed Chrome available only when E2E_BROWSER_CHANNEL or E2E_EXECUTABLE_PATH is explicitly supplied.
- Update TC-109 and preview runner tests to cover the Crashpad-safe default.

## Issues
Closes #1148

## Validation
- npm test -- __tests__/e2e/run-preview.test.ts __tests__/lib/e2e-browser-launch.test.ts __tests__/docs/e2e-cases-drift.test.ts
- node --check e2e/run-preview.js
- git diff --check
- npm run lint (0 errors, existing warnings only)
