### PR TITLE
Test preview executable path override

### DIFF
--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -98,6 +98,14 @@ describe('preview E2E runner', () => {
     expect(env.E2E_BROWSER_CHANNEL).toBe('chrome');
   });
 
+  it('preserves caller-provided executable path override', () => {
+    const env = runner.buildPreviewRuntimeEnv({
+      E2E_EXECUTABLE_PATH: '/usr/bin/chromium',
+    });
+
+    expect(env.E2E_EXECUTABLE_PATH).toBe('/usr/bin/chromium');
+  });
+
   it('preserves caller-provided non-production base url override', () => {
     const env = runner.buildPreviewRuntimeEnv({
       E2E_BASE_URL: 'https://preview-alt.example.com/',


### PR DESCRIPTION
## Summary
- Add explicit Jest coverage for E2E_EXECUTABLE_PATH preview runner passthrough.
- Keep TC-109 step 8 aligned with both explicit browser override modes.

## Issues
Closes #1228

## Validation
- npm test -- __tests__/e2e/run-preview.test.ts
- git diff --check
