### PR TITLE
Clean up broadcast layout validation

### DIFF
--- a/smkc-score-app/__tests__/lib/overlay/layout.test.ts
+++ b/smkc-score-app/__tests__/lib/overlay/layout.test.ts
@@ -21,6 +21,10 @@ describe('overlay broadcast layout', () => {
       player1Score: { x: 150, y: 540 },
       player2Score: { x: 150 },
     })).toBe(true);
+    expect(isOverlayBroadcastLayoutInput({
+      player1Name: { x: 0, y: 0 },
+      player2Name: { x: 1920, y: 1080 },
+    })).toBe(true);
 
     expect(isOverlayBroadcastLayoutInput({
       player3Name: { x: 1, y: 2 },

--- a/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
@@ -167,6 +167,7 @@ export async function PUT(
     const tournamentId = tournament.id;
 
     const updateData: Record<string, string | number | boolean | null | Prisma.InputJsonValue> = {};
+    let normalizedLayout: OverlayBroadcastLayout | undefined;
     if (player1Name !== undefined) {
       updateData.overlayPlayer1Name = player1Name === null ? null : (player1Name as string).trim() || null;
       if (player1NoCamera === undefined) updateData.overlayPlayer1NoCamera = false;
@@ -194,7 +195,8 @@ export async function PUT(
       updateData.overlayMatchFt = matchFt === null ? null : (matchFt as number);
     }
     if (layout !== undefined) {
-      updateData.overlayLayout = normalizeOverlayBroadcastLayout(layout) as unknown as Prisma.InputJsonObject;
+      normalizedLayout = normalizeOverlayBroadcastLayout(layout);
+      updateData.overlayLayout = normalizedLayout as unknown as Prisma.InputJsonObject;
     }
 
     if (Object.keys(updateData).length === 0) {
@@ -231,9 +233,7 @@ export async function PUT(
       matchFt: updateData.overlayMatchFt !== undefined
         ? (updateData.overlayMatchFt ?? null)
         : undefined,
-      layout: updateData.overlayLayout !== undefined
-        ? (updateData.overlayLayout as unknown as OverlayBroadcastLayout)
-        : undefined,
+      layout: normalizedLayout,
     });
   } catch (error) {
     logger.error("Failed to update broadcast state", { error, tournamentId: id });

--- a/smkc-score-app/src/lib/overlay/layout.ts
+++ b/smkc-score-app/src/lib/overlay/layout.ts
@@ -44,13 +44,8 @@ function isFiniteCoordinate(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
-function isCoordinateInBroadcastBounds(key: "x" | "y", value: number): boolean {
-  if (key === "x") {
-    return value >= OVERLAY_BROADCAST_LAYOUT_BOUNDS.minX &&
-      value <= OVERLAY_BROADCAST_LAYOUT_BOUNDS.maxX;
-  }
-  return value >= OVERLAY_BROADCAST_LAYOUT_BOUNDS.minY &&
-    value <= OVERLAY_BROADCAST_LAYOUT_BOUNDS.maxY;
+function isInRange(value: number, min: number, max: number): boolean {
+  return value >= min && value <= max;
 }
 
 function normalizePosition(
@@ -80,7 +75,9 @@ export function isOverlayBroadcastLayoutInput(value: unknown): value is Partial<
     if (!isRecord(position)) return false;
     const x = position.x;
     const y = position.y;
-    return (x === undefined || (isFiniteCoordinate(x) && isCoordinateInBroadcastBounds("x", x))) &&
-      (y === undefined || (isFiniteCoordinate(y) && isCoordinateInBroadcastBounds("y", y)));
+    return (x === undefined || (isFiniteCoordinate(x) &&
+      isInRange(x, OVERLAY_BROADCAST_LAYOUT_BOUNDS.minX, OVERLAY_BROADCAST_LAYOUT_BOUNDS.maxX))) &&
+      (y === undefined || (isFiniteCoordinate(y) &&
+        isInRange(y, OVERLAY_BROADCAST_LAYOUT_BOUNDS.minY, OVERLAY_BROADCAST_LAYOUT_BOUNDS.maxY)));
   });
 }


### PR DESCRIPTION
Summary
- Keep the normalized overlay layout in a typed local variable for the broadcast PUT response.
- Simplify coordinate bounds validation helper names and calls.
- Add boundary-value coverage for x=0/x=1920/y=0/y=1080.

Issues: Closes #1235, Closes #1236, Closes #1237

Validation
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/broadcast/route.test.ts' __tests__/lib/overlay/layout.test.ts
- git diff --check
- npm run lint (passes with existing warnings)
