### PR TITLE
Add layout bounds negative tests

### DIFF
--- a/smkc-score-app/__tests__/lib/overlay/layout.test.ts
+++ b/smkc-score-app/__tests__/lib/overlay/layout.test.ts
@@ -38,5 +38,11 @@ describe('overlay broadcast layout', () => {
     expect(isOverlayBroadcastLayoutInput({
       footer: { x: 180, y: -1 },
     })).toBe(false);
+    expect(isOverlayBroadcastLayoutInput({
+      player1Name: { x: -1, y: 0 },
+    })).toBe(false);
+    expect(isOverlayBroadcastLayoutInput({
+      player1Name: { x: 0, y: 1081 },
+    })).toBe(false);
   });
 });


### PR DESCRIPTION
Summary
- Add explicit negative boundary tests for layout coordinates below x/y minimums and above x/y maximums.

Issues: Closes #1239

Validation
- npm test -- --runTestsByPath __tests__/lib/overlay/layout.test.ts
- git diff --check
