### PR TITLE
Add preview D1 schema preflight

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -218,6 +218,19 @@
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
 - **補助検証**: `smkc-score-app/__tests__/e2e/run-preview.test.ts`
 
+## TC-111: Preview D1 schema preflight
+- **URL**: n/a (runner command)
+- **authRequired**: true (admin profile)
+- **背景**: Preview D1 は wrangler migration の適用状況と Prisma schema がずれると、`npm run e2e:preview:all` がブラウザ起動後に 500 で大量失敗する。`Tournament.publicModes` と `GPMatch.suddenDeathWinnerId` は過去に preview で欠落したため、runner が起動前に必須カラムを検査する。
+- **手順**:
+  1. `smkc-score-app/` で `npm run e2e:preview` を実行する
+  2. runner が `wrangler d1 execute DB --remote --env preview --json` で `Tournament.publicModes` と `GPMatch.suddenDeathWinnerId` を確認する
+  3. 必須カラムが欠落している場合はブラウザを起動せず、`npm run db:migrations:apply:preview` を促すエラーで停止することを確認する
+  4. `GPMatch.suddenDeathWinnerId` が wrangler-format migration にも存在することを確認する
+- **期待結果**: preview D1 schema drift は TC 本体の 500 ではなく、起動前 preflight の明示エラーとして検出される
+- **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
+- **補助検証**: `smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts`
+
 ## TC-110: Preview 管理者ログイン補助スクリプトの要素待機
 - **URL**: /auth/signin
 - **authRequired**: false (ログイン準備)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -96,6 +96,7 @@ describe('E2E case drift coverage', () => {
 
   it.each([
     ['TC-109', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/run-preview.test.ts'],
+    ['TC-111', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts'],
     ['TC-803', 'TC-318 でカバー済み', 'TC-318'],
     ['TC-943', '.github/pull_request_template.md', '__tests__/docs/pr-template.test.ts'],
   ])('keeps %s explicitly classified outside standalone browser runner registration', (tc, marker, coverage) => {

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+const spawnSyncMock = jest.fn();
+
+jest.mock('child_process', () => ({
+  spawnSync: (...args: unknown[]) => spawnSyncMock(...args),
+}));
+
+type PreviewSchemaPreflight = typeof import('../../e2e/lib/preview-schema-preflight');
+
+function loadPreflight() {
+  let loaded: PreviewSchemaPreflight | undefined;
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    loaded = require('../../e2e/lib/preview-schema-preflight') as PreviewSchemaPreflight;
+  });
+  if (!loaded) throw new Error('Failed to load preview schema preflight');
+  return loaded;
+}
+
+describe('preview schema preflight', () => {
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+  });
+
+  it('checks the columns that previously drifted on preview D1', () => {
+    const preflight = loadPreflight();
+
+    expect(preflight.REQUIRED_PREVIEW_COLUMNS).toEqual([
+      { table: 'Tournament', column: 'publicModes' },
+      { table: 'GPMatch', column: 'suddenDeathWinnerId' },
+    ]);
+    expect(preflight.buildPreviewSchemaCheckSql()).toContain("pragma_table_info('Tournament')");
+    expect(preflight.buildPreviewSchemaCheckSql()).toContain("pragma_table_info('GPMatch')");
+  });
+
+  it('passes when wrangler reports all required columns', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify([
+        {
+          results: [
+            { required_column: 'Tournament.publicModes' },
+            { required_column: 'GPMatch.suddenDeathWinnerId' },
+          ],
+        },
+      ]),
+      stderr: '',
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({})).not.toThrow();
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'wrangler',
+      expect.arrayContaining(['d1', 'execute', 'DB', '--remote', '--env', 'preview', '--json']),
+      expect.objectContaining({ encoding: 'utf8' }),
+    );
+  });
+
+  it('fails before browser launch when a required column is missing', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify([{ results: [{ required_column: 'Tournament.publicModes' }] }]),
+      stderr: '',
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({})).toThrow(
+      /Preview D1 schema is missing required columns: GPMatch\.suddenDeathWinnerId/,
+    );
+  });
+
+  it('fails with migration guidance when wrangler cannot run the check', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: '',
+      stderr: 'No migrations to apply',
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({})).toThrow(/db:migrations:apply:preview/);
+  });
+
+  it('keeps the missing GP sudden death column in Wrangler migrations', () => {
+    const migrationPath = path.join(
+      process.cwd(),
+      'migrations',
+      '0035_add_gp_match_sudden_death_winner.sql',
+    );
+
+    expect(readFileSync(migrationPath, 'utf8')).toContain(
+      'ALTER TABLE `GPMatch` ADD COLUMN `suddenDeathWinnerId` TEXT',
+    );
+  });
+});

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -67,6 +67,10 @@ describe('preview E2E runner', () => {
     expect(packageJson.scripts['e2e:preview:login']).toBe('node e2e/login-preview-admin.js');
   });
 
+  it('exposes preview schema preflight for E2E startup checks', () => {
+    expect(typeof runner.assertPreviewD1Schema).toBe('function');
+  });
+
   it('exposes a focused preview debug-fill coverage script', () => {
     expect(packageJson.scripts['e2e:debug-fill']).toBe('node e2e/tc-debug-fill.js');
     expect(packageJson.scripts['e2e:preview:debug-fill']).toBe('node e2e/run-preview.js tc-debug-fill.js');

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -1,0 +1,107 @@
+const { spawnSync } = require('child_process');
+
+const REQUIRED_PREVIEW_COLUMNS = [
+  { table: 'Tournament', column: 'publicModes' },
+  { table: 'GPMatch', column: 'suddenDeathWinnerId' },
+];
+
+function buildPreviewSchemaCheckSql(columns = REQUIRED_PREVIEW_COLUMNS) {
+  return columns
+    .map(({ table, column }) => {
+      const label = `${table}.${column}`;
+      const escapedTable = table.replace(/'/g, "''");
+      const escapedColumn = column.replace(/'/g, "''");
+      const escapedLabel = label.replace(/'/g, "''");
+      return [
+        `SELECT '${escapedLabel}' AS required_column`,
+        `WHERE EXISTS (SELECT 1 FROM pragma_table_info('${escapedTable}') WHERE name = '${escapedColumn}')`,
+      ].join(' ');
+    })
+    .join(' UNION ALL ');
+}
+
+function extractWranglerJson(stdout) {
+  const text = String(stdout || '').trim();
+  if (!text) return null;
+
+  const firstJsonChar = text.search(/[\[{]/);
+  if (firstJsonChar < 0) return null;
+
+  try {
+    return JSON.parse(text.slice(firstJsonChar));
+  } catch (_error) {
+    return null;
+  }
+}
+
+function collectResultRows(parsed) {
+  const payloads = Array.isArray(parsed) ? parsed : [parsed];
+  return payloads.flatMap((payload) => {
+    if (!payload || typeof payload !== 'object') return [];
+    if (Array.isArray(payload.results)) return payload.results;
+    if (payload.result && Array.isArray(payload.result.results)) return payload.result.results;
+    return [];
+  });
+}
+
+function parsePresentColumns(stdout) {
+  const parsed = extractWranglerJson(stdout);
+  if (parsed) {
+    return new Set(
+      collectResultRows(parsed)
+        .map((row) => row?.required_column)
+        .filter((value) => typeof value === 'string'),
+    );
+  }
+
+  const text = String(stdout || '');
+  return new Set(
+    REQUIRED_PREVIEW_COLUMNS
+      .map(({ table, column }) => `${table}.${column}`)
+      .filter((label) => text.includes(label)),
+  );
+}
+
+function assertPreviewD1Schema(env = process.env) {
+  if (env.E2E_SKIP_PREVIEW_SCHEMA_PREFLIGHT === '1') return;
+
+  const sql = buildPreviewSchemaCheckSql();
+  const result = spawnSync(
+    'wrangler',
+    ['d1', 'execute', 'DB', '--remote', '--env', 'preview', '--json', '--command', sql],
+    { encoding: 'utf8', cwd: process.cwd(), env },
+  );
+
+  if (result.status !== 0) {
+    const stderr = String(result.stderr || '').trim();
+    throw new Error(
+      [
+        'Preview D1 schema preflight failed before launching the browser.',
+        `Command exited ${result.status}.`,
+        stderr ? `stderr: ${stderr}` : '',
+        'Run npm run db:migrations:apply:preview, then retry npm run e2e:preview.',
+      ].filter(Boolean).join(' '),
+    );
+  }
+
+  const presentColumns = parsePresentColumns(result.stdout);
+  const missing = REQUIRED_PREVIEW_COLUMNS
+    .map(({ table, column }) => `${table}.${column}`)
+    .filter((label) => !presentColumns.has(label));
+
+  if (missing.length > 0) {
+    throw new Error(
+      [
+        `Preview D1 schema is missing required columns: ${missing.join(', ')}.`,
+        'Run npm run db:migrations:apply:preview before npm run e2e:preview.',
+      ].join(' '),
+    );
+  }
+}
+
+module.exports = {
+  REQUIRED_PREVIEW_COLUMNS,
+  assertPreviewD1Schema,
+  buildPreviewSchemaCheckSql,
+  parsePresentColumns,
+};

--- a/smkc-score-app/e2e/run-preview.js
+++ b/smkc-score-app/e2e/run-preview.js
@@ -8,6 +8,9 @@ const {
   resolveE2EBaseUrl,
   resolveE2EProfileDir,
 } = require('./lib/env');
+const {
+  assertPreviewD1Schema,
+} = require('./lib/preview-schema-preflight');
 
 function buildPreviewRuntimeEnv(env = process.env) {
   const runtimeEnv = {
@@ -75,6 +78,7 @@ async function runTargetScript(targetScript, env = buildPreviewRuntimeEnv()) {
   if (fallbackAddress && !childEnv.E2E_HOST_RESOLVER_RULES) {
     childEnv.E2E_HOST_RESOLVER_RULES = `MAP ${hostname} ${fallbackAddress}`;
   }
+  assertPreviewD1Schema(childEnv);
 
   const targetPath = path.join(__dirname, targetScript);
   return await new Promise((resolve, reject) => {
@@ -114,4 +118,5 @@ module.exports = {
   buildPreviewRuntimeEnv,
   resolveHostViaPublicDns,
   runTargetScript,
+  assertPreviewD1Schema,
 };

--- a/smkc-score-app/migrations/0035_add_gp_match_sudden_death_winner.sql
+++ b/smkc-score-app/migrations/0035_add_gp_match_sudden_death_winner.sql
@@ -1,0 +1,3 @@
+-- Keep Wrangler/D1 migrations aligned with Prisma migration
+-- 0003_gp_match_sudden_death_winner.
+ALTER TABLE `GPMatch` ADD COLUMN `suddenDeathWinnerId` TEXT;


### PR DESCRIPTION
## Summary
- Add TC-111 to cover preview D1 schema preflight before browser E2E startup.
- Add a preview runner preflight that checks `Tournament.publicModes` and `GPMatch.suddenDeathWinnerId` via `wrangler d1 execute` before launching Playwright.
- Add the missing Wrangler/D1 migration for `GPMatch.suddenDeathWinnerId` and focused Jest coverage for the preflight and docs linkage.

## Issues
Closes #1149

## Validation
- `npm test -- __tests__/e2e/preview-schema-preflight.test.ts __tests__/e2e/run-preview.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `node --check e2e/run-preview.js && node --check e2e/lib/preview-schema-preflight.js`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
- `npm run db:migrations:list:preview` attempted with temp Wrangler log path; blocked locally by missing `CLOUDFLARE_API_TOKEN`, not by GitHub/DNS/API connectivity.

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
