### PR TITLE
Tighten preview schema preflight

### DIFF
--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -55,8 +55,26 @@ describe('preview schema preflight', () => {
     expect(spawnSyncMock).toHaveBeenCalledWith(
       'wrangler',
       expect.arrayContaining(['d1', 'execute', 'DB', '--remote', '--env', 'preview', '--json']),
-      expect.objectContaining({ encoding: 'utf8' }),
+      expect.objectContaining({ encoding: 'utf8', timeout: 30_000 }),
     );
+  });
+
+  it('does not trust non-json stdout that merely mentions required column names', () => {
+    const preflight = loadPreflight();
+
+    expect(preflight.parsePresentColumns('Column Tournament.publicModes is invalid')).toEqual(new Set());
+  });
+
+  it('only parses the documented wrangler results array shape', () => {
+    const preflight = loadPreflight();
+
+    expect(
+      preflight.parsePresentColumns(JSON.stringify({
+        result: {
+          results: [{ required_column: 'Tournament.publicModes' }],
+        },
+      })),
+    ).toEqual(new Set());
   });
 
   it('fails before browser launch when a required column is missing', () => {
@@ -81,6 +99,18 @@ describe('preview schema preflight', () => {
     });
 
     expect(() => preflight.assertPreviewD1Schema({})).toThrow(/db:migrations:apply:preview/);
+  });
+
+  it('fails with timeout guidance when wrangler hangs', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: null,
+      stdout: '',
+      stderr: '',
+      error: { code: 'ETIMEDOUT' },
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({})).toThrow(/timed out after 30 seconds/);
   });
 
   it('keeps the missing GP sudden death column in Wrangler migrations', () => {

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -39,26 +39,18 @@ function collectResultRows(parsed) {
   return payloads.flatMap((payload) => {
     if (!payload || typeof payload !== 'object') return [];
     if (Array.isArray(payload.results)) return payload.results;
-    if (payload.result && Array.isArray(payload.result.results)) return payload.result.results;
     return [];
   });
 }
 
 function parsePresentColumns(stdout) {
   const parsed = extractWranglerJson(stdout);
-  if (parsed) {
-    return new Set(
-      collectResultRows(parsed)
-        .map((row) => row?.required_column)
-        .filter((value) => typeof value === 'string'),
-    );
-  }
+  if (!parsed) return new Set();
 
-  const text = String(stdout || '');
   return new Set(
-    REQUIRED_PREVIEW_COLUMNS
-      .map(({ table, column }) => `${table}.${column}`)
-      .filter((label) => text.includes(label)),
+    collectResultRows(parsed)
+      .map((row) => row?.required_column)
+      .filter((value) => typeof value === 'string'),
   );
 }
 
@@ -69,8 +61,17 @@ function assertPreviewD1Schema(env = process.env) {
   const result = spawnSync(
     'wrangler',
     ['d1', 'execute', 'DB', '--remote', '--env', 'preview', '--json', '--command', sql],
-    { encoding: 'utf8', cwd: process.cwd(), env },
+    { encoding: 'utf8', cwd: process.cwd(), env, timeout: 30_000 },
   );
+
+  if (result.error?.code === 'ETIMEDOUT') {
+    throw new Error(
+      [
+        'Preview D1 schema preflight timed out after 30 seconds before launching the browser.',
+        'Check Cloudflare/Wrangler connectivity, run npm run db:migrations:apply:preview if needed, then retry npm run e2e:preview.',
+      ].join(' '),
+    );
+  }
 
   if (result.status !== 0) {
     const stderr = String(result.stderr || '').trim();


### PR DESCRIPTION
## Summary
- Add a 30 second Wrangler timeout to preview schema preflight and report timeout-specific guidance.
- Make `parsePresentColumns` fail safe when Wrangler stdout is not JSON instead of text-searching column names.
- Remove the unused alternate `payload.result.results` parser path and extend focused Jest coverage.

## Issues
Closes #1242
Closes #1243
Closes #1244

## Validation
- `npm test -- __tests__/e2e/preview-schema-preflight.test.ts __tests__/e2e/run-preview.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `node --check e2e/lib/preview-schema-preflight.js && node --check e2e/run-preview.js`
- `git diff --check`
- `npm run lint` (passes with existing warnings)

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
