### PR TITLE
Centralize preview schema timeout

### DIFF
--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -32,6 +32,7 @@ describe('preview schema preflight', () => {
       { table: 'Tournament', column: 'publicModes' },
       { table: 'GPMatch', column: 'suddenDeathWinnerId' },
     ]);
+    expect(preflight.WRANGLER_TIMEOUT_MS).toBe(30_000);
     expect(preflight.buildPreviewSchemaCheckSql()).toContain("pragma_table_info('Tournament')");
     expect(preflight.buildPreviewSchemaCheckSql()).toContain("pragma_table_info('GPMatch')");
   });
@@ -55,7 +56,7 @@ describe('preview schema preflight', () => {
     expect(spawnSyncMock).toHaveBeenCalledWith(
       'wrangler',
       expect.arrayContaining(['d1', 'execute', 'DB', '--remote', '--env', 'preview', '--json']),
-      expect.objectContaining({ encoding: 'utf8', timeout: 30_000 }),
+      expect.objectContaining({ encoding: 'utf8', timeout: preflight.WRANGLER_TIMEOUT_MS }),
     );
   });
 

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -4,6 +4,7 @@ const REQUIRED_PREVIEW_COLUMNS = [
   { table: 'Tournament', column: 'publicModes' },
   { table: 'GPMatch', column: 'suddenDeathWinnerId' },
 ];
+const WRANGLER_TIMEOUT_MS = 30_000;
 
 function buildPreviewSchemaCheckSql(columns = REQUIRED_PREVIEW_COLUMNS) {
   return columns
@@ -61,13 +62,13 @@ function assertPreviewD1Schema(env = process.env) {
   const result = spawnSync(
     'wrangler',
     ['d1', 'execute', 'DB', '--remote', '--env', 'preview', '--json', '--command', sql],
-    { encoding: 'utf8', cwd: process.cwd(), env, timeout: 30_000 },
+    { encoding: 'utf8', cwd: process.cwd(), env, timeout: WRANGLER_TIMEOUT_MS },
   );
 
   if (result.error?.code === 'ETIMEDOUT') {
     throw new Error(
       [
-        'Preview D1 schema preflight timed out after 30 seconds before launching the browser.',
+        `Preview D1 schema preflight timed out after ${WRANGLER_TIMEOUT_MS / 1000} seconds before launching the browser.`,
         'Check Cloudflare/Wrangler connectivity, run npm run db:migrations:apply:preview if needed, then retry npm run e2e:preview.',
       ].join(' '),
     );
@@ -105,4 +106,5 @@ module.exports = {
   assertPreviewD1Schema,
   buildPreviewSchemaCheckSql,
   parsePresentColumns,
+  WRANGLER_TIMEOUT_MS,
 };


### PR DESCRIPTION
## Summary
- Centralize the preview schema preflight Wrangler timeout in `WRANGLER_TIMEOUT_MS`.
- Derive the timeout error message from that constant so future changes cannot drift.
- Extend focused Jest coverage to assert the exported timeout contract.

## Issues
Closes #1246

## Validation
- `npm test -- __tests__/e2e/preview-schema-preflight.test.ts __tests__/e2e/run-preview.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `node --check e2e/lib/preview-schema-preflight.js && node --check e2e/run-preview.js`
- `git diff --check`
- `npm run lint` (passes with existing warnings)

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
