### PR TITLE
Guard preview GP assigned cups schema

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -221,12 +221,12 @@
 ## TC-111: Preview D1 schema preflight
 - **URL**: n/a (runner command)
 - **authRequired**: true (admin profile)
-- **背景**: Preview D1 は wrangler migration の適用状況と Prisma schema がずれると、`npm run e2e:preview:all` がブラウザ起動後に 500 で大量失敗する。`Tournament.publicModes` と `GPMatch.suddenDeathWinnerId` は過去に preview で欠落したため、runner が起動前に必須カラムを検査する。
+- **背景**: Preview D1 は wrangler migration の適用状況と Prisma schema がずれると、`npm run e2e:preview:all` がブラウザ起動後に 500 で大量失敗する。`Tournament.publicModes`、`GPMatch.assignedCups`、`GPMatch.suddenDeathWinnerId` は過去に preview で欠落または確認漏れし、GP finals POST/GET が 500 に見える原因になるため、runner が起動前に必須カラムを検査する。
 - **手順**:
   1. `smkc-score-app/` で `npm run e2e:preview` を実行する
-  2. runner が `wrangler d1 execute DB --remote --env preview --json` で `Tournament.publicModes` と `GPMatch.suddenDeathWinnerId` を確認する
+  2. runner が `wrangler d1 execute DB --remote --env preview --json` で `Tournament.publicModes`、`GPMatch.assignedCups`、`GPMatch.suddenDeathWinnerId` を確認する
   3. 必須カラムが欠落している場合はブラウザを起動せず、`npm run db:migrations:apply:preview` を促すエラーで停止することを確認する
-  4. `GPMatch.suddenDeathWinnerId` が wrangler-format migration にも存在することを確認する
+  4. `GPMatch.assignedCups` と `GPMatch.suddenDeathWinnerId` が wrangler-format migration にも存在することを確認する
 - **期待結果**: preview D1 schema drift は TC 本体の 500 ではなく、起動前 preflight の明示エラーとして検出される
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
 - **補助検証**: `smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts`

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -106,6 +106,14 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain(coverage);
   });
 
+  it('keeps TC-111 aligned with the preview D1 columns that fail GP finals before browser launch', () => {
+    const section = sectionFor('TC-111');
+
+    expect(section).toContain('Tournament.publicModes');
+    expect(section).toContain('GPMatch.assignedCups');
+    expect(section).toContain('GPMatch.suddenDeathWinnerId');
+  });
+
   it('does not leave retired TC identifiers in runnable E2E scripts as false drift signals', () => {
     expect(tcAll).not.toContain('TC-403');
   });

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -30,6 +30,7 @@ describe('preview schema preflight', () => {
 
     expect(preflight.REQUIRED_PREVIEW_COLUMNS).toEqual([
       { table: 'Tournament', column: 'publicModes' },
+      { table: 'GPMatch', column: 'assignedCups' },
       { table: 'GPMatch', column: 'suddenDeathWinnerId' },
     ]);
     expect(preflight.WRANGLER_TIMEOUT_MS).toBe(30_000);
@@ -45,6 +46,7 @@ describe('preview schema preflight', () => {
         {
           results: [
             { required_column: 'Tournament.publicModes' },
+            { required_column: 'GPMatch.assignedCups' },
             { required_column: 'GPMatch.suddenDeathWinnerId' },
           ],
         },
@@ -82,7 +84,14 @@ describe('preview schema preflight', () => {
     const preflight = loadPreflight();
     spawnSyncMock.mockReturnValue({
       status: 0,
-      stdout: JSON.stringify([{ results: [{ required_column: 'Tournament.publicModes' }] }]),
+      stdout: JSON.stringify([
+        {
+          results: [
+            { required_column: 'Tournament.publicModes' },
+            { required_column: 'GPMatch.assignedCups' },
+          ],
+        },
+      ]),
       stderr: '',
     });
 
@@ -123,6 +132,18 @@ describe('preview schema preflight', () => {
 
     expect(readFileSync(migrationPath, 'utf8')).toContain(
       'ALTER TABLE `GPMatch` ADD COLUMN `suddenDeathWinnerId` TEXT',
+    );
+  });
+
+  it('keeps the GP assigned cups column in Wrangler migrations', () => {
+    const migrationPath = path.join(
+      process.cwd(),
+      'migrations',
+      '0033_gp_finals_assigned_cups.sql',
+    );
+
+    expect(readFileSync(migrationPath, 'utf8')).toContain(
+      'ALTER TABLE GPMatch ADD COLUMN assignedCups TEXT',
     );
   });
 });

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -2,6 +2,7 @@ const { spawnSync } = require('child_process');
 
 const REQUIRED_PREVIEW_COLUMNS = [
   { table: 'Tournament', column: 'publicModes' },
+  { table: 'GPMatch', column: 'assignedCups' },
   { table: 'GPMatch', column: 'suddenDeathWinnerId' },
 ];
 const WRANGLER_TIMEOUT_MS = 30_000;


### PR DESCRIPTION
Summary
- Add GPMatch.assignedCups to the preview D1 schema preflight so GP finals schema drift fails before browser E2E starts.
- Update TC-111 documentation and docs drift coverage to keep the preflight column list aligned.
- Add migration coverage for the Wrangler-format assignedCups migration.

Issues: Closes #1150

Validation
- npm test -- __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts
- node --check e2e/lib/preview-schema-preflight.js && git diff --check
- npm run lint (exit 0; existing warnings only)
