### PR TITLE
Document Wrangler migration quote style

### DIFF
--- a/smkc-score-app/README.md
+++ b/smkc-score-app/README.md
@@ -245,6 +245,14 @@ When you modify `prisma/schema.prisma`, create a migration:
 npx prisma migrate dev --name add_new_feature
 ```
 
+For Cloudflare D1, also add the matching Wrangler-format SQL file under
+`migrations/`. New Wrangler/D1 migrations should quote table and column
+identifiers with backticks so examples stay consistent:
+
+```sql
+ALTER TABLE `TableName` ADD COLUMN `columnName` TEXT;
+```
+
 ### Prisma Studio
 
 Prisma Studio provides a GUI for viewing and editing database data:

--- a/smkc-score-app/__tests__/docs/readme-migrations.test.ts
+++ b/smkc-score-app/__tests__/docs/readme-migrations.test.ts
@@ -1,0 +1,12 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('README migration guidance', () => {
+  const readme = fs.readFileSync(path.join(process.cwd(), 'README.md'), 'utf8');
+
+  it('documents backtick-quoted identifiers for new Wrangler D1 migrations', () => {
+    expect(readme).toContain('Wrangler-format SQL file under');
+    expect(readme).toContain('identifiers with backticks');
+    expect(readme).toContain('ALTER TABLE `TableName` ADD COLUMN `columnName` TEXT;');
+  });
+});


### PR DESCRIPTION
Summary
- Document the Wrangler/D1 migration identifier quoting convention in README migration guidance.
- Add a focused docs test so the backtick-quoted example remains present.

Issues: Closes #1249

Validation
- npm test -- __tests__/docs/readme-migrations.test.ts
- git diff --cached --check
