### PR TITLE
Tighten README migration guidance

### DIFF
--- a/smkc-score-app/README.md
+++ b/smkc-score-app/README.md
@@ -247,7 +247,8 @@ npx prisma migrate dev --name add_new_feature
 
 For Cloudflare D1, also add the matching Wrangler-format SQL file under
 `migrations/`. New Wrangler/D1 migrations should quote table and column
-identifiers with backticks so examples stay consistent:
+identifiers with backticks (SQLite syntax) to avoid reserved-word conflicts
+and keep examples consistent:
 
 ```sql
 ALTER TABLE `TableName` ADD COLUMN `columnName` TEXT;

--- a/smkc-score-app/__tests__/docs/readme-migrations.test.ts
+++ b/smkc-score-app/__tests__/docs/readme-migrations.test.ts
@@ -2,10 +2,11 @@ import fs from 'fs';
 import path from 'path';
 
 describe('README migration guidance', () => {
-  const readme = fs.readFileSync(path.join(process.cwd(), 'README.md'), 'utf8');
+  const readme = fs.readFileSync(path.join(__dirname, '../../README.md'), 'utf8');
 
   it('documents backtick-quoted identifiers for new Wrangler D1 migrations', () => {
     expect(readme).toContain('Wrangler-format SQL file under');
+    expect(readme).toContain('avoid reserved-word conflicts');
     expect(readme).toContain('identifiers with backticks');
     expect(readme).toContain('ALTER TABLE `TableName` ADD COLUMN `columnName` TEXT;');
   });


### PR DESCRIPTION
Summary
- Resolve README migration follow-ups by making the docs test path stable from __dirname.
- Explain that D1 migration backticks use SQLite syntax to avoid reserved-word conflicts.

Issues: Closes #1251, Closes #1252

Validation
- npm test -- __tests__/docs/readme-migrations.test.ts
- git diff --check
