### PR TITLE
Isolate preview archive bucket

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2385,6 +2385,8 @@
 - **authRequired**: POST は admin、GET は公開
 - **背景**: 完了済み tournament は admin POST で archive を再生成でき、公開
   `publicModes` を持つ archive は GET で mode payload と overall ranking を返す。
+  preview 実行では `smkc-archives-preview` を使い、production の
+  `smkc-archives` にテスト archive を書き込まない。
 - **手順**:
   1. admin で tournament + BM 予選データを作成
   2. `status: completed`, `publicModes: ['bm', 'overall']` に更新

--- a/smkc-score-app/__tests__/config/wrangler-r2-buckets.test.ts
+++ b/smkc-score-app/__tests__/config/wrangler-r2-buckets.test.ts
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+
+const wranglerTomlPath = path.join(__dirname, '..', '..', 'wrangler.toml');
+const wranglerToml = fs.readFileSync(wranglerTomlPath, 'utf8');
+
+function r2BucketName(sectionName: string) {
+  const sectionHeader = sectionName === 'production'
+    ? '[[r2_buckets]]'
+    : `[[env.${sectionName}.r2_buckets]]`;
+  const sectionStart = wranglerToml.indexOf(sectionHeader);
+  expect(sectionStart).toBeGreaterThanOrEqual(0);
+
+  const nextSectionStart = wranglerToml.indexOf('\n[[', sectionStart + sectionHeader.length);
+  const section = nextSectionStart === -1
+    ? wranglerToml.slice(sectionStart)
+    : wranglerToml.slice(sectionStart, nextSectionStart);
+  const match = section.match(/^\s*bucket_name\s*=\s*"([^"]+)"/m);
+  expect(match).not.toBeNull();
+  return match?.[1];
+}
+
+describe('Wrangler R2 bucket bindings', () => {
+  it('keeps preview archive E2E writes isolated from production archives', () => {
+    expect(r2BucketName('production')).toBe('smkc-archives');
+    expect(r2BucketName('preview')).toBe('smkc-archives-preview');
+    expect(r2BucketName('preview')).not.toBe(r2BucketName('production'));
+  });
+});

--- a/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
@@ -14,4 +14,14 @@ describe('archive E2E case registration', () => {
       expect(section).not.toContain('未スクリプト化');
     },
   );
+
+  it('documents that preview archive coverage writes to a dedicated R2 bucket', () => {
+    const section = cases.slice(
+      cases.indexOf('## TC-ARC-03:'),
+      cases.indexOf('\n---', cases.indexOf('## TC-ARC-03:')),
+    );
+
+    expect(section).toContain('smkc-archives-preview');
+    expect(section).toContain('smkc-archives');
+  });
 });

--- a/smkc-score-app/wrangler.toml
+++ b/smkc-score-app/wrangler.toml
@@ -64,4 +64,4 @@ migrations_dir = "migrations"
 
 [[env.preview.r2_buckets]]
 binding = "ARCHIVE_BUCKET"
-bucket_name = "smkc-archives"
+bucket_name = "smkc-archives-preview"


### PR DESCRIPTION
Summary
- Point preview R2 archive binding at `smkc-archives-preview` instead of the production `smkc-archives` bucket.
- Document the preview archive E2E isolation assumption in TC-ARC-03.
- Add focused Jest coverage for Wrangler R2 bucket separation and archive E2E documentation.

Issues: Closes #1145

Validation
- `npm test -- __tests__/config/wrangler-r2-buckets.test.ts __tests__/docs/e2e-archive-cases.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
