### PR TITLE
Tighten preview R2 bucket tests

### DIFF
--- a/smkc-score-app/__tests__/config/wrangler-r2-buckets.test.ts
+++ b/smkc-score-app/__tests__/config/wrangler-r2-buckets.test.ts
@@ -9,14 +9,13 @@ function r2BucketName(sectionName: string) {
     ? '[[r2_buckets]]'
     : `[[env.${sectionName}.r2_buckets]]`;
   const sectionStart = wranglerToml.indexOf(sectionHeader);
-  expect(sectionStart).toBeGreaterThanOrEqual(0);
+  if (sectionStart === -1) return undefined;
 
   const nextSectionStart = wranglerToml.indexOf('\n[[', sectionStart + sectionHeader.length);
   const section = nextSectionStart === -1
     ? wranglerToml.slice(sectionStart)
     : wranglerToml.slice(sectionStart, nextSectionStart);
   const match = section.match(/^\s*bucket_name\s*=\s*"([^"]+)"/m);
-  expect(match).not.toBeNull();
   return match?.[1];
 }
 

--- a/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
@@ -22,6 +22,6 @@ describe('archive E2E case registration', () => {
     );
 
     expect(section).toContain('smkc-archives-preview');
-    expect(section).toContain('smkc-archives');
+    expect(section).toMatch(/smkc-archives(?!-preview)/);
   });
 });


### PR DESCRIPTION
Summary
- Move the Wrangler R2 bucket helper failure path out of helper-level `expect()` calls.
- Make the archive docs test distinguish the production bucket name from the preview bucket substring.

Issues: Closes #1255, Closes #1256

Validation
- `npm test -- __tests__/config/wrangler-r2-buckets.test.ts __tests__/docs/e2e-archive-cases.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
