### PR TITLE
Fix archived TA finals results display

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
@@ -105,6 +105,10 @@ jest.mock('@/lib/ta/course-selection', () => ({
   getAvailableCourses: jest.fn(),
 }));
 
+jest.mock('@/lib/tournament-archive', () => ({
+  readTournamentArchive: jest.fn(),
+}));
+
 jest.mock('@/lib/rate-limit', () => ({
   rateLimit: jest.fn(() => ({ success: true })),
   getClientIdentifier: jest.fn(() => 'test-client'),
@@ -165,6 +169,7 @@ import {
 import { getPlayedCoursesWithSuddenDeath, getAvailableCourses } from '@/lib/ta/course-selection';
 import { checkStageFrozen } from '@/lib/ta/freeze-check';
 import { auth } from '@/lib/auth';
+import { readTournamentArchive } from '@/lib/tournament-archive';
 import * as phasesRoute from '@/app/api/tournaments/[id]/ta/phases/route';
 
 const { NextResponse } = jest.requireMock('next/server');
@@ -178,6 +183,7 @@ describe('GET /api/tournaments/[id]/ta/phases', () => {
     jest.clearAllMocks();
     // Re-establish logger mock return value after clearAllMocks
     loggerMock.createLogger.mockReturnValue(loggerInstance);
+    (readTournamentArchive as jest.Mock).mockResolvedValue(null);
   });
 
   const mockParams = Promise.resolve({ id: 'tournament-1' });
@@ -244,6 +250,93 @@ describe('GET /api/tournaments/[id]/ta/phases', () => {
       expect(NextResponse.json).toHaveBeenCalledWith(
         expect.objectContaining({ success: false, error: 'Tournament not found' }),
         { status: 404 }
+      );
+    });
+
+    it('reconstructs archived phase3 entries from round history when the archive lacks phase entries', async () => {
+      (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(null);
+      (getAvailableCourses as jest.Mock).mockReturnValue(['DP1']);
+      (readTournamentArchive as jest.Mock).mockResolvedValue({
+        schemaVersion: 1,
+        tournament: { id: 'tournament-1', slug: 'archived', name: 'Archived', status: 'completed' },
+        allPlayers: [],
+        modes: {
+          ta: {
+            entries: [
+              {
+                id: 'qual-1',
+                tournamentId: 'tournament-1',
+                playerId: 'player-1',
+                stage: 'qualification',
+                lives: 3,
+                eliminated: false,
+                rank: 1,
+                totalTime: 60000,
+                player: { id: 'player-1', name: 'Winner', nickname: 'Winner' },
+              },
+              {
+                id: 'qual-2',
+                tournamentId: 'tournament-1',
+                playerId: 'player-2',
+                stage: 'qualification',
+                lives: 3,
+                eliminated: false,
+                rank: 2,
+                totalTime: 65000,
+                player: { id: 'player-2', name: 'Runner', nickname: 'Runner' },
+              },
+            ],
+            phaseRounds: [
+              {
+                id: 'round-1',
+                tournamentId: 'tournament-1',
+                phase: 'phase3',
+                roundNumber: 1,
+                course: 'MC1',
+                results: [
+                  { playerId: 'player-1', timeMs: 60000, isRetry: false },
+                  { playerId: 'player-2', timeMs: 70000, isRetry: false },
+                ],
+                eliminatedIds: ['player-2'],
+                livesReset: false,
+                manualOverride: false,
+              },
+            ],
+          },
+          bm: {},
+          mr: {},
+          gp: {},
+        },
+      });
+
+      await phasesRoute.GET(createRequest('?phase=phase3'), { params: mockParams });
+
+      const call = NextResponse.json.mock.calls[0][0];
+      expect(call).toEqual(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            archived: true,
+            phaseStatus: expect.objectContaining({
+              phase3: expect.objectContaining({ total: 2, active: 1, eliminated: 1, winner: 'Winner' }),
+            }),
+            entries: expect.arrayContaining([
+              expect.objectContaining({
+                playerId: 'player-1',
+                stage: 'phase3',
+                eliminated: false,
+                player: expect.objectContaining({ nickname: 'Winner' }),
+              }),
+              expect.objectContaining({
+                playerId: 'player-2',
+                stage: 'phase3',
+                eliminated: true,
+                player: expect.objectContaining({ nickname: 'Runner' }),
+              }),
+            ]),
+            rounds: [expect.objectContaining({ id: 'round-1' })],
+          }),
+        })
       );
     });
   });

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
@@ -164,24 +164,140 @@ function summarizeArchivedPhase(entries: unknown[], phase: PhaseName) {
   };
 }
 
+function getRoundResultPlayerIds(rounds: unknown[], phase: PhaseName) {
+  const playerIds = new Set<string>();
+  for (const round of rounds) {
+    if ((round as { phase?: unknown }).phase !== phase) continue;
+    const results = (round as { results?: unknown }).results;
+    if (Array.isArray(results)) {
+      for (const result of results) {
+        const playerId = (result as { playerId?: unknown }).playerId;
+        if (typeof playerId === "string") playerIds.add(playerId);
+      }
+    }
+    const eliminatedIds = (round as { eliminatedIds?: unknown }).eliminatedIds;
+    if (Array.isArray(eliminatedIds)) {
+      for (const playerId of eliminatedIds) {
+        if (typeof playerId === "string") playerIds.add(playerId);
+      }
+    }
+  }
+  return playerIds;
+}
+
+function replayArchivedPhaseLives(rounds: unknown[], playerIds: Set<string>) {
+  const livesByPlayer = new Map([...playerIds].map((playerId) => [playerId, 3]));
+  const eliminated = new Set<string>();
+
+  const phase3Rounds = rounds
+    .filter((round) => (round as { phase?: unknown }).phase === "phase3")
+    .sort((a, b) =>
+      ((a as { roundNumber?: number }).roundNumber ?? 0) -
+      ((b as { roundNumber?: number }).roundNumber ?? 0)
+    );
+
+  for (const round of phase3Rounds) {
+    const results = (round as { results?: unknown }).results;
+    if (Array.isArray(results)) {
+      const sorted = [...results].sort((a, b) =>
+        ((a as { timeMs?: number }).timeMs ?? Number.POSITIVE_INFINITY) -
+        ((b as { timeMs?: number }).timeMs ?? Number.POSITIVE_INFINITY)
+      );
+      const bottomHalf = sorted.slice(Math.ceil(sorted.length / 2));
+      for (const result of bottomHalf) {
+        const playerId = (result as { playerId?: unknown }).playerId;
+        if (typeof playerId !== "string" || eliminated.has(playerId)) continue;
+        livesByPlayer.set(playerId, Math.max(0, (livesByPlayer.get(playerId) ?? 3) - 1));
+      }
+    }
+
+    const eliminatedIds = (round as { eliminatedIds?: unknown }).eliminatedIds;
+    if (Array.isArray(eliminatedIds)) {
+      for (const playerId of eliminatedIds) {
+        if (typeof playerId !== "string") continue;
+        eliminated.add(playerId);
+        livesByPlayer.set(playerId, 0);
+      }
+    }
+
+    if ((round as { livesReset?: unknown }).livesReset === true) {
+      for (const playerId of playerIds) {
+        if (!eliminated.has(playerId)) livesByPlayer.set(playerId, 3);
+      }
+    }
+  }
+
+  return { livesByPlayer, eliminated };
+}
+
+function getArchivedPhaseEntries(entries: unknown[], rounds: unknown[], phase: PhaseName) {
+  const phaseEntries = entries.filter((entry) => (entry as { stage?: unknown }).stage === phase);
+  if (phaseEntries.length > 0) return phaseEntries;
+
+  const playerIds = getRoundResultPlayerIds(rounds, phase);
+  if (playerIds.size === 0) return phaseEntries;
+
+  const sourceByPlayerId = new Map(
+    entries
+      .map((entry) => [(entry as { playerId?: unknown }).playerId, entry] as const)
+      .filter(([playerId]) => typeof playerId === "string")
+  );
+  const eliminated = new Set<string>();
+  const livesByPlayer = new Map<string, number>();
+
+  if (phase === "phase3") {
+    const replay = replayArchivedPhaseLives(rounds, playerIds);
+    replay.eliminated.forEach((playerId) => eliminated.add(playerId));
+    replay.livesByPlayer.forEach((lives, playerId) => livesByPlayer.set(playerId, lives));
+  } else {
+    for (const round of rounds) {
+      if ((round as { phase?: unknown }).phase !== phase) continue;
+      const eliminatedIds = (round as { eliminatedIds?: unknown }).eliminatedIds;
+      if (!Array.isArray(eliminatedIds)) continue;
+      eliminatedIds.forEach((playerId) => {
+        if (typeof playerId === "string") eliminated.add(playerId);
+      });
+    }
+  }
+
+  return [...playerIds].map((playerId) => {
+    const source = (sourceByPlayerId.get(playerId) ?? {}) as Record<string, unknown>;
+    return {
+      ...source,
+      id: `${String(source.id ?? playerId)}-${phase}`,
+      playerId,
+      stage: phase,
+      lives: phase === "phase3" ? (livesByPlayer.get(playerId) ?? 3) : 0,
+      eliminated: eliminated.has(playerId),
+      player: source.player ?? { id: playerId, name: playerId, nickname: playerId },
+    };
+  });
+}
+
 async function getArchivedPhaseResponse(id: string, phase?: PhaseName) {
   const archive = await readTournamentArchive(id);
   if (!archive) return null;
 
   const entries = archive.modes.ta.entries ?? [];
   const rounds = archive.modes.ta.phaseRounds ?? [];
+  const phase1Entries = getArchivedPhaseEntries(entries, rounds, "phase1");
+  const phase2Entries = getArchivedPhaseEntries(entries, rounds, "phase2");
+  const phase3Entries = getArchivedPhaseEntries(entries, rounds, "phase3");
   const response: Record<string, unknown> = {
     phaseStatus: {
-      phase1: summarizeArchivedPhase(entries, "phase1"),
-      phase2: summarizeArchivedPhase(entries, "phase2"),
-      phase3: summarizeArchivedPhase(entries, "phase3"),
+      phase1: summarizeArchivedPhase(phase1Entries, "phase1"),
+      phase2: summarizeArchivedPhase(phase2Entries, "phase2"),
+      phase3: summarizeArchivedPhase(phase3Entries, "phase3"),
       currentPhase: "completed",
     },
     archived: true,
   };
 
   if (phase) {
-    const phaseEntries = entries.filter((entry) => (entry as { stage?: unknown }).stage === phase);
+    const phaseEntries =
+      phase === "phase1" ? phase1Entries :
+      phase === "phase2" ? phase2Entries :
+      phase3Entries;
     const phaseRounds = rounds
       .filter((round) => (round as { phase?: unknown }).phase === phase)
       .map((round) => normalizePhaseRound(round as { results: unknown; eliminatedIds?: unknown }));


### PR DESCRIPTION
## Summary
- Reconstruct archived TA phase entries from phase round history when the archive lacks phase1/phase2/phase3 TTEntry rows
- Preserve completed Phase 3 champion/result display for archived tournaments such as jsmkc2026
- Add regression coverage for archived Phase 3 data with missing phase entries

## Validation
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts'
- npm run lint -- 'src/app/api/tournaments/[id]/ta/phases/route.ts' '__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts'
- npm run build
- PR checks: Lint & Test passed; Cloudflare Workers Build passed

## Deployment
- Local npm run deploy was attempted twice, including escalated execution, but Wrangler stopped at auth: Failed to fetch auth token: 400 Bad Request; CLOUDFLARE_API_TOKEN is required in non-interactive environments
- Cloudflare PR build passed, but production custom-domain verification still returns entries: [] for /api/tournaments/jsmkc2026/ta/phases?phase=phase3, so this branch is not yet serving production traffic