### PR TITLE
Cover TA archive phase rebuild fallbacks

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2420,6 +2420,29 @@
 
 ---
 
+## TC-ARC-05: TA archive phase entries — phase1/phase2 round history fallback
+- **URL**: GET /api/tournaments/:id/ta/phases?phase=phase1, GET /api/tournaments/:id/ta/phases?phase=phase2
+- **authRequired**: false (公開GETエンドポイント)
+- **背景**: 古い archive bundle は TA phase round history を持っていても
+  `TTEntry.stage = phase1/phase2` の entries を持たない場合がある。この場合でも
+  phase API は round history から entries を再構築し、phase1/phase2 では lives を
+  0 固定として返す。
+- **手順**:
+  1. `modes.ta.entries` に qualification entries のみを持つ archive fixture を用意する
+  2. `modes.ta.phaseRounds` に phase1 と phase2 の submitted round history を用意する
+  3. `/api/tournaments/:id/ta/phases?phase=phase1` を GET
+  4. `/api/tournaments/:id/ta/phases?phase=phase2` を GET
+  5. phase1/phase2 の entries が round results 由来の playerId で再構築されることを確認
+  6. eliminatedIds に含まれる player は `eliminated: true`、phase1/phase2 の `lives` は 0 であることを確認
+- **期待結果**:
+  - phase1/phase2 とも HTTP 200
+  - `data.archived === true`
+  - entries が round history から再構築される
+  - phase1/phase2 の再構築 entries は `lives === 0`
+- **補助検証**: `smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts`
+
+---
+
 ## TC-DBG-01: デバッグモードトーナメント作成 → 4モード予選スコア自動入力
 - **URL**: POST /api/tournaments, POST /api/tournaments/:id/{bm,mr,gp,ta}/debug-fill
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
@@ -339,6 +339,88 @@ describe('GET /api/tournaments/[id]/ta/phases', () => {
         })
       );
     });
+
+    it.each([
+      ['phase1', ['player-17', 'player-18'], ['player-18']],
+      ['phase2', ['player-13', 'player-14'], ['player-14']],
+    ])('reconstructs archived %s entries from round history with zero lives', async (phase, playerIds, eliminatedIds) => {
+      (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(null);
+      (getAvailableCourses as jest.Mock).mockReturnValue(['DP1']);
+      (readTournamentArchive as jest.Mock).mockResolvedValue({
+        schemaVersion: 1,
+        tournament: { id: 'tournament-1', slug: 'archived', name: 'Archived', status: 'completed' },
+        allPlayers: [],
+        modes: {
+          ta: {
+            entries: playerIds.map((playerId, index) => ({
+              id: `qual-${playerId}`,
+              tournamentId: 'tournament-1',
+              playerId,
+              stage: 'qualification',
+              lives: 3,
+              eliminated: false,
+              rank: index + 1,
+              totalTime: 60000 + index * 1000,
+              player: { id: playerId, name: `Player ${playerId}`, nickname: `P${index + 1}` },
+            })),
+            phaseRounds: [
+              {
+                id: `round-${phase}`,
+                tournamentId: 'tournament-1',
+                phase,
+                roundNumber: 1,
+                course: 'MC1',
+                results: playerIds.map((playerId, index) => ({
+                  playerId,
+                  timeMs: 60000 + index * 1000,
+                  isRetry: false,
+                })),
+                eliminatedIds,
+                livesReset: false,
+                manualOverride: false,
+              },
+            ],
+          },
+          bm: {},
+          mr: {},
+          gp: {},
+        },
+      });
+
+      await phasesRoute.GET(createRequest(`?phase=${phase}`), { params: mockParams });
+
+      const call = NextResponse.json.mock.calls[0][0];
+      expect(call).toEqual(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            archived: true,
+            phaseStatus: expect.objectContaining({
+              [phase]: expect.objectContaining({
+                total: 2,
+                active: 1,
+                eliminated: 1,
+              }),
+            }),
+            entries: expect.arrayContaining([
+              expect.objectContaining({
+                playerId: playerIds[0],
+                stage: phase,
+                lives: 0,
+                eliminated: false,
+              }),
+              expect.objectContaining({
+                playerId: playerIds[1],
+                stage: phase,
+                lives: 0,
+                eliminated: true,
+              }),
+            ]),
+            rounds: [expect.objectContaining({ id: `round-${phase}` })],
+          }),
+        })
+      );
+    });
   });
 
   describe('Phase parameter validation', () => {

--- a/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
@@ -15,6 +15,19 @@ describe('archive E2E case registration', () => {
     },
   );
 
+  it('documents TC-ARC-05 as TA archive phase1/phase2 fallback coverage', () => {
+    const section = cases.slice(
+      cases.indexOf('## TC-ARC-05:'),
+      cases.indexOf('\n---', cases.indexOf('## TC-ARC-05:')),
+    );
+
+    expect(section).toContain('/api/tournaments/:id/ta/phases?phase=phase1');
+    expect(section).toContain('/api/tournaments/:id/ta/phases?phase=phase2');
+    expect(section).toContain('round history');
+    expect(section).toContain('lives === 0');
+    expect(section).toContain('smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts');
+  });
+
   it('documents that preview archive coverage writes to a dedicated R2 bucket', () => {
     const section = cases.slice(
       cases.indexOf('## TC-ARC-03:'),

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
@@ -185,7 +185,7 @@ function getRoundResultPlayerIds(rounds: unknown[], phase: PhaseName) {
   return playerIds;
 }
 
-function replayArchivedPhaseLives(rounds: unknown[], playerIds: Set<string>) {
+function replayArchivedPhase3Lives(rounds: unknown[], playerIds: Set<string>) {
   const livesByPlayer = new Map([...playerIds].map((playerId) => [playerId, 3]));
   const eliminated = new Set<string>();
 
@@ -246,7 +246,7 @@ function getArchivedPhaseEntries(entries: unknown[], rounds: unknown[], phase: P
   const livesByPlayer = new Map<string, number>();
 
   if (phase === "phase3") {
-    const replay = replayArchivedPhaseLives(rounds, playerIds);
+    const replay = replayArchivedPhase3Lives(rounds, playerIds);
     replay.eliminated.forEach((playerId) => eliminated.add(playerId));
     replay.livesByPlayer.forEach((lives, playerId) => livesByPlayer.set(playerId, lives));
   } else {


### PR DESCRIPTION
## Summary
- Rename the archived TA phase-life replay helper to make its Phase 3-only responsibility explicit
- Add TC-ARC-05 scenario documentation for archived phase1/phase2 entry reconstruction from round history
- Add route regression coverage proving phase1/phase2 archive fallback rebuilds entries with zero lives and eliminated status

## Issues
Closes #1259
Closes #1260

## Validation
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts' '__tests__/docs/e2e-archive-cases.test.ts'
- npm run lint -- 'src/app/api/tournaments/[id]/ta/phases/route.ts' '__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts' '__tests__/docs/e2e-archive-cases.test.ts'
- git diff --check

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
