### PR TITLE
Type tournament archive payload rows

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2402,6 +2402,28 @@
 
 ---
 
+## TC-ARC-06: トーナメントアーカイブ API — BM match/player payload の型付き保存
+- **URL**: POST /api/tournaments/:id/archive, GET /api/tournaments/:id/archive
+- **authRequired**: POST は admin、GET は公開
+- **背景**: archive bundle は Prisma 由来の match / qualification / player 行を
+  API fallback に再利用する。R2 保存後も `modes.bm.matches` の stage と
+  `player1`/`player2` の公開 player fields が失われると、archive 経由の
+  qualification/finals API が実行時 cast 依存になり壊れやすい。
+- **手順**:
+  1. admin で tournament + BM 予選データを作成
+  2. `status: completed`, `publicModes: ['bm', 'overall']` に更新
+  3. `/api/tournaments/:id/archive` に POST
+  4. 同じ URL を GET
+  5. `data.modes.bm.matches[0]` の `stage`, `player1`, `player2` を確認
+- **期待結果**:
+  - HTTP 200
+  - `data.modes.bm.matches[0].stage === 'qualification'`
+  - `player1.id` / `player2.id` は string
+  - player payload は公開 field (`name`, `nickname`) を含む
+- **スクリプト**: tc-archive.js TC-ARC-06 (`npm run e2e:archive`, preview: `npm run e2e:preview:archive`)
+
+---
+
 ## TC-ARC-04: トーナメントアーカイブ API — 公開 mode のない archive は非公開
 - **URL**: GET /api/tournaments/:id/archive
 - **authRequired**: false (公開GETエンドポイント)

--- a/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
@@ -5,7 +5,7 @@ describe('archive E2E case registration', () => {
   const casesPath = path.join(process.cwd(), '..', 'E2E_TEST_CASES.md');
   const cases = fs.readFileSync(casesPath, 'utf8');
 
-  it.each(['TC-ARC-01', 'TC-ARC-02', 'TC-ARC-03', 'TC-ARC-04'])(
+  it.each(['TC-ARC-01', 'TC-ARC-02', 'TC-ARC-03', 'TC-ARC-04', 'TC-ARC-06'])(
     'documents %s as a runnable archive script case',
     (tc) => {
       const section = cases.slice(cases.indexOf(`## ${tc}:`), cases.indexOf('\n---', cases.indexOf(`## ${tc}:`)));
@@ -14,6 +14,18 @@ describe('archive E2E case registration', () => {
       expect(section).not.toContain('未スクリプト化');
     },
   );
+
+  it('documents TC-ARC-06 as concrete archive match/player payload coverage', () => {
+    const section = cases.slice(
+      cases.indexOf('## TC-ARC-06:'),
+      cases.indexOf('\n---', cases.indexOf('## TC-ARC-06:')),
+    );
+
+    expect(section).toContain('modes.bm.matches[0]');
+    expect(section).toContain("stage === 'qualification'");
+    expect(section).toContain('player1.id');
+    expect(section).toContain('player2.id');
+  });
 
   it('documents TC-ARC-05 as TA archive phase1/phase2 fallback coverage', () => {
     const section = cases.slice(

--- a/smkc-score-app/__tests__/lib/tournament-archive.test.ts
+++ b/smkc-score-app/__tests__/lib/tournament-archive.test.ts
@@ -1,9 +1,12 @@
 import {
+  getArchivedFinalsPayload,
+  getArchivedModePayload,
   getTournamentArchiveKeys,
   readTournamentArchive,
   TOURNAMENT_ARCHIVE_SCHEMA_VERSION,
   type TournamentArchiveBundle,
 } from "@/lib/tournament-archive";
+import { COURSES } from "@/lib/constants";
 
 const objects = new Map<string, unknown>();
 
@@ -47,7 +50,7 @@ function makeArchive(overrides: Partial<TournamentArchiveBundle> = {}): Tourname
       ta: {
         entries: [],
         phaseRounds: [],
-        courses: [],
+        courses: COURSES,
         qualificationRegistrationLocked: true,
         qualificationEditingLockedForPlayers: true,
         frozenStages: [],
@@ -95,5 +98,126 @@ describe("tournament archive", () => {
     });
 
     await expect(readTournamentArchive("tournament-1")).resolves.toBeNull();
+  });
+
+  it("filters typed archived qualification matches without runtime stage casts", () => {
+    type BMArchiveMatch = NonNullable<TournamentArchiveBundle["modes"]["bm"]["matches"]>[number];
+    const qualificationMatch = {
+      id: "bm-match-q",
+      tournamentId: "tournament-1",
+      matchNumber: 1,
+      stage: "qualification",
+      round: null,
+      tvNumber: null,
+      roundNumber: null,
+      isBye: false,
+      player1Id: "player-1",
+      player1Side: 1,
+      player2Id: "player-2",
+      player2Side: 2,
+      score1: 4,
+      score2: 0,
+      completed: true,
+      assignedCourses: null,
+      rounds: null,
+      startingCourseNumber: null,
+      bracket: null,
+      bracketPosition: null,
+      losses: 0,
+      isGrandFinal: false,
+      player1ReportedScore1: null,
+      player1ReportedScore2: null,
+      player2ReportedScore1: null,
+      player2ReportedScore2: null,
+      deletedAt: null,
+      version: 0,
+      createdAt: "2026-05-07T00:00:00.000Z",
+      updatedAt: "2026-05-07T00:00:00.000Z",
+      player1: { id: "player-1", name: "Player 1", nickname: "p1", country: null, noCamera: false },
+      player2: { id: "player-2", name: "Player 2", nickname: "p2", country: null, noCamera: false },
+    } as unknown as BMArchiveMatch;
+    const finalsMatch = {
+      ...qualificationMatch,
+      id: "bm-match-f",
+      matchNumber: 2,
+      stage: "finals",
+      round: "winners_final",
+    } as unknown as BMArchiveMatch;
+
+    const archive = makeArchive({
+      modes: {
+        ...makeArchive().modes,
+        bm: { qualifications: [], matches: [qualificationMatch, finalsMatch], qualificationConfirmed: true },
+      },
+    });
+
+    const payload = getArchivedModePayload(archive, "bm");
+
+    const matches = payload.matches ?? [];
+    expect(matches).toHaveLength(1);
+    expect(matches[0].stage).toBe("qualification");
+    expect(matches[0].player1.name).toBe("Player 1");
+  });
+
+  it("groups typed archived finals matches by round prefix", () => {
+    type BMArchiveMatch = NonNullable<TournamentArchiveBundle["modes"]["bm"]["matches"]>[number];
+    const baseMatch = {
+      id: "bm-match-f",
+      tournamentId: "tournament-1",
+      matchNumber: 1,
+      stage: "finals",
+      round: "winners_final",
+      tvNumber: null,
+      roundNumber: null,
+      isBye: false,
+      player1Id: "player-1",
+      player1Side: 1,
+      player2Id: "player-2",
+      player2Side: 2,
+      score1: 4,
+      score2: 2,
+      completed: true,
+      assignedCourses: null,
+      rounds: null,
+      startingCourseNumber: null,
+      bracket: "winners",
+      bracketPosition: null,
+      losses: 0,
+      isGrandFinal: false,
+      player1ReportedScore1: null,
+      player1ReportedScore2: null,
+      player2ReportedScore1: null,
+      player2ReportedScore2: null,
+      deletedAt: null,
+      version: 0,
+      createdAt: "2026-05-07T00:00:00.000Z",
+      updatedAt: "2026-05-07T00:00:00.000Z",
+      player1: { id: "player-1", name: "Player 1", nickname: "p1", country: null, noCamera: false },
+      player2: { id: "player-2", name: "Player 2", nickname: "p2", country: null, noCamera: false },
+    } as unknown as BMArchiveMatch;
+    const archive = makeArchive({
+      modes: {
+        ...makeArchive().modes,
+        bm: {
+          qualifications: [],
+          matches: [
+            baseMatch,
+            { ...baseMatch, id: "bm-match-l", matchNumber: 2, round: "losers_final" },
+            { ...baseMatch, id: "bm-match-g", matchNumber: 3, round: "grand_final_reset" },
+          ],
+          qualificationConfirmed: true,
+        },
+      },
+    });
+
+    const payload = getArchivedFinalsPayload(archive, "bm", "grouped") as {
+      winnersMatches: unknown[];
+      losersMatches: unknown[];
+      grandFinalMatches: unknown[];
+    };
+
+    expect(payload.winnersMatches).toHaveLength(1);
+    expect(payload.losersMatches).toHaveLength(1);
+    expect(payload.grandFinalMatches).toHaveLength(1);
   });
 });

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -6,6 +6,7 @@
  *   TC-ARC-02  Archive regeneration rejects non-completed tournaments.
  *   TC-ARC-03  Completed public tournament archive can be regenerated and read.
  *   TC-ARC-04  Completed private archive is not publicly readable.
+ *   TC-ARC-06  Archive BM match rows keep stage and public player payloads.
  *
  * Run: node e2e/tc-archive.js  (from smkc-score-app/)  or: npm run e2e:archive
  */
@@ -108,8 +109,21 @@ async function tcArc03(page) {
 
     log('TC-ARC-03', ok ? 'PASS' : 'FAIL',
       `post=${post.status} get=${get.status} publicModes=${archive?.tournament?.publicModes?.join(',') || ''}`);
+
+    const archivedMatch = archive?.modes?.bm?.matches?.[0];
+    const typedMatchOk = (
+      get.status === 200 &&
+      archivedMatch?.stage === 'qualification' &&
+      typeof archivedMatch?.player1?.id === 'string' &&
+      typeof archivedMatch?.player2?.id === 'string' &&
+      typeof archivedMatch?.player1?.name === 'string' &&
+      typeof archivedMatch?.player2?.nickname === 'string'
+    );
+    log('TC-ARC-06', typedMatchOk ? 'PASS' : 'FAIL',
+      `stage=${archivedMatch?.stage || ''} p1=${archivedMatch?.player1?.id || ''} p2=${archivedMatch?.player2?.id || ''}`);
   } catch (error) {
     log('TC-ARC-03', 'FAIL', error instanceof Error ? error.message : String(error));
+    log('TC-ARC-06', 'FAIL', error instanceof Error ? error.message : String(error));
   } finally {
     await apiDeleteTournament(page, tournamentId);
     for (const player of players) await apiDeletePlayer(page, player.id);

--- a/smkc-score-app/src/lib/tournament-archive.ts
+++ b/smkc-score-app/src/lib/tournament-archive.ts
@@ -1,9 +1,10 @@
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import type { R2Bucket } from "@cloudflare/workers-types";
+import type { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { PLAYER_PUBLIC_SELECT } from "@/lib/prisma-selects";
 import { computeQualificationRanks } from "@/lib/server-ranking";
-import { getOverallRankings } from "@/lib/points/overall-ranking";
+import { getOverallRankings, type PlayerTournamentScore } from "@/lib/points/overall-ranking";
 import { COURSES } from "@/lib/constants";
 import { generateBracketStructure, generatePlayoffStructure, roundNames } from "@/lib/double-elimination";
 
@@ -11,12 +12,49 @@ export const TOURNAMENT_ARCHIVE_SCHEMA_VERSION = 1;
 const twoPlayerQualificationOrder = () => [{ group: "asc" }, { score: "desc" }, { points: "desc" }] as const;
 const GP_MATCH_SCORE_FIELDS = { p1: "points1", p2: "points2" };
 
-export type TournamentArchiveModePayload = {
-  qualifications?: unknown[];
-  matches?: unknown[];
-  entries?: unknown[];
-  phaseRounds?: unknown[];
+type ArchivePlayer = Prisma.PlayerGetPayload<{ select: typeof PLAYER_PUBLIC_SELECT }>;
+type RankedQualification<T> = T & { _rank?: number; _rankOverridden?: boolean };
+type BMQualificationArchiveRow = RankedQualification<Prisma.BMQualificationGetPayload<{
+  include: { player: { select: typeof PLAYER_PUBLIC_SELECT } };
+}>>;
+type MRQualificationArchiveRow = RankedQualification<Prisma.MRQualificationGetPayload<{
+  include: { player: { select: typeof PLAYER_PUBLIC_SELECT } };
+}>>;
+type GPQualificationArchiveRow = RankedQualification<Prisma.GPQualificationGetPayload<{
+  include: { player: { select: typeof PLAYER_PUBLIC_SELECT } };
+}>>;
+type BMMatchArchiveRow = Prisma.BMMatchGetPayload<{
+  include: {
+    player1: { select: typeof PLAYER_PUBLIC_SELECT };
+    player2: { select: typeof PLAYER_PUBLIC_SELECT };
+  };
+}>;
+type MRMatchArchiveRow = Prisma.MRMatchGetPayload<{
+  include: {
+    player1: { select: typeof PLAYER_PUBLIC_SELECT };
+    player2: { select: typeof PLAYER_PUBLIC_SELECT };
+  };
+}>;
+type GPMatchArchiveRow = Prisma.GPMatchGetPayload<{
+  include: {
+    player1: { select: typeof PLAYER_PUBLIC_SELECT };
+    player2: { select: typeof PLAYER_PUBLIC_SELECT };
+  };
+}>;
+type TTEntryArchiveRow = Prisma.TTEntryGetPayload<{
+  include: { player: { select: typeof PLAYER_PUBLIC_SELECT } };
+}>;
+type TTPhaseRoundArchiveRow = Prisma.TTPhaseRoundGetPayload<Record<string, never>>;
+
+export type TournamentArchiveModePayload<TQualification = never, TMatch = never> = {
+  qualifications?: TQualification[];
+  matches?: TMatch[];
   qualificationConfirmed?: boolean;
+};
+
+export type TournamentArchiveTaPayload = {
+  entries?: TTEntryArchiveRow[];
+  phaseRounds?: TTPhaseRoundArchiveRow[];
 };
 
 export type TournamentArchiveBundle = {
@@ -37,24 +75,24 @@ export type TournamentArchiveBundle = {
     createdAt: string | Date;
     updatedAt: string | Date;
   };
-  allPlayers: unknown[];
+  allPlayers: ArchivePlayer[];
   modes: {
-    ta: TournamentArchiveModePayload & {
+    ta: TournamentArchiveTaPayload & {
       courses: typeof COURSES;
       qualificationRegistrationLocked: boolean;
       qualificationEditingLockedForPlayers: boolean;
       frozenStages: unknown;
       taPlayerSelfEdit: boolean;
     };
-    bm: TournamentArchiveModePayload;
-    mr: TournamentArchiveModePayload;
-    gp: TournamentArchiveModePayload;
+    bm: TournamentArchiveModePayload<BMQualificationArchiveRow, BMMatchArchiveRow>;
+    mr: TournamentArchiveModePayload<MRQualificationArchiveRow, MRMatchArchiveRow>;
+    gp: TournamentArchiveModePayload<GPQualificationArchiveRow, GPMatchArchiveRow>;
   };
   overallRanking: {
     tournamentId: string;
     tournamentName: string;
     lastUpdated: string;
-    rankings: unknown[];
+    rankings: PlayerTournamentScore[];
   };
   archived: true;
 };
@@ -132,23 +170,22 @@ export async function readTournamentArchive(identifier: string): Promise<Tournam
   return null;
 }
 
-function uniquePlayersFromArchive(bundle: Pick<TournamentArchiveBundle, "modes">): unknown[] {
-  const byId = new Map<string, unknown>();
-  const remember = (player: unknown) => {
-    const id = player && typeof player === "object" ? (player as { id?: unknown }).id : null;
-    if (typeof id === "string") byId.set(id, player);
+function uniquePlayersFromArchive(bundle: Pick<TournamentArchiveBundle, "modes">): ArchivePlayer[] {
+  const byId = new Map<string, ArchivePlayer>();
+  const remember = (player: ArchivePlayer) => {
+    if (player.id) byId.set(player.id, player);
   };
 
   for (const entry of bundle.modes.ta.entries ?? []) {
-    remember((entry as { player?: unknown }).player);
+    remember(entry.player);
   }
   for (const mode of [bundle.modes.bm, bundle.modes.mr, bundle.modes.gp]) {
     for (const qualification of mode.qualifications ?? []) {
-      remember((qualification as { player?: unknown }).player);
+      remember(qualification.player);
     }
     for (const match of mode.matches ?? []) {
-      remember((match as { player1?: unknown; player2?: unknown }).player1);
-      remember((match as { player1?: unknown; player2?: unknown }).player2);
+      remember(match.player1);
+      remember(match.player2);
     }
   }
   return [...byId.values()];
@@ -167,9 +204,7 @@ export function getArchivedModePayload(
   }
   return {
     qualifications: bundle.modes[mode].qualifications ?? [],
-    matches: (bundle.modes[mode].matches ?? []).filter((match) =>
-      (match as { stage?: unknown }).stage === "qualification"
-    ),
+    matches: (bundle.modes[mode].matches ?? []).filter((match) => match.stage === "qualification"),
     allPlayers: bundle.allPlayers,
     qualificationConfirmed: bundle.modes[mode].qualificationConfirmed ?? true,
     archived: true,
@@ -182,14 +217,14 @@ export function getArchivedFinalsPayload(
   style: "grouped" | "simple" | "paginated",
 ) {
   const allMatches = bundle.modes[mode].matches ?? [];
-  const matches = allMatches.filter((match) => (match as { stage?: unknown }).stage === "finals");
-  const playoffMatches = allMatches.filter((match) => (match as { stage?: unknown }).stage === "playoff");
+  const matches = allMatches.filter((match) => match.stage === "finals");
+  const playoffMatches = allMatches.filter((match) => match.stage === "playoff");
   const bracketSize = matches.length > 20 ? 16 : 8;
   const bracketStructure = matches.length > 0 ? generateBracketStructure(bracketSize) : [];
   const playoffStructure = playoffMatches.length > 0 ? generatePlayoffStructure(12) : [];
   const playoffComplete = playoffMatches
-    .filter((match) => (match as { round?: unknown }).round === "playoff_r2")
-    .every((match) => (match as { completed?: unknown }).completed === true);
+    .filter((match) => match.round === "playoff_r2")
+    .every((match) => match.completed === true);
   const phase = matches.length > 0 ? "finals" : playoffMatches.length > 0 ? "playoff" : "finals";
   const qualificationConfirmed = bundle.modes[mode].qualificationConfirmed ?? true;
   const common = {
@@ -216,15 +251,9 @@ export function getArchivedFinalsPayload(
   if (style === "grouped") {
     return {
       matches,
-      winnersMatches: matches.filter((match) =>
-        ((match as { round?: string | null }).round ?? "").startsWith("winners_")
-      ),
-      losersMatches: matches.filter((match) =>
-        ((match as { round?: string | null }).round ?? "").startsWith("losers_")
-      ),
-      grandFinalMatches: matches.filter((match) =>
-        ((match as { round?: string | null }).round ?? "").startsWith("grand_final")
-      ),
+      winnersMatches: matches.filter((match) => (match.round ?? "").startsWith("winners_")),
+      losersMatches: matches.filter((match) => (match.round ?? "").startsWith("losers_")),
+      grandFinalMatches: matches.filter((match) => (match.round ?? "").startsWith("grand_final")),
       ...common,
     };
   }
@@ -365,7 +394,7 @@ export async function buildTournamentArchiveBundle(tournamentId: string): Promis
         [...twoPlayerQualificationOrder()],
         bmMatches.filter((match) => match.stage === "qualification"),
         { matchScoreFields: { p1: "score1", p2: "score2" } },
-      ),
+      ) as BMQualificationArchiveRow[],
       matches: bmMatches,
       qualificationConfirmed: tournament.bmQualificationConfirmed,
     },
@@ -375,7 +404,7 @@ export async function buildTournamentArchiveBundle(tournamentId: string): Promis
         [...twoPlayerQualificationOrder()],
         mrMatches.filter((match) => match.stage === "qualification"),
         { matchScoreFields: { p1: "score1", p2: "score2" } },
-      ),
+      ) as MRQualificationArchiveRow[],
       matches: mrMatches,
       qualificationConfirmed: tournament.mrQualificationConfirmed,
     },
@@ -385,7 +414,7 @@ export async function buildTournamentArchiveBundle(tournamentId: string): Promis
         [...twoPlayerQualificationOrder()],
         gpMatches.filter((match) => match.stage === "qualification"),
         { matchScoreFields: GP_MATCH_SCORE_FIELDS },
-      ),
+      ) as GPQualificationArchiveRow[],
       matches: gpMatches,
       qualificationConfirmed: tournament.gpQualificationConfirmed,
     },


### PR DESCRIPTION
## Summary
- Type tournament archive mode payloads with Prisma-backed qualification, match, TA entry, phase round, and overall ranking rows instead of broad unknown arrays.
- Remove runtime stage/player casts from archive mode/finals helpers and keep unique archive players typed from public player payloads.
- Add TC-ARC-06 archive E2E coverage plus focused docs and unit coverage for typed match/player payloads.

## Issues
Closes #1142

## Validation
- node --check e2e/tc-archive.js
- npm test -- __tests__/lib/tournament-archive.test.ts __tests__/docs/e2e-archive-cases.test.ts
- npm run lint
- git diff --check
- npx tsc --noEmit --pretty false (fails on pre-existing unrelated test typing errors; no tournament-archive/tc-archive/e2e-archive-cases errors when filtered)
