### PR TITLE
Address archive payload review followups

### DIFF
--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -48,6 +48,37 @@ function bmAssignments(players) {
   }));
 }
 
+async function createCompletedPublicBmArchive(page, prefix, caseName) {
+  const players = [];
+  let tournamentId = null;
+  try {
+    players.push(...await createPlayers(page, prefix, 4));
+    tournamentId = await apiCreateTournament(page, `E2E ${caseName} ${Date.now()}`);
+    const setup = await apiSetupBmGroup(page, tournamentId, bmAssignments(players));
+    if (setup.s !== 201) throw new Error(`BM setup failed (${setup.s})`);
+
+    const completed = await apiUpdateTournament(page, tournamentId, {
+      status: 'completed',
+      publicModes: ['bm', 'overall'],
+      bmQualificationConfirmed: true,
+    });
+    if (completed.s !== 200) throw new Error(`completion update failed (${completed.s})`);
+
+    const post = await apiJson(page, `/api/tournaments/${tournamentId}/archive`, { method: 'POST' });
+    const get = await apiJson(page, `/api/tournaments/${tournamentId}/archive`);
+    return { tournamentId, players, post, get, archive: get.body?.data };
+  } catch (error) {
+    await apiDeleteTournament(page, tournamentId);
+    for (const player of players) await apiDeletePlayer(page, player.id);
+    throw error;
+  }
+}
+
+async function cleanupArchiveFixture(page, fixture) {
+  await apiDeleteTournament(page, fixture?.tournamentId);
+  for (const player of fixture?.players ?? []) await apiDeletePlayer(page, player.id);
+}
+
 async function tcArc01(page) {
   const stamp = Date.now();
   try {
@@ -78,24 +109,10 @@ async function tcArc02(page) {
 }
 
 async function tcArc03(page) {
-  let tournamentId = null;
-  const players = [];
+  let fixture = null;
   try {
-    players.push(...await createPlayers(page, 'TCARC03', 4));
-    tournamentId = await apiCreateTournament(page, `E2E TC-ARC-03 ${Date.now()}`);
-    const setup = await apiSetupBmGroup(page, tournamentId, bmAssignments(players));
-    if (setup.s !== 201) throw new Error(`BM setup failed (${setup.s})`);
-
-    const completed = await apiUpdateTournament(page, tournamentId, {
-      status: 'completed',
-      publicModes: ['bm', 'overall'],
-      bmQualificationConfirmed: true,
-    });
-    if (completed.s !== 200) throw new Error(`completion update failed (${completed.s})`);
-
-    const post = await apiJson(page, `/api/tournaments/${tournamentId}/archive`, { method: 'POST' });
-    const get = await apiJson(page, `/api/tournaments/${tournamentId}/archive`);
-    const archive = get.body?.data;
+    fixture = await createCompletedPublicBmArchive(page, 'TCARC03', 'TC-ARC-03');
+    const { tournamentId, post, get, archive } = fixture;
     const ok = (
       post.status === 200 &&
       get.status === 200 &&
@@ -109,10 +126,20 @@ async function tcArc03(page) {
 
     log('TC-ARC-03', ok ? 'PASS' : 'FAIL',
       `post=${post.status} get=${get.status} publicModes=${archive?.tournament?.publicModes?.join(',') || ''}`);
+  } catch (error) {
+    log('TC-ARC-03', 'FAIL', error instanceof Error ? error.message : String(error));
+  } finally {
+    await cleanupArchiveFixture(page, fixture);
+  }
+}
 
-    const archivedMatch = archive?.modes?.bm?.matches?.[0];
+async function tcArc06(page) {
+  let fixture = null;
+  try {
+    fixture = await createCompletedPublicBmArchive(page, 'TCARC06', 'TC-ARC-06');
+    const archivedMatch = fixture.archive?.modes?.bm?.matches?.[0];
     const typedMatchOk = (
-      get.status === 200 &&
+      fixture.get.status === 200 &&
       archivedMatch?.stage === 'qualification' &&
       typeof archivedMatch?.player1?.id === 'string' &&
       typeof archivedMatch?.player2?.id === 'string' &&
@@ -122,11 +149,9 @@ async function tcArc03(page) {
     log('TC-ARC-06', typedMatchOk ? 'PASS' : 'FAIL',
       `stage=${archivedMatch?.stage || ''} p1=${archivedMatch?.player1?.id || ''} p2=${archivedMatch?.player2?.id || ''}`);
   } catch (error) {
-    log('TC-ARC-03', 'FAIL', error instanceof Error ? error.message : String(error));
     log('TC-ARC-06', 'FAIL', error instanceof Error ? error.message : String(error));
   } finally {
-    await apiDeleteTournament(page, tournamentId);
-    for (const player of players) await apiDeletePlayer(page, player.id);
+    await cleanupArchiveFixture(page, fixture);
   }
 }
 
@@ -158,6 +183,7 @@ async function runArchiveTests(page) {
   await tcArc02(page);
   await tcArc03(page);
   await tcArc04(page);
+  await tcArc06(page);
 
   const failed = results.filter((result) => result.s === 'FAIL');
   console.log(`\nTC-ARC summary: ${results.length - failed.length}/${results.length} passed`);

--- a/smkc-score-app/src/lib/server-ranking.ts
+++ b/smkc-score-app/src/lib/server-ranking.ts
@@ -12,27 +12,39 @@ export interface ComputeRanksOptions {
   matchScoreFields?: { p1: string; p2: string };
 }
 
-function assignRanksForPartition(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  qualifications: any[],
+type RankableQualification = {
+  playerId: string;
+  group?: string | null;
+  rankOverride?: number | null;
+  [key: string]: unknown;
+};
+type RankableMatch = {
+  player1Id: string;
+  player2Id: string;
+  completed?: boolean;
+  isBye?: boolean;
+  [key: string]: unknown;
+};
+export type RankedQualification<TQualification> = TQualification & {
+  _rank: number;
+  _rankOverridden?: boolean;
+};
+
+function assignRanksForPartition<TQualification extends RankableQualification, TMatch extends RankableMatch>(
+  qualifications: TQualification[],
   orderBy: Array<Partial<Record<string, 'asc' | 'desc'>>>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  matches: any[],
+  matches: TMatch[],
   options: ComputeRanksOptions,
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-): any[] {
+): RankedQualification<TQualification>[] {
   if (qualifications.length === 0) return [];
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const ranked: any[] = [];
+  const ranked: RankedQualification<TQualification>[] = [];
   for (let i = 0; i < qualifications.length; i++) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const q = qualifications[i] as any;
+    const q = qualifications[i];
     if (i === 0) {
       ranked.push({ ...q, _rank: 1 });
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const prev = qualifications[i - 1] as any;
+      const prev = qualifications[i - 1];
       const isTied = (orderBy ?? []).every((ob) => {
         const field = Object.keys(ob)[0];
         return q[field] === prev[field];
@@ -70,8 +82,7 @@ function assignRanksForPartition(
      */
     const playerIdSet = new Set(tiedPlayerIds);
     const h2hMatches = matches.filter(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (m: any) =>
+      (m) =>
         // standings-route.ts uses Prisma select without completed/isBye fields,
         // so treat undefined as "include this match" (caller already filtered).
         (m.completed === undefined || m.completed === true) &&
@@ -90,15 +101,14 @@ function assignRanksForPartition(
       const gPlayerIds = group.map((e: { playerId: string }) => e.playerId);
       const gPlayerIdSet = new Set(gPlayerIds);
       const groupMatches = h2hMatches.filter(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (m: any) => gPlayerIdSet.has(m.player1Id) && gPlayerIdSet.has(m.player2Id),
+        (m) => gPlayerIdSet.has(m.player1Id) && gPlayerIdSet.has(m.player2Id),
       );
 
       /* Tally H2H wins; draws award no win to either player */
       const h2hWins = new Map<string, number>(gPlayerIds.map((id) => [id, 0]));
       for (const m of groupMatches) {
-        const s1: number = m[scoreFields.p1];
-        const s2: number = m[scoreFields.p2];
+        const s1 = Number(m[scoreFields.p1] ?? 0);
+        const s2 = Number(m[scoreFields.p2] ?? 0);
         if (s1 > s2) h2hWins.set(m.player1Id, (h2hWins.get(m.player1Id) ?? 0) + 1);
         else if (s2 > s1) h2hWins.set(m.player2Id, (h2hWins.get(m.player2Id) ?? 0) + 1);
       }
@@ -123,8 +133,7 @@ function assignRanksForPartition(
     ranked.splice(0, ranked.length, ...resolved);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const withOverrides = ranked.map((entry: any) =>
+  const withOverrides = ranked.map((entry) =>
     entry.rankOverride != null
       ? { ...entry, _rank: entry.rankOverride, _rankOverridden: true }
       : entry,
@@ -158,15 +167,12 @@ function assignRanksForPartition(
  * @param options        - Optional score field mapping for H2H winner detection.
  * @returns              - New array with `_rank` / `_rankOverridden` injected.
  */
-export function computeQualificationRanks(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  qualifications: any[],
+export function computeQualificationRanks<TQualification extends RankableQualification, TMatch extends RankableMatch>(
+  qualifications: TQualification[],
   orderBy: Array<Partial<Record<string, 'asc' | 'desc'>>>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  matches: any[],
+  matches: TMatch[],
   options: ComputeRanksOptions = {},
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-): any[] {
+): RankedQualification<TQualification>[] {
   if (qualifications.length === 0) return [];
 
   const firstOrderField = Object.keys(orderBy[0] ?? {})[0];
@@ -181,8 +187,7 @@ export function computeQualificationRanks(
       partitions.set(group, groupEntries);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const rankedByGroup: any[] = [];
+    const rankedByGroup: RankedQualification<TQualification>[] = [];
     for (const groupEntries of partitions.values()) {
       const groupPlayerIds = new Set(groupEntries.map((entry) => entry.playerId));
       const groupMatches = matches.filter(

--- a/smkc-score-app/src/lib/tournament-archive.ts
+++ b/smkc-score-app/src/lib/tournament-archive.ts
@@ -3,7 +3,7 @@ import type { R2Bucket } from "@cloudflare/workers-types";
 import type { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { PLAYER_PUBLIC_SELECT } from "@/lib/prisma-selects";
-import { computeQualificationRanks } from "@/lib/server-ranking";
+import { computeQualificationRanks, type RankedQualification } from "@/lib/server-ranking";
 import { getOverallRankings, type PlayerTournamentScore } from "@/lib/points/overall-ranking";
 import { COURSES } from "@/lib/constants";
 import { generateBracketStructure, generatePlayoffStructure, roundNames } from "@/lib/double-elimination";
@@ -13,7 +13,6 @@ const twoPlayerQualificationOrder = () => [{ group: "asc" }, { score: "desc" }, 
 const GP_MATCH_SCORE_FIELDS = { p1: "points1", p2: "points2" };
 
 type ArchivePlayer = Prisma.PlayerGetPayload<{ select: typeof PLAYER_PUBLIC_SELECT }>;
-type RankedQualification<T> = T & { _rank?: number; _rankOverridden?: boolean };
 type BMQualificationArchiveRow = RankedQualification<Prisma.BMQualificationGetPayload<{
   include: { player: { select: typeof PLAYER_PUBLIC_SELECT } };
 }>>;
@@ -46,7 +45,7 @@ type TTEntryArchiveRow = Prisma.TTEntryGetPayload<{
 }>;
 type TTPhaseRoundArchiveRow = Prisma.TTPhaseRoundGetPayload<Record<string, never>>;
 
-export type TournamentArchiveModePayload<TQualification = never, TMatch = never> = {
+export type TournamentArchiveModePayload<TQualification = unknown, TMatch = unknown> = {
   qualifications?: TQualification[];
   matches?: TMatch[];
   qualificationConfirmed?: boolean;
@@ -394,7 +393,7 @@ export async function buildTournamentArchiveBundle(tournamentId: string): Promis
         [...twoPlayerQualificationOrder()],
         bmMatches.filter((match) => match.stage === "qualification"),
         { matchScoreFields: { p1: "score1", p2: "score2" } },
-      ) as BMQualificationArchiveRow[],
+      ),
       matches: bmMatches,
       qualificationConfirmed: tournament.bmQualificationConfirmed,
     },
@@ -404,7 +403,7 @@ export async function buildTournamentArchiveBundle(tournamentId: string): Promis
         [...twoPlayerQualificationOrder()],
         mrMatches.filter((match) => match.stage === "qualification"),
         { matchScoreFields: { p1: "score1", p2: "score2" } },
-      ) as MRQualificationArchiveRow[],
+      ),
       matches: mrMatches,
       qualificationConfirmed: tournament.mrQualificationConfirmed,
     },
@@ -414,7 +413,7 @@ export async function buildTournamentArchiveBundle(tournamentId: string): Promis
         [...twoPlayerQualificationOrder()],
         gpMatches.filter((match) => match.stage === "qualification"),
         { matchScoreFields: GP_MATCH_SCORE_FIELDS },
-      ) as GPQualificationArchiveRow[],
+      ),
       matches: gpMatches,
       qualificationConfirmed: tournament.gpQualificationConfirmed,
     },


### PR DESCRIPTION
## Summary
- Split TC-ARC-06 into its own E2E function with independent archive fixture setup/cleanup.
- Make `computeQualificationRanks` generic and return `RankedQualification<T>[]`, removing archive-side row-array casts and updating shared qualification delegates to return rankable rows.
- Change `TournamentArchiveModePayload` default type parameters from `never` to `unknown`.

## Issues
Closes #1263
Closes #1264
Closes #1265

## Validation
- node --check e2e/tc-archive.js
- npm test -- __tests__/lib/server-ranking.test.ts __tests__/lib/tournament-archive.test.ts __tests__/docs/e2e-archive-cases.test.ts
- npm run lint
- git diff --check
- HOME=/tmp/jsmkc-home WRANGLER_LOG_PATH=/tmp/jsmkc-wrangler.log npm run build:cf
- npx tsc --noEmit --pretty false | rg "server-ranking|tournament-archive|qual-initial-data|qualification-route|tc-archive|e2e-archive-cases" (no matching errors; full tsc still has pre-existing unrelated test typing failures)
