### PR TITLE
Fix typed ranking delegate build

### DIFF
--- a/smkc-score-app/src/lib/api-factories/qual-initial-data.ts
+++ b/smkc-score-app/src/lib/api-factories/qual-initial-data.ts
@@ -13,7 +13,7 @@
 import prisma from '@/lib/prisma';
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { resolveTournament } from '@/lib/tournament-identifier';
-import { computeQualificationRanks } from '@/lib/server-ranking';
+import { computeQualificationRanks, type RankableMatch, type RankableQualification } from '@/lib/server-ranking';
 import type { EventTypeConfig } from '@/lib/event-types/types';
 import type { Player } from '@/lib/types';
 
@@ -64,9 +64,9 @@ export async function fetchQualInitialData(
     // incompatibility: p[QualificationModelKey] produces a union of three Prisma
     // delegates whose findMany type parameters are mutually incompatible in TS.
     // Results are typed as unknown[] in QualInitialData so the cast is safe (#788).
-    type FindManyDelegate = { findMany: (args: Record<string, unknown>) => Promise<unknown[]> };
-    const qualModel = prisma[config.qualificationModel] as unknown as FindManyDelegate;
-    const matchModel = prisma[config.matchModel] as unknown as FindManyDelegate;
+    type FindManyDelegate<T> = { findMany: (args: Record<string, unknown>) => Promise<T[]> };
+    const qualModel = prisma[config.qualificationModel] as unknown as FindManyDelegate<RankableQualification>;
+    const matchModel = prisma[config.matchModel] as unknown as FindManyDelegate<RankableMatch>;
 
     const [qualifications, matches, allPlayers] = await Promise.all([
       qualModel.findMany({

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -25,7 +25,7 @@ import { resolveTournament, resolveTournamentId } from '@/lib/tournament-identif
 import { checkQualificationConfirmed } from '@/lib/qualification-confirmed-check';
 import { generateETag, invalidate } from '@/lib/standings-cache';
 import { invalidateOverallRankingsCache } from '@/lib/points/overall-ranking';
-import { computeQualificationRanks } from '@/lib/server-ranking';
+import { computeQualificationRanks, type RankableMatch, type RankableQualification } from '@/lib/server-ranking';
 import { getArchivedModePayload, readTournamentArchive } from '@/lib/tournament-archive';
 import { bulkUpdateQualificationStats } from '@/lib/api-factories/score-report-helpers';
 import {
@@ -267,7 +267,7 @@ export function createQualificationHandlers(config: EventTypeConfig) {
   // signature incompatibility: p[QualificationModelKey] produces a union of
   // three Prisma delegates whose type parameters are mutually incompatible (#788).
   type QualDelegate = {
-    findMany: (args: Record<string, unknown>) => Promise<unknown[]>;
+    findMany: (args: Record<string, unknown>) => Promise<RankableQualification[]>;
     findFirst: (args: Record<string, unknown>) => Promise<unknown>;
     deleteMany: (args: Record<string, unknown>) => Promise<unknown>;
     createMany: (args: Record<string, unknown>) => Promise<{ count: number }>;
@@ -275,7 +275,7 @@ export function createQualificationHandlers(config: EventTypeConfig) {
     update: (args: Record<string, unknown>) => Promise<unknown>;
   };
   type MatchDelegate = {
-    findMany: (args: Record<string, unknown>) => Promise<unknown[]>;
+    findMany: (args: Record<string, unknown>) => Promise<RankableMatch[]>;
     findFirst: (args: Record<string, unknown>) => Promise<Record<string, unknown> | null>;
     deleteMany: (args: Record<string, unknown>) => Promise<unknown>;
     createMany: (args: Record<string, unknown>) => Promise<{ count: number }>;

--- a/smkc-score-app/src/lib/server-ranking.ts
+++ b/smkc-score-app/src/lib/server-ranking.ts
@@ -12,13 +12,13 @@ export interface ComputeRanksOptions {
   matchScoreFields?: { p1: string; p2: string };
 }
 
-type RankableQualification = {
+export type RankableQualification = {
   playerId: string;
   group?: string | null;
   rankOverride?: number | null;
   [key: string]: unknown;
 };
-type RankableMatch = {
+export type RankableMatch = {
   player1Id: string;
   player2Id: string;
   completed?: boolean;


### PR DESCRIPTION
## Summary
- Fix the build failure introduced by the generic `computeQualificationRanks` follow-up by typing shared qualification delegates as rankable rows instead of `unknown[]`.
- Keep the generic ranking contract intact for archive payload typing while allowing `qual-initial-data` and qualification routes to compile in the Cloudflare build.

## Issues
Closes #1263
Closes #1264
Closes #1265

## Validation
- npm test -- __tests__/lib/server-ranking.test.ts __tests__/lib/tournament-archive.test.ts __tests__/docs/e2e-archive-cases.test.ts
- git diff --check
- HOME=/tmp/jsmkc-home WRANGLER_LOG_PATH=/tmp/jsmkc-wrangler.log npm run build:cf
