### PR TITLE
Fix archive E2E fixture cleanup and scores

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2411,15 +2411,19 @@
   qualification/finals API が実行時 cast 依存になり壊れやすい。
 - **手順**:
   1. admin で tournament + BM 予選データを作成
-  2. `status: completed`, `publicModes: ['bm', 'overall']` に更新
-  3. `/api/tournaments/:id/archive` に POST
-  4. 同じ URL を GET
-  5. `data.modes.bm.matches[0]` の `stage`, `player1`, `player2` を確認
+  2. BM 予選 match に固定スコア `score1=3`, `score2=1` を保存
+  3. `status: completed`, `publicModes: ['bm', 'overall']` に更新
+  4. `/api/tournaments/:id/archive` に POST
+  5. 同じ URL を GET
+  6. `data.modes.bm.matches[0]` の `stage`, `score1`, `score2`, `player1`, `player2` を確認
 - **期待結果**:
   - HTTP 200
   - `data.modes.bm.matches[0].stage === 'qualification'`
+  - `data.modes.bm.matches[0].score1 === 3`
+  - `data.modes.bm.matches[0].score2 === 1`
   - `player1.id` / `player2.id` は string
   - player payload は公開 field (`name`, `nickname`) を含む
+  - cleanup は tournament 削除に失敗しても player 削除まで試行し、失敗は warn に留める
 - **スクリプト**: tc-archive.js TC-ARC-06 (`npm run e2e:archive`, preview: `npm run e2e:preview:archive`)
 
 ---

--- a/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
@@ -23,8 +23,11 @@ describe('archive E2E case registration', () => {
 
     expect(section).toContain('modes.bm.matches[0]');
     expect(section).toContain("stage === 'qualification'");
+    expect(section).toContain('score1 === 3');
+    expect(section).toContain('score2 === 1');
     expect(section).toContain('player1.id');
     expect(section).toContain('player2.id');
+    expect(section).toContain('cleanup は tournament 削除に失敗しても player 削除まで試行');
   });
 
   it('documents TC-ARC-05 as TA archive phase1/phase2 fallback coverage', () => {

--- a/smkc-score-app/__tests__/e2e/tc-archive-fixtures.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-archive-fixtures.test.ts
@@ -1,0 +1,80 @@
+describe('archive E2E fixtures', () => {
+  async function loadArchiveSuite(commonOverrides: Record<string, unknown> = {}) {
+    jest.resetModules();
+
+    const common = {
+      makeResults: jest.fn(() => []),
+      makeLog: jest.fn(() => jest.fn()),
+      apiCreatePlayer: jest.fn(async (_page, name, nickname) => ({ id: `${nickname}-id`, nickname, name })),
+      apiCreateTournament: jest.fn(async () => 'tournament-1'),
+      apiJson: jest.fn(async (_page, path, options = {}) => ({
+        status: options && typeof options === 'object' && 'method' in options ? 200 : 200,
+        body: { data: { archived: true, path } },
+      })),
+      apiDeletePlayer: jest.fn(async () => undefined),
+      apiDeleteTournament: jest.fn(async () => undefined),
+      apiSetupBmGroup: jest.fn(async () => ({ s: 201, b: {} })),
+      apiPutAllBmQualScores: jest.fn(async () => undefined),
+      apiUpdateTournament: jest.fn(async () => ({ s: 200, b: {} })),
+      launchPersistentChromiumContext: jest.fn(),
+      resolveE2EProfileDir: jest.fn(() => '/tmp/e2e-profile'),
+      BASE: 'http://localhost:3000',
+      ...commonOverrides,
+    };
+
+    jest.doMock('../../e2e/lib/common', () => common);
+    jest.doMock('../../e2e/lib/runner', () => ({
+      closeBrowser: jest.fn(),
+      envMs: jest.fn((_name, fallback) => fallback),
+      exitAfterCleanup: jest.fn(),
+    }));
+
+    const suite = await import('../../e2e/tc-archive');
+    return { suite, common };
+  }
+
+  it('scores BM qualification matches before archiving the completed public fixture', async () => {
+    const { suite, common } = await loadArchiveSuite();
+
+    await suite.createCompletedPublicBmArchive({}, 'TCARC06', 'TC-ARC-06');
+
+    expect(common.apiSetupBmGroup).toHaveBeenCalledWith(expect.anything(), 'tournament-1', expect.any(Array));
+    expect(common.apiPutAllBmQualScores).toHaveBeenCalledWith(
+      expect.anything(),
+      'tournament-1',
+      { score1: 3, score2: 1, randomize: false },
+    );
+    expect(common.apiPutAllBmQualScores.mock.invocationCallOrder[0])
+      .toBeLessThan(common.apiUpdateTournament.mock.invocationCallOrder[0]);
+    expect(common.apiUpdateTournament).toHaveBeenCalledWith(
+      expect.anything(),
+      'tournament-1',
+      expect.objectContaining({ status: 'completed', publicModes: ['bm', 'overall'] }),
+    );
+  });
+
+  it('attempts every cleanup deletion and warns instead of throwing on failures', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { suite, common } = await loadArchiveSuite({
+      apiDeleteTournament: jest.fn(async () => {
+        throw new Error('tournament delete failed');
+      }),
+      apiDeletePlayer: jest.fn(async (_page, id) => {
+        if (id === 'player-2') throw new Error('player delete failed');
+      }),
+    });
+
+    await expect(suite.cleanupArchiveFixture({}, {
+      tournamentId: 'tournament-1',
+      players: [{ id: 'player-1' }, { id: 'player-2' }],
+    })).resolves.toBeUndefined();
+
+    expect(common.apiDeleteTournament).toHaveBeenCalledWith(expect.anything(), 'tournament-1');
+    expect(common.apiDeletePlayer).toHaveBeenCalledTimes(2);
+    expect(common.apiDeletePlayer).toHaveBeenNthCalledWith(1, expect.anything(), 'player-1');
+    expect(common.apiDeletePlayer).toHaveBeenNthCalledWith(2, expect.anything(), 'player-2');
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('cleanup failed for tournament tournament-1'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('cleanup failed for player player-2'));
+    warn.mockRestore();
+  });
+});

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -19,6 +19,7 @@ const {
   apiDeletePlayer,
   apiDeleteTournament,
   apiSetupBmGroup,
+  apiPutAllBmQualScores,
   apiUpdateTournament,
   launchPersistentChromiumContext,
   resolveE2EProfileDir,
@@ -56,6 +57,7 @@ async function createCompletedPublicBmArchive(page, prefix, caseName) {
     tournamentId = await apiCreateTournament(page, `E2E ${caseName} ${Date.now()}`);
     const setup = await apiSetupBmGroup(page, tournamentId, bmAssignments(players));
     if (setup.s !== 201) throw new Error(`BM setup failed (${setup.s})`);
+    await apiPutAllBmQualScores(page, tournamentId, { score1: 3, score2: 1, randomize: false });
 
     const completed = await apiUpdateTournament(page, tournamentId, {
       status: 'completed',
@@ -68,15 +70,23 @@ async function createCompletedPublicBmArchive(page, prefix, caseName) {
     const get = await apiJson(page, `/api/tournaments/${tournamentId}/archive`);
     return { tournamentId, players, post, get, archive: get.body?.data };
   } catch (error) {
-    await apiDeleteTournament(page, tournamentId);
-    for (const player of players) await apiDeletePlayer(page, player.id);
+    await cleanupArchiveFixture(page, { tournamentId, players });
     throw error;
   }
 }
 
 async function cleanupArchiveFixture(page, fixture) {
-  await apiDeleteTournament(page, fixture?.tournamentId);
-  for (const player of fixture?.players ?? []) await apiDeletePlayer(page, player.id);
+  const deletions = [
+    apiDeleteTournament(page, fixture?.tournamentId),
+    ...(fixture?.players ?? []).map((player) => apiDeletePlayer(page, player.id)),
+  ];
+  const results = await Promise.allSettled(deletions);
+  results.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      const target = index === 0 ? `tournament ${fixture?.tournamentId ?? ''}` : `player ${fixture?.players?.[index - 1]?.id ?? ''}`;
+      console.warn(`[tc-archive] cleanup failed for ${target}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`);
+    }
+  });
 }
 
 async function tcArc01(page) {
@@ -141,13 +151,15 @@ async function tcArc06(page) {
     const typedMatchOk = (
       fixture.get.status === 200 &&
       archivedMatch?.stage === 'qualification' &&
+      archivedMatch?.score1 === 3 &&
+      archivedMatch?.score2 === 1 &&
       typeof archivedMatch?.player1?.id === 'string' &&
       typeof archivedMatch?.player2?.id === 'string' &&
       typeof archivedMatch?.player1?.name === 'string' &&
       typeof archivedMatch?.player2?.nickname === 'string'
     );
     log('TC-ARC-06', typedMatchOk ? 'PASS' : 'FAIL',
-      `stage=${archivedMatch?.stage || ''} p1=${archivedMatch?.player1?.id || ''} p2=${archivedMatch?.player2?.id || ''}`);
+      `stage=${archivedMatch?.stage || ''} score=${archivedMatch?.score1}-${archivedMatch?.score2} p1=${archivedMatch?.player1?.id || ''} p2=${archivedMatch?.player2?.id || ''}`);
   } catch (error) {
     log('TC-ARC-06', 'FAIL', error instanceof Error ? error.message : String(error));
   } finally {
@@ -225,4 +237,6 @@ if (require.main === module) {
 
 module.exports = {
   runArchiveTests,
+  createCompletedPublicBmArchive,
+  cleanupArchiveFixture,
 };


### PR DESCRIPTION
Summary
- Score BM qualification matches before TC-ARC-06 archive generation so archived fixtures contain concrete score values.
- Make archive E2E fixture cleanup attempt tournament and player deletion with allSettled-style warning behavior.
- Add focused Jest/docs coverage for archive fixture scoring and cleanup contracts.

Issues: Closes #1267, Closes #1268

Validation
- node --check smkc-score-app/e2e/tc-archive.js
- npm test -- __tests__/e2e/tc-archive-fixtures.test.ts __tests__/docs/e2e-archive-cases.test.ts
- git diff --check
- npm run lint (passes with existing warnings)
