### PR TITLE
Address archive fixture review followups

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-archive-fixtures.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-archive-fixtures.test.ts
@@ -7,8 +7,8 @@ describe('archive E2E fixtures', () => {
       makeLog: jest.fn(() => jest.fn()),
       apiCreatePlayer: jest.fn(async (_page, name, nickname) => ({ id: `${nickname}-id`, nickname, name })),
       apiCreateTournament: jest.fn(async () => 'tournament-1'),
-      apiJson: jest.fn(async (_page, path, options = {}) => ({
-        status: options && typeof options === 'object' && 'method' in options ? 200 : 200,
+      apiJson: jest.fn(async (_page, path) => ({
+        status: 200,
         body: { data: { archived: true, path } },
       })),
       apiDeletePlayer: jest.fn(async () => undefined),

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -77,14 +77,16 @@ async function createCompletedPublicBmArchive(page, prefix, caseName) {
 
 async function cleanupArchiveFixture(page, fixture) {
   const deletions = [
-    apiDeleteTournament(page, fixture?.tournamentId),
-    ...(fixture?.players ?? []).map((player) => apiDeletePlayer(page, player.id)),
+    { label: `tournament ${fixture?.tournamentId ?? ''}`, promise: apiDeleteTournament(page, fixture?.tournamentId) },
+    ...(fixture?.players ?? []).map((player) => ({
+      label: `player ${player.id}`,
+      promise: apiDeletePlayer(page, player.id),
+    })),
   ];
-  const results = await Promise.allSettled(deletions);
+  const results = await Promise.allSettled(deletions.map((deletion) => deletion.promise));
   results.forEach((result, index) => {
     if (result.status === 'rejected') {
-      const target = index === 0 ? `tournament ${fixture?.tournamentId ?? ''}` : `player ${fixture?.players?.[index - 1]?.id ?? ''}`;
-      console.warn(`[tc-archive] cleanup failed for ${target}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`);
+      console.warn(`[tc-archive] cleanup failed for ${deletions[index].label}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`);
     }
   });
 }


### PR DESCRIPTION
Summary
- Remove the dead apiJson mock ternary from the archive fixture Jest test.
- Pair cleanup promises with labels so cleanupArchiveFixture warning targets do not depend on array index assumptions.

Issues: Closes #1271, Closes #1272

Validation
- node --check smkc-score-app/e2e/tc-archive.js
- npm test -- __tests__/e2e/tc-archive-fixtures.test.ts __tests__/docs/e2e-archive-cases.test.ts
- git diff --check
- npm run lint (passes with existing warnings)
