### PR TITLE
Fix TA archive fallback for missing tournaments

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2428,6 +2428,27 @@
 
 ---
 
+## TC-ARC-07: TA API — DB に tournament がない完了済み archive fallback
+- **URL**: GET /api/tournaments/:id/ta
+- **authRequired**: false (公開GETエンドポイント)
+- **背景**: 完了済み tournament の DB 行が削除されても、公開済み archive が
+  R2 に残っている場合は TA API も archive payload を返す必要がある。
+  `/api/tournaments/:id/ta` は DB エラー時だけでなく、DB が正常に
+  `tournament not found` を返す場合も archive fallback する。
+- **手順**:
+  1. `modes.ta.entries` を持つ archive fixture を用意する
+  2. DB の tournament 解決が `null` を返す状態で `/api/tournaments/:id/ta` を GET
+  3. `entries`, `courses`, `allPlayers` を含む archived TA payload を確認
+- **期待結果**:
+  - HTTP 200
+  - `data.archived === true`
+  - `data.entries` が archive の TA entries を返す
+  - DB tournament が存在しない場合は live `TTEntry` クエリを実行しない
+- **スクリプト**: tc-archive.js TC-ARC-07 (`npm run e2e:archive`, preview: `npm run e2e:preview:archive`)
+- **補助検証**: `smkc-score-app/__tests__/app/api/tournaments/[id]/ta/route.test.ts`
+
+---
+
 ## TC-ARC-04: トーナメントアーカイブ API — 公開 mode のない archive は非公開
 - **URL**: GET /api/tournaments/:id/archive
 - **authRequired**: false (公開GETエンドポイント)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/route.test.ts
@@ -90,6 +90,11 @@ jest.mock('@/lib/ta/freeze-check', () => ({
   checkStageFrozen: jest.fn(() => Promise.resolve(null)),
 }));
 
+jest.mock('@/lib/tournament-archive', () => ({
+  getArchivedModePayload: jest.requireActual('@/lib/tournament-archive').getArchivedModePayload,
+  readTournamentArchive: jest.fn(),
+}));
+
 // Mock next/server with MockNextRequest that supports URL parsing
 jest.mock('next/server', () => {
   const mockJson = jest.fn();
@@ -129,6 +134,7 @@ import { NextRequest } from 'next/server';
 import { auth } from '@/lib/auth';
 import prisma from '@/lib/prisma';
 import * as taRoute from '@/app/api/tournaments/[id]/ta/route';
+import { readTournamentArchive } from '@/lib/tournament-archive';
 import { configureNextResponseMock } from '../../../../../helpers/next-response-mock';
 
 // Access mocks via requireMock to get references to the same mock functions
@@ -171,6 +177,7 @@ describe('/api/tournaments/[id]/ta', () => {
     rateLimitMock.getClientIdentifier.mockReturnValue('127.0.0.1');
     rateLimitMock.getUserAgent.mockReturnValue('test-agent');
     (prisma.tTEntry.findFirst as jest.Mock).mockResolvedValue(null);
+    (readTournamentArchive as jest.Mock).mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -197,7 +204,11 @@ describe('/api/tournaments/[id]/ta', () => {
       ];
 
       (prisma.tTEntry.findMany as jest.Mock).mockResolvedValue(mockEntries);
-      (prisma.tournament.findUnique as jest.Mock).mockResolvedValue({ frozenStages: [] });
+      (prisma.tournament.findFirst as jest.Mock).mockResolvedValue({
+        id: VALID_UUID,
+        frozenStages: [],
+        taPlayerSelfEdit: true,
+      });
       (prisma.tTEntry.count as jest.Mock).mockResolvedValueOnce(10);
 
       await taRoute.GET(
@@ -223,7 +234,11 @@ describe('/api/tournaments/[id]/ta', () => {
 
     it('should report qualification editing as locked for players after knockout starts', async () => {
       (prisma.tTEntry.findMany as jest.Mock).mockResolvedValue([]);
-      (prisma.tournament.findUnique as jest.Mock).mockResolvedValue({ frozenStages: [] });
+      (prisma.tournament.findFirst as jest.Mock).mockResolvedValue({
+        id: VALID_UUID,
+        frozenStages: [],
+        taPlayerSelfEdit: true,
+      });
       (prisma.tTEntry.count as jest.Mock).mockResolvedValueOnce(24);
       (prisma.tTEntry.findFirst as jest.Mock).mockResolvedValueOnce({ id: 'phase-entry-1' });
 
@@ -246,7 +261,6 @@ describe('/api/tournaments/[id]/ta', () => {
     it('should resolve tournament slug for GET', async () => {
       (prisma.tournament.findFirst as jest.Mock).mockResolvedValueOnce({ id: VALID_UUID });
       (prisma.tTEntry.findMany as jest.Mock).mockResolvedValue([]);
-      (prisma.tournament.findUnique as jest.Mock).mockResolvedValue({ frozenStages: [] });
       (prisma.tTEntry.count as jest.Mock).mockResolvedValueOnce(0);
 
       await taRoute.GET(
@@ -266,7 +280,69 @@ describe('/api/tournaments/[id]/ta', () => {
       );
     });
 
+    it('should return archived TA payload when tournament lookup returns not found', async () => {
+      const archivedEntry = {
+        id: 'archived-entry-1',
+        playerId: 'archived-player-1',
+        stage: 'qualification',
+        totalTime: 83456,
+        player: { id: 'archived-player-1', name: 'Archived Player', nickname: 'archived' },
+      };
+      (prisma.tournament.findFirst as jest.Mock).mockResolvedValue(null);
+      (readTournamentArchive as jest.Mock).mockResolvedValue({
+        schemaVersion: 1,
+        tournament: { id: VALID_UUID, publicModes: ['ta'] },
+        modes: {
+          ta: { entries: [archivedEntry], courses: ['MC1'] },
+          bm: {},
+          mr: {},
+          gp: {},
+        },
+        allPlayers: [archivedEntry.player],
+      });
+
+      await taRoute.GET(
+        new NextRequest(`http://localhost:3000/api/tournaments/${VALID_UUID}/ta`),
+        { params: Promise.resolve({ id: VALID_UUID }) }
+      );
+
+      expect(readTournamentArchive).toHaveBeenCalledWith(VALID_UUID);
+      expect(prisma.tTEntry.findMany).not.toHaveBeenCalled();
+      expect(prisma.tTEntry.count).not.toHaveBeenCalled();
+      expect(NextResponse.json).toHaveBeenCalledWith({
+        success: true,
+        data: expect.objectContaining({
+          archived: true,
+          entries: [archivedEntry],
+          courses: ['MC1'],
+          allPlayers: [archivedEntry.player],
+        }),
+      });
+    });
+
+    it('should return 404 when tournament and archive are both missing', async () => {
+      (prisma.tournament.findFirst as jest.Mock).mockResolvedValue(null);
+      (readTournamentArchive as jest.Mock).mockResolvedValue(null);
+
+      await taRoute.GET(
+        new NextRequest(`http://localhost:3000/api/tournaments/${VALID_UUID}/ta`),
+        { params: Promise.resolve({ id: VALID_UUID }) }
+      );
+
+      expect(readTournamentArchive).toHaveBeenCalledWith(VALID_UUID);
+      expect(prisma.tTEntry.findMany).not.toHaveBeenCalled();
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        { success: false, error: 'Tournament not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    });
+
     it('should handle database errors with 500', async () => {
+      (prisma.tournament.findFirst as jest.Mock).mockResolvedValue({
+        id: VALID_UUID,
+        frozenStages: [],
+        taPlayerSelfEdit: true,
+      });
       (prisma.tTEntry.findMany as jest.Mock).mockRejectedValue(new Error('DB error'));
 
       await taRoute.GET(

--- a/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
@@ -5,7 +5,7 @@ describe('archive E2E case registration', () => {
   const casesPath = path.join(process.cwd(), '..', 'E2E_TEST_CASES.md');
   const cases = fs.readFileSync(casesPath, 'utf8');
 
-  it.each(['TC-ARC-01', 'TC-ARC-02', 'TC-ARC-03', 'TC-ARC-04', 'TC-ARC-06'])(
+  it.each(['TC-ARC-01', 'TC-ARC-02', 'TC-ARC-03', 'TC-ARC-04', 'TC-ARC-06', 'TC-ARC-07'])(
     'documents %s as a runnable archive script case',
     (tc) => {
       const section = cases.slice(cases.indexOf(`## ${tc}:`), cases.indexOf('\n---', cases.indexOf(`## ${tc}:`)));
@@ -41,6 +41,20 @@ describe('archive E2E case registration', () => {
     expect(section).toContain('round history');
     expect(section).toContain('lives === 0');
     expect(section).toContain('smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts');
+  });
+
+  it('documents TC-ARC-07 as TA not-found archive fallback coverage', () => {
+    const section = cases.slice(
+      cases.indexOf('## TC-ARC-07:'),
+      cases.indexOf('\n---', cases.indexOf('## TC-ARC-07:')),
+    );
+
+    expect(section).toContain('/api/tournaments/:id/ta');
+    expect(section).toContain('tournament not found');
+    expect(section).toContain('archive fallback');
+    expect(section).toContain('data.archived === true');
+    expect(section).toContain('live `TTEntry` クエリを実行しない');
+    expect(section).toContain('smkc-score-app/__tests__/app/api/tournaments/[id]/ta/route.test.ts');
   });
 
   it('documents that preview archive coverage writes to a dedicated R2 bucket', () => {

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -7,6 +7,7 @@
  *   TC-ARC-03  Completed public tournament archive can be regenerated and read.
  *   TC-ARC-04  Completed private archive is not publicly readable.
  *   TC-ARC-06  Archive BM match rows keep stage and public player payloads.
+ *   TC-ARC-07  TA API falls back to archive when live tournament row is gone.
  *
  * Run: node e2e/tc-archive.js  (from smkc-score-app/)  or: npm run e2e:archive
  */
@@ -169,6 +170,37 @@ async function tcArc06(page) {
   }
 }
 
+async function tcArc07(page) {
+  let tournamentId = null;
+  try {
+    tournamentId = await apiCreateTournament(page, `E2E TC-ARC-07 ${Date.now()}`);
+    const completed = await apiUpdateTournament(page, tournamentId, {
+      status: 'completed',
+      publicModes: ['ta'],
+    });
+    if (completed.s !== 200) throw new Error(`completion update failed (${completed.s})`);
+
+    const post = await apiJson(page, `/api/tournaments/${tournamentId}/archive`, { method: 'POST' });
+    await apiDeleteTournament(page, tournamentId);
+    const response = await apiJson(page, `/api/tournaments/${tournamentId}/ta`);
+
+    const ok = (
+      post.status === 200 &&
+      response.status === 200 &&
+      response.body?.data?.archived === true &&
+      Array.isArray(response.body?.data?.entries) &&
+      Array.isArray(response.body?.data?.courses) &&
+      Array.isArray(response.body?.data?.allPlayers)
+    );
+    log('TC-ARC-07', ok ? 'PASS' : 'FAIL',
+      `post=${post.status} get=${response.status} archived=${response.body?.data?.archived}`);
+  } catch (error) {
+    log('TC-ARC-07', 'FAIL', error instanceof Error ? error.message : String(error));
+  } finally {
+    await apiDeleteTournament(page, tournamentId);
+  }
+}
+
 async function tcArc04(page) {
   let tournamentId = null;
   try {
@@ -198,6 +230,7 @@ async function runArchiveTests(page) {
   await tcArc03(page);
   await tcArc04(page);
   await tcArc06(page);
+  await tcArc07(page);
 
   const failed = results.filter((result) => result.s === 'FAIL');
   console.log(`\nTC-ARC summary: ${results.length - failed.length}/${results.length} passed`);

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
@@ -178,7 +178,14 @@ async function handleGET(
     /* Single query: resolve slug/id AND fetch frozenStages/taPlayerSelfEdit (#692).
        Then run the remaining three queries in parallel using the resolved id. */
     const tournament = await resolveTournament(id, { id: true, frozenStages: true, taPlayerSelfEdit: true });
-    const tournamentId = tournament?.id ?? id;
+    if (!tournament) {
+      const archived = await readTournamentArchive(id);
+      if (archived) {
+        return createSuccessResponse(getArchivedModePayload(archived, "ta"));
+      }
+      return createErrorResponse("Tournament not found", 404, "NOT_FOUND");
+    }
+    const tournamentId = tournament.id;
 
     const [entries, qualCount, knockoutStarted] = await Promise.all([
       prisma.tTEntry.findMany({


### PR DESCRIPTION
Summary
- Add TC-ARC-07 coverage for `/api/tournaments/:id/ta` archive fallback when the live tournament row is gone.
- Return archived TA mode payload from `ta/route.ts` when `resolveTournament` returns null, otherwise return a 404 without querying live TTEntry rows.
- Cover the new behavior in focused route and E2E archive documentation tests.

Issues: Closes #1141

Validation
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/ta/route.test.ts' __tests__/docs/e2e-archive-cases.test.ts`
- `node --check e2e/tc-archive.js`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
