### PR TITLE
Address TA archive fallback followups

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/route.test.ts
@@ -337,6 +337,32 @@ describe('/api/tournaments/[id]/ta', () => {
       );
     });
 
+    it('should return 404 when archive exists without TA mode payload', async () => {
+      (prisma.tournament.findFirst as jest.Mock).mockResolvedValue(null);
+      (readTournamentArchive as jest.Mock).mockResolvedValue({
+        schemaVersion: 1,
+        tournament: { id: VALID_UUID, publicModes: ['bm'] },
+        modes: {
+          bm: {},
+          mr: {},
+          gp: {},
+        },
+        allPlayers: [],
+      });
+
+      await taRoute.GET(
+        new NextRequest(`http://localhost:3000/api/tournaments/${VALID_UUID}/ta`),
+        { params: Promise.resolve({ id: VALID_UUID }) }
+      );
+
+      expect(readTournamentArchive).toHaveBeenCalledWith(VALID_UUID);
+      expect(prisma.tTEntry.findMany).not.toHaveBeenCalled();
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        { success: false, error: 'Tournament not found', code: 'NOT_FOUND' },
+        { status: 404 }
+      );
+    });
+
     it('should handle database errors with 500', async () => {
       (prisma.tournament.findFirst as jest.Mock).mockResolvedValue({
         id: VALID_UUID,

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -172,6 +172,7 @@ async function tcArc06(page) {
 
 async function tcArc07(page) {
   let tournamentId = null;
+  let tournamentDeleted = false;
   try {
     tournamentId = await apiCreateTournament(page, `E2E TC-ARC-07 ${Date.now()}`);
     const completed = await apiUpdateTournament(page, tournamentId, {
@@ -182,6 +183,7 @@ async function tcArc07(page) {
 
     const post = await apiJson(page, `/api/tournaments/${tournamentId}/archive`, { method: 'POST' });
     await apiDeleteTournament(page, tournamentId);
+    tournamentDeleted = true;
     const response = await apiJson(page, `/api/tournaments/${tournamentId}/ta`);
 
     const ok = (
@@ -197,7 +199,9 @@ async function tcArc07(page) {
   } catch (error) {
     log('TC-ARC-07', 'FAIL', error instanceof Error ? error.message : String(error));
   } finally {
-    await apiDeleteTournament(page, tournamentId);
+    if (!tournamentDeleted) {
+      await apiDeleteTournament(page, tournamentId);
+    }
   }
 }
 

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
@@ -38,7 +38,11 @@ import { checkStageFrozen } from "@/lib/ta/freeze-check";
 import { createErrorResponse, createSuccessResponse } from "@/lib/error-handling";
 import { resolveTournamentId, resolveTournament } from "@/lib/tournament-identifier";
 import { withApiTiming } from "@/lib/perf/api-timing";
-import { getArchivedModePayload, readTournamentArchive } from "@/lib/tournament-archive";
+import {
+  getArchivedModePayload,
+  readTournamentArchive,
+  type TournamentArchiveBundle,
+} from "@/lib/tournament-archive";
 
 const KNOCKOUT_STAGES = ["phase1", "phase2", "phase3"] as const;
 
@@ -92,6 +96,13 @@ async function hasKnockoutStageStarted(tournamentId: string): Promise<boolean> {
  * Note: "finals" values may still exist in production DB but are no longer
  * queryable through this endpoint. */
 const StageSchema = z.enum(["qualification", "revival_1", "revival_2"]);
+
+function getArchivedTaPayload(archive: TournamentArchiveBundle) {
+  if (!("ta" in archive.modes) || !archive.modes.ta) {
+    return null;
+  }
+  return getArchivedModePayload(archive, "ta");
+}
 
 /**
  * POST request body schema.
@@ -181,7 +192,10 @@ async function handleGET(
     if (!tournament) {
       const archived = await readTournamentArchive(id);
       if (archived) {
-        return createSuccessResponse(getArchivedModePayload(archived, "ta"));
+        const archivedTaPayload = getArchivedTaPayload(archived);
+        if (archivedTaPayload) {
+          return createSuccessResponse(archivedTaPayload);
+        }
       }
       return createErrorResponse("Tournament not found", 404, "NOT_FOUND");
     }
@@ -215,7 +229,10 @@ async function handleGET(
     logger.error("Failed to fetch TA data", { error, tournamentId: id });
     const archived = await readTournamentArchive(id);
     if (archived) {
-      return createSuccessResponse(getArchivedModePayload(archived, "ta"));
+      const archivedTaPayload = getArchivedTaPayload(archived);
+      if (archivedTaPayload) {
+        return createSuccessResponse(archivedTaPayload);
+      }
     }
     return createErrorResponse("Failed to fetch time attack data", 500, "INTERNAL_ERROR");
   }


### PR DESCRIPTION
Summary
- Guard TC-ARC-07 cleanup so the intentionally deleted tournament is not deleted a second time in `finally`.
- Add a TA archive payload guard so missing `modes.ta` archives return the existing not-found response instead of a partial success payload.
- Cover the missing-TA archive edge case in the focused TA route test.

Issues: Closes #1275, Closes #1276

Validation
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/ta/route.test.ts'`
- `node --check e2e/tc-archive.js`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
