### PR TITLE
Fix tournament archive index race

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2402,6 +2402,27 @@
 
 ---
 
+## TC-ARC-08: トーナメントアーカイブ API — 複数 archive の独立保存
+- **URL**: POST /api/tournaments/:id/archive, GET /api/tournaments/:id/archive
+- **authRequired**: POST は admin、GET は公開
+- **背景**: archive 一覧は `archives/index.json` の read-modify-write に依存せず、
+  R2 の `archives/by-id/*/latest.json` から再構築する。複数 tournament を連続して
+  archive 化しても、後続の保存が先行 archive bundle を消してはいけない。
+- **手順**:
+  1. admin で 2 つの completed public BM tournament を作成
+  2. それぞれ `/api/tournaments/:id/archive` に POST
+  3. それぞれの `/api/tournaments/:id/archive` を GET
+  4. 2 つの archive bundle が別々の tournament id/name を保持していることを確認
+- **期待結果**:
+  - 2 件とも POST/GET が HTTP 200
+  - 2 件とも `data.archived === true`
+  - 2 件の `data.tournament.id` は互いに異なる
+  - archive index の補助単体テストは `archives/by-id/*/latest.json` の list 由来で複数件を返す
+- **スクリプト**: tc-archive.js TC-ARC-08 (`npm run e2e:archive`, preview: `npm run e2e:preview:archive`)
+- **補助検証**: `smkc-score-app/__tests__/lib/tournament-archive.test.ts`
+
+---
+
 ## TC-ARC-06: トーナメントアーカイブ API — BM match/player payload の型付き保存
 - **URL**: POST /api/tournaments/:id/archive, GET /api/tournaments/:id/archive
 - **authRequired**: POST は admin、GET は公開

--- a/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
@@ -5,7 +5,7 @@ describe('archive E2E case registration', () => {
   const casesPath = path.join(process.cwd(), '..', 'E2E_TEST_CASES.md');
   const cases = fs.readFileSync(casesPath, 'utf8');
 
-  it.each(['TC-ARC-01', 'TC-ARC-02', 'TC-ARC-03', 'TC-ARC-04', 'TC-ARC-06', 'TC-ARC-07'])(
+  it.each(['TC-ARC-01', 'TC-ARC-02', 'TC-ARC-03', 'TC-ARC-04', 'TC-ARC-06', 'TC-ARC-07', 'TC-ARC-08'])(
     'documents %s as a runnable archive script case',
     (tc) => {
       const section = cases.slice(cases.indexOf(`## ${tc}:`), cases.indexOf('\n---', cases.indexOf(`## ${tc}:`)));
@@ -55,6 +55,17 @@ describe('archive E2E case registration', () => {
     expect(section).toContain('data.archived === true');
     expect(section).toContain('live `TTEntry` クエリを実行しない');
     expect(section).toContain('smkc-score-app/__tests__/app/api/tournaments/[id]/ta/route.test.ts');
+  });
+
+  it('documents TC-ARC-08 as multi-archive index/list coverage', () => {
+    const section = cases.slice(
+      cases.indexOf('## TC-ARC-08:'),
+      cases.indexOf('\n---', cases.indexOf('## TC-ARC-08:')),
+    );
+
+    expect(section).toContain('archives/by-id/*/latest.json');
+    expect(section).toContain('複数件を返す');
+    expect(section).toContain('smkc-score-app/__tests__/lib/tournament-archive.test.ts');
   });
 
   it('documents that preview archive coverage writes to a dedicated R2 bucket', () => {

--- a/smkc-score-app/__tests__/lib/tournament-archive.test.ts
+++ b/smkc-score-app/__tests__/lib/tournament-archive.test.ts
@@ -2,6 +2,7 @@ import {
   getArchivedFinalsPayload,
   getArchivedModePayload,
   getTournamentArchiveKeys,
+  readTournamentArchiveIndex,
   readTournamentArchive,
   TOURNAMENT_ARCHIVE_SCHEMA_VERSION,
   type TournamentArchiveBundle,
@@ -20,6 +21,19 @@ jest.mock("@opennextjs/cloudflare", () => ({
         }),
         put: jest.fn(async (key: string, value: string) => {
           objects.set(key, JSON.parse(value));
+        }),
+        list: jest.fn(async ({ prefix, cursor }: { prefix?: string; cursor?: string } = {}) => {
+          const keys = [...objects.keys()]
+            .filter((key) => !prefix || key.startsWith(prefix))
+            .sort();
+          const start = cursor ? Number(cursor) : 0;
+          const page = keys.slice(start, start + 2);
+          const next = start + page.length;
+          return {
+            objects: page.map((key) => ({ key })),
+            delimitedPrefixes: [],
+            ...(next < keys.length ? { truncated: true, cursor: String(next) } : { truncated: false }),
+          };
         }),
       },
     },
@@ -98,6 +112,49 @@ describe("tournament archive", () => {
     });
 
     await expect(readTournamentArchive("tournament-1")).resolves.toBeNull();
+  });
+
+  it("derives archive index entries from by-id archive objects without relying on the legacy index object", async () => {
+    const older = makeArchive({
+      generatedAt: "2026-05-07T00:00:00.000Z",
+      tournament: {
+        ...makeArchive().tournament,
+        id: "tournament-old",
+        slug: "old-slug",
+        name: "Old Archive",
+        date: "2026-05-07T00:00:00.000Z",
+      },
+    });
+    const newer = makeArchive({
+      generatedAt: "2026-05-08T00:00:00.000Z",
+      tournament: {
+        ...makeArchive().tournament,
+        id: "tournament-new",
+        slug: "new-slug",
+        name: "New Archive",
+        date: "2026-05-08T00:00:00.000Z",
+      },
+    });
+    objects.set("archives/index.json", [
+      {
+        id: "stale-only",
+        slug: "stale",
+        name: "Stale Legacy Index",
+        date: "2026-05-09T00:00:00.000Z",
+        status: "completed",
+        publicModes: [],
+        createdAt: "2026-05-09T00:00:00.000Z",
+        archivedAt: "2026-05-09T00:00:00.000Z",
+      },
+    ]);
+    objects.set("archives/by-id/tournament-old/latest.json", older);
+    objects.set("archives/by-id/tournament-new/latest.json", newer);
+    objects.set("archives/by-slug/new-slug/latest.json", newer);
+
+    await expect(readTournamentArchiveIndex()).resolves.toEqual([
+      expect.objectContaining({ id: "tournament-new", slug: "new-slug", name: "New Archive" }),
+      expect.objectContaining({ id: "tournament-old", slug: "old-slug", name: "Old Archive" }),
+    ]);
   });
 
   it("filters typed archived qualification matches without runtime stage casts", () => {

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -8,6 +8,7 @@
  *   TC-ARC-04  Completed private archive is not publicly readable.
  *   TC-ARC-06  Archive BM match rows keep stage and public player payloads.
  *   TC-ARC-07  TA API falls back to archive when live tournament row is gone.
+ *   TC-ARC-08  Two completed archives stay independently readable.
  *
  * Run: node e2e/tc-archive.js  (from smkc-score-app/)  or: npm run e2e:archive
  */
@@ -170,6 +171,37 @@ async function tcArc06(page) {
   }
 }
 
+async function tcArc08(page) {
+  let firstFixture = null;
+  let secondFixture = null;
+  try {
+    firstFixture = await createCompletedPublicBmArchive(page, 'TCARC08A', 'TC-ARC-08A');
+    secondFixture = await createCompletedPublicBmArchive(page, 'TCARC08B', 'TC-ARC-08B');
+
+    const first = await apiJson(page, `/api/tournaments/${firstFixture.tournamentId}/archive`);
+    const second = await apiJson(page, `/api/tournaments/${secondFixture.tournamentId}/archive`);
+    const firstId = first.body?.data?.tournament?.id;
+    const secondId = second.body?.data?.tournament?.id;
+    const ok = (
+      first.status === 200 &&
+      second.status === 200 &&
+      first.body?.data?.archived === true &&
+      second.body?.data?.archived === true &&
+      firstId === firstFixture.tournamentId &&
+      secondId === secondFixture.tournamentId &&
+      firstId !== secondId
+    );
+
+    log('TC-ARC-08', ok ? 'PASS' : 'FAIL',
+      `first=${first.status}:${firstId || ''} second=${second.status}:${secondId || ''}`);
+  } catch (error) {
+    log('TC-ARC-08', 'FAIL', error instanceof Error ? error.message : String(error));
+  } finally {
+    await cleanupArchiveFixture(page, firstFixture);
+    await cleanupArchiveFixture(page, secondFixture);
+  }
+}
+
 async function tcArc07(page) {
   let tournamentId = null;
   let tournamentDeleted = false;
@@ -235,6 +267,7 @@ async function runArchiveTests(page) {
   await tcArc04(page);
   await tcArc06(page);
   await tcArc07(page);
+  await tcArc08(page);
 
   const failed = results.filter((result) => result.s === 'FAIL');
   console.log(`\nTC-ARC summary: ${results.length - failed.length}/${results.length} passed`);

--- a/smkc-score-app/src/lib/tournament-archive.ts
+++ b/smkc-score-app/src/lib/tournament-archive.ts
@@ -276,15 +276,8 @@ export function getArchivedTournamentSummary(bundle: TournamentArchiveBundle, is
   };
 }
 
-export async function readTournamentArchiveIndex(): Promise<TournamentArchiveIndexItem[]> {
-  const index = await readJsonFromR2<unknown>("archives/index.json");
-  if (!index || !Array.isArray(index)) return [];
-  return index as TournamentArchiveIndexItem[];
-}
-
-async function updateTournamentArchiveIndex(bundle: TournamentArchiveBundle) {
-  const existing = await readTournamentArchiveIndex();
-  const item: TournamentArchiveIndexItem = {
+function archiveIndexItemFromBundle(bundle: TournamentArchiveBundle): TournamentArchiveIndexItem {
+  return {
     id: bundle.tournament.id,
     slug: bundle.tournament.slug,
     name: bundle.tournament.name,
@@ -294,11 +287,39 @@ async function updateTournamentArchiveIndex(bundle: TournamentArchiveBundle) {
     createdAt: bundle.tournament.createdAt,
     archivedAt: bundle.generatedAt,
   };
-  const next = [
-    item,
-    ...existing.filter((entry) => entry.id !== item.id && entry.slug !== item.slug),
-  ].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-  await putJsonToR2("archives/index.json", next);
+}
+
+function sortTournamentArchiveIndex(index: TournamentArchiveIndexItem[]) {
+  return index.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}
+
+async function readLegacyTournamentArchiveIndex(): Promise<TournamentArchiveIndexItem[]> {
+  const index = await readJsonFromR2<unknown>("archives/index.json");
+  if (!index || !Array.isArray(index)) return [];
+  return sortTournamentArchiveIndex(index as TournamentArchiveIndexItem[]);
+}
+
+export async function readTournamentArchiveIndex(): Promise<TournamentArchiveIndexItem[]> {
+  const bucket = getArchiveBucket();
+  if (!bucket) return [];
+
+  const items = new Map<string, TournamentArchiveIndexItem>();
+  let cursor: string | undefined;
+  do {
+    const listed = await bucket.list({ prefix: "archives/by-id/", cursor });
+    await Promise.all(listed.objects.map(async (object) => {
+      if (!object.key.endsWith("/latest.json")) return;
+      const bundle = await readJsonFromR2<unknown>(object.key);
+      if (isArchiveBundle(bundle)) {
+        items.set(bundle.tournament.id, archiveIndexItemFromBundle(bundle));
+      }
+    }));
+    cursor = listed.truncated ? listed.cursor : undefined;
+  } while (cursor);
+
+  const listedIndex = sortTournamentArchiveIndex([...items.values()]);
+  if (listedIndex.length > 0) return listedIndex;
+  return readLegacyTournamentArchiveIndex();
 }
 
 export async function buildTournamentArchiveBundle(tournamentId: string): Promise<TournamentArchiveBundle> {
@@ -444,6 +465,5 @@ export async function buildTournamentArchiveBundle(tournamentId: string): Promis
 export async function persistTournamentArchive(tournamentId: string): Promise<TournamentArchiveBundle> {
   const bundle = await buildTournamentArchiveBundle(tournamentId);
   await Promise.all(getTournamentArchiveKeys(bundle.tournament).map((key) => putJsonToR2(key, bundle)));
-  await updateTournamentArchiveIndex(bundle);
   return bundle;
 }


### PR DESCRIPTION
## Summary
- Add TC-ARC-08 scenario and archive E2E coverage for preserving multiple completed archives.
- Build tournament archive listing from `archives/by-id/*/latest.json` via R2 list instead of rewriting `archives/index.json`.
- Add unit/docs coverage that ignores stale legacy index content and returns multiple by-id archives sorted by date.

## Issues: Closes #1140

## Validation
- `node --check smkc-score-app/e2e/tc-archive.js`
- `npm test -- __tests__/lib/tournament-archive.test.ts __tests__/docs/e2e-archive-cases.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
- `npx tsc --noEmit --pretty false` (fails on pre-existing unrelated test typing errors; no archive-index errors reported)
