### PR TITLE
Address archive index review followups

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2406,7 +2406,8 @@
 - **URL**: POST /api/tournaments/:id/archive, GET /api/tournaments/:id/archive
 - **authRequired**: POST は admin、GET は公開
 - **背景**: archive 一覧は `archives/index.json` の read-modify-write に依存せず、
-  R2 の `archives/by-id/*/latest.json` から再構築する。複数 tournament を連続して
+  R2 の軽量 `archives/by-id/*/meta.json` を優先し、既存 archive は
+  `archives/by-id/*/latest.json` から再構築する。複数 tournament を連続して
   archive 化しても、後続の保存が先行 archive bundle を消してはいけない。
 - **手順**:
   1. admin で 2 つの completed public BM tournament を作成
@@ -2417,7 +2418,7 @@
   - 2 件とも POST/GET が HTTP 200
   - 2 件とも `data.archived === true`
   - 2 件の `data.tournament.id` は互いに異なる
-  - archive index の補助単体テストは `archives/by-id/*/latest.json` の list 由来で複数件を返す
+  - archive index の補助単体テストは `archives/by-id/*/meta.json` を優先し、legacy fallback も検証する
 - **スクリプト**: tc-archive.js TC-ARC-08 (`npm run e2e:archive`, preview: `npm run e2e:preview:archive`)
 - **補助検証**: `smkc-score-app/__tests__/lib/tournament-archive.test.ts`
 

--- a/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
@@ -63,8 +63,8 @@ describe('archive E2E case registration', () => {
       cases.indexOf('\n---', cases.indexOf('## TC-ARC-08:')),
     );
 
-    expect(section).toContain('archives/by-id/*/latest.json');
-    expect(section).toContain('複数件を返す');
+    expect(section).toContain('archives/by-id/*/meta.json');
+    expect(section).toContain('legacy fallback');
     expect(section).toContain('smkc-score-app/__tests__/lib/tournament-archive.test.ts');
   });
 

--- a/smkc-score-app/__tests__/lib/tournament-archive.test.ts
+++ b/smkc-score-app/__tests__/lib/tournament-archive.test.ts
@@ -10,12 +10,14 @@ import {
 import { COURSES } from "@/lib/constants";
 
 const objects = new Map<string, unknown>();
+const getKeys: string[] = [];
 
 jest.mock("@opennextjs/cloudflare", () => ({
   getCloudflareContext: () => ({
     env: {
       ARCHIVE_BUCKET: {
         get: jest.fn(async (key: string) => {
+          getKeys.push(key);
           if (!objects.has(key)) return null;
           return { json: async () => objects.get(key) };
         }),
@@ -88,6 +90,7 @@ function makeArchive(overrides: Partial<TournamentArchiveBundle> = {}): Tourname
 describe("tournament archive", () => {
   beforeEach(() => {
     objects.clear();
+    getKeys.length = 0;
   });
 
   it("stores latest archive keys by id and slug", () => {
@@ -155,6 +158,57 @@ describe("tournament archive", () => {
       expect.objectContaining({ id: "tournament-new", slug: "new-slug", name: "New Archive" }),
       expect.objectContaining({ id: "tournament-old", slug: "old-slug", name: "Old Archive" }),
     ]);
+  });
+
+  it("builds archive index from lightweight by-id meta objects before reading full bundles", async () => {
+    const meta = {
+      id: "tournament-meta",
+      slug: "meta-slug",
+      name: "Meta Archive",
+      date: "2026-05-10T00:00:00.000Z",
+      status: "completed",
+      publicModes: ["bm"],
+      createdAt: "2026-05-10T00:00:00.000Z",
+      archivedAt: "2026-05-10T00:00:00.000Z",
+    };
+    objects.set("archives/by-id/tournament-meta/meta.json", meta);
+    objects.set("archives/by-id/tournament-meta/latest.json", { schemaVersion: 999 });
+
+    await expect(readTournamentArchiveIndex()).resolves.toEqual([meta]);
+    expect(getKeys).toContain("archives/by-id/tournament-meta/meta.json");
+    expect(getKeys).not.toContain("archives/by-id/tournament-meta/latest.json");
+  });
+
+  it("falls back to the legacy index when by-id archives are not present without mutating legacy order", async () => {
+    const legacy = [
+      {
+        id: "older",
+        slug: "older-slug",
+        name: "Older Archive",
+        date: "2026-05-07T00:00:00.000Z",
+        status: "completed",
+        publicModes: ["bm"],
+        createdAt: "2026-05-07T00:00:00.000Z",
+        archivedAt: "2026-05-07T00:00:00.000Z",
+      },
+      {
+        id: "newer",
+        slug: "newer-slug",
+        name: "Newer Archive",
+        date: "2026-05-08T00:00:00.000Z",
+        status: "completed",
+        publicModes: ["gp"],
+        createdAt: "2026-05-08T00:00:00.000Z",
+        archivedAt: "2026-05-08T00:00:00.000Z",
+      },
+    ];
+    objects.set("archives/index.json", legacy);
+
+    await expect(readTournamentArchiveIndex()).resolves.toEqual([
+      expect.objectContaining({ id: "newer" }),
+      expect.objectContaining({ id: "older" }),
+    ]);
+    expect(objects.get("archives/index.json")).toEqual(legacy);
   });
 
   it("filters typed archived qualification matches without runtime stage casts", () => {

--- a/smkc-score-app/src/lib/tournament-archive.ts
+++ b/smkc-score-app/src/lib/tournament-archive.ts
@@ -126,6 +126,10 @@ export function getTournamentArchiveKeys(tournament: { id: string; slug?: string
   return keys;
 }
 
+function getTournamentArchiveMetaKey(tournament: { id: string }) {
+  return `archives/by-id/${tournament.id}/meta.json`;
+}
+
 function archiveLookupKeys(identifier: string) {
   return [
     `archives/by-id/${identifier}/latest.json`,
@@ -140,6 +144,17 @@ function isArchiveBundle(value: unknown): value is TournamentArchiveBundle {
     (value as { schemaVersion?: unknown }).schemaVersion === TOURNAMENT_ARCHIVE_SCHEMA_VERSION &&
     (value as { tournament?: unknown }).tournament &&
     (value as { modes?: unknown }).modes,
+  );
+}
+
+function isTournamentArchiveIndexItem(value: unknown): value is TournamentArchiveIndexItem {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    typeof (value as { id?: unknown }).id === "string" &&
+    typeof (value as { name?: unknown }).name === "string" &&
+    (value as { status?: unknown }).status === "completed" &&
+    typeof (value as { archivedAt?: unknown }).archivedAt === "string",
   );
 }
 
@@ -290,7 +305,7 @@ function archiveIndexItemFromBundle(bundle: TournamentArchiveBundle): Tournament
 }
 
 function sortTournamentArchiveIndex(index: TournamentArchiveIndexItem[]) {
-  return index.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  return [...index].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 }
 
 async function readLegacyTournamentArchiveIndex(): Promise<TournamentArchiveIndexItem[]> {
@@ -304,18 +319,32 @@ export async function readTournamentArchiveIndex(): Promise<TournamentArchiveInd
   if (!bucket) return [];
 
   const items = new Map<string, TournamentArchiveIndexItem>();
+  const latestKeys: string[] = [];
   let cursor: string | undefined;
   do {
     const listed = await bucket.list({ prefix: "archives/by-id/", cursor });
     await Promise.all(listed.objects.map(async (object) => {
-      if (!object.key.endsWith("/latest.json")) return;
-      const bundle = await readJsonFromR2<unknown>(object.key);
-      if (isArchiveBundle(bundle)) {
-        items.set(bundle.tournament.id, archiveIndexItemFromBundle(bundle));
+      if (object.key.endsWith("/meta.json")) {
+        const item = await readJsonFromR2<unknown>(object.key);
+        if (isTournamentArchiveIndexItem(item)) {
+          items.set(item.id, item);
+        }
+        return;
       }
+      if (!object.key.endsWith("/latest.json")) return;
+      latestKeys.push(object.key);
     }));
     cursor = listed.truncated ? listed.cursor : undefined;
   } while (cursor);
+
+  await Promise.all(latestKeys.map(async (key) => {
+    const [, id] = key.match(/^archives\/by-id\/(.+)\/latest\.json$/) ?? [];
+    if (!id || items.has(id)) return;
+    const bundle = await readJsonFromR2<unknown>(key);
+    if (isArchiveBundle(bundle)) {
+      items.set(bundle.tournament.id, archiveIndexItemFromBundle(bundle));
+    }
+  }));
 
   const listedIndex = sortTournamentArchiveIndex([...items.values()]);
   if (listedIndex.length > 0) return listedIndex;
@@ -464,6 +493,9 @@ export async function buildTournamentArchiveBundle(tournamentId: string): Promis
 
 export async function persistTournamentArchive(tournamentId: string): Promise<TournamentArchiveBundle> {
   const bundle = await buildTournamentArchiveBundle(tournamentId);
-  await Promise.all(getTournamentArchiveKeys(bundle.tournament).map((key) => putJsonToR2(key, bundle)));
+  await Promise.all([
+    ...getTournamentArchiveKeys(bundle.tournament).map((key) => putJsonToR2(key, bundle)),
+    putJsonToR2(getTournamentArchiveMetaKey(bundle.tournament), archiveIndexItemFromBundle(bundle)),
+  ]);
   return bundle;
 }


### PR DESCRIPTION
## Summary
- Store lightweight archive index metadata at `archives/by-id/:id/meta.json` and prefer it when listing archives.
- Keep legacy `latest.json` and `archives/index.json` fallback paths for existing archive objects.
- Make archive index sorting non-mutating and add coverage for meta-first and legacy fallback paths.

## Issues: Closes #1281, Closes #1282, Closes #1283

## Validation
- `node --check smkc-score-app/e2e/tc-archive.js`
- `npm test -- __tests__/lib/tournament-archive.test.ts __tests__/docs/e2e-archive-cases.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
- `npx tsc --noEmit --pretty false` (fails on pre-existing unrelated test typing errors; no archive-index errors reported)
