### PR TITLE
Harden archive index metadata validation

### DIFF
--- a/smkc-score-app/__tests__/lib/tournament-archive.test.ts
+++ b/smkc-score-app/__tests__/lib/tournament-archive.test.ts
@@ -179,6 +179,38 @@ describe("tournament archive", () => {
     expect(getKeys).not.toContain("archives/by-id/tournament-meta/latest.json");
   });
 
+  it("falls back to the full archive bundle when by-id meta validation fails", async () => {
+    const archive = makeArchive({
+      generatedAt: "2026-05-11T00:00:00.000Z",
+      tournament: {
+        ...makeArchive().tournament,
+        id: "tournament-invalid-meta",
+        slug: "invalid-meta-slug",
+        name: "Invalid Meta Archive",
+        date: "2026-05-11T00:00:00.000Z",
+      },
+    });
+    objects.set("archives/by-id/tournament-invalid-meta/meta.json", {
+      id: "tournament-invalid-meta",
+      slug: "invalid-meta-slug",
+      name: "Invalid Meta Archive",
+      status: "draft",
+      archivedAt: "2026-05-11T00:00:00.000Z",
+    });
+    objects.set("archives/by-id/tournament-invalid-meta/latest.json", archive);
+
+    await expect(readTournamentArchiveIndex()).resolves.toEqual([
+      expect.objectContaining({
+        id: "tournament-invalid-meta",
+        slug: "invalid-meta-slug",
+        name: "Invalid Meta Archive",
+        status: "completed",
+      }),
+    ]);
+    expect(getKeys).toContain("archives/by-id/tournament-invalid-meta/meta.json");
+    expect(getKeys).toContain("archives/by-id/tournament-invalid-meta/latest.json");
+  });
+
   it("falls back to the legacy index when by-id archives are not present without mutating legacy order", async () => {
     const legacy = [
       {

--- a/smkc-score-app/src/lib/tournament-archive.ts
+++ b/smkc-score-app/src/lib/tournament-archive.ts
@@ -153,6 +153,8 @@ function isTournamentArchiveIndexItem(value: unknown): value is TournamentArchiv
     typeof value === "object" &&
     typeof (value as { id?: unknown }).id === "string" &&
     typeof (value as { name?: unknown }).name === "string" &&
+    (typeof (value as { date?: unknown }).date === "string" ||
+      (value as { date?: unknown }).date instanceof Date) &&
     (value as { status?: unknown }).status === "completed" &&
     typeof (value as { archivedAt?: unknown }).archivedAt === "string",
   );


### PR DESCRIPTION
## Summary
- Validate `date` on archive index meta objects before accepting them.
- Add coverage that invalid `meta.json` entries fall back to the corresponding full `latest.json` archive bundle.

## Issues: Closes #1285, Closes #1286

## Validation
- `npm test -- __tests__/lib/tournament-archive.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
