### PR TITLE
Remove dead archive index date branch

### DIFF
--- a/smkc-score-app/src/lib/tournament-archive.ts
+++ b/smkc-score-app/src/lib/tournament-archive.ts
@@ -153,8 +153,7 @@ function isTournamentArchiveIndexItem(value: unknown): value is TournamentArchiv
     typeof value === "object" &&
     typeof (value as { id?: unknown }).id === "string" &&
     typeof (value as { name?: unknown }).name === "string" &&
-    (typeof (value as { date?: unknown }).date === "string" ||
-      (value as { date?: unknown }).date instanceof Date) &&
+    typeof (value as { date?: unknown }).date === "string" &&
     (value as { status?: unknown }).status === "completed" &&
     typeof (value as { archivedAt?: unknown }).archivedAt === "string",
   );


### PR DESCRIPTION
## Summary
- Remove the unreachable `instanceof Date` branch from archive index metadata date validation.

## Issues: Closes #1288

## Validation
- `npm test -- __tests__/lib/tournament-archive.test.ts`
- `git diff --check`
