### PR TITLE
Restore parallel archive page fetches

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2424,6 +2424,26 @@
 
 ---
 
+## TC-ARC-09: アーカイブ対応ページ — qualification data と player list を並列取得
+- **URL**: `/tournaments/:id/ta`, `/tournaments/:id/bm`, `/tournaments/:id/mr`, `/tournaments/:id/gp`
+- **authRequired**: false (公開済み mode の閲覧) / admin controls は session 依存
+- **背景**: archive fallback 対応後も通常 tournament では mode data と
+  `/api/players?limit=100` を直列取得してはいけない。TA/BM/MR/GP の
+  qualification page は `Promise.all` で同時に開始し、players endpoint が失敗した
+  場合だけ archive payload の `allPlayers` に fallback する。
+- **手順**:
+  1. TA/BM/MR/GP の page-client fetch 関数を読み込む
+  2. mode API と `/api/players?limit=100` が同じ `Promise.all` 内で開始されることを確認
+  3. players fetch が失敗した場合に mode payload の `allPlayers` が使われることを確認
+- **期待結果**:
+  - TA/BM/MR/GP 全てで mode API と players API が並列に起動する
+  - players API 成功時は最新の player list を使う
+  - players API 失敗時は archive fallback の `allPlayers` を使い、空配列に落ちても throw しない
+- **スクリプト**: tc-archive.js TC-ARC-09 (`npm run e2e:archive`, preview: `npm run e2e:preview:archive`)
+- **補助検証**: `smkc-score-app/__tests__/lib/qualification-page-data.test.ts`
+
+---
+
 ## TC-ARC-06: トーナメントアーカイブ API — BM match/player payload の型付き保存
 - **URL**: POST /api/tournaments/:id/archive, GET /api/tournaments/:id/archive
 - **authRequired**: POST は admin、GET は公開

--- a/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
@@ -5,7 +5,7 @@ describe('archive E2E case registration', () => {
   const casesPath = path.join(process.cwd(), '..', 'E2E_TEST_CASES.md');
   const cases = fs.readFileSync(casesPath, 'utf8');
 
-  it.each(['TC-ARC-01', 'TC-ARC-02', 'TC-ARC-03', 'TC-ARC-04', 'TC-ARC-06', 'TC-ARC-07', 'TC-ARC-08'])(
+  it.each(['TC-ARC-01', 'TC-ARC-02', 'TC-ARC-03', 'TC-ARC-04', 'TC-ARC-06', 'TC-ARC-07', 'TC-ARC-08', 'TC-ARC-09'])(
     'documents %s as a runnable archive script case',
     (tc) => {
       const section = cases.slice(cases.indexOf(`## ${tc}:`), cases.indexOf('\n---', cases.indexOf(`## ${tc}:`)));
@@ -76,5 +76,18 @@ describe('archive E2E case registration', () => {
 
     expect(section).toContain('smkc-archives-preview');
     expect(section).toMatch(/smkc-archives(?!-preview)/);
+  });
+
+  it('documents TC-ARC-09 as qualification page parallel fetch coverage', () => {
+    const section = cases.slice(
+      cases.indexOf('## TC-ARC-09:'),
+      cases.indexOf('\n---', cases.indexOf('## TC-ARC-09:')),
+    );
+
+    expect(section).toContain('TA/BM/MR/GP');
+    expect(section).toContain('Promise.all');
+    expect(section).toContain('/api/players?limit=100');
+    expect(section).toContain('archive fallback');
+    expect(section).toContain('smkc-score-app/__tests__/lib/qualification-page-data.test.ts');
   });
 });

--- a/smkc-score-app/__tests__/lib/qualification-page-data.test.ts
+++ b/smkc-score-app/__tests__/lib/qualification-page-data.test.ts
@@ -1,0 +1,34 @@
+import { fetchAllPlayersForSetup, resolveAllPlayers } from "@/lib/qualification-page-data";
+import { fetchWithRetry } from "@/lib/fetch-with-retry";
+
+jest.mock("@/lib/fetch-with-retry", () => ({
+  fetchWithRetry: jest.fn(),
+}));
+
+const mockedFetchWithRetry = fetchWithRetry as jest.MockedFunction<typeof fetchWithRetry>;
+
+describe("qualification page data helpers", () => {
+  beforeEach(() => {
+    mockedFetchWithRetry.mockReset();
+  });
+
+  it("requests the setup player list with the API cap", async () => {
+    mockedFetchWithRetry.mockResolvedValue(Response.json({ data: [{ id: "p1" }] }) as never);
+
+    await expect(fetchAllPlayersForSetup<{ id: string }>()).resolves.toEqual([{ id: "p1" }]);
+    expect(mockedFetchWithRetry).toHaveBeenCalledWith("/api/players?limit=100");
+  });
+
+  it("returns null instead of throwing when the players endpoint is unavailable", async () => {
+    mockedFetchWithRetry.mockRejectedValue(new Error("players down"));
+
+    await expect(fetchAllPlayersForSetup()).resolves.toBeNull();
+  });
+
+  it("prefers the fresh players response and falls back to archived allPlayers", () => {
+    expect(resolveAllPlayers([{ id: "fresh" }], [{ id: "archive" }])).toEqual([{ id: "fresh" }]);
+    expect(resolveAllPlayers(null, [{ id: "archive" }])).toEqual([{ id: "archive" }]);
+    expect(resolveAllPlayers(null, undefined)).toEqual([]);
+  });
+});
+

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -9,6 +9,7 @@
  *   TC-ARC-06  Archive BM match rows keep stage and public player payloads.
  *   TC-ARC-07  TA API falls back to archive when live tournament row is gone.
  *   TC-ARC-08  Two completed archives stay independently readable.
+ *   TC-ARC-09  Qualification pages keep mode data and players fetches parallel.
  *
  * Run: node e2e/tc-archive.js  (from smkc-score-app/)  or: npm run e2e:archive
  */
@@ -28,6 +29,8 @@ const {
   BASE,
 } = require('./lib/common');
 const { closeBrowser, envMs, exitAfterCleanup } = require('./lib/runner');
+const fs = require('fs');
+const path = require('path');
 
 const results = makeResults();
 const log = makeLog(results);
@@ -260,6 +263,24 @@ async function tcArc04(page) {
   }
 }
 
+function tcArc09() {
+  try {
+    const root = path.join(__dirname, '..');
+    const files = ['ta', 'bm', 'mr', 'gp'].map((mode) =>
+      path.join(root, 'src', 'app', 'tournaments', '[id]', mode, 'page-client.tsx'));
+    const failures = files.filter((file) => {
+      const source = fs.readFileSync(file, 'utf8');
+      return !source.includes('Promise.all([') ||
+        !source.includes('fetchAllPlayersForSetup<Player>()') ||
+        !source.includes('resolveAllPlayers(playersResult');
+    });
+    log('TC-ARC-09', failures.length === 0 ? 'PASS' : 'FAIL',
+      failures.length === 0 ? 'TA/BM/MR/GP fetch mode data and players in parallel' : `missing parallel fetch in ${failures.map((file) => path.basename(path.dirname(file))).join(',')}`);
+  } catch (error) {
+    log('TC-ARC-09', 'FAIL', error instanceof Error ? error.message : String(error));
+  }
+}
+
 async function runArchiveTests(page) {
   await tcArc01(page);
   await tcArc02(page);
@@ -268,6 +289,7 @@ async function runArchiveTests(page) {
   await tcArc06(page);
   await tcArc07(page);
   await tcArc08(page);
+  tcArc09();
 
   const failed = results.filter((result) => result.s === 'FAIL');
   console.log(`\nTC-ARC summary: ${results.length - failed.length}/${results.length} passed`);

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page-client.tsx
@@ -70,7 +70,7 @@ import {
   findUnresolvedTies,
 } from "@/lib/ranking-utils";
 import { POLLING_INTERVAL, TV_NUMBER_OPTIONS } from "@/lib/constants";
-import { extractArrayData } from "@/lib/api-response";
+import { fetchAllPlayersForSetup, resolveAllPlayers } from "@/lib/qualification-page-data";
 import { usePolling } from "@/lib/hooks/usePolling";
 import type { QualInitialData } from "@/lib/api-factories/qual-initial-data";
 import { useQualificationActions } from "@/lib/hooks/useQualificationActions";
@@ -180,7 +180,10 @@ export default function BattleModePageClient({
    * This is the polling function called at the standard interval for live updates.
    */
   const fetchTournamentData = useCallback(async () => {
-    const bmResponse = await fetchWithRetry(`/api/tournaments/${tournamentId}/bm`);
+    const [bmResponse, playersResult] = await Promise.all([
+      fetchWithRetry(`/api/tournaments/${tournamentId}/bm`),
+      fetchAllPlayersForSetup<Player>(),
+    ]);
 
     if (!bmResponse.ok) {
       throw new Error(`Failed to fetch BM data: ${bmResponse.status}`);
@@ -188,17 +191,7 @@ export default function BattleModePageClient({
 
     const bmJson = await bmResponse.json();
     const bmData = bmJson.data ?? bmJson;
-    let allPlayers = bmData.allPlayers || [];
-    try {
-      /* limit=100 (API cap) avoids truncating the Setup dialog player list — see ta/page.tsx for rationale. */
-      const playersResponse = await fetchWithRetry("/api/players?limit=100");
-      if (playersResponse.ok) {
-        const playersJson = await playersResponse.json();
-        allPlayers = extractArrayData<Player>(playersJson);
-      }
-    } catch {
-      // Archived mode payloads carry the tournament players, so read-only pages can survive DB outages.
-    }
+    const allPlayers = resolveAllPlayers(playersResult, bmData.allPlayers);
 
     return {
       qualifications: bmData.qualifications || [],

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
@@ -74,7 +74,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { COURSE_INFO, CUPS, CUP_SUBSTITUTIONS, GP_POSITION_OPTIONS, POLLING_INTERVAL, TOTAL_GP_RACES, TV_NUMBER_OPTIONS, getDriverPoints, type CourseAbbr } from "@/lib/constants";
 import { formatGpPosition } from "@/lib/gp-utils";
-import { extractArrayData } from "@/lib/api-response";
+import { fetchAllPlayersForSetup, resolveAllPlayers } from "@/lib/qualification-page-data";
 import { usePolling } from "@/lib/hooks/usePolling";
 import type { QualInitialData } from "@/lib/api-factories/qual-initial-data";
 import { useQualificationActions } from "@/lib/hooks/useQualificationActions";
@@ -205,7 +205,10 @@ export default function GrandPrixPageClient({
    * Returns qualification standings, matches, and all registered players.
    */
   const fetchTournamentData = useCallback(async () => {
-    const gpResponse = await fetchWithRetry(`/api/tournaments/${tournamentId}/gp`);
+    const [gpResponse, playersResult] = await Promise.all([
+      fetchWithRetry(`/api/tournaments/${tournamentId}/gp`),
+      fetchAllPlayersForSetup<Player>(),
+    ]);
 
     if (!gpResponse.ok) {
       throw new Error(`Failed to fetch GP data: ${gpResponse.status}`);
@@ -213,17 +216,7 @@ export default function GrandPrixPageClient({
 
     const gpJson = await gpResponse.json();
     const gpData = gpJson.data ?? gpJson;
-    let allPlayers = gpData.allPlayers || [];
-    try {
-      /* limit=100 (API cap) avoids truncating the Setup dialog player list — see ta/page.tsx for rationale. */
-      const playersResponse = await fetchWithRetry("/api/players?limit=100");
-      if (playersResponse.ok) {
-        const playersJson = await playersResponse.json();
-        allPlayers = extractArrayData<Player>(playersJson);
-      }
-    } catch {
-      // Archived mode payloads carry the tournament players, so read-only pages can survive DB outages.
-    }
+    const allPlayers = resolveAllPlayers(playersResult, gpData.allPlayers);
 
     return {
       qualifications: gpData.qualifications || [],

--- a/smkc-score-app/src/app/tournaments/[id]/mr/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/page-client.tsx
@@ -68,7 +68,7 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { COURSE_INFO, POLLING_INTERVAL, TOTAL_MR_RACES, TV_NUMBER_OPTIONS, type CourseAbbr } from "@/lib/constants";
-import { extractArrayData } from "@/lib/api-response";
+import { fetchAllPlayersForSetup, resolveAllPlayers } from "@/lib/qualification-page-data";
 import { usePolling } from "@/lib/hooks/usePolling";
 import type { QualInitialData } from "@/lib/api-factories/qual-initial-data";
 import { useQualificationActions } from "@/lib/hooks/useQualificationActions";
@@ -178,7 +178,10 @@ export default function MatchRacePageClient({
    * Called by the polling hook for real-time updates.
    */
   const fetchTournamentData = useCallback(async () => {
-    const mrResponse = await fetchWithRetry(`/api/tournaments/${tournamentId}/mr`);
+    const [mrResponse, playersResult] = await Promise.all([
+      fetchWithRetry(`/api/tournaments/${tournamentId}/mr`),
+      fetchAllPlayersForSetup<Player>(),
+    ]);
 
     if (!mrResponse.ok) {
       throw new Error(`Failed to fetch MR data: ${mrResponse.status}`);
@@ -186,17 +189,7 @@ export default function MatchRacePageClient({
 
     const mrJson = await mrResponse.json();
     const mrData = mrJson.data ?? mrJson;
-    let allPlayers = mrData.allPlayers || [];
-    try {
-      /* limit=100 (API cap) avoids truncating the Setup dialog player list — see ta/page.tsx for rationale. */
-      const playersResponse = await fetchWithRetry("/api/players?limit=100");
-      if (playersResponse.ok) {
-        const playersJson = await playersResponse.json();
-        allPlayers = extractArrayData<Player>(playersJson);
-      }
-    } catch {
-      // Archived mode payloads carry the tournament players, so read-only pages can survive DB outages.
-    }
+    const allPlayers = resolveAllPlayers(playersResult, mrData.allPlayers);
 
     return {
       qualifications: mrData.qualifications || [],

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
@@ -68,7 +68,7 @@ import { canEditTaEntry } from "@/lib/ta/entry-access";
 import { calculateCourseFirstPlaceCounts } from "@/lib/ta/qualification-results";
 import { TA_TIME_ENTRY_CUP_GRID_CLASS, TA_TIME_INPUT_HELP_CLASS, getTaTimeInputProps } from "@/lib/ta/time-entry-layout";
 import { canShowTaPhasePromotion, shouldShowTaFinalsPhaseManagement, type TaPhaseStatus } from "@/lib/ta/phase-controls";
-import { extractArrayData } from "@/lib/api-response";
+import { fetchAllPlayersForSetup, resolveAllPlayers } from "@/lib/qualification-page-data";
 import { autoFormatTime, generateRandomTimeString, msToDisplayTime, timeToMs } from "@/lib/ta/time-utils";
 import { usePolling } from "@/lib/hooks/usePolling";
 import { useBroadcastReflect } from "@/lib/hooks/use-broadcast-reflect";
@@ -203,7 +203,10 @@ export default function TimeAttackPageClient({
   // === Data Fetching ===
   // Fetch tournament data and player list in parallel
   const fetchTournamentData = useCallback(async () => {
-    const taResponse = await fetchWithRetry(`/api/tournaments/${tournamentId}/ta?stage=qualification`);
+    const [taResponse, playersResult] = await Promise.all([
+      fetchWithRetry(`/api/tournaments/${tournamentId}/ta?stage=qualification`),
+      fetchAllPlayersForSetup<Player>(),
+    ]);
 
     if (!taResponse.ok) {
       const errorData = await taResponse.json().catch(() => ({}));
@@ -214,21 +217,7 @@ export default function TimeAttackPageClient({
 
     // Unwrap createSuccessResponse wrapper: { success, data: { entries, ... } }
     const taData = taJson.data ?? taJson;
-    let allPlayers = taData.allPlayers || [];
-    try {
-      /* limit=100 is the API's hard cap (src/lib/pagination.ts). The default of 50
-       * silently truncates the Setup Players search once the roster grows past
-       * that — newly-created players end up paginated out and can no longer be
-       * added from the dialog. Request the max in one hop; if a deployment
-       * ever needs >100, the dialog must switch to server-side search instead. */
-      const playersResponse = await fetchWithRetry("/api/players?limit=100");
-      if (playersResponse.ok) {
-        const playersJson = await playersResponse.json();
-        allPlayers = extractArrayData<Player>(playersJson);
-      }
-    } catch {
-      // Archived mode payloads carry the tournament players, so read-only pages can survive DB outages.
-    }
+    const allPlayers = resolveAllPlayers(playersResult, taData.allPlayers);
 
     return {
       entries: taData.entries || [],

--- a/smkc-score-app/src/lib/qualification-page-data.ts
+++ b/smkc-score-app/src/lib/qualification-page-data.ts
@@ -1,0 +1,22 @@
+import { extractArrayData } from "@/lib/api-response";
+import { fetchWithRetry } from "@/lib/fetch-with-retry";
+
+const SETUP_PLAYERS_URL = "/api/players?limit=100";
+
+export async function fetchAllPlayersForSetup<TPlayer>(): Promise<TPlayer[] | null> {
+  try {
+    const response = await fetchWithRetry(SETUP_PLAYERS_URL);
+    if (!response.ok) return null;
+    return extractArrayData<TPlayer>(await response.json());
+  } catch {
+    return null;
+  }
+}
+
+export function resolveAllPlayers<TPlayer>(
+  fetchedPlayers: TPlayer[] | null,
+  archivedPlayers: TPlayer[] | null | undefined,
+): TPlayer[] {
+  return fetchedPlayers ?? archivedPlayers ?? [];
+}
+


### PR DESCRIPTION
Summary
- Restore parallel mode-data and player-list fetches on TA/BM/MR/GP qualification pages.
- Add shared setup-player fallback helper so archive `allPlayers` is still used when `/api/players?limit=100` is unavailable.
- Document and register TC-ARC-09 with focused Jest and archive E2E static coverage.

Issues: Closes #1139

Validation
- npm test -- __tests__/lib/qualification-page-data.test.ts __tests__/docs/e2e-archive-cases.test.ts
- node --check e2e/tc-archive.js
- git diff --check
- npm run lint
