### PR TITLE
Add runtime TC-ARC-09 qualification fetch check

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2432,9 +2432,10 @@
   qualification page は `Promise.all` で同時に開始し、players endpoint が失敗した
   場合だけ archive payload の `allPlayers` に fallback する。
 - **手順**:
-  1. TA/BM/MR/GP の page-client fetch 関数を読み込む
-  2. mode API と `/api/players?limit=100` が同じ `Promise.all` 内で開始されることを確認
-  3. players fetch が失敗した場合に mode payload の `allPlayers` が使われることを確認
+  1. TA/BM/MR/GP の qualification page を Playwright で開く
+  2. route interception で mode API と `/api/players?limit=100` の応答を両方の request が揃うまで保留する
+  3. 片方の API response を待たずに両方の request が開始されることを確認
+  4. players fetch が失敗した場合に mode payload の `allPlayers` が使われることを確認
 - **期待結果**:
   - TA/BM/MR/GP 全てで mode API と players API が並列に起動する
   - players API 成功時は最新の player list を使う

--- a/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-archive-cases.test.ts
@@ -85,7 +85,8 @@ describe('archive E2E case registration', () => {
     );
 
     expect(section).toContain('TA/BM/MR/GP');
-    expect(section).toContain('Promise.all');
+    expect(section).toContain('Playwright');
+    expect(section).toContain('route interception');
     expect(section).toContain('/api/players?limit=100');
     expect(section).toContain('archive fallback');
     expect(section).toContain('smkc-score-app/__tests__/lib/qualification-page-data.test.ts');

--- a/smkc-score-app/__tests__/e2e/tc-archive-fixtures.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-archive-fixtures.test.ts
@@ -77,4 +77,78 @@ describe('archive E2E fixtures', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('cleanup failed for player player-2'));
     warn.mockRestore();
   });
+
+  it('classifies qualification page runtime fetch requests', async () => {
+    const { suite } = await loadArchiveSuite();
+
+    expect(suite.requestKindForQualificationFetch(
+      'https://preview.example.test/api/tournaments/tournament-1/bm',
+      'tournament-1',
+      'bm',
+    )).toBe('mode');
+    expect(suite.requestKindForQualificationFetch(
+      'https://preview.example.test/api/players?limit=100',
+      'tournament-1',
+      'bm',
+    )).toBe('players');
+    expect(suite.requestKindForQualificationFetch(
+      'https://preview.example.test/api/players?limit=50',
+      'tournament-1',
+      'bm',
+    )).toBeNull();
+  });
+
+  it('waits for both qualification requests before fulfilling either response', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-11T00:00:00.000Z'));
+    const { suite } = await loadArchiveSuite({ BASE: 'https://preview.example.test' });
+    const fulfillOrder: string[] = [];
+    const pendingRequests: Array<{ predicate: (request: { url: () => string }) => boolean; resolve: (request: unknown) => void }> = [];
+    let routeHandler: ((route: unknown) => Promise<void>) | null = null;
+
+    const requestFor = (url: string) => ({ url: () => url });
+    const routeFor = (kind: string, url: string) => ({
+      request: () => requestFor(url),
+      fulfill: jest.fn(async () => {
+        fulfillOrder.push(kind);
+      }),
+      continue: jest.fn(async () => undefined),
+    });
+    const resolveWaiters = (url: string) => {
+      const request = requestFor(url);
+      for (const waiter of pendingRequests) {
+        if (waiter.predicate(request)) waiter.resolve(request);
+      }
+    };
+
+    const page = {
+      route: jest.fn(async (_pattern, handler) => {
+        routeHandler = handler;
+      }),
+      unroute: jest.fn(async () => undefined),
+      waitForRequest: jest.fn((predicate) =>
+        new Promise((resolve) => pendingRequests.push({ predicate, resolve }))),
+      goto: jest.fn(async () => {
+        if (!routeHandler) throw new Error('route handler missing');
+        const modeUrl = 'https://preview.example.test/api/tournaments/tournament-1/bm';
+        const playersUrl = 'https://preview.example.test/api/players?limit=100';
+        resolveWaiters(modeUrl);
+        const modePromise = routeHandler(routeFor('mode', modeUrl));
+        await Promise.resolve();
+        expect(fulfillOrder).toEqual([]);
+        resolveWaiters(playersUrl);
+        const playersPromise = routeHandler(routeFor('players', playersUrl));
+        await Promise.all([modePromise, playersPromise]);
+      }),
+    };
+
+    await expect(suite.assertQualificationFetchesStartInParallel(page, 'tournament-1', 'bm'))
+      .resolves.toBe(0);
+    expect(fulfillOrder.sort()).toEqual(['mode', 'players']);
+    expect(page.goto).toHaveBeenCalledWith(
+      'https://preview.example.test/tournaments/tournament-1/bm',
+      { waitUntil: 'domcontentloaded' },
+    );
+    jest.useRealTimers();
+  });
 });

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -29,11 +29,11 @@ const {
   BASE,
 } = require('./lib/common');
 const { closeBrowser, envMs, exitAfterCleanup } = require('./lib/runner');
-const fs = require('fs');
-const path = require('path');
 
 const results = makeResults();
 const log = makeLog(results);
+const QUALIFICATION_MODES = ['ta', 'bm', 'mr', 'gp'];
+const QUALIFICATION_FETCH_TIMEOUT_MS = 15_000;
 
 async function createPlayers(page, prefix, count) {
   const stamp = Date.now();
@@ -263,21 +263,128 @@ async function tcArc04(page) {
   }
 }
 
-function tcArc09() {
+function qualificationModePayload(mode) {
+  const base = {
+    allPlayers: [],
+    qualificationConfirmed: false,
+  };
+  if (mode === 'ta') {
+    return { ...base, entries: [] };
+  }
+  return { ...base, qualifications: [], matches: [] };
+}
+
+function requestKindForQualificationFetch(url, tournamentId, mode) {
   try {
-    const root = path.join(__dirname, '..');
-    const files = ['ta', 'bm', 'mr', 'gp'].map((mode) =>
-      path.join(root, 'src', 'app', 'tournaments', '[id]', mode, 'page-client.tsx'));
-    const failures = files.filter((file) => {
-      const source = fs.readFileSync(file, 'utf8');
-      return !source.includes('Promise.all([') ||
-        !source.includes('fetchAllPlayersForSetup<Player>()') ||
-        !source.includes('resolveAllPlayers(playersResult');
+    const parsed = new URL(url);
+    if (parsed.pathname === `/api/tournaments/${tournamentId}/${mode}`) {
+      return 'mode';
+    }
+    if (parsed.pathname === '/api/players' && parsed.searchParams.get('limit') === '100') {
+      return 'players';
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+async function assertQualificationFetchesStartInParallel(page, tournamentId, mode) {
+  const starts = {};
+  const pending = {};
+  let released = false;
+  let timeout = null;
+
+  const payloads = {
+    mode: { data: qualificationModePayload(mode) },
+    players: { data: [] },
+  };
+
+  const releasePending = () => {
+    if (released || !pending.mode || !pending.players) return;
+    released = true;
+    if (timeout) clearTimeout(timeout);
+    Promise.all(Object.entries(pending).map(([kind, item]) =>
+      item.route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(payloads[kind]),
+      }).finally(item.done),
+    ));
+  };
+
+  const routeHandler = (route) => {
+    const kind = requestKindForQualificationFetch(route.request().url(), tournamentId, mode);
+    if (!kind) {
+      return route.continue();
+    }
+    starts[kind] = starts[kind] ?? Date.now();
+    return new Promise((done) => {
+      pending[kind] = { route, done };
+      releasePending();
     });
-    log('TC-ARC-09', failures.length === 0 ? 'PASS' : 'FAIL',
-      failures.length === 0 ? 'TA/BM/MR/GP fetch mode data and players in parallel' : `missing parallel fetch in ${failures.map((file) => path.basename(path.dirname(file))).join(',')}`);
+  };
+
+  await page.route('**/api/**', routeHandler);
+  try {
+    timeout = setTimeout(() => {
+      for (const item of Object.values(pending)) {
+        item.route.fulfill({
+          status: 504,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'TC-ARC-09 timed out waiting for paired request' }),
+        }).finally(item.done);
+      }
+    }, QUALIFICATION_FETCH_TIMEOUT_MS);
+
+    const modeRequest = page.waitForRequest(
+      (request) => requestKindForQualificationFetch(request.url(), tournamentId, mode) === 'mode',
+      { timeout: QUALIFICATION_FETCH_TIMEOUT_MS },
+    );
+    const playersRequest = page.waitForRequest(
+      (request) => requestKindForQualificationFetch(request.url(), tournamentId, mode) === 'players',
+      { timeout: QUALIFICATION_FETCH_TIMEOUT_MS },
+    );
+
+    await page.goto(`${BASE}/tournaments/${tournamentId}/${mode}`, { waitUntil: 'domcontentloaded' });
+    await Promise.all([modeRequest, playersRequest]);
+    releasePending();
+
+    if (!starts.mode || !starts.players) {
+      throw new Error(`${mode}: missing mode or players request`);
+    }
+    const deltaMs = Math.abs(starts.mode - starts.players);
+    if (deltaMs > 1_000) {
+      throw new Error(`${mode}: request start delta ${deltaMs}ms exceeded 1000ms`);
+    }
+    return deltaMs;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    await page.unroute('**/api/**', routeHandler).catch(() => {});
+  }
+}
+
+async function tcArc09(page) {
+  let tournamentId = null;
+  try {
+    tournamentId = await apiCreateTournament(page, `E2E TC-ARC-09 ${Date.now()}`);
+    const activated = await apiUpdateTournament(page, tournamentId, {
+      status: 'active',
+      publicModes: QUALIFICATION_MODES,
+    });
+    if (activated.s !== 200) throw new Error(`activation update failed (${activated.s})`);
+
+    const deltas = {};
+    for (const mode of QUALIFICATION_MODES) {
+      deltas[mode] = await assertQualificationFetchesStartInParallel(page, tournamentId, mode);
+    }
+
+    log('TC-ARC-09', 'PASS',
+      `TA/BM/MR/GP requested mode data and /api/players?limit=100 before either response resolved (${Object.entries(deltas).map(([mode, ms]) => `${mode}:${ms}ms`).join(' ')})`);
   } catch (error) {
     log('TC-ARC-09', 'FAIL', error instanceof Error ? error.message : String(error));
+  } finally {
+    await apiDeleteTournament(page, tournamentId);
   }
 }
 
@@ -289,7 +396,7 @@ async function runArchiveTests(page) {
   await tcArc06(page);
   await tcArc07(page);
   await tcArc08(page);
-  tcArc09();
+  await tcArc09(page);
 
   const failed = results.filter((result) => result.s === 'FAIL');
   console.log(`\nTC-ARC summary: ${results.length - failed.length}/${results.length} passed`);
@@ -333,4 +440,6 @@ module.exports = {
   runArchiveTests,
   createCompletedPublicBmArchive,
   cleanupArchiveFixture,
+  assertQualificationFetchesStartInParallel,
+  requestKindForQualificationFetch,
 };

--- a/smkc-score-app/src/lib/qualification-page-data.ts
+++ b/smkc-score-app/src/lib/qualification-page-data.ts
@@ -1,6 +1,8 @@
 import { extractArrayData } from "@/lib/api-response";
 import { fetchWithRetry } from "@/lib/fetch-with-retry";
 
+// API hard cap from pagination.ts. The default limit=50 silently paginates
+// Setup Players once rosters exceed 50; switch to server-side search above 100.
 const SETUP_PLAYERS_URL = "/api/players?limit=100";
 
 export async function fetchAllPlayersForSetup<TPlayer>(): Promise<TPlayer[] | null> {
@@ -19,4 +21,3 @@ export function resolveAllPlayers<TPlayer>(
 ): TPlayer[] {
   return fetchedPlayers ?? archivedPlayers ?? [];
 }
-


### PR DESCRIPTION
Summary
- Replace TC-ARC-09 source-string inspection with a Playwright runtime request check that holds mode/player API responses until both requests start.
- Document the runtime E2E scenario and preserve focused tests for request classification/release behavior.
- Add the missing `limit=100` setup-player comment in `qualification-page-data.ts`.

Issues: Closes #1291, Closes #1292

Validation
- `node --check smkc-score-app/e2e/tc-archive.js`
- `npm test -- __tests__/e2e/tc-archive-fixtures.test.ts __tests__/docs/e2e-archive-cases.test.ts __tests__/lib/qualification-page-data.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
