### PR TITLE
Harden TC-ARC-09 route release handling

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-archive-fixtures.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-archive-fixtures.test.ts
@@ -103,6 +103,7 @@ describe('archive E2E fixtures', () => {
     jest.setSystemTime(new Date('2026-05-11T00:00:00.000Z'));
     const { suite } = await loadArchiveSuite({ BASE: 'https://preview.example.test' });
     const fulfillOrder: string[] = [];
+    const continueOrder: string[] = [];
     const pendingRequests: Array<{ predicate: (request: { url: () => string }) => boolean; resolve: (request: unknown) => void }> = [];
     let routeHandler: ((route: unknown) => Promise<void>) | null = null;
 
@@ -112,7 +113,9 @@ describe('archive E2E fixtures', () => {
       fulfill: jest.fn(async () => {
         fulfillOrder.push(kind);
       }),
-      continue: jest.fn(async () => undefined),
+      continue: jest.fn(async () => {
+        continueOrder.push(kind);
+      }),
     });
     const resolveWaiters = (url: string) => {
       const request = requestFor(url);
@@ -134,6 +137,7 @@ describe('archive E2E fixtures', () => {
         const playersUrl = 'https://preview.example.test/api/players?limit=100';
         resolveWaiters(modeUrl);
         const modePromise = routeHandler(routeFor('mode', modeUrl));
+        await routeHandler(routeFor('mode-duplicate', modeUrl));
         await Promise.resolve();
         expect(fulfillOrder).toEqual([]);
         resolveWaiters(playersUrl);
@@ -149,6 +153,7 @@ describe('archive E2E fixtures', () => {
       'https://preview.example.test/tournaments/tournament-1/bm',
       { waitUntil: 'domcontentloaded' },
     );
+    expect(continueOrder).toEqual(['mode-duplicate']);
     jest.useRealTimers();
   });
 });

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -293,6 +293,7 @@ async function assertQualificationFetchesStartInParallel(page, tournamentId, mod
   const starts = {};
   const pending = {};
   let released = false;
+  let releasePromise = null;
   let timeout = null;
 
   const payloads = {
@@ -301,21 +302,28 @@ async function assertQualificationFetchesStartInParallel(page, tournamentId, mod
   };
 
   const releasePending = () => {
-    if (released || !pending.mode || !pending.players) return;
+    if (released) return releasePromise;
+    if (!pending.mode || !pending.players) return null;
     released = true;
     if (timeout) clearTimeout(timeout);
-    Promise.all(Object.entries(pending).map(([kind, item]) =>
+    releasePromise = Promise.all(Object.entries(pending).map(([kind, item]) =>
       item.route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify(payloads[kind]),
       }).finally(item.done),
-    ));
+    )).catch((error) => {
+      console.error('TC-ARC-09 releasePending error:', error);
+    });
+    return releasePromise;
   };
 
   const routeHandler = (route) => {
     const kind = requestKindForQualificationFetch(route.request().url(), tournamentId, mode);
     if (!kind) {
+      return route.continue();
+    }
+    if (pending[kind]) {
       return route.continue();
     }
     starts[kind] = starts[kind] ?? Date.now();
@@ -328,13 +336,17 @@ async function assertQualificationFetchesStartInParallel(page, tournamentId, mod
   await page.route('**/api/**', routeHandler);
   try {
     timeout = setTimeout(() => {
-      for (const item of Object.values(pending)) {
+      if (released) return;
+      released = true;
+      releasePromise = Promise.all(Object.values(pending).map((item) =>
         item.route.fulfill({
           status: 504,
           contentType: 'application/json',
           body: JSON.stringify({ error: 'TC-ARC-09 timed out waiting for paired request' }),
-        }).finally(item.done);
-      }
+        }).finally(item.done),
+      )).catch((error) => {
+        console.error('TC-ARC-09 releasePending error:', error);
+      });
     }, QUALIFICATION_FETCH_TIMEOUT_MS);
 
     const modeRequest = page.waitForRequest(
@@ -348,7 +360,7 @@ async function assertQualificationFetchesStartInParallel(page, tournamentId, mod
 
     await page.goto(`${BASE}/tournaments/${tournamentId}/${mode}`, { waitUntil: 'domcontentloaded' });
     await Promise.all([modeRequest, playersRequest]);
-    releasePending();
+    await releasePending();
 
     if (!starts.mode || !starts.players) {
       throw new Error(`${mode}: missing mode or players request`);


### PR DESCRIPTION
Summary
- Await/log TC-ARC-09 route release failures so Playwright fulfill errors are visible.
- Mark timeout release as final to avoid 504/200 double-fulfill races.
- Continue duplicate mode/player requests instead of overwriting pending route promises, with focused test coverage.

Issues: Closes #1294, Closes #1295, Closes #1296

Validation
- `node --check smkc-score-app/e2e/tc-archive.js`
- `npm test -- __tests__/e2e/tc-archive-fixtures.test.ts __tests__/docs/e2e-archive-cases.test.ts __tests__/lib/qualification-page-data.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
