### PR TITLE
Use TC-ARC-09 timeout constant in tests

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-archive-fixtures.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-archive-fixtures.test.ts
@@ -161,6 +161,7 @@ describe('archive E2E fixtures', () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2026-05-11T00:00:00.000Z'));
     const { suite } = await loadArchiveSuite({ BASE: 'https://preview.example.test' });
+    const timeoutMs = suite.QUALIFICATION_FETCH_TIMEOUT_MS;
     const fulfillStatuses: number[] = [];
     const continueOrder: string[] = [];
     const pendingRequests: Array<{ predicate: (request: { url: () => string }) => boolean; resolve: (request: unknown) => void }> = [];
@@ -196,7 +197,7 @@ describe('archive E2E fixtures', () => {
         const playersUrl = 'https://preview.example.test/api/players?limit=100';
         resolveWaiters(modeUrl);
         const modePromise = routeHandler(routeFor('mode', modeUrl));
-        await jest.advanceTimersByTimeAsync(15_000);
+        await jest.advanceTimersByTimeAsync(timeoutMs);
         await modePromise;
         resolveWaiters(playersUrl);
         await routeHandler(routeFor('players-late', playersUrl));

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -455,6 +455,7 @@ module.exports = {
   runArchiveTests,
   createCompletedPublicBmArchive,
   cleanupArchiveFixture,
+  QUALIFICATION_FETCH_TIMEOUT_MS,
   assertQualificationFetchesStartInParallel,
   requestKindForQualificationFetch,
 };


### PR DESCRIPTION
Summary
- Export the TC-ARC-09 qualification fetch timeout constant from the archive E2E suite.
- Use that constant in the timeout-race fixture test instead of a hard-coded `15_000`.

Issues: Closes #1301

Validation
- `node --check smkc-score-app/e2e/tc-archive.js`
- `npm test -- __tests__/e2e/tc-archive-fixtures.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
