### PR TITLE
Warn on unresolved Top-24 playoff winners

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1264,6 +1264,17 @@
 - **期待結果**: BM の合算順位タブが全グループの参加者を表示し、順位列が昇順で描画される
 - **スクリプト**: tc-bm.js TC-533
 
+## TC-534: BM Top-24 Phase 2 preview — winner 不定時の warning
+- **URL**: /tournaments/[id]/bm/finals
+- **authRequired**: true (admin)
+- **背景**: Top-24 playoff の Phase 2 preview は `playoff_r2` が completed でも同点・欠損 playerId などで winner を決められない場合がある。該当シードを静かに欠落させると Phase 2 デバッグが難しくなるため、未解決 winner を warning として残す。
+- **手順**:
+  1. Top-24 playoff を生成し、`playoff_r2` のうち 1 試合を winner 不定の completed 状態にする
+  2. `GET /api/tournaments/[id]/bm/finals` で Phase 2 preview を取得する
+  3. preview は取得できるが、未解決 winner の `matchNumber` と `advancesToUpperSeed` が warning に記録されることを確認
+- **期待結果**: Phase 2 preview は未解決 winner を黙って無視せず、原因調査に使える warning を残す
+- **スクリプト**: n/a（server-side warning のため `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts` で検証）
+
 ---
 
 ## MR (Match Race) フルワークフローテスト

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -114,6 +114,18 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('GPMatch.suddenDeathWinnerId');
   });
 
+  it('documents TC-534 as BM Top-24 unresolved winner warning coverage', () => {
+    const section = sectionFor('TC-534');
+
+    expect(section).toContain('playoff_r2');
+    expect(section).toContain('winner 不定');
+    expect(section).toContain('warning');
+    expect(section).toContain('matchNumber');
+    expect(section).toContain('advancesToUpperSeed');
+    expect(section).toContain('finals-route.test.ts');
+    expect(section).toContain('server-side warning');
+  });
+
   it('does not leave retired TC identifiers in runnable E2E scripts as false drift signals', () => {
     expect(tcAll).not.toContain('TC-403');
   });

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1317,6 +1317,36 @@ describe('Finals Route Factory', () => {
       expect(seedMap.get(14)).toBe('winner-14');
       expect(seedMap.get(10)).toBe('winner-10');
     });
+
+    it('GET Top-24 preview warns when a completed playoff R2 winner cannot be resolved', async () => {
+      (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(24));
+      const playoffRows = [
+        { id: 'p-r2-5', matchNumber: 5, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 5, player1Id: 'player-19', player2Id: 'player-8', player1: { id: 'player-19' }, player2: { id: 'player-8' } },
+        { id: 'p-r2-6', matchNumber: 6, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-6', player2Id: 'player-21', player1: { id: 'player-6' }, player2: { id: 'player-21' } },
+        { id: 'p-r2-7', matchNumber: 7, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-7', player2Id: 'player-20', player1: { id: 'player-7' }, player2: { id: 'player-20' } },
+        { id: 'p-r2-8', matchNumber: 8, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-18', player2Id: 'player-9', player1: { id: 'player-18' }, player2: { id: 'player-9' } },
+      ];
+      (prisma.bMMatch as any).findMany.mockImplementation((args: any) => {
+        if (args?.where?.stage === 'playoff') return Promise.resolve(playoffRows);
+        return Promise.resolve([]);
+      });
+      (prisma.bMMatch as any).count.mockResolvedValue(0);
+
+      const config = createMockConfig({ getStyle: 'grouped' });
+      const { GET } = createFinalsHandlers(config);
+
+      const response = await GET(new NextRequest('http://localhost:3000'), {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockLogger.warn).toHaveBeenCalledWith('Top-24 playoff winner could not be resolved', {
+        tournamentId: 'tournament-123',
+        eventTypeCode: 'bm',
+        matchNumber: 5,
+        advancesToUpperSeed: 16,
+      });
+    });
   });
 
   // ============================================================

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -64,8 +64,20 @@ interface FinalsMatchResultError {
 interface SeededFinalsPlayer {
   seed: number;
   playerId: string;
-  player: unknown;
+  player: PublicFinalsPlayer;
   qualificationRankLabel?: string;
+}
+
+interface PublicFinalsPlayer {
+  id: string;
+  name?: string | null;
+  nickname?: string | null;
+  country?: string | null;
+  noCamera?: boolean;
+}
+
+function isPublicFinalsPlayer(value: unknown): value is PublicFinalsPlayer {
+  return Boolean(value && typeof value === 'object' && typeof (value as { id?: unknown }).id === 'string');
 }
 
 function fisherYatesShuffle<T>(arr: readonly T[]): T[] {
@@ -574,7 +586,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
 
   function getCompletedMatchWinner(
     match: Record<string, unknown>,
-  ): { winnerId: string; winnerPlayer: unknown } | null {
+  ): { winnerId: string; winnerPlayer: PublicFinalsPlayer } | null {
     const score1 = Number(match[config.putScoreFields.dbField1]);
     const score2 = Number(match[config.putScoreFields.dbField2]);
     if (!Number.isFinite(score1) || !Number.isFinite(score2) || score1 === score2) {
@@ -586,9 +598,14 @@ export function createFinalsHandlers(config: FinalsConfig) {
       return null;
     }
 
+    const winnerPlayer = match.player1Id === winnerId ? match.player1 : match.player2;
+    if (!isPublicFinalsPlayer(winnerPlayer)) {
+      return null;
+    }
+
     return {
       winnerId,
-      winnerPlayer: match.player1Id === winnerId ? match.player1 : match.player2,
+      winnerPlayer,
     };
   }
 
@@ -694,6 +711,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
     tournamentId: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     playoffMatches: any[],
+    logger: ReturnType<typeof createLogger>,
   ): Promise<{
     bracketStructure: ReturnType<typeof generateBracketStructure>;
     seededPlayers: SeededFinalsPlayer[];
@@ -723,7 +741,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
       const seededPlayers: SeededFinalsPlayer[] = selection.directSeeds.map(({ seed, qualification }) => ({
         seed,
         playerId: qualification.playerId,
-        player: qualification.player,
+        player: qualification.player as PublicFinalsPlayer,
         qualificationRankLabel: qualificationRankLabels.get(qualification.playerId),
       }));
 
@@ -740,7 +758,15 @@ export function createFinalsHandlers(config: FinalsConfig) {
         if (!dbMatch?.completed) continue;
 
         const winner = getCompletedMatchWinner(dbMatch);
-        if (!winner) continue;
+        if (!winner) {
+          logger.warn('Top-24 playoff winner could not be resolved', {
+            tournamentId,
+            eventTypeCode: config.eventTypeCode,
+            matchNumber: r2BracketMatch.matchNumber,
+            advancesToUpperSeed: r2BracketMatch.advancesToUpperSeed,
+          });
+          continue;
+        }
         seededPlayers.push({
           seed: r2BracketMatch.advancesToUpperSeed,
           playerId: winner.winnerId,
@@ -946,7 +972,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
         : playoffMatches.length > 0 ? 'playoff' as const
         : 'finals' as const;
       const top24FinalsPreview = hasFinals === 0
-        ? await buildTop24FinalsPreview(tournamentId, playoffMatches)
+        ? await buildTop24FinalsPreview(tournamentId, playoffMatches, logger)
         : null;
 
       /* Normalize GP cup sequences for legacy finals rows before paginating or
@@ -1514,7 +1540,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
 
       /* Derive each playoff winner and map to its advancesToUpperSeed target. */
       const playoffStructure = generatePlayoffStructure(PLAYOFF_ENTRANT_COUNT);
-      const upperSeedToPlayer = new Map<number, { playerId: string; player: unknown }>();
+      const upperSeedToPlayer = new Map<number, { playerId: string; player: PublicFinalsPlayer }>();
 
       for (const r2BracketMatch of playoffStructure.filter(m => m.round === 'playoff_r2')) {
         const dbMatch = r2Matches.find(
@@ -1537,7 +1563,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
       const directPlayers = selection.directSeeds.map(({ seed, qualification }) => ({
         seed,
         playerId: qualification.playerId,
-        player: qualification.player,
+        player: qualification.player as PublicFinalsPlayer,
         qualificationRankLabel: qualificationRankLabels.get(qualification.playerId),
       }));
       const playoffUpperSeeds = playoffStructure


### PR DESCRIPTION
Summary
- Add TC-534 scenario coverage for unresolved BM Top-24 Phase 2 preview winners.
- Type `getCompletedMatchWinner` with a public player shape instead of returning `unknown`.
- Warn with tournament/match/upper-seed context when a completed playoff R2 winner cannot be resolved in the preview path.

Issues: Closes #1137, Closes #1136

Validation
- npm test -- __tests__/lib/api-factories/finals-route.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- node --check smkc-score-app/e2e/tc-bm.js
- git diff --check
- npm run lint (passes with existing warnings)
