### PR TITLE
Guard Top-24 seeded player resolution

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1347,6 +1347,67 @@ describe('Finals Route Factory', () => {
         advancesToUpperSeed: 16,
       });
     });
+
+    it('GET Top-24 preview warns and skips a direct seed with an invalid player payload', async () => {
+      const qualifications = createMockQualifications(24);
+      qualifications[0].player = null;
+      (prisma.bMQualification as any).findMany.mockResolvedValue(qualifications);
+      const playoffRows = [
+        { id: 'p-r2-5', matchNumber: 5, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-19', player2Id: 'player-8', player1: { id: 'player-19' }, player2: { id: 'player-8' } },
+      ];
+      (prisma.bMMatch as any).findMany.mockImplementation((args: any) => {
+        if (args?.where?.stage === 'playoff') return Promise.resolve(playoffRows);
+        return Promise.resolve([]);
+      });
+      (prisma.bMMatch as any).count.mockResolvedValue(0);
+
+      const config = createMockConfig({ getStyle: 'grouped' });
+      const { GET } = createFinalsHandlers(config);
+
+      const response = await GET(new NextRequest('http://localhost:3000'), {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockLogger.warn).toHaveBeenCalledWith('Top-24 direct seed player could not be resolved', {
+        tournamentId: 'tournament-123',
+        eventTypeCode: 'bm',
+        seed: 1,
+        playerId: 'player-0',
+      });
+    });
+
+    it('Phase 2 warns before failing when a completed playoff R2 winner cannot be resolved', async () => {
+      (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(24));
+      const playoffRows = [
+        { id: 'p-r2-5', matchNumber: 5, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 5, player1Id: 'player-19', player2Id: 'player-8', player1: { id: 'player-19' }, player2: { id: 'player-8' } },
+        { id: 'p-r2-6', matchNumber: 6, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-6', player2Id: 'player-21', player1: { id: 'player-6' }, player2: { id: 'player-21' } },
+        { id: 'p-r2-7', matchNumber: 7, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-7', player2Id: 'player-20', player1: { id: 'player-7' }, player2: { id: 'player-20' } },
+        { id: 'p-r2-8', matchNumber: 8, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-18', player2Id: 'player-9', player1: { id: 'player-18' }, player2: { id: 'player-9' } },
+      ];
+      (prisma.bMMatch as any).findMany.mockImplementation((args: any) => {
+        if (args?.where?.stage === 'finals') return Promise.resolve([]);
+        return Promise.resolve(playoffRows);
+      });
+
+      const config = createMockConfig();
+      const { POST } = createFinalsHandlers(config);
+
+      const response = await POST(new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 24 }),
+      }), {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(500);
+      expect(mockLogger.warn).toHaveBeenCalledWith('Top-24 playoff winner could not be resolved', {
+        tournamentId: 'tournament-123',
+        eventTypeCode: 'bm',
+        matchNumber: 5,
+        advancesToUpperSeed: 16,
+      });
+    });
   });
 
   // ============================================================

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -609,6 +609,36 @@ export function createFinalsHandlers(config: FinalsConfig) {
     };
   }
 
+  function buildDirectSeededPlayers(
+    directSeeds: Array<{ seed: number; qualification: { playerId: string; player: unknown } }>,
+    qualificationRankLabels: Map<string, string>,
+    tournamentId: string,
+    logger: ReturnType<typeof createLogger>,
+  ): SeededFinalsPlayer[] {
+    const seededPlayers: SeededFinalsPlayer[] = [];
+
+    for (const { seed, qualification } of directSeeds) {
+      if (!isPublicFinalsPlayer(qualification.player)) {
+        logger.warn('Top-24 direct seed player could not be resolved', {
+          tournamentId,
+          eventTypeCode: config.eventTypeCode,
+          seed,
+          playerId: qualification.playerId,
+        });
+        continue;
+      }
+
+      seededPlayers.push({
+        seed,
+        playerId: qualification.playerId,
+        player: qualification.player,
+        qualificationRankLabel: qualificationRankLabels.get(qualification.playerId),
+      });
+    }
+
+    return seededPlayers;
+  }
+
   function hasAutomaticRankTies(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     qualifications: any[],
@@ -738,12 +768,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
         rankedQualifications as Array<{ playerId: string; player: unknown; group: string }>,
       );
 
-      const seededPlayers: SeededFinalsPlayer[] = selection.directSeeds.map(({ seed, qualification }) => ({
-        seed,
-        playerId: qualification.playerId,
-        player: qualification.player as PublicFinalsPlayer,
-        qualificationRankLabel: qualificationRankLabels.get(qualification.playerId),
-      }));
+      const seededPlayers = buildDirectSeededPlayers(
+        selection.directSeeds,
+        qualificationRankLabels,
+        tournamentId,
+        logger,
+      );
 
       const playoffStructure = generatePlayoffStructure(PLAYOFF_ENTRANT_COUNT);
       const r2Matches = playoffMatches.filter(
@@ -1549,6 +1579,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
         if (!dbMatch || !r2BracketMatch.advancesToUpperSeed) continue;
         const winner = getCompletedMatchWinner(dbMatch);
         if (!winner) {
+          logger.warn('Top-24 playoff winner could not be resolved', {
+            tournamentId,
+            eventTypeCode: config.eventTypeCode,
+            matchNumber: r2BracketMatch.matchNumber,
+            advancesToUpperSeed: r2BracketMatch.advancesToUpperSeed,
+          });
           throw new Error(`Playoff winner for match ${r2BracketMatch.matchNumber} not resolved`);
         }
         upperSeedToPlayer.set(r2BracketMatch.advancesToUpperSeed, {
@@ -1560,12 +1596,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
       /* Build the 16 seeded players: direct advancers use their actual Upper
        * Bracket seed numbers (2 groups: fixed CDM paper layout), and playoff
        * winners fill the barrage slots declared by generatePlayoffStructure. */
-      const directPlayers = selection.directSeeds.map(({ seed, qualification }) => ({
-        seed,
-        playerId: qualification.playerId,
-        player: qualification.player as PublicFinalsPlayer,
-        qualificationRankLabel: qualificationRankLabels.get(qualification.playerId),
-      }));
+      const directPlayers = buildDirectSeededPlayers(
+        selection.directSeeds,
+        qualificationRankLabels,
+        tournamentId,
+        logger,
+      );
       const playoffUpperSeeds = playoffStructure
         .filter((m) => m.round === 'playoff_r2' && m.advancesToUpperSeed)
         .map((m) => m.advancesToUpperSeed as number);


### PR DESCRIPTION
Summary
- Add direct-seed player guards for Top-24 preview and Phase 2 bracket creation.
- Reuse guarded seeded-player construction instead of unsafe direct casts.
- Warn in the Phase 2 POST path before failing on an unresolved playoff R2 winner.

Issues: Closes #1304, Closes #1305

Validation
- npm test -- __tests__/lib/api-factories/finals-route.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- git diff --check
- npm run lint (passes with existing warnings)
