### PR TITLE
Cover skipped Top-24 seeded slots

### DIFF
--- a/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
@@ -231,6 +231,33 @@ describe("DoubleEliminationBracket TBD rendering (issue #574)", () => {
     expect(winnersR1Cards[3].textContent).toContain(seed2.nickname);
     expect(winnersR1Cards[3].textContent).toContain("TBD");
   });
+
+  it("renders a skipped Top-24 direct seed as TBD while keeping the bracket slot visible", () => {
+    const bracketStructure = generateBracketStructure(16);
+    const seededPreview = [
+      ...seededPlayers.filter((entry) => entry.seed !== 1),
+      { seed: 16, playerId: "p16", player: { id: "p16", name: "Mika M", nickname: "Mika" } },
+    ];
+
+    const { container } = render(
+      <DoubleEliminationBracket
+        matches={[]}
+        bracketStructure={bracketStructure}
+        roundNames={{}}
+        seededPlayers={seededPreview}
+      />,
+    );
+
+    const winnersR1M1 = Array.from(
+      container.querySelectorAll<HTMLElement>("[role='button']"),
+    ).find((el) => el.querySelector("div.text-xs")?.textContent === "M1");
+
+    expect(winnersR1M1).toBeDefined();
+    expect(winnersR1M1!.textContent).toContain("[1]");
+    expect(winnersR1M1!.textContent).toContain("TBD");
+    expect(winnersR1M1!.textContent).toContain("[16]");
+    expect(winnersR1M1!.textContent).toContain("Mika");
+  });
 });
 
 describe("DoubleEliminationBracket startingCourseNumber display (issue #731)", () => {

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1369,6 +1369,15 @@ describe('Finals Route Factory', () => {
       });
 
       expect(response.status).toBe(200);
+      const json = await response.json();
+      const previewSeededPlayers = json.data.seededPlayers as Array<{ seed: number; playerId: string }>;
+      expect(previewSeededPlayers).toBeDefined();
+      expect(previewSeededPlayers).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ seed: 1, playerId: 'player-0' })]),
+      );
+      expect(previewSeededPlayers).toEqual(
+        expect.arrayContaining([expect.objectContaining({ seed: 16, playerId: 'player-19' })]),
+      );
       expect(mockLogger.warn).toHaveBeenCalledWith('Top-24 direct seed player could not be resolved', {
         tournamentId: 'tournament-123',
         eventTypeCode: 'bm',


### PR DESCRIPTION
Summary
- Assert the Top-24 preview response omits invalid direct-seed players while preserving valid playoff winners.
- Cover the 16-player bracket preview UI rendering a skipped direct seed as TBD without dropping the bracket slot.

Issues: Closes #1307

Validation
- npm test -- __tests__/lib/api-factories/finals-route.test.ts __tests__/components/tournament/double-elimination-bracket.test.tsx __tests__/docs/e2e-cases-drift.test.ts --runInBand
- git diff --check
- npm run lint (passes with existing warnings)
