### PR TITLE
Harden Top-24 preview tests

### DIFF
--- a/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
@@ -15,7 +15,7 @@
  * scrolls horizontally instead of breaking the surrounding layout.
  */
 
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
 import { generateBracketStructure } from "@/lib/double-elimination";
 
@@ -239,7 +239,7 @@ describe("DoubleEliminationBracket TBD rendering (issue #574)", () => {
       { seed: 16, playerId: "p16", player: { id: "p16", name: "Mika M", nickname: "Mika" } },
     ];
 
-    const { container } = render(
+    render(
       <DoubleEliminationBracket
         matches={[]}
         bracketStructure={bracketStructure}
@@ -248,15 +248,14 @@ describe("DoubleEliminationBracket TBD rendering (issue #574)", () => {
       />,
     );
 
-    const winnersR1M1 = Array.from(
-      container.querySelectorAll<HTMLElement>("[role='button']"),
-    ).find((el) => el.querySelector("div.text-xs")?.textContent === "M1");
+    const winnersR1M1 = screen.getByRole("button", {
+      name: /Match 1: TBD vs Mika/,
+    });
 
-    expect(winnersR1M1).toBeDefined();
-    expect(winnersR1M1!.textContent).toContain("[1]");
-    expect(winnersR1M1!.textContent).toContain("TBD");
-    expect(winnersR1M1!.textContent).toContain("[16]");
-    expect(winnersR1M1!.textContent).toContain("Mika");
+    expect(winnersR1M1.textContent).toContain("[1]");
+    expect(winnersR1M1.textContent).toContain("TBD");
+    expect(winnersR1M1.textContent).toContain("[16]");
+    expect(winnersR1M1.textContent).toContain("Mika");
   });
 });
 

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1370,12 +1370,11 @@ describe('Finals Route Factory', () => {
 
       expect(response.status).toBe(200);
       const json = await response.json();
-      const previewSeededPlayers = json.data.seededPlayers as Array<{ seed: number; playerId: string }>;
-      expect(previewSeededPlayers).toBeDefined();
-      expect(previewSeededPlayers).not.toEqual(
+      expect(json.data.seededPlayers).toBeDefined();
+      expect(json.data.seededPlayers).not.toEqual(
         expect.arrayContaining([expect.objectContaining({ seed: 1, playerId: 'player-0' })]),
       );
-      expect(previewSeededPlayers).toEqual(
+      expect(json.data.seededPlayers).toEqual(
         expect.arrayContaining([expect.objectContaining({ seed: 16, playerId: 'player-19' })]),
       );
       expect(mockLogger.warn).toHaveBeenCalledWith('Top-24 direct seed player could not be resolved', {


### PR DESCRIPTION
Summary
- Replace the skipped-seed bracket test DOM traversal with an accessible role/name query.
- Remove the finals-route response `as` cast and assert directly against the response body.

Issues: Closes #1309, Closes #1310

Validation
- npm test -- __tests__/lib/api-factories/finals-route.test.ts __tests__/components/tournament/double-elimination-bracket.test.tsx __tests__/docs/e2e-cases-drift.test.ts --runInBand
- git diff --check
- npm run lint (passes with existing warnings)
