### PR TITLE
Avoid duplicate GP assigned cup label evaluation

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1837,6 +1837,17 @@
 - **期待結果**: ラウンドをまたいだ同カップは許可されるが、同じラウンドのカップ組み合わせは FT3 の5件目を除いて重複しない。FT数ぶんの初期カップ欄は削除できず、追加したカップ欄だけ削除できる
 - **スクリプト**: tc-gp.js TC-717
 
+## TC-726: GP決勝 — 管理者スコア入力ダイアログの割り当てカップ表示を一度だけ評価する
+- **URL**: /tournaments/[id]/gp/finals
+- **authRequired**: true (admin)
+- **背景**: 管理者のシンプルなカップ勝利数入力ダイアログでは、`selectedMatch.assignedCups` から表示用ラベルを作る。JSX 内で同じ `getAssignedCupLabelsForMatch(selectedMatch)` を length 判定と map で2回呼ぶと、軽微だが不要な再評価になり、将来 helper に副作用や重い処理が入った場合の回帰点になる。
+- **手順**:
+  1. GP 決勝ページ実装を確認する
+  2. `selectedMatch` 用の割り当てカップ表示ラベルが JSX の手前で `selectedMatchAssignedCupLabels` に一度だけ格納されることを確認する
+  3. ダイアログ内の表示条件と badge 描画が `selectedMatchAssignedCupLabels` を共有していることを確認する
+- **期待結果**: `getAssignedCupLabelsForMatch(selectedMatch)` は render 内で一度だけ評価され、length 判定と badge 描画が同じ配列を使う
+- **スクリプト**: n/a (source guard) — smkc-score-app/__tests__/components/gp-finals-page-source.test.ts
+
 ## TC-718: GP決勝 — 管理者の手動合計スコア入力 (PR #585 マニュアルフォーム)
 - **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/components/gp-finals-page-source.test.ts
+++ b/smkc-score-app/__tests__/components/gp-finals-page-source.test.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('GP finals page source guards', () => {
+  const pageSource = fs.readFileSync(
+    path.join(process.cwd(), 'src/app/tournaments/[id]/gp/finals/page.tsx'),
+    'utf8',
+  );
+
+  it('evaluates assigned cup labels once for the selected match render', () => {
+    const selectedMatchCalls = pageSource.match(/getAssignedCupLabelsForMatch\(selectedMatch\)/g) ?? [];
+
+    expect(selectedMatchCalls).toHaveLength(1);
+    expect(pageSource).toContain(
+      'const selectedMatchAssignedCupLabels = selectedMatch ? getAssignedCupLabelsForMatch(selectedMatch) : [];',
+    );
+    expect(pageSource).toContain('selectedMatchAssignedCupLabels.length > 0');
+    expect(pageSource).toContain('selectedMatchAssignedCupLabels.map((cup, index) => (');
+  });
+});

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -97,6 +97,7 @@ describe('E2E case drift coverage', () => {
   it.each([
     ['TC-109', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/run-preview.test.ts'],
     ['TC-111', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts'],
+    ['TC-726', 'n/a (source guard)', 'smkc-score-app/__tests__/components/gp-finals-page-source.test.ts'],
     ['TC-803', 'TC-318 でカバー済み', 'TC-318'],
     ['TC-943', '.github/pull_request_template.md', '__tests__/docs/pr-template.test.ts'],
   ])('keeps %s explicitly classified outside standalone browser runner registration', (tc, marker, coverage) => {

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -688,6 +688,7 @@ export default function GrandPrixFinals({
   const simpleScore1 = parseManualScore(simpleScoreForm.score1);
   const simpleScore2 = parseManualScore(simpleScoreForm.score2);
   const selectedMatchTargetWins = selectedMatch ? getTargetWinsForMatch(selectedMatch) : 1;
+  const selectedMatchAssignedCupLabels = selectedMatch ? getAssignedCupLabelsForMatch(selectedMatch) : [];
   const simpleScoreInputsReady = Boolean(selectedMatch && usesCupWinScoreOnly(selectedMatch) &&
     simpleScore1 !== null &&
     simpleScore2 !== null &&
@@ -952,11 +953,11 @@ export default function GrandPrixFinals({
                   </div>
                   <Badge variant="outline">FT{selectedMatchTargetWins}</Badge>
                 </div>
-                {getAssignedCupLabelsForMatch(selectedMatch).length > 0 && (
+                {selectedMatchAssignedCupLabels.length > 0 && (
                   <div className="space-y-2">
                     <div className="text-xs font-medium text-muted-foreground">{tGp('assignedCups')}</div>
                     <div className="flex flex-wrap gap-2">
-                      {getAssignedCupLabelsForMatch(selectedMatch).map((cup, index) => (
+                      {selectedMatchAssignedCupLabels.map((cup, index) => (
                         <Badge key={`${selectedMatch.id}-assigned-cup-${index}-${cup}`} variant="secondary">
                           {index + 1}. {tGp('cupLabel', { cup })}
                         </Badge>


### PR DESCRIPTION
## Summary
- Add TC-726 coverage for the GP finals assigned-cup label render guard.
- Reuse one `selectedMatchAssignedCupLabels` value for the dialog length check and badge rendering.
- Add focused source/docs regression tests for the single-evaluation contract.

## Issues
Closes #1133

## Validation
- `npm test -- __tests__/components/gp-finals-page-source.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/tc-gp-assigned-cups.test.ts`
- `node --check e2e/tc-gp.js`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
