### PR TITLE
Document GP assigned cup legacy fallback

### DIFF
--- a/smkc-score-app/src/lib/gp-finals-assigned-cups.ts
+++ b/smkc-score-app/src/lib/gp-finals-assigned-cups.ts
@@ -9,5 +9,6 @@ export function getAssignedCupLabelsForMatch(match: AssignedCupLabelMatch): stri
     : [];
 
   if (assigned.length > 0) return assigned;
+  // Matches created before assignedCups existed still store their display cup here.
   return match.cup ? [match.cup] : [];
 }


### PR DESCRIPTION
## Summary
- Document why GP assigned-cup labels fall back to the legacy `cup` field.

## Issues
Closes #1317

## Validation
- `npm test -- __tests__/lib/gp-finals-assigned-cups.test.ts`
- `git diff --check`
