### PR TITLE
Clarify GP simple score validation

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1872,6 +1872,19 @@
 - **期待結果**: アッパーブラケットは `2-0` のような取得カップ数だけで保存・進行でき、不要なカップ別明細を作らない
 - **スクリプト**: tc-gp.js TC-1103 (`npm run e2e:gp`, preview: `npm run e2e:preview:gp`)
 
+## TC-727: GP決勝 — 取得カップ数がFT上限を超える保存を拒否する
+- **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)
+- **authRequired**: true (admin)
+- **背景**: GP決勝のシンプル入力は取得カップ数だけを保存するが、FT2/FT3の必要勝利数を超える値は進行状態を壊すため拒否する。
+- **手順**:
+  1. 8名以上の GP 予選を完了し、決勝ブラケットを生成する
+  2. FT2 のアッパーブラケット M1 に `{ score1: 3, score2: 0 }` をPUTする
+  3. HTTP 400 と `Cup wins must be integers from 0 to 2` が返ることを確認する
+  4. `GET /api/.../gp/finals` で M1 を再取得する
+  5. M1 が未完了のまま更新されていないことを確認する
+- **期待結果**: FT上限を超えるシンプル取得カップ数は保存されず、ブラケット進行も発生しない
+- **スクリプト**: tc-gp.js TC-727 (`npm run e2e:gp`, preview: `npm run e2e:preview:gp`)
+
 ## TC-710: GP カップ不一致修正の拒否
 - **URL**: /api/tournaments/[temp-id]/gp (PATCH with correction)
 - **authRequired**: true (player)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -720,6 +720,42 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       });
     });
 
+    it('should reject score-only cup wins above the target before updating the match', async () => {
+      const mockMatch = {
+        id: 'm1',
+        tournamentId: 't1',
+        matchNumber: 1,
+        round: 'winners_qf',
+        stage: 'finals',
+        player1Id: 'p1',
+        player2Id: 'p2',
+        points1: 0,
+        points2: 0,
+        completed: false,
+        player1: { id: 'p1' },
+        player2: { id: 'p2' },
+      };
+
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+
+      const request = new MockNextRequest(
+        'http://localhost:3000/api/tournaments/t1/gp/finals',
+        { matchId: 'm1', score1: 3, score2: 0 },
+      );
+      const params = Promise.resolve({ id: 't1' });
+      const result = await PUT(request, { params });
+
+      expect(result.data).toEqual({
+        success: false,
+        error: 'Cup wins must be integers from 0 to 2',
+        code: 'VALIDATION_ERROR',
+        details: { field: 'score' },
+      });
+      expect(result.status).toBe(400);
+      expect(prisma.gPMatch.update).not.toHaveBeenCalled();
+      expect(prisma.gPMatch.findFirst).not.toHaveBeenCalled();
+    });
+
     it('should reject excessive GP finals cupResults before updating the match', async () => {
       const mockMatch = {
         id: 'm1',

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -735,6 +735,41 @@ async function runTc1103(adminPage) {
   }
 }
 
+/* ───────── TC-727: GP finals rejects score-only cup wins above FT target ───────── */
+async function runTc727(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedGpFinalsSetup(adminPage);
+
+    const gen = await apiGenerateGpFinals(adminPage, setup.tournamentId, 8);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`Bracket gen failed (${gen.s})`);
+
+    const before = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const m1 = before.find((m) => m.matchNumber === 1 && m.round === 'winners_qf');
+    if (!m1) throw new Error('Upper-bracket Match 1 missing');
+
+    const invalid = await apiSetGpFinalsScore(adminPage, setup.tournamentId, m1.id, 3, 0);
+    const rejected = invalid.s === 400 &&
+      String(invalid.b?.error ?? '').includes('Cup wins must be integers from 0 to 2');
+
+    const after = await apiFetchGpFinalsMatches(adminPage, setup.tournamentId);
+    const unchanged = after.find((m) => m.id === m1.id);
+    const notMutated = unchanged?.completed === false &&
+      (unchanged.points1 ?? 0) === (m1.points1 ?? 0) &&
+      (unchanged.points2 ?? 0) === (m1.points2 ?? 0);
+
+    log('TC-727', rejected && notMutated ? 'PASS' : 'FAIL',
+      !rejected
+        ? `invalid score accepted/status=${invalid.s} error=${invalid.b?.error ?? ''}`
+        : !notMutated ? `match mutated completed=${unchanged?.completed} points=${unchanged?.points1}-${unchanged?.points2}`
+        : '');
+  } catch (err) {
+    log('TC-727', 'FAIL', err instanceof Error ? err.message : 'GP 727 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
 /* ───────── TC-715: GP Top-24 Playoff UI Flow ─────────
  * Validates the full Top-24 → Top-16 playoff UI path for GP:
  * 1. Qualification page shows "Start Playoff (Top 24)" when players > 16
@@ -1585,6 +1620,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       // TC-1103 is intentionally grouped with the TC-718 finals score-save
       // coverage before the longer TC-715/TC-716 playoff UI flows.
       { name: 'TC-1103', fn: runTc1103 },
+      { name: 'TC-727', fn: runTc727 },
       { name: 'TC-715', fn: runTc715 },
       { name: 'TC-716', fn: runTc716 },
       { name: 'TC-710', fn: runTc710 },
@@ -1604,7 +1640,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 module.exports = {
   runTc701, runTc702, runTc703, runTc704, runTc705, runTc706,
   runTc707, runTc708, runTc709, runTc710, runTc712, runTc713,
-  runTc715, runTc716, runTc717, runTc718, runTc1103, runTc719,
+  runTc715, runTc716, runTc717, runTc718, runTc1103, runTc727, runTc719,
   runTc720, runTc721, runTc722, runTc724, runTc725, runTc821, runTc831, runTc832,
   gpAssignedCupSequence, gpFinalsUpdatedMatchFromPutResult,
   getSuite,

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -583,13 +583,16 @@ export default function GrandPrixFinals({
       const score2 = parseManualScore(simpleScoreForm.score2);
       const player1Won = score1 === targetWins && score2 !== null && score2 < targetWins;
       const player2Won = score2 === targetWins && score1 !== null && score1 < targetWins;
+      const noPlayerWon = !player1Won && !player2Won;
+      const bothPlayersWon = player1Won && player2Won;
 
       if (
         score1 === null ||
         score2 === null ||
         score1 > targetWins ||
         score2 > targetWins ||
-        player1Won === player2Won
+        noPlayerWon ||
+        bothPlayersWon
       ) {
         alert(tFinals('matchNeedWinner', { targetWins }));
         return;


### PR DESCRIPTION
## Summary
- Add TC-727 coverage for rejecting GP finals score-only cup wins above the FT target.
- Clarify the GP finals simple-score winner validation condition in the admin page.
- Add route coverage for the `score > targetWins` validation path.

## Issues
Closes #1131

## Validation
- `node --check smkc-score-app/e2e/tc-gp.js`
- `npm test -- __tests__/docs/e2e-cases-drift.test.ts`
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts'`
- `git diff --check`
- `npm run lint` (passes with existing warnings)

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
