### PR TITLE
Remove unreachable GP score branch

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -584,15 +584,13 @@ export default function GrandPrixFinals({
       const player1Won = score1 === targetWins && score2 !== null && score2 < targetWins;
       const player2Won = score2 === targetWins && score1 !== null && score1 < targetWins;
       const noPlayerWon = !player1Won && !player2Won;
-      const bothPlayersWon = player1Won && player2Won;
 
       if (
         score1 === null ||
         score2 === null ||
         score1 > targetWins ||
         score2 > targetWins ||
-        noPlayerWon ||
-        bothPlayersWon
+        noPlayerWon
       ) {
         alert(tFinals('matchNeedWinner', { targetWins }));
         return;


### PR DESCRIPTION
## Summary
- Remove the unreachable `bothPlayersWon` branch from GP finals simple-score validation.
- Keep the existing explicit `noPlayerWon` guard for ties and incomplete score-only states.

## Issues
Closes #1320

## Validation
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts'`
- `git diff --check`
- `npm run lint` (passes with existing warnings)

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
