### PR TITLE
Test GP simple score validation

### DIFF
--- a/smkc-score-app/__tests__/lib/gp-finals-simple-score.test.ts
+++ b/smkc-score-app/__tests__/lib/gp-finals-simple-score.test.ts
@@ -1,0 +1,22 @@
+import { isValidGpFinalsSimpleScore } from '@/lib/gp-finals-simple-score';
+
+describe('isValidGpFinalsSimpleScore', () => {
+  it.each([
+    [2, 0, 2],
+    [0, 2, 2],
+    [3, 2, 3],
+  ])('accepts exactly one side reaching targetWins (%s-%s FT%s)', (score1, score2, targetWins) => {
+    expect(isValidGpFinalsSimpleScore(score1, score2, targetWins)).toBe(true);
+  });
+
+  it.each([
+    [null, 0, 2],
+    [0, null, 2],
+    [1, 0, 2],
+    [2, 2, 2],
+    [3, 0, 2],
+    [0, 3, 2],
+  ])('rejects incomplete, tied, and above-target scores (%s-%s FT%s)', (score1, score2, targetWins) => {
+    expect(isValidGpFinalsSimpleScore(score1, score2, targetWins)).toBe(false);
+  });
+});

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -85,6 +85,7 @@ import { buildMatchLabel } from "@/lib/overlay/phase";
 import { getGpFinalsMaxCups, getGpFinalsTargetWins } from "@/lib/finals-target-wins";
 import { getCupForFormIndex, isRemovableCupForm, removeCupFormAt } from "@/lib/gp-finals-score-form";
 import { getAssignedCupLabelsForMatch } from "@/lib/gp-finals-assigned-cups";
+import { isValidGpFinalsSimpleScore } from "@/lib/gp-finals-simple-score";
 import { GP_DRIVER_POINTS_INPUT_PROPS } from "@/lib/gp-driver-points-input";
 
 /** Client-side logger for error tracking */
@@ -581,17 +582,8 @@ export default function GrandPrixFinals({
       const targetWins = getTargetWinsForMatch(selectedMatch);
       const score1 = parseManualScore(simpleScoreForm.score1);
       const score2 = parseManualScore(simpleScoreForm.score2);
-      const player1Won = score1 === targetWins && score2 !== null && score2 < targetWins;
-      const player2Won = score2 === targetWins && score1 !== null && score1 < targetWins;
-      const noPlayerWon = !player1Won && !player2Won;
 
-      if (
-        score1 === null ||
-        score2 === null ||
-        score1 > targetWins ||
-        score2 > targetWins ||
-        noPlayerWon
-      ) {
+      if (!isValidGpFinalsSimpleScore(score1, score2, targetWins)) {
         alert(tFinals('matchNeedWinner', { targetWins }));
         return;
       }
@@ -686,14 +678,7 @@ export default function GrandPrixFinals({
   const selectedMatchTargetWins = selectedMatch ? getTargetWinsForMatch(selectedMatch) : 1;
   const selectedMatchAssignedCupLabels = selectedMatch ? getAssignedCupLabelsForMatch(selectedMatch) : [];
   const simpleScoreInputsReady = Boolean(selectedMatch && usesCupWinScoreOnly(selectedMatch) &&
-    simpleScore1 !== null &&
-    simpleScore2 !== null &&
-    simpleScore1 <= selectedMatchTargetWins &&
-    simpleScore2 <= selectedMatchTargetWins &&
-    (
-      (simpleScore1 === selectedMatchTargetWins && simpleScore2 < selectedMatchTargetWins) ||
-      (simpleScore2 === selectedMatchTargetWins && simpleScore1 < selectedMatchTargetWins)
-    ));
+    isValidGpFinalsSimpleScore(simpleScore1, simpleScore2, selectedMatchTargetWins));
   const scoreInputsReady = selectedMatch && usesCupWinScoreOnly(selectedMatch)
     ? simpleScoreInputsReady
     : cupForms.length > 0 && cupForms.every((cup) => calculateCupPoints(cup).valid);

--- a/smkc-score-app/src/lib/gp-finals-simple-score.ts
+++ b/smkc-score-app/src/lib/gp-finals-simple-score.ts
@@ -1,0 +1,18 @@
+export function isValidGpFinalsSimpleScore(
+  score1: number | null,
+  score2: number | null,
+  targetWins: number,
+): boolean {
+  if (
+    score1 === null ||
+    score2 === null ||
+    score1 > targetWins ||
+    score2 > targetWins
+  ) {
+    return false;
+  }
+
+  const player1Won = score1 === targetWins && score2 < targetWins;
+  const player2Won = score2 === targetWins && score1 < targetWins;
+  return player1Won || player2Won;
+}


### PR DESCRIPTION
## Summary
- Extract GP finals simple score validation into a shared pure helper.
- Use the helper from both submit validation and button-ready state.
- Add unit coverage for valid, incomplete, tied, and above-target simple scores.

## Issues
Closes #1322

## Validation
- `npm test -- __tests__/lib/gp-finals-simple-score.test.ts --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts'`
- `git diff --check`
- `npm run lint` (passes with existing warnings)

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
