### PR TITLE
Cover player two GP simple score wins

### DIFF
--- a/smkc-score-app/__tests__/lib/gp-finals-simple-score.test.ts
+++ b/smkc-score-app/__tests__/lib/gp-finals-simple-score.test.ts
@@ -5,6 +5,8 @@ describe('isValidGpFinalsSimpleScore', () => {
     [2, 0, 2],
     [0, 2, 2],
     [3, 2, 3],
+    [1, 2, 2],
+    [2, 3, 3],
   ])('accepts exactly one side reaching targetWins (%s-%s FT%s)', (score1, score2, targetWins) => {
     expect(isValidGpFinalsSimpleScore(score1, score2, targetWins)).toBe(true);
   });


### PR DESCRIPTION
## Summary
- Add symmetric player-two winning cases for GP finals simple score validation.
- Cover player two wins when player one has a non-zero score under FT2 and FT3 targets.

## Issues
Closes #1324

## Validation
- `npm test -- __tests__/lib/gp-finals-simple-score.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
