### PR TITLE
Cover player one GP simple score wins

### DIFF
--- a/smkc-score-app/__tests__/lib/gp-finals-simple-score.test.ts
+++ b/smkc-score-app/__tests__/lib/gp-finals-simple-score.test.ts
@@ -3,6 +3,7 @@ import { isValidGpFinalsSimpleScore } from '@/lib/gp-finals-simple-score';
 describe('isValidGpFinalsSimpleScore', () => {
   it.each([
     [2, 0, 2],
+    [2, 1, 2],
     [0, 2, 2],
     [3, 2, 3],
     [1, 2, 2],


### PR DESCRIPTION
## Summary
- Add the missing symmetric player-one FT2 simple-score winning case.
- Keep GP finals simple-score unit coverage balanced across both winner sides.

## Issues
Closes #1326

## Validation
- `npm test -- __tests__/lib/gp-finals-simple-score.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
