### PR TITLE
Centralize GP qualification ranking

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1808,6 +1808,18 @@
 - **期待結果**: GP の合算順位タブが全グループの参加者を表示し、順位列が昇順で描画され、勝点列とドライバー点列を区別できる
 - **スクリプト**: tc-gp.js TC-724
 
+## TC-728: GP 予選順位基準 — サーバーとクライアントが同じ score→points 定義を使う
+- **URL**: n/a (unit coverage)
+- **authRequired**: false
+- **背景**: GP 予選順位は勝点 (`score`) を主キー、ドライバーズポイント (`points`) を副キーにする。DB orderBy とクライアント comparator が別々に定義されると、将来の仕様変更時に finals・standings・ページ表示のどれかが更新漏れになる。
+- **手順**:
+  1. `src/lib/gp-ranking.ts` の共有 orderBy/comparator を確認する
+  2. GP config、GP finals route、GP standings route が共有 orderBy helper を参照していることを確認する
+  3. GP page-client のグループ別順位と合算順位が共有 comparator を参照していることを確認する
+  4. comparator が `score` を `points` より優先して並べることを単体テストで確認する
+- **期待結果**: GP のサーバー取得順とクライアント表示順が単一の共有定義から決まり、`score → points` の優先順位が全経路で一致する
+- **スクリプト**: smkc-score-app/__tests__/lib/gp-ranking.test.ts
+
 ## TC-725: GP 予選カップ割り当て — ラウンド境界で同じカップが連続しない
 - **URL**: /api/tournaments/[temp-id]/gp (GET)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -98,6 +98,7 @@ describe('E2E case drift coverage', () => {
     ['TC-109', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/run-preview.test.ts'],
     ['TC-111', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts'],
     ['TC-726', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-finals-assigned-cups.test.ts'],
+    ['TC-728', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-ranking.test.ts'],
     ['TC-803', 'TC-318 でカバー済み', 'TC-318'],
     ['TC-943', '.github/pull_request_template.md', '__tests__/docs/pr-template.test.ts'],
   ])('keeps %s explicitly classified outside standalone browser runner registration', (tc, marker, coverage) => {

--- a/smkc-score-app/__tests__/lib/gp-ranking.test.ts
+++ b/smkc-score-app/__tests__/lib/gp-ranking.test.ts
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import path from 'path';
+import {
+  compareGpQualificationEntries,
+  gpQualificationOrderBy,
+  gpStandingsOrderBy,
+} from '@/lib/gp-ranking';
+
+const root = process.cwd();
+
+function readSource(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+describe('gp-ranking', () => {
+  it('defines the GP qualification DB order once for grouped qualification fetches', () => {
+    expect(gpQualificationOrderBy()).toEqual([
+      { group: 'asc' },
+      { score: 'desc' },
+      { points: 'desc' },
+    ]);
+  });
+
+  it('defines the GP standings DB order without group partitioning', () => {
+    expect(gpStandingsOrderBy()).toEqual([
+      { score: 'desc' },
+      { points: 'desc' },
+    ]);
+  });
+
+  it('returns defensive order-by copies so callers cannot mutate the source definition', () => {
+    const orderBy = gpQualificationOrderBy();
+    orderBy[0].group = 'desc';
+
+    expect(gpQualificationOrderBy()).toEqual([
+      { group: 'asc' },
+      { score: 'desc' },
+      { points: 'desc' },
+    ]);
+  });
+
+  it('uses match score before driver points for client-side GP ranking', () => {
+    const entries = [
+      { id: 'driver-points-leader', score: 4, points: 99 },
+      { id: 'match-points-leader', score: 5, points: 1 },
+      { id: 'driver-points-tiebreaker', score: 4, points: 100 },
+    ];
+
+    expect([...entries].sort(compareGpQualificationEntries).map((entry) => entry.id)).toEqual([
+      'match-points-leader',
+      'driver-points-tiebreaker',
+      'driver-points-leader',
+    ]);
+  });
+
+  it('keeps GP routes and page-client wired to the shared ranking source', () => {
+    expect(readSource('src/lib/event-types/gp-config.ts')).toContain('gpQualificationOrderBy()');
+    expect(readSource('src/app/api/tournaments/[id]/gp/finals/route.ts')).toContain('gpQualificationOrderBy()');
+    expect(readSource('src/app/api/tournaments/[id]/gp/standings/route.ts')).toContain('gpStandingsOrderBy()');
+    expect(readSource('src/app/tournaments/[id]/gp/page-client.tsx')).toContain('compareGpQualificationEntries');
+  });
+});

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/finals/route.ts
@@ -9,6 +9,7 @@ import { withApiTiming } from '@/lib/perf/api-timing';
 import { createFinalsHandlers } from '@/lib/api-factories/finals-route';
 import { getGpFinalsTargetWins } from '@/lib/finals-target-wins';
 import { CUPS, DRIVER_POINTS } from '@/lib/constants';
+import { gpQualificationOrderBy } from '@/lib/gp-ranking';
 
 type GpCupResultInput = {
   cup?: unknown;
@@ -91,7 +92,7 @@ const { GET: _GET, POST, PUT, PATCH } = createFinalsHandlers({
   // GP uses match points first, then driver points (per requirements.md Section 4.1)
   /* `group: 'asc'` is first so that Top-24 → Top-16 Playoff (#454) can pick
    * per-group Top-N deterministically. Within-group order: score → points. */
-  qualificationOrderBy: [{ group: 'asc' }, { score: 'desc' }, { points: 'desc' }],
+  qualificationOrderBy: gpQualificationOrderBy(),
   getStyle: 'paginated',
   putScoreFields: { dbField1: 'points1', dbField2: 'points2' },
   putAdditionalFields: ['races', 'cup', 'cupResults', 'tvNumber'],

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/standings/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/standings/route.ts
@@ -13,6 +13,7 @@
 
 import { withApiTiming } from '@/lib/perf/api-timing';
 import { createStandingsHandlers } from '@/lib/api-factories/standings-route';
+import { gpStandingsOrderBy } from '@/lib/gp-ranking';
 
 const { GET: _GET } = createStandingsHandlers({
   loggerName: 'gp-standings-api',
@@ -21,7 +22,7 @@ const { GET: _GET } = createStandingsHandlers({
   usePagination: false,
   // GP ranking uses match score (Win=2, Tie=1, Loss=0) first,
   // with driver points as tiebreaker.
-  orderBy: [{ score: 'desc' }, { points: 'desc' }],
+  orderBy: gpStandingsOrderBy(),
   // H2H tiebreaker (requirements §4.1 step 3): resolve tied players by direct match results
   // GP matches store driver points as points1/points2 (not score1/score2 like BM/MR)
   matchModel: 'gPMatch',

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
@@ -74,6 +74,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { COURSE_INFO, CUPS, CUP_SUBSTITUTIONS, GP_POSITION_OPTIONS, POLLING_INTERVAL, TOTAL_GP_RACES, TV_NUMBER_OPTIONS, getDriverPoints, type CourseAbbr } from "@/lib/constants";
 import { formatGpPosition } from "@/lib/gp-utils";
+import { compareGpQualificationEntries } from "@/lib/gp-ranking";
 import { fetchAllPlayersForSetup, resolveAllPlayers } from "@/lib/qualification-page-data";
 import { usePolling } from "@/lib/hooks/usePolling";
 import type { QualInitialData } from "@/lib/api-factories/qual-initial-data";
@@ -784,7 +785,7 @@ export default function GrandPrixPageClient({
                       // GP: match score primary, driver points secondary.
                       const byEffectiveRank = computeTieAwareRanks(
                         groupEntries,
-                        (a, b) => b.score - a.score || b.points - a.points
+                        compareGpQualificationEntries
                       );
                       const tiedIds = findUnresolvedTies(byEffectiveRank);
                       // Suppress trivial 0-0 ties: only flag players who have actually played.
@@ -886,7 +887,7 @@ export default function GrandPrixPageClient({
                 {(() => {
                   const combinedRankings = computeCombinedRanks(
                     qualifications,
-                    (a, b) => b.score - a.score || b.points - a.points
+                    compareGpQualificationEntries
                   );
                   return (
                     <Table>

--- a/smkc-score-app/src/lib/event-types/gp-config.ts
+++ b/smkc-score-app/src/lib/event-types/gp-config.ts
@@ -16,6 +16,7 @@ import { AUDIT_ACTIONS } from '@/lib/audit-log';
 import { validateGPRacePosition } from '@/lib/score-validation';
 import { DRIVER_POINTS, CUPS, CUP_SUBSTITUTIONS, TOTAL_GP_RACES } from '@/lib/constants';
 import { updateWithRetry } from '@/lib/optimistic-locking';
+import { gpQualificationOrderBy } from '@/lib/gp-ranking';
 
 /**
  * Calculate driver points from race finishing positions.
@@ -69,7 +70,7 @@ export const gpConfig: EventTypeConfig = {
   loggerName: 'gp-api',
   eventDisplayName: 'grand prix',
   // Per requirements.md §4.1: GP ranks by match points first, then driver points within each group.
-  qualificationOrderBy: [{ group: 'asc' }, { score: 'desc' }, { points: 'desc' }],
+  qualificationOrderBy: gpQualificationOrderBy(),
   // §7.4: Pre-assign a cup to each qualification round at setup time.
   // Cups are shuffled 5 times and assigned sequentially without adjacent repeats.
   assignCupRandomly: true,

--- a/smkc-score-app/src/lib/gp-ranking.ts
+++ b/smkc-score-app/src/lib/gp-ranking.ts
@@ -1,0 +1,30 @@
+type SortDirection = 'asc' | 'desc';
+type OrderByClause = Record<string, SortDirection>;
+
+export interface GpRankableEntry {
+  score: number;
+  points: number;
+}
+
+export const GP_QUALIFICATION_ORDER_BY = [
+  { group: 'asc' },
+  { score: 'desc' },
+  { points: 'desc' },
+] as const satisfies readonly OrderByClause[];
+
+export const GP_STANDINGS_ORDER_BY = [
+  { score: 'desc' },
+  { points: 'desc' },
+] as const satisfies readonly OrderByClause[];
+
+export function gpQualificationOrderBy(): OrderByClause[] {
+  return GP_QUALIFICATION_ORDER_BY.map((clause) => ({ ...clause }));
+}
+
+export function gpStandingsOrderBy(): OrderByClause[] {
+  return GP_STANDINGS_ORDER_BY.map((clause) => ({ ...clause }));
+}
+
+export function compareGpQualificationEntries<T extends GpRankableEntry>(a: T, b: T): number {
+  return b.score - a.score || b.points - a.points;
+}


### PR DESCRIPTION
## Summary
- Add shared GP ranking order/comparator helpers for score-then-driver-points ordering
- Wire GP config, finals, standings, and page-client ranking paths to the shared source
- Add TC-728 scenario docs plus focused unit/docs drift coverage

## Issues
Closes #1125

## Validation
- npm test -- __tests__/lib/gp-ranking.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm test -- __tests__/lib/gp-ranking.test.ts __tests__/lib/event-types/gp-config.test.ts __tests__/app/api/tournaments/[id]/gp/standings/route.test.ts __tests__/app/api/tournaments/[id]/gp/route.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm test -- --runTestsByPath __tests__/app/api/tournaments/[id]/gp/standings/route.test.ts __tests__/app/api/tournaments/[id]/gp/route.test.ts __tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
- npm run lint
- git diff --check
- npx tsc --noEmit --pretty false --incremental false (fails on pre-existing e2e/test typing errors; no touched-file matches)

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.