### PR TITLE
Tighten GP ranking helper API

### DIFF
--- a/smkc-score-app/__tests__/lib/gp-ranking.test.ts
+++ b/smkc-score-app/__tests__/lib/gp-ranking.test.ts
@@ -6,10 +6,17 @@ import {
   gpStandingsOrderBy,
 } from '@/lib/gp-ranking';
 
-const root = process.cwd();
+const srcRoot = path.join(__dirname, '../../src');
 
 function readSource(relativePath: string): string {
-  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+  return fs.readFileSync(path.join(srcRoot, relativePath), 'utf8');
+}
+
+function expectSourceToUse(relativePath: string, symbol: string): void {
+  const source = readSource(relativePath);
+  if (!source.includes(symbol)) {
+    throw new Error(`${relativePath} should use ${symbol}`);
+  }
 }
 
 describe('gp-ranking', () => {
@@ -54,9 +61,9 @@ describe('gp-ranking', () => {
   });
 
   it('keeps GP routes and page-client wired to the shared ranking source', () => {
-    expect(readSource('src/lib/event-types/gp-config.ts')).toContain('gpQualificationOrderBy()');
-    expect(readSource('src/app/api/tournaments/[id]/gp/finals/route.ts')).toContain('gpQualificationOrderBy()');
-    expect(readSource('src/app/api/tournaments/[id]/gp/standings/route.ts')).toContain('gpStandingsOrderBy()');
-    expect(readSource('src/app/tournaments/[id]/gp/page-client.tsx')).toContain('compareGpQualificationEntries');
+    expectSourceToUse('lib/event-types/gp-config.ts', 'gpQualificationOrderBy()');
+    expectSourceToUse('app/api/tournaments/[id]/gp/finals/route.ts', 'gpQualificationOrderBy()');
+    expectSourceToUse('app/api/tournaments/[id]/gp/standings/route.ts', 'gpStandingsOrderBy()');
+    expectSourceToUse('app/tournaments/[id]/gp/page-client.tsx', 'compareGpQualificationEntries');
   });
 });

--- a/smkc-score-app/__tests__/lib/optimistic-locking.test.ts
+++ b/smkc-score-app/__tests__/lib/optimistic-locking.test.ts
@@ -203,17 +203,28 @@ describe('updateWithRetry', () => {
       clientVersion: '5.0.0',
     });
 
-    const startTime = Date.now();
+    const delays: number[] = [];
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout').mockImplementation((callback, delay) => {
+      delays.push(Number(delay));
+      if (typeof callback === 'function') {
+        callback();
+      }
+      return 0 as unknown as NodeJS.Timeout;
+    });
     let callCount = 0;
 
-    await updateWithRetry(mockPrisma, async () => {
-      callCount++;
-      if (callCount === 1) throw lockError;
-      return 'success';
-    }, { baseDelay: 10, maxDelay: 100 });
+    try {
+      await updateWithRetry(mockPrisma, async () => {
+        callCount++;
+        if (callCount === 1) throw lockError;
+        return 'success';
+      }, { baseDelay: 10, maxDelay: 100 });
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
 
-    const elapsedTime = Date.now() - startTime;
-    expect(elapsedTime).toBeGreaterThanOrEqual(10); // Should wait at least baseDelay
+    expect(delays).toHaveLength(1);
+    expect(delays[0]).toBeGreaterThanOrEqual(10); // Should wait at least baseDelay
   });
 });
 

--- a/smkc-score-app/src/lib/gp-ranking.ts
+++ b/smkc-score-app/src/lib/gp-ranking.ts
@@ -6,13 +6,13 @@ export interface GpRankableEntry {
   points: number;
 }
 
-export const GP_QUALIFICATION_ORDER_BY = [
+const GP_QUALIFICATION_ORDER_BY = [
   { group: 'asc' },
   { score: 'desc' },
   { points: 'desc' },
 ] as const satisfies readonly OrderByClause[];
 
-export const GP_STANDINGS_ORDER_BY = [
+const GP_STANDINGS_ORDER_BY = [
   { score: 'desc' },
   { points: 'desc' },
 ] as const satisfies readonly OrderByClause[];


### PR DESCRIPTION
## Summary
- Keep GP order-by constants private so callers use the defensive-copy helper functions
- Make gp-ranking wiring assertions independent of process.cwd() and include target file/symbol details on failure
- Stabilize the optimistic-locking retry delay test by asserting the requested timeout instead of wall-clock elapsed time

## Issues
Closes #1331
Closes #1332

## Validation
- npm test -- __tests__/lib/gp-ranking.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm test -- __tests__/lib/optimistic-locking.test.ts __tests__/lib/gp-ranking.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint -- --quiet
- git diff --check
- npx tsc --noEmit --pretty false --incremental false | rg gp-ranking... (no touched-file matches; command exits via rg when no matches)

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.