### PR TITLE
Use Jest assertion for GP ranking wiring test

### DIFF
--- a/smkc-score-app/__tests__/lib/gp-ranking.test.ts
+++ b/smkc-score-app/__tests__/lib/gp-ranking.test.ts
@@ -13,10 +13,7 @@ function readSource(relativePath: string): string {
 }
 
 function expectSourceToUse(relativePath: string, symbol: string): void {
-  const source = readSource(relativePath);
-  if (!source.includes(symbol)) {
-    throw new Error(`${relativePath} should use ${symbol}`);
-  }
+  expect(readSource(relativePath)).toContain(symbol);
 }
 
 describe('gp-ranking', () => {


### PR DESCRIPTION
## Summary
- Replace manual throw in the GP ranking wiring helper with Jest toContain assertion

## Issues
Closes #1334

## Validation
- npm test -- __tests__/lib/gp-ranking.test.ts
- npm run lint -- --quiet
- git diff --check

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.