### PR TITLE
Handle Wrangler auth/log preflight failures

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -226,7 +226,9 @@
   1. `smkc-score-app/` で `npm run e2e:preview` を実行する
   2. runner が `wrangler d1 execute DB --remote --env preview --json` で `Tournament.publicModes`、`GPMatch.assignedCups`、`GPMatch.suddenDeathWinnerId` を確認する
   3. 必須カラムが欠落している場合はブラウザを起動せず、`npm run db:migrations:apply:preview` を促すエラーで停止することを確認する
-  4. `GPMatch.assignedCups` と `GPMatch.suddenDeathWinnerId` が wrangler-format migration にも存在することを確認する
+  4. Wrangler の auth token 取得失敗や log file 書き込み失敗は schema 欠落として扱わず、`wrangler login` / `CLOUDFLARE_API_TOKEN` と `WRANGLER_LOG_PATH` の確認を促すことを確認する
+  5. runner が `WRANGLER_LOG_PATH` 未指定時に writable な一時ログパスを渡し、`~/Library/Preferences/.wrangler/logs` 権限で停止しないことを確認する
+  6. `GPMatch.assignedCups` と `GPMatch.suddenDeathWinnerId` が wrangler-format migration にも存在することを確認する
 - **期待結果**: preview D1 schema drift は TC 本体の 500 ではなく、起動前 preflight の明示エラーとして検出される
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
 - **補助検証**: `smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts`

--- a/smkc-score-app/README.md
+++ b/smkc-score-app/README.md
@@ -363,6 +363,14 @@ npm run e2e:preview:cleanup -- --dry-run
 npm run e2e:preview:bm
 ```
 
+The preview runner runs a D1 schema preflight before launching Chromium. It
+sets `WRANGLER_LOG_PATH` to a temporary writable file when the variable is not
+already set, so local macOS `.wrangler/logs` permissions do not block the
+schema check. If the preflight reports a Wrangler auth/log setup failure,
+refresh Wrangler auth with `wrangler login` or `CLOUDFLARE_API_TOKEN` and make
+sure `WRANGLER_LOG_PATH` points to a writable file. Only missing required D1
+columns should be handled with `npm run db:migrations:apply:preview`.
+
 If the fixed preview custom domain changes or DNS is not ready yet, you can
 override the target without editing the package scripts:
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -125,6 +125,8 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('Tournament.publicModes');
     expect(section).toContain('GPMatch.assignedCups');
     expect(section).toContain('GPMatch.suddenDeathWinnerId');
+    expect(section).toContain('WRANGLER_LOG_PATH');
+    expect(section).toContain('wrangler login');
   });
 
   it('documents TC-534 as BM Top-24 unresolved winner warning coverage', () => {

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -58,7 +58,40 @@ describe('preview schema preflight', () => {
     expect(spawnSyncMock).toHaveBeenCalledWith(
       'wrangler',
       expect.arrayContaining(['d1', 'execute', 'DB', '--remote', '--env', 'preview', '--json']),
-      expect.objectContaining({ encoding: 'utf8', timeout: preflight.WRANGLER_TIMEOUT_MS }),
+      expect.objectContaining({
+        encoding: 'utf8',
+        timeout: preflight.WRANGLER_TIMEOUT_MS,
+        env: expect.objectContaining({
+          PATH: expect.stringContaining('node_modules/.bin'),
+          WRANGLER_LOG_PATH: expect.stringContaining('jsmkc-wrangler-preflight.log'),
+        }),
+      }),
+    );
+  });
+
+  it('preserves an explicit Wrangler log path for preview preflight', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify([
+        {
+          results: [
+            { required_column: 'Tournament.publicModes' },
+            { required_column: 'GPMatch.assignedCups' },
+            { required_column: 'GPMatch.suddenDeathWinnerId' },
+          ],
+        },
+      ]),
+      stderr: '',
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({ WRANGLER_LOG_PATH: '/tmp/custom-wrangler.log' })).not.toThrow();
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'wrangler',
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({ WRANGLER_LOG_PATH: '/tmp/custom-wrangler.log' }),
+      }),
     );
   });
 
@@ -111,6 +144,22 @@ describe('preview schema preflight', () => {
     expect(() => preflight.assertPreviewD1Schema({})).toThrow(/db:migrations:apply:preview/);
   });
 
+  it('separates Wrangler auth and log setup failures from schema migration guidance', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: '',
+      stderr: [
+        "Failed to write to log file Error: EPERM: operation not permitted, open '/Users/me/Library/Preferences/.wrangler/logs/wrangler.log'",
+        'Failed to fetch auth token: 400 Bad Request',
+      ].join('\n'),
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({})).toThrow(/Wrangler auth\/log setup failed/);
+    expect(() => preflight.assertPreviewD1Schema({})).toThrow(/WRANGLER_LOG_PATH/);
+    expect(() => preflight.assertPreviewD1Schema({})).not.toThrow(/db:migrations:apply:preview/);
+  });
+
   it('fails with timeout guidance when wrangler hangs', () => {
     const preflight = loadPreflight();
     spawnSyncMock.mockReturnValue({
@@ -121,6 +170,18 @@ describe('preview schema preflight', () => {
     });
 
     expect(() => preflight.assertPreviewD1Schema({})).toThrow(/timed out after 30 seconds/);
+  });
+
+  it('fails with tool setup guidance when Wrangler is unavailable', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: null,
+      stdout: '',
+      stderr: '',
+      error: { code: 'ENOENT', message: 'spawnSync wrangler ENOENT' },
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({ PATH: '/usr/bin' })).toThrow(/Wrangler could not be started/);
   });
 
   it('keeps the missing GP sudden death column in Wrangler migrations', () => {

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -1,4 +1,6 @@
 const { spawnSync } = require('child_process');
+const os = require('os');
+const path = require('path');
 
 const REQUIRED_PREVIEW_COLUMNS = [
   { table: 'Tournament', column: 'publicModes' },
@@ -6,6 +8,7 @@ const REQUIRED_PREVIEW_COLUMNS = [
   { table: 'GPMatch', column: 'suddenDeathWinnerId' },
 ];
 const WRANGLER_TIMEOUT_MS = 30_000;
+const DEFAULT_WRANGLER_LOG_PATH = path.join(os.tmpdir(), 'jsmkc-wrangler-preflight.log');
 
 function buildPreviewSchemaCheckSql(columns = REQUIRED_PREVIEW_COLUMNS) {
   return columns
@@ -56,14 +59,37 @@ function parsePresentColumns(stdout) {
   );
 }
 
+function buildWranglerEnv(env = process.env) {
+  const localBinPath = path.join(process.cwd(), 'node_modules', '.bin');
+  const existingPath = env.PATH || '';
+  return {
+    ...env,
+    PATH: existingPath.split(path.delimiter).includes(localBinPath)
+      ? existingPath
+      : [localBinPath, existingPath].filter(Boolean).join(path.delimiter),
+    WRANGLER_LOG_PATH: env.WRANGLER_LOG_PATH || DEFAULT_WRANGLER_LOG_PATH,
+  };
+}
+
+function isWranglerAuthOrLogFailure(stderr) {
+  return [
+    /failed to write to log file/i,
+    /operation not permitted.*\.wrangler[/\\]logs/i,
+    /failed to fetch auth token/i,
+    /not logged in/i,
+    /wrangler login/i,
+  ].some((pattern) => pattern.test(stderr));
+}
+
 function assertPreviewD1Schema(env = process.env) {
   if (env.E2E_SKIP_PREVIEW_SCHEMA_PREFLIGHT === '1') return;
 
   const sql = buildPreviewSchemaCheckSql();
+  const wranglerEnv = buildWranglerEnv(env);
   const result = spawnSync(
     'wrangler',
     ['d1', 'execute', 'DB', '--remote', '--env', 'preview', '--json', '--command', sql],
-    { encoding: 'utf8', cwd: process.cwd(), env, timeout: WRANGLER_TIMEOUT_MS },
+    { encoding: 'utf8', cwd: process.cwd(), env: wranglerEnv, timeout: WRANGLER_TIMEOUT_MS },
   );
 
   if (result.error?.code === 'ETIMEDOUT') {
@@ -75,8 +101,30 @@ function assertPreviewD1Schema(env = process.env) {
     );
   }
 
+  if (result.error) {
+    throw new Error(
+      [
+        'Preview D1 schema preflight failed before launching the browser because Wrangler could not be started.',
+        `Error ${result.error.code || 'UNKNOWN'}: ${result.error.message}`,
+        'Run npm install in smkc-score-app or run through npm run e2e:preview so node_modules/.bin/wrangler is available.',
+      ].join(' '),
+    );
+  }
+
   if (result.status !== 0) {
     const stderr = String(result.stderr || '').trim();
+    if (isWranglerAuthOrLogFailure(stderr)) {
+      throw new Error(
+        [
+          'Preview D1 schema preflight failed before launching the browser because Wrangler auth/log setup failed.',
+          `Command exited ${result.status}.`,
+          stderr ? `stderr: ${stderr}` : '',
+          `WRANGLER_LOG_PATH=${wranglerEnv.WRANGLER_LOG_PATH}`,
+          'Refresh Wrangler auth with wrangler login or CLOUDFLARE_API_TOKEN, ensure WRANGLER_LOG_PATH is writable, then retry npm run e2e:preview.',
+        ].filter(Boolean).join(' '),
+      );
+    }
+
     throw new Error(
       [
         'Preview D1 schema preflight failed before launching the browser.',
@@ -105,7 +153,10 @@ function assertPreviewD1Schema(env = process.env) {
 module.exports = {
   REQUIRED_PREVIEW_COLUMNS,
   assertPreviewD1Schema,
+  buildWranglerEnv,
   buildPreviewSchemaCheckSql,
+  DEFAULT_WRANGLER_LOG_PATH,
+  isWranglerAuthOrLogFailure,
   parsePresentColumns,
   WRANGLER_TIMEOUT_MS,
 };


### PR DESCRIPTION
## Summary
- Add TC-111 coverage for Wrangler auth/log setup failures and the writable preflight log path.
- Make preview D1 preflight pass a local `node_modules/.bin` PATH and default `WRANGLER_LOG_PATH` to a temp file.
- Separate Wrangler auth/log/tool setup failures from actual preview D1 schema-missing guidance.

## Issues
Closes #1329

## Validation
- `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `node --check e2e/lib/preview-schema-preflight.js`
- `git diff --check`
- `npm run lint -- --quiet`
- `node -e "try { require('./e2e/lib/preview-schema-preflight').assertPreviewD1Schema(process.env); console.log('preflight ok'); } catch (error) { console.error(error instanceof Error ? error.message : error); process.exit(1); }"` (expected local auth failure now classified as Wrangler auth/log setup, with temp `WRANGLER_LOG_PATH`)
