### PR TITLE
Tighten preview preflight diagnostics

### DIFF
--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -95,6 +95,14 @@ describe('preview schema preflight', () => {
     );
   });
 
+  it('does not duplicate the local Wrangler bin path when it is already present', () => {
+    const preflight = loadPreflight();
+    const localBinPath = path.join(process.cwd(), 'node_modules', '.bin');
+    const built = preflight.buildWranglerEnv({ PATH: [localBinPath, '/usr/bin'].join(path.delimiter) });
+
+    expect(built.PATH.split(path.delimiter).filter((entry) => entry === localBinPath)).toHaveLength(1);
+  });
+
   it('does not trust non-json stdout that merely mentions required column names', () => {
     const preflight = loadPreflight();
 
@@ -144,6 +152,13 @@ describe('preview schema preflight', () => {
     expect(() => preflight.assertPreviewD1Schema({})).toThrow(/db:migrations:apply:preview/);
   });
 
+  it('does not classify generic wrangler login help text as an auth failure', () => {
+    const preflight = loadPreflight();
+
+    expect(preflight.isWranglerAuthOrLogFailure('Run wrangler login if you need account access.')).toBe(false);
+    expect(preflight.isWranglerAuthOrLogFailure('Failed to fetch auth token: 400 Bad Request')).toBe(true);
+  });
+
   it('separates Wrangler auth and log setup failures from schema migration guidance', () => {
     const preflight = loadPreflight();
     spawnSyncMock.mockReturnValue({
@@ -155,9 +170,20 @@ describe('preview schema preflight', () => {
       ].join('\n'),
     });
 
-    expect(() => preflight.assertPreviewD1Schema({})).toThrow(/Wrangler auth\/log setup failed/);
-    expect(() => preflight.assertPreviewD1Schema({})).toThrow(/WRANGLER_LOG_PATH/);
-    expect(() => preflight.assertPreviewD1Schema({})).not.toThrow(/db:migrations:apply:preview/);
+    let message = '';
+    try {
+      preflight.assertPreviewD1Schema({});
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toMatch(/Wrangler auth\/log setup failed/);
+    expect(message).toMatch(/WRANGLER_LOG_PATH/);
+    expect(message).not.toMatch(/db:migrations:apply:preview/);
+    expect(message.split('\n')).toEqual(expect.arrayContaining([
+      expect.stringMatching(/Command exited 1/),
+      expect.stringMatching(/WRANGLER_LOG_PATH=/),
+    ]));
   });
 
   it('fails with timeout guidance when wrangler hangs', () => {

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -77,8 +77,11 @@ function isWranglerAuthOrLogFailure(stderr) {
     /operation not permitted.*\.wrangler[/\\]logs/i,
     /failed to fetch auth token/i,
     /not logged in/i,
-    /wrangler login/i,
   ].some((pattern) => pattern.test(stderr));
+}
+
+function formatPreflightError(lines) {
+  return lines.filter(Boolean).join('\n');
 }
 
 function assertPreviewD1Schema(env = process.env) {
@@ -94,20 +97,20 @@ function assertPreviewD1Schema(env = process.env) {
 
   if (result.error?.code === 'ETIMEDOUT') {
     throw new Error(
-      [
+      formatPreflightError([
         `Preview D1 schema preflight timed out after ${WRANGLER_TIMEOUT_MS / 1000} seconds before launching the browser.`,
         'Check Cloudflare/Wrangler connectivity, run npm run db:migrations:apply:preview if needed, then retry npm run e2e:preview.',
-      ].join(' '),
+      ]),
     );
   }
 
   if (result.error) {
     throw new Error(
-      [
+      formatPreflightError([
         'Preview D1 schema preflight failed before launching the browser because Wrangler could not be started.',
         `Error ${result.error.code || 'UNKNOWN'}: ${result.error.message}`,
         'Run npm install in smkc-score-app or run through npm run e2e:preview so node_modules/.bin/wrangler is available.',
-      ].join(' '),
+      ]),
     );
   }
 
@@ -115,23 +118,23 @@ function assertPreviewD1Schema(env = process.env) {
     const stderr = String(result.stderr || '').trim();
     if (isWranglerAuthOrLogFailure(stderr)) {
       throw new Error(
-        [
+        formatPreflightError([
           'Preview D1 schema preflight failed before launching the browser because Wrangler auth/log setup failed.',
           `Command exited ${result.status}.`,
           stderr ? `stderr: ${stderr}` : '',
           `WRANGLER_LOG_PATH=${wranglerEnv.WRANGLER_LOG_PATH}`,
           'Refresh Wrangler auth with wrangler login or CLOUDFLARE_API_TOKEN, ensure WRANGLER_LOG_PATH is writable, then retry npm run e2e:preview.',
-        ].filter(Boolean).join(' '),
+        ]),
       );
     }
 
     throw new Error(
-      [
+      formatPreflightError([
         'Preview D1 schema preflight failed before launching the browser.',
         `Command exited ${result.status}.`,
         stderr ? `stderr: ${stderr}` : '',
         'Run npm run db:migrations:apply:preview, then retry npm run e2e:preview.',
-      ].filter(Boolean).join(' '),
+      ]),
     );
   }
 
@@ -142,10 +145,10 @@ function assertPreviewD1Schema(env = process.env) {
 
   if (missing.length > 0) {
     throw new Error(
-      [
+      formatPreflightError([
         `Preview D1 schema is missing required columns: ${missing.join(', ')}.`,
         'Run npm run db:migrations:apply:preview before npm run e2e:preview.',
-      ].join(' '),
+      ]),
     );
   }
 }
@@ -156,6 +159,7 @@ module.exports = {
   buildWranglerEnv,
   buildPreviewSchemaCheckSql,
   DEFAULT_WRANGLER_LOG_PATH,
+  formatPreflightError,
   isWranglerAuthOrLogFailure,
   parsePresentColumns,
   WRANGLER_TIMEOUT_MS,


### PR DESCRIPTION
## Summary
- Remove the broad `wrangler login` auth/log classifier pattern to avoid schema-error misclassification.
- Format preview preflight errors with newlines instead of single-line space joins.
- Add direct coverage for PATH deduplication in `buildWranglerEnv`.

## Issues
Closes #1338
Closes #1339
Closes #1340

## Validation
- `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
- `node --check e2e/lib/preview-schema-preflight.js`
- `git diff --check`
- `npm run lint -- --quiet`
- `node -e "try { require('./e2e/lib/preview-schema-preflight').assertPreviewD1Schema(process.env); console.log('preflight ok'); } catch (error) { console.error(error instanceof Error ? error.message : error); process.exit(1); }"` (expected local auth failure remains classified as Wrangler auth/log setup and is newline-formatted)
