### PR TITLE
Keep preflight formatter private

### DIFF
--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -159,7 +159,6 @@ module.exports = {
   buildWranglerEnv,
   buildPreviewSchemaCheckSql,
   DEFAULT_WRANGLER_LOG_PATH,
-  formatPreflightError,
   isWranglerAuthOrLogFailure,
   parsePresentColumns,
   WRANGLER_TIMEOUT_MS,


### PR DESCRIPTION
## Summary
- Keep `formatPreflightError` private by removing its unused CommonJS export.

## Issues
Closes #1342

## Validation
- `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
- `node --check e2e/lib/preview-schema-preflight.js`
- `git diff --check`
