### PR TITLE
test: cover bracket qualification labels

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1277,6 +1277,18 @@
 - **期待結果**: Phase 2 preview は未解決 winner を黙って無視せず、原因調査に使える warning を残す
 - **スクリプト**: n/a（server-side warning のため `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts` で検証）
 
+## TC-535: BM Top-24 playoff — 予選グループ順位ラベル表示
+- **URL**: /tournaments/[id]/bm/finals
+- **authRequired**: true (admin)
+- **背景**: Top-24 playoff と Phase 2 finals preview は、紙の組み合わせ表に合わせて seed 番号だけでなく `A8` / `B7` などの予選グループ内順位ラベルを表示する。`buildQualificationRankLabelMap` は各グループ内で順位順に並んだ qualification 入力からこのラベルを作るため、入力順と UI 表示の両方を固定する。
+- **手順**:
+  1. 28名 BM 予選を作成し、2グループの順位を確定する
+  2. Top-24 playoff を生成し、`playoffSeededPlayers` が barrage seed ごとに `qualificationRankLabel` を持つことを確認する
+  3. playoff Round 1/2 の表示で seed 番号 `[1]` ではなく group-rank ラベル `[A9]` / `[B12]` 等が表示されることを確認する
+  4. playoff 完了後に Phase 2 finals を生成し、direct seed 側も `qualificationRankLabel` を保持していることを確認する
+- **期待結果**: Top-24 playoff と Phase 2 finals のシード表示は、seed 番号ではなく予選グループ順位ラベルを優先する
+- **スクリプト**: tc-bm.js TC-510（API payload の `qualificationRankLabel` を検証） + `smkc-score-app/__tests__/components/tournament/playoff-bracket.test.tsx`（UI 表示を検証）
+
 ---
 
 ## MR (Match Race) フルワークフローテスト

--- a/smkc-score-app/__tests__/components/tournament/playoff-bracket.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/playoff-bracket.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { PlayoffBracket } from "@/components/tournament/playoff-bracket";
+
+const seededPlayers = [
+  { seed: 1, playerId: "p1", player: { id: "p1", name: "Alice A", nickname: "Alice" }, qualificationRankLabel: "A9" },
+  { seed: 2, playerId: "p2", player: { id: "p2", name: "Bob B", nickname: "Bob" }, qualificationRankLabel: "B12" },
+  { seed: 5, playerId: "p5", player: { id: "p5", name: "Carol C", nickname: "Carol" }, qualificationRankLabel: "B8" },
+];
+
+const playoffStructure = [
+  { matchNumber: 1, round: "playoff_r1", bracket: "winners" as const, player1Seed: 1, player2Seed: 2 },
+  { matchNumber: 5, round: "playoff_r2", bracket: "winners" as const, player1Seed: 5, player2Seed: 1, advancesToUpperSeed: 16 },
+];
+
+describe("PlayoffBracket qualification rank labels", () => {
+  it("prefers group-rank labels over raw seed numbers", () => {
+    render(
+      <PlayoffBracket
+        playoffMatches={[]}
+        playoffStructure={playoffStructure}
+        roundNames={{ playoff_r1: "Round 1", playoff_r2: "Round 2" }}
+        seededPlayers={seededPlayers}
+      />,
+    );
+
+    const round1Match = screen.getByRole("button", {
+      name: /Match 1: Alice vs Bob/,
+    });
+    expect(round1Match.textContent).toContain("[A9]");
+    expect(round1Match.textContent).toContain("[B12]");
+    expect(round1Match.textContent).not.toContain("[1]");
+    expect(round1Match.textContent).not.toContain("[2]");
+
+    const round2Match = screen.getByRole("button", {
+      name: /Match 5: Carol vs Alice/,
+    });
+    expect(round2Match.textContent).toContain("[B8]");
+    expect(round2Match.textContent).toContain("[A9]");
+    expect(round2Match.textContent).not.toContain("[5]");
+  });
+
+  it("falls back to raw seed numbers when group-rank labels are absent", () => {
+    render(
+      <PlayoffBracket
+        playoffMatches={[]}
+        playoffStructure={[playoffStructure[0]]}
+        roundNames={{ playoff_r1: "Round 1", playoff_r2: "Round 2" }}
+        seededPlayers={seededPlayers.map(({ qualificationRankLabel, ...entry }) => entry)}
+      />,
+    );
+
+    const round1Match = screen.getByRole("button", {
+      name: /Match 1: Alice vs Bob/,
+    });
+
+    expect(round1Match.textContent).toContain("[1]");
+    expect(round1Match.textContent).toContain("[2]");
+    expect(round1Match.textContent).not.toContain("[A9]");
+    expect(round1Match.textContent).not.toContain("[B12]");
+  });
+});

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -26,6 +26,7 @@ function sectionFor(tc: string) {
 
 describe('E2E case drift coverage', () => {
   const tcAll = readE2eScript('tc-all.js');
+  const tcBm = readE2eScript('tc-bm.js');
   const tcGp = readE2eScript('tc-gp.js');
   const tcOverlay = readE2eScript('tc-overlay.js');
   const tcDebugFill = readE2eScript('tc-debug-fill.js');
@@ -139,6 +140,18 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('advancesToUpperSeed');
     expect(section).toContain('finals-route.test.ts');
     expect(section).toContain('server-side warning');
+  });
+
+  it('documents TC-535 as BM Top-24 qualification label coverage', () => {
+    const section = sectionFor('TC-535');
+
+    expect(section).toContain('qualificationRankLabel');
+    expect(section).toContain('buildQualificationRankLabelMap');
+    expect(section).toContain('tc-bm.js TC-510');
+    expect(section).toContain('playoff-bracket.test.tsx');
+    expect(tcBm).toContain('qualificationRankLabel');
+    expect(tcBm).toContain('playoffSeedLabelsOk');
+    expect(tcBm).toContain('directSeedLabelsOk');
   });
 
   it('does not leave retired TC identifiers in runnable E2E scripts as false drift signals', () => {

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -25,6 +25,7 @@
  *   TC-530  BM finals/playoff legacy null repair on GET (#728)
  *   TC-532  BM qualification standings show 0-1000 qualification points
  *   TC-533  BM combined standings tab shows rows with ascending ranks
+ *   TC-535  BM Top-24 playoff seed labels use group-rank labels
  *
  * Setup:
  *   - Uses Playwright persistent profile at /tmp/playwright-smkc-preview-profile by default.
@@ -205,8 +206,14 @@ function expectedTwoGroupPaperSeedIds(qualifications) {
     directSeeds: directTokensByUpperSeed.map(([seed, token]) => ({
       seed,
       playerId: playerIdForToken(token),
+      qualificationRankLabel: token,
     })),
     barrage: barrageTokensBySeed.map(playerIdForToken),
+    barrageSeeds: barrageTokensBySeed.map((token, index) => ({
+      seed: index + 1,
+      playerId: playerIdForToken(token),
+      qualificationRankLabel: token,
+    })),
     barrageBlocks: [
       ['A9', 'B12', 'B8'],
       ['B10', 'A11', 'A7'],
@@ -878,6 +885,10 @@ async function runTc510(adminPage) {
     const expectedSeedIds = expectedTwoGroupPaperSeedIds(bmQualificationData.qualifications || []);
     const playoffSeedIds = (phase1Data.playoffSeededPlayers || []).map((p) => p.playerId);
     const playoffSeedOrderOk = playoffSeedIds.join(',') === expectedSeedIds.barrage.join(',');
+    const playoffSeedLabelsOk = expectedSeedIds.barrageSeeds.every(({ seed, playerId, qualificationRankLabel }) => {
+      const seeded = (phase1Data.playoffSeededPlayers || []).find((p) => p.seed === seed);
+      return seeded?.playerId === playerId && seeded?.qualificationRankLabel === qualificationRankLabel;
+    });
 
     let state = await apiFetchBmFinalsState(adminPage, tournamentId);
     const r1 = state.playoffMatches.filter((m) => m.round === 'playoff_r1');
@@ -944,6 +955,10 @@ async function runTc510(adminPage) {
       const seeded = seededPlayers.find((p) => p.seed === seed);
       return seeded?.playerId === playerId;
     });
+    const directSeedLabelsOk = expectedSeedIds.directSeeds.every(({ seed, qualificationRankLabel }) => {
+      const seeded = seededPlayers.find((p) => p.seed === seed);
+      return seeded?.qualificationRankLabel === qualificationRankLabel;
+    });
     const playoffWinnersSeeded = [10, 12, 14, 16].every((seed) => {
       const seeded = seededPlayers.find((p) => p.seed === seed);
       return seeded?.playerId === r2WinnersByUpperSeed.get(seed);
@@ -954,17 +969,19 @@ async function runTc510(adminPage) {
       state.matches.length === 31 &&
       state.bracketSize === 16 &&
       directSeedOrderOk &&
+      directSeedLabelsOk &&
       playoffWinnersSeeded;
 
-    const ok = playoffCreated && playoffSeedOrderOk && playoffBlocksOk && phase2Blocked && r1Routed && playoffCompleteSignal && finalsCreated;
+    const ok = playoffCreated && playoffSeedOrderOk && playoffSeedLabelsOk && playoffBlocksOk && phase2Blocked && r1Routed && playoffCompleteSignal && finalsCreated;
     log('TC-510', ok ? 'PASS' : 'FAIL',
       !playoffCreated ? `playoff=${state.playoffMatches.length} finals=${state.matches.length} r1=${r1.length} r2=${r2.length}`
       : !playoffSeedOrderOk ? `playoff seed order mismatch expected=${expectedSeedIds.barrage.join(',')} actual=${playoffSeedIds.join(',')}`
+      : !playoffSeedLabelsOk ? `playoff qualification labels mismatch expected=${JSON.stringify(expectedSeedIds.barrageSeeds)} actual=${JSON.stringify(phase1Data.playoffSeededPlayers || [])}`
       : !playoffBlocksOk ? `playoff blocks mismatch expected=${JSON.stringify(expectedSeedIds.barrageBlocks)}`
       : !phase2Blocked ? `Phase 2 was not blocked before completion (${blocked.s}, ${blocked.b?.code || blocked.b?.error})`
       : !r1Routed ? 'R1 winner did not route into R2 player2'
       : !playoffCompleteSignal ? 'Last R2 PUT did not signal playoffComplete=true'
-      : !finalsCreated ? `finals=${state.matches.length} bracketSize=${state.bracketSize} directSeedOrder=${directSeedOrderOk} winnersSeeded=${playoffWinnersSeeded}`
+      : !finalsCreated ? `finals=${state.matches.length} bracketSize=${state.bracketSize} directSeedOrder=${directSeedOrderOk} directSeedLabels=${directSeedLabelsOk} winnersSeeded=${playoffWinnersSeeded}`
       : '');
   } catch (err) {
     log('TC-510', 'FAIL', err instanceof Error ? err.message : 'BM 510 failed');

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -30,6 +30,7 @@ import { cn } from "@/lib/utils";
 import { TV_NUMBER_OPTIONS } from "@/lib/constants";
 
 import type { Player } from "@/lib/types";
+import type { SeededPlayer } from "@/types/bracket";
 
 /** BM match data from the database including player relations */
 interface BMMatch {
@@ -72,7 +73,7 @@ interface DoubleEliminationBracketProps {
   /** Optional callback when a match card is clicked (for score entry) */
   onMatchClick?: (match: BMMatch) => void;
   /** Optional seeded player data for displaying qualification labels */
-  seededPlayers?: { seed: number; playerId: string; player: Player; qualificationRankLabel?: string }[];
+  seededPlayers?: SeededPlayer[];
   /** Number of wins required to highlight a completed match winner. */
   getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
   /**
@@ -106,7 +107,7 @@ function MatchCard({
 }: {
   match?: BMMatch;
   bracketMatch: BracketMatch;
-  seededPlayers?: { seed: number; playerId: string; player: Player; qualificationRankLabel?: string }[];
+  seededPlayers?: SeededPlayer[];
   onClick?: () => void;
   isTBD: { player1: boolean; player2: boolean };
   getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;

--- a/smkc-score-app/src/components/tournament/playoff-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/playoff-bracket.tsx
@@ -25,6 +25,7 @@ import { cn } from "@/lib/utils";
 import { TV_NUMBER_OPTIONS } from "@/lib/constants";
 
 import type { Player } from "@/lib/types";
+import type { SeededPlayer } from "@/types/bracket";
 
 /** BM match data from the database including player relations */
 interface BMMatch {
@@ -66,7 +67,7 @@ interface PlayoffBracketProps {
   /** Optional callback when a match card is clicked (for score entry) */
   onMatchClick?: (match: BMMatch) => void;
   /** Seeded player data for displaying qualification labels */
-  seededPlayers?: { seed: number; playerId: string; player: Player; qualificationRankLabel?: string }[];
+  seededPlayers?: SeededPlayer[];
   /** Number of wins required to highlight a completed match winner */
   getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
   /** See `DoubleEliminationBracket.onTvNumberChange` — same select-to-save UX. */
@@ -90,7 +91,7 @@ function PlayoffMatchCard({
 }: {
   match?: BMMatch;
   bracketMatch: BracketMatch;
-  seededPlayers?: { seed: number; playerId: string; player: Player; qualificationRankLabel?: string }[];
+  seededPlayers?: SeededPlayer[];
   onClick?: () => void;
   isPlayer1TBD: boolean;
   isPlayer2TBD: boolean;

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -710,6 +710,9 @@ export function createFinalsHandlers(config: FinalsConfig) {
   function buildQualificationRankLabelMap(
     qualifications: Array<{ playerId: string; group?: string | null }>,
   ): Map<string, string> {
+    /* Callers must pass qualifications already ordered by qualification rank
+     * within each group. The loop below derives A1/A2/B1 labels by counting
+     * the rows in that order rather than re-sorting here. */
     const rankByPlayerId = new Map<string, string>();
     const groupCounts = new Map<string, number>();
 

--- a/smkc-score-app/src/types/bracket.ts
+++ b/smkc-score-app/src/types/bracket.ts
@@ -14,6 +14,8 @@
  *   import type { BracketMatch, BracketRound } from '@/types/bracket';
  */
 
+import type { Player } from "@/lib/types";
+
 /** Bracket type for double elimination tournament */
 export type BracketType = "winners" | "losers" | "grand_final";
 
@@ -55,4 +57,12 @@ export interface BracketMatch {
    * playoff round matches (playoff_r2) whose winners advance to Upper Bracket.
    */
   advancesToUpperSeed?: number;
+}
+
+/** Seeded player payload used by finals bracket components. */
+export interface SeededPlayer {
+  seed: number;
+  playerId: string;
+  player: Player;
+  qualificationRankLabel?: string;
 }


### PR DESCRIPTION
## Summary
- Add TC-535 scenario coverage for BM Top-24 qualification rank labels in playoff/finals seed payloads.
- Share the `SeededPlayer` bracket type between playoff and double-elimination components.
- Add PlayoffBracket qualification label/fallback unit coverage and document the rank-label map ordering precondition.

## Issues
Closes #1119
Closes #1120
Closes #1121

## Validation
- `node --check smkc-score-app/e2e/tc-bm.js`
- `npm test -- --runTestsByPath __tests__/components/tournament/playoff-bracket.test.tsx __tests__/components/tournament/double-elimination-bracket.test.tsx __tests__/docs/e2e-cases-drift.test.ts`
- `git diff --check`
- `npm run lint -- --quiet`

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
