### PR TITLE
fix: harden qualification rank labels

### DIFF
--- a/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
@@ -168,6 +168,8 @@ describe("DoubleEliminationBracket TBD rendering (issue #574)", () => {
     expect(winnersQF1).toBeDefined();
     expect(winnersQF1!.textContent).toContain(seed1.nickname);
     expect(winnersQF1!.textContent).toContain(seed8.nickname);
+    expect(winnersQF1!.textContent).toContain("[1]");
+    expect(winnersQF1!.textContent).toContain("[8]");
   });
 
   it("shows qualification group-rank labels when seeded players include them", () => {

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -708,15 +708,27 @@ export function createFinalsHandlers(config: FinalsConfig) {
   }
 
   function buildQualificationRankLabelMap(
-    qualifications: Array<{ playerId: string; group?: string | null }>,
+    qualifications: Array<{
+      playerId: string;
+      group?: string | null;
+      _rank?: number;
+      rankOverride?: number | null;
+    }>,
   ): Map<string, string> {
-    /* Callers must pass qualifications already ordered by qualification rank
-     * within each group. The loop below derives A1/A2/B1 labels by counting
-     * the rows in that order rather than re-sorting here. */
+    const orderedQualifications = qualifications
+      .map((qualification, index) => ({ qualification, index }))
+      .sort((a, b) => {
+        const groupCompare = (a.qualification.group ?? '').localeCompare(b.qualification.group ?? '');
+        if (groupCompare !== 0) return groupCompare;
+
+        const rankA = a.qualification._rank ?? a.qualification.rankOverride ?? Number.MAX_SAFE_INTEGER;
+        const rankB = b.qualification._rank ?? b.qualification.rankOverride ?? Number.MAX_SAFE_INTEGER;
+        return rankA - rankB || a.index - b.index;
+      });
     const rankByPlayerId = new Map<string, string>();
     const groupCounts = new Map<string, number>();
 
-    for (const q of qualifications) {
+    for (const { qualification: q } of orderedQualifications) {
       const group = q.group ?? '';
       const rank = (groupCounts.get(group) ?? 0) + 1;
       groupCounts.set(group, rank);


### PR DESCRIPTION
## Summary
- Sort qualification rank-label inputs by group and computed rank before assigning A1/B1 labels.
- Add DoubleEliminationBracket fallback assertions for raw seed labels when no group-rank label is present.

## Issues
Closes #1346
Closes #1347

## Validation
- `node --check smkc-score-app/e2e/tc-bm.js`
- `npm test -- --runTestsByPath __tests__/components/tournament/double-elimination-bracket.test.tsx __tests__/components/tournament/playoff-bracket.test.tsx __tests__/docs/e2e-cases-drift.test.ts`
- `git diff --check`
- `npm run lint -- --quiet`

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
