### PR TITLE
test: cover qualification label helper

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -31,7 +31,7 @@
  */
 // @ts-nocheck - This test file uses complex mock types that are difficult to type correctly
 
-import { createFinalsHandlers } from '@/lib/api-factories/finals-route';
+import { buildQualificationRankLabelMap, createFinalsHandlers } from '@/lib/api-factories/finals-route';
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { NextRequest } from 'next/server';
 
@@ -100,6 +100,50 @@ describe('Finals Route Factory', () => {
     points: 6,
     player: { id: 'player-1', name: 'Player 1' },
     ...overrides,
+  });
+
+  describe('buildQualificationRankLabelMap', () => {
+    it('assigns group labels from rank order even when input rows are shuffled', () => {
+      const labels = buildQualificationRankLabelMap([
+        { playerId: 'b2', group: 'B', _rank: 2 },
+        { playerId: 'a2', group: 'A', _rank: 2 },
+        { playerId: 'b1', group: 'B', _rank: 1 },
+        { playerId: 'a1', group: 'A', _rank: 1 },
+      ]);
+
+      expect(Object.fromEntries(labels)).toEqual({
+        a1: 'A1',
+        a2: 'A2',
+        b1: 'B1',
+        b2: 'B2',
+      });
+    });
+
+    it('keeps original order for tied ranks within the same group', () => {
+      const labels = buildQualificationRankLabelMap([
+        { playerId: 'a-first', group: 'A', _rank: 1 },
+        { playerId: 'a-second', group: 'A', _rank: 1 },
+        { playerId: 'a-third', group: 'A', _rank: 3 },
+      ]);
+
+      expect(Object.fromEntries(labels)).toEqual({
+        'a-first': 'A1',
+        'a-second': 'A2',
+        'a-third': 'A3',
+      });
+    });
+
+    it('uses numeric labels when qualifications have no group', () => {
+      const labels = buildQualificationRankLabelMap([
+        { playerId: 'p2', group: null, _rank: 2 },
+        { playerId: 'p1', group: null, _rank: 1 },
+      ]);
+
+      expect(Object.fromEntries(labels)).toEqual({
+        p1: '1',
+        p2: '2',
+      });
+    });
   });
 
   beforeEach(() => {

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -76,6 +76,36 @@ interface PublicFinalsPlayer {
   noCamera?: boolean;
 }
 
+export interface QualificationRankLabelInput {
+  playerId: string;
+  group?: string | null;
+  _rank: number;
+}
+
+export function buildQualificationRankLabelMap(
+  qualifications: QualificationRankLabelInput[],
+): Map<string, string> {
+  const orderedQualifications = qualifications
+    .map((qualification, index) => ({ qualification, index }))
+    .sort((a, b) => {
+      const groupCompare = (a.qualification.group ?? '').localeCompare(b.qualification.group ?? '');
+      if (groupCompare !== 0) return groupCompare;
+
+      return a.qualification._rank - b.qualification._rank || a.index - b.index;
+    });
+  const rankByPlayerId = new Map<string, string>();
+  const groupCounts = new Map<string, number>();
+
+  for (const { qualification: q } of orderedQualifications) {
+    const group = q.group ?? '';
+    const rank = (groupCounts.get(group) ?? 0) + 1;
+    groupCounts.set(group, rank);
+    rankByPlayerId.set(q.playerId, group ? `${group}${rank}` : `${rank}`);
+  }
+
+  return rankByPlayerId;
+}
+
 function isPublicFinalsPlayer(value: unknown): value is PublicFinalsPlayer {
   return Boolean(value && typeof value === 'object' && typeof (value as { id?: unknown }).id === 'string');
 }
@@ -705,37 +735,6 @@ export function createFinalsHandlers(config: FinalsConfig) {
       matches,
       { matchScoreFields: scoreFields },
     );
-  }
-
-  function buildQualificationRankLabelMap(
-    qualifications: Array<{
-      playerId: string;
-      group?: string | null;
-      _rank?: number;
-      rankOverride?: number | null;
-    }>,
-  ): Map<string, string> {
-    const orderedQualifications = qualifications
-      .map((qualification, index) => ({ qualification, index }))
-      .sort((a, b) => {
-        const groupCompare = (a.qualification.group ?? '').localeCompare(b.qualification.group ?? '');
-        if (groupCompare !== 0) return groupCompare;
-
-        const rankA = a.qualification._rank ?? a.qualification.rankOverride ?? Number.MAX_SAFE_INTEGER;
-        const rankB = b.qualification._rank ?? b.qualification.rankOverride ?? Number.MAX_SAFE_INTEGER;
-        return rankA - rankB || a.index - b.index;
-      });
-    const rankByPlayerId = new Map<string, string>();
-    const groupCounts = new Map<string, number>();
-
-    for (const { qualification: q } of orderedQualifications) {
-      const group = q.group ?? '';
-      const rank = (groupCounts.get(group) ?? 0) + 1;
-      groupCounts.set(group, rank);
-      rankByPlayerId.set(q.playerId, group ? `${group}${rank}` : `${rank}`);
-    }
-
-    return rankByPlayerId;
   }
 
   function getRoundAssignmentData(


### PR DESCRIPTION
## Summary
- Export `buildQualificationRankLabelMap` as a pure helper with `_rank` required in its input type.
- Add direct helper coverage for shuffled group rows, tied-rank stability, and ungrouped numeric labels.
- Remove the unreachable `rankOverride` fallback now that callers pass ranked qualification rows.

## Issues
Closes #1349
Closes #1350

## Validation
- `node --check smkc-score-app/e2e/tc-bm.js`
- `npm test -- --runTestsByPath __tests__/lib/api-factories/finals-route.test.ts __tests__/components/tournament/double-elimination-bracket.test.tsx __tests__/components/tournament/playoff-bracket.test.tsx`
- `git diff --check`
- `npm run lint -- --quiet`

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
