### PR TITLE
docs: document qualification label helper

### DIFF
--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -82,6 +82,14 @@ export interface QualificationRankLabelInput {
   _rank: number;
 }
 
+/**
+ * Builds the playerId -> qualification rank label map used by finals seed UI.
+ *
+ * Labels are assigned after grouping by `group` and ordering by computed
+ * `_rank`: grouped rows become `A1`, `B2`, etc.; ungrouped rows become `1`,
+ * `2`, etc. When rows in the same group have the same `_rank`, the original
+ * input order is kept so tied players receive deterministic adjacent labels.
+ */
 export function buildQualificationRankLabelMap(
   qualifications: QualificationRankLabelInput[],
 ): Map<string, string> {


### PR DESCRIPTION
## Summary
- Add JSDoc for `buildQualificationRankLabelMap`, including grouped, ungrouped, and tied-rank behavior.

## Issues
Closes #1352

## Validation
- `npm test -- --runTestsByPath __tests__/lib/api-factories/finals-route.test.ts`
- `git diff --check`
- `npm run lint -- --quiet`

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
