### PR TITLE
fix: make GP BREAK matches scoreable

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1648,6 +1648,20 @@
   6. クリーンアップ
 - **期待結果**: GP participant 入力でdriver points合計送信→永続化が動作
 
+## TC-729: GP奇数人数BREAK — ソロ走行ドライバーズポイント入力
+- **URL**: /tournaments/[temp-id]/gp
+- **authRequired**: true (admin)
+- **背景**: GP予選の奇数人数グループでは、BREAK相手の試合はBM/MRの不戦勝とは異なり、1人でカップを走って実際のドライバーズポイントをスコアとして記録する
+- **手順**:
+  1. 管理者セッションで一時トーナメントとGPプレイヤー3名を作成する
+  2. GP予選グループ設定で3名を同一グループに登録し、BREAK試合を生成する
+  3. BREAK試合が未完了で、GPカップが割り当てられていることを確認する
+  4. BREAK試合へ `{ matchId, cup, races }` をPUTし、P1の順位のみからドライバーズポイントを計算できることを確認する
+  5. API再取得でBREAK試合が completed、`points1` が実走ドライバーズポイント、`points2=0` として保存されていることを確認する
+  6. クリーンアップ
+- **期待結果**: GPのBREAKは自動45-0ではなく、ソロ走行の実ドライバーズポイントで順位表に反映される
+- **スクリプト**: tc-gp.js TC-729
+
 ## TC-703: GP予選28名フル + 決勝ブラケット生成・1試合スコア入力
 - **URL**: /tournaments/[temp-id]/gp/finals
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -40,6 +40,7 @@ describe('E2E case drift coverage', () => {
     ['TC-722', tcGp],
     ['TC-1103', tcGp],
     ['TC-725', tcGp],
+    ['TC-729', tcGp],
     ['TC-926', tcOverlay],
     ['TC-TA-FLOW-24', tcTaFlow],
   ])('keeps %s documented and registered in its runnable E2E script', (tc, scriptSource) => {

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -1012,8 +1012,8 @@ describe('Qualification Route Factory', () => {
     it('should assign unique cups while consuming the first GP qualification round deck', async () => {
       /*
        * With 3 players in one group (odd → BREAK added → 4 participants → 6 matches),
-       * there are 3 real rounds. They should consume the first shuffled cup
-       * deck without repeating before all 4 cups are used.
+       * there are 3 real rounds plus 3 scoreable GP solo BREAK cups. They
+       * should consume the first shuffled cup deck without adjacent repeats.
        */
       const players = [
         { playerId: 'player-1', group: 'A', seeding: 1 },
@@ -1056,17 +1056,39 @@ describe('Qualification Route Factory', () => {
       const createCall = (prisma.gPMatch as any).createMany.mock.calls[0];
       expect(createCall[0].data.length).toBe(6);
 
-      // BYE matches are auto-completed and skip cup assignment, so only real
-      // matches carry a cup. Filter out the byes before asserting cup coverage.
-      const realMatchCups = createCall[0].data
-        .filter((m: any) => !m.isBye)
-        .map((m: any) => m.cup);
-      realMatchCups.forEach((cup: string) => {
+      const matchCups = createCall[0].data.map((m: any) => m.cup);
+      matchCups.forEach((cup: string) => {
         expect(cupList).toContain(cup);
       });
-      // With 3 real rounds drawn from 4 shuffled cups, all should be unique.
-      const uniqueCups = new Set(realMatchCups);
-      expect(uniqueCups.size).toBe(realMatchCups.length);
+
+      const cupByRound = new Map<number, string>();
+      for (const row of createCall[0].data) {
+        const previous = cupByRound.get(row.roundNumber);
+        if (previous) {
+          expect(row.cup).toBe(previous);
+        } else {
+          cupByRound.set(row.roundNumber, row.cup);
+        }
+      }
+      const roundCups = [...cupByRound.entries()]
+        .sort(([a], [b]) => a - b)
+        .map(([, cup]) => cup);
+      for (let i = 1; i < roundCups.length; i++) {
+        expect(roundCups[i]).not.toBe(roundCups[i - 1]);
+      }
+
+      const byeMatches = createCall[0].data.filter((m: any) => m.isBye);
+      expect(byeMatches).toHaveLength(3);
+      byeMatches.forEach((match: any) => {
+        expect(match).toEqual(expect.objectContaining({
+          player2Id: '__BREAK__',
+          cup: expect.any(String),
+        }));
+        expect(match).not.toHaveProperty('completed');
+        expect(match).not.toHaveProperty('points1');
+        expect(match).not.toHaveProperty('points2');
+      });
+      expect(config.aggregatePlayerStats).not.toHaveBeenCalled();
     });
 
     it('should build GP qualification round cups from 5 shuffled full-cup decks', async () => {

--- a/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
+++ b/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
@@ -287,10 +287,15 @@ describe('Overall Ranking module', () => {
       expect(result.get('p1')?.normalizedPoints).toBe(1000);
     });
 
-    it('does not award GP qualification points when only BREAK matches are completed', async () => {
-      mockPrisma.gPMatch.findMany.mockResolvedValueOnce([]);
+    it('awards GP qualification points when only scoreable BREAK matches are completed', async () => {
+      mockPrisma.gPMatch.findMany.mockResolvedValueOnce([
+        { id: 'gp-bye-1' },
+      ]);
       mockPrisma.gPQualification.findMany.mockResolvedValue([
         { playerId: 'p1', wins: 1, ties: 0, losses: 0, mp: 1, points: 45, player: PLAYER_P1 },
+      ]);
+      getMockCalculateQualificationPointsFromMatches().mockReturnValue([
+        { playerId: 'p1', normalizedPoints: 1000 },
       ]);
 
       const result = await calculateGPQualificationPointsFromDB(
@@ -298,17 +303,18 @@ describe('Overall Ranking module', () => {
         TOURNAMENT_ID
       );
 
-      expect(result.size).toBe(0);
+      expect(result.get('p1')?.normalizedPoints).toBe(1000);
       expect(mockPrisma.gPMatch.findMany).toHaveBeenCalledWith(expect.objectContaining({
         where: expect.objectContaining({
           tournamentId: TOURNAMENT_ID,
           stage: 'qualification',
           completed: true,
-          isBye: false,
         }),
       }));
-      expect(mockPrisma.gPQualification.findMany).not.toHaveBeenCalled();
-      expect(getMockCalculateQualificationPointsFromMatches()).not.toHaveBeenCalled();
+      expect(mockPrisma.gPMatch.findMany.mock.calls[0][0].where).not.toHaveProperty('isBye');
+      expect(mockPrisma.gPQualification.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { tournamentId: TOURNAMENT_ID } })
+      );
     });
   });
 

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -22,6 +22,7 @@
  *   TC-831  GP finals added cup form can be removed without stale scores
  *   TC-723  GP qualification standings show 0-1000 qualification points
  *   TC-724  GP combined standings tab shows rows with point headers and ascending ranks
+ *   TC-729  GP odd-player BREAK stays scoreable as a solo driver-points cup
  *
  * Setup:
  *   - Uses Playwright persistent profile at /tmp/playwright-smkc-preview-profile by default.
@@ -210,6 +211,67 @@ async function runTc725(adminPage) {
     log('TC-725', 'FAIL', err instanceof Error ? err.message : 'GP 725 failed');
   } finally {
     if (setup) await setup.cleanup();
+  }
+}
+
+function makeSoloGpByeRaces(cup = 'Mushroom') {
+  const coursesByCup = {
+    Mushroom: ['MC1', 'DP1', 'GV1', 'BC1', 'MC2'],
+    Flower: ['CI1', 'GV2', 'DP2', 'BC2', 'MC3'],
+    Star: ['KB1', 'CI2', 'VL1', 'BC3', 'MC4'],
+    Special: ['DP3', 'KB2', 'GV3', 'VL2', 'RR'],
+  };
+  const courses = coursesByCup[cup] || coursesByCup.Mushroom;
+  return courses.map((course, index) => ({
+    course,
+    position1: index === 0 ? 1 : 2,
+    position2: 0,
+  }));
+}
+
+/* ───────── TC-729: GP odd-player BREAK is a scoreable solo cup ───────── */
+async function runTc729(adminPage) {
+  let tournamentId = null;
+  const players = [];
+  try {
+    const tournament = await uiCreateTournament(adminPage, `GP Solo BREAK ${Date.now()}`, 'gp-solo-break');
+    tournamentId = tournament.id;
+    for (let i = 0; i < 3; i++) {
+      players.push(await uiCreatePlayer(adminPage, `GP Solo ${Date.now()} ${i + 1}`));
+    }
+
+    await setupModePlayersViaUi(adminPage, 'gp', tournamentId, players);
+    const before = await apiFetchGp(adminPage, tournamentId);
+    const bye = (before.matches || []).find((m) => m.isBye && m.player2Id === '__BREAK__');
+    if (!bye) throw new Error('No GP BREAK match found for odd group');
+    if (!bye.cup) throw new Error('GP BREAK match has no assigned cup');
+
+    const soloRaces = makeSoloGpByeRaces(bye.cup);
+    const expectedPoints = 9 + 6 + 6 + 6 + 6;
+    const put = await apiPutGpQualScore(adminPage, tournamentId, bye.id, bye.cup, soloRaces);
+    const after = await apiFetchGp(adminPage, tournamentId);
+    const updated = (after.matches || []).find((m) => m.id === bye.id);
+    const qualification = (after.qualifications || []).find((q) => q.playerId === bye.player1Id);
+
+    const initiallyPending = bye.completed === false && (bye.points1 ?? 0) === 0 && (bye.points2 ?? 0) === 0;
+    const persisted = put.s === 200 &&
+      updated?.completed === true &&
+      updated.points1 === expectedPoints &&
+      updated.points2 === 0;
+    const standingsUpdated = qualification?.points === expectedPoints && qualification?.wins === 1;
+
+    log('TC-729', initiallyPending && persisted && standingsUpdated ? 'PASS' : 'FAIL',
+      !initiallyPending ? `initial BREAK completed=${bye.completed} points=${bye.points1}-${bye.points2}`
+      : !persisted ? `PUT=${put.s} updated=${updated?.points1}-${updated?.points2} completed=${updated?.completed}`
+      : !standingsUpdated ? `qualification points=${qualification?.points} wins=${qualification?.wins}`
+      : '');
+  } catch (err) {
+    log('TC-729', 'FAIL', err instanceof Error ? err.message : 'GP 729 failed');
+  } finally {
+    for (const player of players) {
+      await apiDeletePlayer(adminPage, player.id).catch(() => {});
+    }
+    if (tournamentId) await apiDeleteTournament(adminPage, tournamentId).catch(() => {});
   }
 }
 
@@ -1610,6 +1672,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-701', fn: runTc701 },
       { name: 'TC-724', fn: runTc724 },
       { name: 'TC-725', fn: runTc725 },
+      { name: 'TC-729', fn: runTc729 },
       { name: 'TC-703', fn: runTc703 },
       { name: 'TC-704', fn: runTc704 },
       { name: 'TC-705', fn: runTc705 },
@@ -1640,7 +1703,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 module.exports = {
   runTc701, runTc702, runTc703, runTc704, runTc705, runTc706,
   runTc707, runTc708, runTc709, runTc710, runTc712, runTc713,
-  runTc715, runTc716, runTc717, runTc718, runTc1103, runTc727, runTc719,
+  runTc715, runTc716, runTc717, runTc718, runTc1103, runTc727, runTc729, runTc719,
   runTc720, runTc721, runTc722, runTc724, runTc725, runTc821, runTc831, runTc832,
   gpAssignedCupSequence, gpFinalsUpdatedMatchFromPutResult,
   getSuite,

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -579,19 +579,22 @@ export function createQualificationHandlers(config: EventTypeConfig) {
            * BYE matches are auto-completed immediately (§10.2) and don't actually play
            * the courses, so skip assignment for BYE matches.
            */
+          const isScoreableGpBye = config.eventTypeCode === 'gp' && m.isBye;
           const isRealMatch = !m.isBye;
+          const shouldAssignPlayableCourse = isRealMatch || isScoreableGpBye;
           // MR: random per-round course draw shared by every match in that round
           // BM: fixed battle-course list (same for every real match)
-          const assignedCourses = shuffledCourses && isRealMatch
+          const assignedCourses = shuffledCourses && shouldAssignPlayableCourse
             ? getAssignedCoursesForRound(shuffledCourses, m.day)
-            : fixedCourses && isRealMatch
+            : fixedCourses && shouldAssignPlayableCourse
               ? fixedCourses
               : undefined;
 
           /* §7.4: Pick a cup from the shuffled list for this round (GP only) */
-          const assignedCup = shuffledCups && isRealMatch
+          const assignedCup = shuffledCups && shouldAssignPlayableCourse
             ? getAssignedCupForRound(shuffledCups, m.day)
             : undefined;
+          const autoCompleteBye = m.isBye && !isScoreableGpBye;
 
           matchData.push({
             tournamentId,
@@ -607,11 +610,15 @@ export function createQualificationHandlers(config: EventTypeConfig) {
             ...(assignedCourses ? { assignedCourses } : {}),
             /* Pre-assigned cup for the match (undefined for BM/MR without cup assignment) */
             ...(assignedCup ? { cup: assignedCup } : {}),
-            /* Auto-complete BYE matches with fixed scores (§10.2) */
-            ...(m.isBye ? { completed: true, ...byeData } : {}),
+            /*
+             * BM/MR BREAK remains an auto-completed walkover. GP BREAK is a
+             * scoreable solo cup: the player runs alone and records the actual
+             * driver points earned, so it must stay pending until score entry.
+             */
+            ...(autoCompleteBye ? { completed: true, ...byeData } : {}),
           });
 
-          if (m.isBye) {
+          if (autoCompleteBye) {
             byeRecipientIds.add(p1Id);
           } else {
             matchSequenceIndex++;

--- a/smkc-score-app/src/lib/points/overall-ranking.ts
+++ b/smkc-score-app/src/lib/points/overall-ranking.ts
@@ -548,11 +548,12 @@ async function hasCompletedRealQualificationMatch(
   tournamentId: string,
   matchModel: MatchQualificationModel,
 ): Promise<boolean> {
+  const isByeFilter = matchModel === "gPMatch" ? undefined : false;
   const where = {
     tournamentId,
     stage: "qualification",
     completed: true,
-    isBye: false,
+    ...(isByeFilter === undefined ? {} : { isBye: isByeFilter }),
     deletedAt: null,
   };
   const select = { id: true };


### PR DESCRIPTION
Summary
- Treat GP qualification BREAK matches as scoreable solo cups instead of auto-completed 45-0 walkovers.
- Add TC-729 scenario/E2E coverage plus focused unit coverage for GP BREAK setup and overall qualification points.

Issues: Closes #1117

Validation
- npm test -- --runTestsByPath __tests__/lib/api-factories/qualification-route.test.ts __tests__/lib/points/overall-ranking.test.ts __tests__/docs/e2e-cases-drift.test.ts
- node --check e2e/tc-gp.js
- git diff --check
- npm run lint -- --quiet
