### PR TITLE
docs: clarify GP scoreable BREAK comments

### DIFF
--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -247,6 +247,7 @@ async function runTc729(adminPage) {
     if (!bye.cup) throw new Error('GP BREAK match has no assigned cup');
 
     const soloRaces = makeSoloGpByeRaces(bye.cup);
+    // race 1: 1st place = 9 pts; races 2-5: 2nd place = 6 pts each.
     const expectedPoints = 9 + 6 + 6 + 6 + 6;
     const put = await apiPutGpQualScore(adminPage, tournamentId, bye.id, bye.cup, soloRaces);
     const after = await apiFetchGp(adminPage, tournamentId);

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -576,8 +576,9 @@ export function createQualificationHandlers(config: EventTypeConfig) {
 
           /*
            * §10.5: Assign 4 pre-determined courses to this round from the shuffled list.
-           * BYE matches are auto-completed immediately (§10.2) and don't actually play
-           * the courses, so skip assignment for BYE matches.
+           * BM/MR BYE matches are auto-completed walkovers and skip course/cup assignment.
+           * GP BREAK matches are scoreable solo cups, so they receive the same assignment
+           * as real GP matches and remain pending until actual driver points are entered.
            */
           const isScoreableGpBye = config.eventTypeCode === 'gp' && m.isBye;
           const isRealMatch = !m.isBye;
@@ -648,9 +649,10 @@ export function createQualificationHandlers(config: EventTypeConfig) {
 
       /*
        * Update qualification stats for BYE recipients immediately.
-       * BYE matches are auto-completed on creation, so the player's win
-       * must be reflected in standings right away — not deferred until
-       * their first real match is submitted via PUT.
+       * BM/MR BYE matches are auto-completed on creation, so the player's
+       * win must be reflected in standings right away — not deferred until
+       * their first real match is submitted via PUT. GP BREAK matches are
+       * scoreable and intentionally excluded from this immediate update path.
        *
        * Implementation: a single findMany retrieves every completed BYE
        * match touching any recipient, then we partition the result in


### PR DESCRIPTION
Summary
- Clarify qualification setup comments now that GP BREAK matches are scoreable solo cups.
- Document TC-729's expected driver-points total from the race-position scoring table.

Issues: Closes #1355, Closes #1356

Validation
- npm test -- --runTestsByPath __tests__/lib/api-factories/qualification-route.test.ts __tests__/docs/e2e-cases-drift.test.ts
- node --check e2e/tc-gp.js
- git diff --check
