### PR TITLE
test: keep TC717 response contract assertion

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -68,6 +68,7 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('FT2 相当');
     expect(section).toContain('FT3 相当');
     expect(section).toContain('逐次待ちせず並列に開始');
+    expect(section).toContain('一部失敗しても閲覧レスポンスを継続');
     expect(section).toContain('失敗件数と理由を警告ログ');
     expect(section).toContain('gp/finals/route.test.ts');
     expect(tcGp).toContain("require('./lib/gp-finals-validators')");


### PR DESCRIPTION
## Summary
- Restore the TC-717 docs drift assertion for the partial-failure response-continuation contract.

## Issues
Closes #1364

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
