### PR TITLE
fix: stabilize GP backfill sequence ordering

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -227,7 +227,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         .mockResolvedValueOnce(mixedRoundMatches)
         .mockResolvedValueOnce([]);
 
-      (prisma.gPMatch as any).update = jest.fn().mockResolvedValue({});
+      (prisma.gPMatch.update as jest.Mock).mockResolvedValue({});
 
       (paginate as jest.Mock).mockResolvedValue({
         data: [],
@@ -420,8 +420,14 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const result = await GET(request, { params });
 
       expect(result.status).toBe(200);
-      expect((prisma.gPMatch as any).update).toHaveBeenCalledTimes(1);
-      expect((prisma.gPMatch as any).update).toHaveBeenCalledWith({
+      expect(prisma.gPMatch.findMany).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        orderBy: { matchNumber: 'asc' },
+      }));
+      expect(prisma.gPMatch.findMany).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        orderBy: { matchNumber: 'asc' },
+      }));
+      expect(prisma.gPMatch.update).toHaveBeenCalledTimes(1);
+      expect(prisma.gPMatch.update).toHaveBeenCalledWith({
         where: { id: 'pm2' },
         data: { cup: 'Star', assignedCups: ['Star'] },
       });

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -277,10 +277,9 @@ async function normalizeRoundCupsToSingleSequence(
 
     let canonical: string[] | undefined;
     let dominantCount = 0;
-    /* Map iteration preserves insertion order, so equal-count sequences keep
-     * the first valid sequence seen in this round. This makes legacy
-     * divergent-row repair deterministic without adding another arbitrary
-     * sort key. */
+    /* Callers pass matches in matchNumber order. Map iteration then preserves
+     * insertion order, so equal-count sequences keep the first valid sequence
+     * seen in this round without adding another arbitrary sort key. */
     for (const [key, count] of keyCounts) {
       if (count > dominantCount) {
         canonical = keyToArray.get(key);
@@ -1050,6 +1049,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
         const legacyFinals = await model(prisma).findMany({
           where: { tournamentId, stage: 'finals' },
           select: { id: true, round: true, cup: true, assignedCups: true },
+          orderBy: { matchNumber: 'asc' },
         });
         if (legacyFinals.length > 0) {
           await normalizeRoundCupsToSingleSequence(


### PR DESCRIPTION
Summary
- Ensure legacy GP finals assigned-cup scans are read in matchNumber order before first-seen tie-breaking.
- Clarify that first-seen tie-breaks rely on matchNumber-ordered inputs.
- Align GP finals route test update mocks with the existing jest.Mock style and assert ordered scans.

Issues: Closes #1367, Closes #1368

Validation
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts'
- git diff --check
- npm run lint -- --quiet
