### PR TITLE
fix: guard GP cup round numbers

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1860,6 +1860,18 @@
 - **期待結果**: 通常GP設定では同一ラウンド内のカップが揃い、隣接ラウンドで同じカップが連続しない。単一カップ設定の防御警告は `qualification-route.test.ts` でカバーする
 - **スクリプト**: tc-gp.js TC-725
 
+## TC-1087: GP 予選カップ割り当て — roundNumber は正の1始まりだけを使う
+- **URL**: /api/tournaments/[temp-id]/gp (GET)
+- **authRequired**: true (admin)
+- **背景**: GP 予選カップ選択は `(roundNumber - 1) % deck.length` でシャッフル済みデッキを参照する。`roundNumber <= 0` が混入すると JavaScript の負剰余により `undefined` cup が割り当たるため、API 生成結果と単体ガードの両方で正の1始まりを保証する。
+- **手順**:
+  1. 共有 GP フィクスチャと同じ構成で GP 予選を作成する
+  2. `GET /api/.../gp` で予選マッチ一覧を取得する
+  3. BYE を除いた全マッチの `roundNumber` が正の整数であることを確認する
+  4. 同じ全マッチに `cup` が割り当たっていることを確認する
+- **期待結果**: E2E の GP 予選生成経路は `roundNumber >= 1` のみを返し、無効値入力時の例外は `qualification-route.test.ts` でカバーする
+- **スクリプト**: tc-gp.js TC-1087
+
 ## TC-717: GP決勝 — ラウンドごとのカップ組み合わせがFT3の5カップ目以外で重複しない
 - **URL**: /api/tournaments/[temp-id]/gp/finals (GET)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -40,6 +40,7 @@ describe('E2E case drift coverage', () => {
     ['TC-722', tcGp],
     ['TC-1103', tcGp],
     ['TC-725', tcGp],
+    ['TC-1087', tcGp],
     ['TC-729', tcGp],
     ['TC-926', tcOverlay],
     ['TC-TA-FLOW-24', tcTaFlow],

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -32,7 +32,7 @@
  */
 // @ts-nocheck - This test file uses complex mock types that are difficult to type correctly
 
-import { createQualificationHandlers } from '@/lib/api-factories/qualification-route';
+import { createQualificationHandlers, getAssignedCupForRound } from '@/lib/api-factories/qualification-route';
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { NextRequest } from 'next/server';
 import { EventTypeConfig } from '@/lib/event-types/types';
@@ -1007,6 +1007,21 @@ describe('Qualification Route Factory', () => {
         expect(new Set(cups).size).toBe(1);
         expect(cupList).toContain(cups[0]);
       }
+    });
+
+    it('rejects non-positive GP round numbers before cup assignment (#1087)', () => {
+      const shuffled = ['Mushroom', 'Flower', 'Star', 'Special'];
+
+      expect(() => getAssignedCupForRound(shuffled, 0)).toThrow(
+        'GP qualification roundNumber must be a positive integer: 0',
+      );
+      expect(() => getAssignedCupForRound(shuffled, -1)).toThrow(
+        'GP qualification roundNumber must be a positive integer: -1',
+      );
+      expect(() => getAssignedCupForRound(shuffled, 1.5)).toThrow(
+        'GP qualification roundNumber must be a positive integer: 1.5',
+      );
+      expect(getAssignedCupForRound(shuffled, 1)).toBe('Mushroom');
     });
 
     it('should assign unique cups while consuming the first GP qualification round deck', async () => {

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -13,6 +13,7 @@
  *   TC-709  GP finals admin-only enforcement (403)
  *   TC-713  GP qualification tie resolution (tie warning → resolveAllTies)
  *   TC-725  GP qualification cup deck avoids adjacent round repeats
+ *   TC-1087 GP qualification cup assignment uses positive one-based rounds
  *   TC-717  GP finals same-cup-per-round enforcement (PR #585 normalizer)
  *   TC-718  GP finals admin manual total-score override (PR #585 manual form)
  *   TC-1103 GP finals upper bracket score-only cup-win save
@@ -209,6 +210,31 @@ async function runTc725(adminPage) {
       : '');
   } catch (err) {
     log('TC-725', 'FAIL', err instanceof Error ? err.message : 'GP 725 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-1087: GP qualification cups only use positive one-based rounds ───────── */
+async function runTc1087(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedGpFinalsSetup(adminPage);
+    const data = await apiFetchGp(adminPage, setup.tournamentId);
+    const realMatches = (data.matches || []).filter((m) => !m.isBye);
+    const invalidRoundMatches = realMatches.filter((match) =>
+      !Number.isInteger(match.roundNumber) || match.roundNumber < 1
+    );
+    const missingCupMatches = realMatches.filter((match) => !match.cup);
+    const ok = realMatches.length > 0 && invalidRoundMatches.length === 0 && missingCupMatches.length === 0;
+
+    log('TC-1087', ok ? 'PASS' : 'FAIL',
+      realMatches.length === 0 ? 'no real GP qualification matches found'
+      : invalidRoundMatches.length > 0 ? `invalid roundNumber matches=${invalidRoundMatches.map((m) => m.matchNumber).join(',')}`
+      : missingCupMatches.length > 0 ? `missing cup matches=${missingCupMatches.map((m) => m.matchNumber).join(',')}`
+      : '');
+  } catch (err) {
+    log('TC-1087', 'FAIL', err instanceof Error ? err.message : 'GP 1087 failed');
   } finally {
     if (setup) await setup.cleanup();
   }
@@ -1675,6 +1701,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-701', fn: runTc701 },
       { name: 'TC-724', fn: runTc724 },
       { name: 'TC-725', fn: runTc725 },
+      { name: 'TC-1087', fn: runTc1087 },
       { name: 'TC-729', fn: runTc729 },
       { name: 'TC-703', fn: runTc703 },
       { name: 'TC-704', fn: runTc704 },
@@ -1707,7 +1734,7 @@ module.exports = {
   runTc701, runTc702, runTc703, runTc704, runTc705, runTc706,
   runTc707, runTc708, runTc709, runTc710, runTc712, runTc713,
   runTc715, runTc716, runTc717, runTc718, runTc1103, runTc727, runTc729, runTc719,
-  runTc720, runTc721, runTc722, runTc724, runTc725, runTc821, runTc831, runTc832,
+  runTc720, runTc721, runTc722, runTc724, runTc725, runTc1087, runTc821, runTc831, runTc832,
   gpAssignedCupSequence, gpFinalsUpdatedMatchFromPutResult,
   getSuite,
   results,

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -132,7 +132,10 @@ function getAssignedCoursesForRound(shuffled: string[], roundNumber: number): st
  * deck item 0. All groups and matches with the same round number therefore
  * share the same selected cup.
  */
-function getAssignedCupForRound(shuffled: string[], roundNumber: number): string {
+export function getAssignedCupForRound(shuffled: string[], roundNumber: number): string {
+  if (!Number.isInteger(roundNumber) || roundNumber < 1) {
+    throw new Error(`GP qualification roundNumber must be a positive integer: ${roundNumber}`);
+  }
   return shuffled[(roundNumber - 1) % shuffled.length];
 }
 


### PR DESCRIPTION
Summary
- Add a defensive guard so GP qualification cup assignment rejects non-positive or non-integer round numbers before modulo lookup.
- Add TC-1087 scenario coverage and E2E runner registration for positive one-based GP qualification rounds.
- Cover the guard and E2E doc/script alignment with focused Jest tests.

Issues: Closes #1087

Validation
- `npm test -- --runTestsByPath __tests__/lib/api-factories/qualification-route.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `node --check e2e/tc-gp.js`
- `git diff --check`
- `npm run lint` (exit 0; existing warnings only)
