### PR TITLE
test: cover GP cup invalid round numbers

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1863,13 +1863,13 @@
 ## TC-1087: GP 予選カップ割り当て — roundNumber は正の1始まりだけを使う
 - **URL**: /api/tournaments/[temp-id]/gp (GET)
 - **authRequired**: true (admin)
-- **背景**: GP 予選カップ選択は `(roundNumber - 1) % deck.length` でシャッフル済みデッキを参照する。`roundNumber <= 0` が混入すると JavaScript の負剰余により `undefined` cup が割り当たるため、API 生成結果と単体ガードの両方で正の1始まりを保証する。
+- **背景**: GP 予選カップ選択は `(roundNumber - 1) % deck.length` でシャッフル済みデッキを参照する。`roundNumber <= 0` や `NaN` / `Infinity` が混入すると `undefined` cup が割り当たるため、API 生成結果と単体ガードの両方で有限な正の1始まり整数を保証する。
 - **手順**:
   1. 共有 GP フィクスチャと同じ構成で GP 予選を作成する
   2. `GET /api/.../gp` で予選マッチ一覧を取得する
-  3. BYE を除いた全マッチの `roundNumber` が正の整数であることを確認する
+  3. BYE を除いた全マッチの `roundNumber` が有限な正の整数であることを確認する
   4. 同じ全マッチに `cup` が割り当たっていることを確認する
-- **期待結果**: E2E の GP 予選生成経路は `roundNumber >= 1` のみを返し、無効値入力時の例外は `qualification-route.test.ts` でカバーする
+- **期待結果**: E2E の GP 予選生成経路は有限な `roundNumber >= 1` のみを返し、`0` / `-1` / `1.5` / `NaN` / `Infinity` 入力時の例外は `qualification-route.test.ts` でカバーする
 - **スクリプト**: tc-gp.js TC-1087
 
 ## TC-717: GP決勝 — ラウンドごとのカップ組み合わせがFT3の5カップ目以外で重複しない

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -83,6 +83,16 @@ describe('E2E case drift coverage', () => {
     }));
   });
 
+  it('keeps TC-1087 aligned with finite positive round-number guards', () => {
+    const section = sectionFor('TC-1087');
+
+    expect(section).toContain('有限な正の1始まり整数');
+    expect(section).toContain('NaN');
+    expect(section).toContain('Infinity');
+    expect(tcGp).toContain('Number.isFinite(match.roundNumber)');
+    expect(tcGp).toContain('Number.isInteger(match.roundNumber)');
+  });
+
   it('keeps TC-722 from duplicating GP finals target-wins logic in E2E', () => {
     const section = sectionFor('TC-722');
 

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -1021,6 +1021,12 @@ describe('Qualification Route Factory', () => {
       expect(() => getAssignedCupForRound(shuffled, 1.5)).toThrow(
         'GP qualification roundNumber must be a positive integer: 1.5',
       );
+      expect(() => getAssignedCupForRound(shuffled, NaN)).toThrow(
+        'GP qualification roundNumber must be a positive integer: NaN',
+      );
+      expect(() => getAssignedCupForRound(shuffled, Infinity)).toThrow(
+        'GP qualification roundNumber must be a positive integer: Infinity',
+      );
       expect(getAssignedCupForRound(shuffled, 1)).toBe('Mushroom');
     });
 

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -223,7 +223,7 @@ async function runTc1087(adminPage) {
     const data = await apiFetchGp(adminPage, setup.tournamentId);
     const realMatches = (data.matches || []).filter((m) => !m.isBye);
     const invalidRoundMatches = realMatches.filter((match) =>
-      !Number.isInteger(match.roundNumber) || match.roundNumber < 1
+      !Number.isFinite(match.roundNumber) || !Number.isInteger(match.roundNumber) || match.roundNumber < 1
     );
     const missingCupMatches = realMatches.filter((match) => !match.cup);
     const ok = realMatches.length > 0 && invalidRoundMatches.length === 0 && missingCupMatches.length === 0;


### PR DESCRIPTION
## Summary
- Document TC-1087 as guarding finite positive GP qualification round numbers, including NaN and Infinity edge cases
- Extend the TC-1087 runner check to reject non-finite roundNumber values
- Add focused Jest coverage for getAssignedCupForRound rejecting NaN and Infinity, plus drift coverage that keeps the scenario and runner aligned

## Issues
Closes #1371

## Validation
- npm test -- --runTestsByPath __tests__/lib/api-factories/qualification-route.test.ts __tests__/docs/e2e-cases-drift.test.ts
- node --check e2e/tc-gp.js
- git diff --check
- npm run lint -- --quiet

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
