### PR TITLE
docs: explain GP round finite guard

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -89,6 +89,7 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('有限な正の1始まり整数');
     expect(section).toContain('NaN');
     expect(section).toContain('Infinity');
+    expect(tcGp).toContain('Keep the finite check explicit');
     expect(tcGp).toContain('Number.isFinite(match.roundNumber)');
     expect(tcGp).toContain('Number.isInteger(match.roundNumber)');
   });

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -222,6 +222,7 @@ async function runTc1087(adminPage) {
     setup = await prepareSharedGpFinalsSetup(adminPage);
     const data = await apiFetchGp(adminPage, setup.tournamentId);
     const realMatches = (data.matches || []).filter((m) => !m.isBye);
+    // Keep the finite check explicit so TC-1087 documents the NaN/Infinity edge cases.
     const invalidRoundMatches = realMatches.filter((match) =>
       !Number.isFinite(match.roundNumber) || !Number.isInteger(match.roundNumber) || match.roundNumber < 1
     );


### PR DESCRIPTION
## Summary
- Add an inline TC-1087 comment explaining why the finite check is kept explicit for NaN and Infinity coverage
- Extend the E2E drift test so the explanatory comment stays paired with the runner guard

## Issues
Closes #1373

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts
- node --check e2e/tc-gp.js
- git diff --check
- npm run lint -- --quiet

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
