### PR TITLE
fix: remove GP finals cup lock wrapper

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1928,6 +1928,18 @@
 - **期待結果**: アッパーブラケットは `2-0` のような取得カップ数だけで保存・進行でき、不要なカップ別明細を作らない
 - **スクリプト**: tc-gp.js TC-1103 (`npm run e2e:gp`, preview: `npm run e2e:preview:gp`)
 
+## TC-1109: GP決勝 — カップフォーム固定数は最大カップ数ヘルパーを直接使う
+- **URL**: /tournaments/[temp-id]/gp/finals
+- **authRequired**: true (admin)
+- **背景**: GP決勝の入力ダイアログでは、FT2/FT3に必要な最低カップフォーム数を `getGpFinalsMaxCups` で決める。ページ内に薄い別名ラッパーを置くと、ターゲット勝利数と最大カップ数の責務が読み取りづらくなる。
+- **手順**:
+  1. GP決勝ページ実装を確認する
+  2. スコアダイアログ初期化時の固定カップ数が `getGpFinalsMaxCups` を直接参照していることを確認する
+  3. 追加カップ削除ボタンの保護数も `getGpFinalsMaxCups` を直接参照していることを確認する
+  4. `getLockedCupCountForMatch` のようなページ内ラッパーが残っていないことを確認する
+- **期待結果**: FT2は3カップ、FT3は5カップまでの固定フォーム数を最大カップ数ヘルパーで直接表現し、ページ内の薄いラッパーを経由しない
+- **スクリプト**: tc-gp.js TC-1109 (`npm run e2e:gp`, preview: `npm run e2e:preview:gp`)
+
 ## TC-727: GP決勝 — 取得カップ数がFT上限を超える保存を拒否する
 - **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/app/gp-finals-page-source.test.ts
+++ b/smkc-score-app/__tests__/app/gp-finals-page-source.test.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+
+const pagePath = path.join(
+  process.cwd(),
+  'src',
+  'app',
+  'tournaments',
+  '[id]',
+  'gp',
+  'finals',
+  'page.tsx',
+);
+
+describe('GP finals page source', () => {
+  it('uses the shared GP max-cups helper directly for locked cup-form counts', () => {
+    const source = fs.readFileSync(pagePath, 'utf8');
+
+    expect(source).toContain('getGpFinalsMaxCups');
+    expect(source).not.toContain('getLockedCupCountForMatch');
+    expect(source.match(/getGpFinalsMaxCups\(/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -39,6 +39,7 @@ describe('E2E case drift coverage', () => {
     ['TC-717', tcGp],
     ['TC-722', tcGp],
     ['TC-1103', tcGp],
+    ['TC-1109', tcGp],
     ['TC-725', tcGp],
     ['TC-1087', tcGp],
     ['TC-729', tcGp],
@@ -105,6 +106,18 @@ describe('E2E case drift coverage', () => {
     expect(tcGp).toContain('gpFinalsUpdatedMatchFromPutResult');
     expect(tcGp).toContain('updated?.completed === true');
     expect(tcGp).not.toContain('gpFinalsTargetWinsForRound');
+  });
+
+  it('keeps TC-1109 aligned with direct GP max-cups usage', () => {
+    const section = sectionFor('TC-1109');
+
+    expect(section).toContain('getGpFinalsMaxCups');
+    expect(section).toContain('getLockedCupCountForMatch');
+    expect(section).toContain('FT2は3カップ');
+    expect(section).toContain('FT3は5カップ');
+    expect(tcGp).toContain("log('TC-1109'");
+    expect(tcGp).toContain('getGpFinalsMaxCups');
+    expect(tcGp).toContain('getLockedCupCountForMatch');
   });
 
   it.each(['TC-DBG-01', 'TC-DBG-02', 'TC-DBG-03', 'TC-DBG-04'])(

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -19,6 +19,7 @@
  *   TC-1103 GP finals upper bracket score-only cup-win save
  *           Kept next to TC-718 because both cover finals score-save variants
  *           before the suite moves into the longer playoff UI flows.
+ *   TC-1109 GP finals cup-form lock count uses the max-cups helper directly
  *   TC-719  GP tied cup extends non-grand-final bracket match
  *   TC-831  GP finals added cup form can be removed without stale scores
  *   TC-723  GP qualification standings show 0-1000 qualification points
@@ -51,6 +52,8 @@ const {
 const { createSharedE2eFixture, setupModePlayersViaUi, ensurePlayerPassword } = require('./lib/fixtures');
 const { runSuite } = require('./lib/runner');
 const { validateGpFinalsAssignedCupSequences } = require('./lib/gp-finals-validators');
+const fs = require('fs');
+const path = require('path');
 
 const results = makeResults();
 const log = makeLog(results);
@@ -824,6 +827,24 @@ async function runTc1103(adminPage) {
     log('TC-1103', 'FAIL', err instanceof Error ? err.message : 'GP 1103 failed');
   } finally {
     if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-1109: GP finals cup-form lock count uses max-cups helper directly ───────── */
+async function runTc1109() {
+  try {
+    const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'app', 'tournaments', '[id]', 'gp', 'finals', 'page.tsx'), 'utf8');
+    const importsMaxCups = source.includes('getGpFinalsMaxCups');
+    const wrapperRemoved = !source.includes('getLockedCupCountForMatch');
+    const directCalls = (source.match(/getGpFinalsMaxCups\(/g) ?? []).length >= 2;
+
+    log('TC-1109', importsMaxCups && wrapperRemoved && directCalls ? 'PASS' : 'FAIL',
+      !importsMaxCups ? 'getGpFinalsMaxCups import missing'
+      : !wrapperRemoved ? 'getLockedCupCountForMatch wrapper still exists'
+      : !directCalls ? 'expected direct max-cups calls for form lock counts'
+      : '');
+  } catch (err) {
+    log('TC-1109', 'FAIL', err instanceof Error ? err.message : 'GP 1109 failed');
   }
 }
 
@@ -1714,6 +1735,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       // TC-1103 is intentionally grouped with the TC-718 finals score-save
       // coverage before the longer TC-715/TC-716 playoff UI flows.
       { name: 'TC-1103', fn: runTc1103 },
+      { name: 'TC-1109', fn: runTc1109 },
       { name: 'TC-727', fn: runTc727 },
       { name: 'TC-715', fn: runTc715 },
       { name: 'TC-716', fn: runTc716 },

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -441,9 +441,6 @@ export default function GrandPrixFinals({
   const getTargetWinsForMatch = (match?: Pick<GPMatch, "round"> & { stage?: string | null } | null) =>
     getGpFinalsTargetWins({ round: match?.round, stage: match?.stage ?? "finals" });
 
-  const getLockedCupCountForMatch = (match?: Pick<GPMatch, "round"> & { stage?: string | null } | null) =>
-    getGpFinalsMaxCups({ round: match?.round, stage: match?.stage ?? "finals" });
-
   const usesCupWinScoreOnly = (match?: Pick<GPMatch, "stage"> | null) =>
     match?.stage !== "playoff";
 
@@ -548,7 +545,7 @@ export default function GrandPrixFinals({
           };
         })
       : [makeBlankCupForm(0, cup, match.assignedCups)];
-    const lockedCupCount = getLockedCupCountForMatch(match);
+    const lockedCupCount = getGpFinalsMaxCups({ round: match.round, stage: match.stage ?? "finals" });
     const forms = Array.from(
       { length: Math.max(savedForms.length, lockedCupCount) },
       (_, index) => savedForms[index] ?? makeBlankCupForm(index, cup, match.assignedCups),
@@ -1047,7 +1044,12 @@ export default function GrandPrixFinals({
                         <div className="text-sm font-medium">
                           {selectedMatch?.player1.nickname}: {points.points1} pts / {selectedMatch?.player2.nickname}: {points.points2} pts
                         </div>
-                        {isRemovableCupForm(cupIndex, selectedMatch ? getLockedCupCountForMatch(selectedMatch) : 1) && (
+                        {isRemovableCupForm(
+                          cupIndex,
+                          selectedMatch
+                            ? getGpFinalsMaxCups({ round: selectedMatch.round, stage: selectedMatch.stage ?? "finals" })
+                            : 1,
+                        ) && (
                           <Button
                             type="button"
                             variant="ghost"
@@ -1057,7 +1059,9 @@ export default function GrandPrixFinals({
                             onClick={() => setCupForms((current) => removeCupFormAt(
                               current,
                               cupIndex,
-                              selectedMatch ? getLockedCupCountForMatch(selectedMatch) : 1,
+                              selectedMatch
+                                ? getGpFinalsMaxCups({ round: selectedMatch.round, stage: selectedMatch.stage ?? "finals" })
+                                : 1,
                             ))}
                           >
                             <XIcon className="size-4" />


### PR DESCRIPTION
Summary
- Added TC-1109 to the GP E2E scenario catalog and registered a runnable E2E source guard.
- Removed the GP finals page-local `getLockedCupCountForMatch` wrapper and call `getGpFinalsMaxCups` directly for locked cup-form counts.
- Added Jest coverage to keep the E2E case and GP finals page source aligned.

Issues: Closes #1109

Validation
- `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/app/gp-finals-page-source.test.ts __tests__/lib/finals-target-wins.test.ts --runInBand`
- `node --check e2e/tc-gp.js`
- `git diff --check`
- `npm run lint -- --quiet`
