### PR TITLE
test: loosen TC1109 source guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1934,8 +1934,8 @@
 - **背景**: GP決勝の入力ダイアログでは、FT2/FT3に必要な最低カップフォーム数を `getGpFinalsMaxCups` で決める。ページ内に薄い別名ラッパーや同じ引数構築を複数置くと、ターゲット勝利数と最大カップ数の責務が読み取りづらくなる。
 - **手順**:
   1. GP決勝ページ実装を確認する
-  2. スコアダイアログ初期化時の固定カップ数が `getGpFinalsMaxCups(match)` を直接参照していることを確認する
-  3. 追加カップ削除ボタンの保護数も `getGpFinalsMaxCups(selectedMatch)` を直接参照していることを確認する
+  2. スコアダイアログ初期化時の固定カップ数が `getGpFinalsMaxCups(...)` を match-shaped identifier で直接参照していることを確認する
+  3. 追加カップ削除ボタンの保護数も `getGpFinalsMaxCups(...)` を match-shaped identifier で直接参照していることを確認する
   4. `getLockedCupCountForMatch` のようなページ内ラッパーが残っていないことを確認する
 - **期待結果**: FT2は3カップ、FT3は5カップまでの固定フォーム数を最大カップ数ヘルパーで直接表現し、ページ内の薄いラッパーや重複した引数構築を経由しない
 - **スクリプト**: tc-gp.js TC-1109 (`npm run e2e:gp`, preview: `npm run e2e:preview:gp`)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -113,13 +113,14 @@ describe('E2E case drift coverage', () => {
 
     expect(section).toContain('getGpFinalsMaxCups');
     expect(section).toContain('getLockedCupCountForMatch');
+    expect(section).toContain('match-shaped identifier');
     expect(section).toContain('FT2は3カップ');
     expect(section).toContain('FT3は5カップ');
     expect(tcGp).toContain("log('TC-1109'");
     expect(tcGp).toContain('getGpFinalsMaxCups');
     expect(tcGp).toContain('getLockedCupCountForMatch');
-    expect(tcGp).toContain('getGpFinalsMaxCups(match)');
-    expect(tcGp).toContain('getGpFinalsMaxCups(selectedMatch)');
+    expect(tcGp).toContain('/getGpFinalsMaxCups\\([A-Za-z_][A-Za-z0-9_]*\\)/g');
+    expect(tcGp).toContain('directMatchCalls.length >= 2');
   });
 
   it.each(['TC-DBG-01', 'TC-DBG-02', 'TC-DBG-03', 'TC-DBG-04'])(

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -836,13 +836,12 @@ async function runTc1109() {
     const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'app', 'tournaments', '[id]', 'gp', 'finals', 'page.tsx'), 'utf8');
     const importsMaxCups = source.includes('getGpFinalsMaxCups');
     const wrapperRemoved = !source.includes('getLockedCupCountForMatch');
-    const usesMatchDirectly = source.includes('getGpFinalsMaxCups(match)') &&
-      source.includes('getGpFinalsMaxCups(selectedMatch)');
+    const directMatchCalls = source.match(/getGpFinalsMaxCups\([A-Za-z_][A-Za-z0-9_]*\)/g) ?? [];
 
-    log('TC-1109', importsMaxCups && wrapperRemoved && usesMatchDirectly ? 'PASS' : 'FAIL',
+    log('TC-1109', importsMaxCups && wrapperRemoved && directMatchCalls.length >= 2 ? 'PASS' : 'FAIL',
       !importsMaxCups ? 'getGpFinalsMaxCups import missing'
       : !wrapperRemoved ? 'getLockedCupCountForMatch wrapper still exists'
-      : !usesMatchDirectly ? 'expected match-shaped max-cups calls for form lock counts'
+      : directMatchCalls.length < 2 ? 'expected match-shaped max-cups calls for form lock counts'
       : '');
   } catch (err) {
     log('TC-1109', 'FAIL', err instanceof Error ? err.message : 'GP 1109 failed');


### PR DESCRIPTION
Summary
- Updated TC-1109 to detect match-shaped `getGpFinalsMaxCups(...)` calls by identifier pattern instead of hard-coded variable names.
- Adjusted the E2E scenario wording and drift guard so variable renames do not cause false failures.

Issues: Closes #1381

Validation
- `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts --runInBand`
- `node --check e2e/tc-gp.js`
- `git diff --check`
- `npm run lint -- --quiet`
