### PR TITLE
fix: share GP driver points limit

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1648,6 +1648,18 @@
   6. クリーンアップ
 - **期待結果**: GP participant 入力でdriver points合計送信→永続化が動作
 
+## TC-1098: GPドライバーズポイント上限を共有定数で参照する
+- **URL**: n/a (source guard)
+- **authRequired**: false
+- **背景**: GP participant 入力と report API がそれぞれ `MAX_GP_DRIVER_POINTS = 45` を定義すると、GPレース数やポイント配点の変更時に片方だけ更新されるリスクがある。
+- **手順**:
+  1. `src/lib/constants.ts` が `MAX_GP_DRIVER_POINTS` をエクスポートしていることを確認する
+  2. `gp/participant/page.tsx` が `@/lib/constants` から `MAX_GP_DRIVER_POINTS` を import していることを確認する
+  3. `gp/match/[matchId]/report/route.ts` が `@/lib/constants` から `MAX_GP_DRIVER_POINTS` を import していることを確認する
+  4. participant page と API route に `const MAX_GP_DRIVER_POINTS = 45` のような page-local / route-local 定義が残っていないことを確認する
+- **期待結果**: GPドライバーズポイント上限は UI/API とも共有定数を参照し、上限変更時の drift を起こさない
+- **スクリプト**: tc-gp.js TC-1098
+
 ## TC-729: GP奇数人数BREAK — ソロ走行ドライバーズポイント入力
 - **URL**: /tournaments/[temp-id]/gp
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -40,6 +40,7 @@ describe('E2E case drift coverage', () => {
     ['TC-722', tcGp],
     ['TC-1103', tcGp],
     ['TC-1109', tcGp],
+    ['TC-1098', tcGp],
     ['TC-725', tcGp],
     ['TC-1087', tcGp],
     ['TC-729', tcGp],
@@ -121,6 +122,20 @@ describe('E2E case drift coverage', () => {
     expect(tcGp).toContain('getLockedCupCountForMatch');
     expect(tcGp).toContain('/getGpFinalsMaxCups\\([A-Za-z_][A-Za-z0-9_]*\\)/g');
     expect(tcGp).toContain('directMatchCalls.length >= 2');
+  });
+
+  it('keeps TC-1098 aligned with shared GP driver-points max usage', () => {
+    const section = sectionFor('TC-1098');
+
+    expect(section).toContain('MAX_GP_DRIVER_POINTS');
+    expect(section).toContain('src/lib/constants.ts');
+    expect(section).toContain('gp/participant/page.tsx');
+    expect(section).toContain('gp/match/[matchId]/report/route.ts');
+    expect(section).toContain('page-local / route-local');
+    expect(tcGp).toContain("log('TC-1098'");
+    expect(tcGp).toContain('participantImportsConstant');
+    expect(tcGp).toContain('routeImportsConstant');
+    expect(tcGp).toContain('localDefinitionsRemoved');
   });
 
   it.each(['TC-DBG-01', 'TC-DBG-02', 'TC-DBG-03', 'TC-DBG-04'])(

--- a/smkc-score-app/__tests__/lib/gp-driver-points-limit.test.ts
+++ b/smkc-score-app/__tests__/lib/gp-driver-points-limit.test.ts
@@ -1,0 +1,8 @@
+import { DRIVER_POINTS, MAX_GP_DRIVER_POINTS, TOTAL_GP_RACES } from "@/lib/constants";
+
+describe("GP driver points limit", () => {
+  it("derives the per-match maximum from first-place points and GP race count", () => {
+    expect(MAX_GP_DRIVER_POINTS).toBe(DRIVER_POINTS[1] * TOTAL_GP_RACES);
+    expect(MAX_GP_DRIVER_POINTS).toBe(45);
+  });
+});

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -11,6 +11,7 @@
  *   TC-707  GP dual report — agreement → autoConfirmed (2 players)
  *   TC-708  GP dual report — mismatch (2 players)
  *   TC-709  GP finals admin-only enforcement (403)
+ *   TC-1098 GP driver-points max uses the shared constants module
  *   TC-713  GP qualification tie resolution (tie warning → resolveAllTies)
  *   TC-725  GP qualification cup deck avoids adjacent round repeats
  *   TC-1087 GP qualification cup assignment uses positive one-based rounds
@@ -67,6 +68,30 @@ function sharedGpPlayers(count = 28) {
 async function loginSharedPlayer(adminPage, player) {
   await ensurePlayerPassword(adminPage, player);
   return loginPlayerBrowser(player.nickname, player.password);
+}
+
+/* ───────── TC-1098: GP driver-points max uses shared constant ───────── */
+async function runTc1098() {
+  try {
+    const constantsSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'lib', 'constants.ts'), 'utf8');
+    const participantSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'app', 'tournaments', '[id]', 'gp', 'participant', 'page.tsx'), 'utf8');
+    const routeSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'app', 'api', 'tournaments', '[id]', 'gp', 'match', '[matchId]', 'report', 'route.ts'), 'utf8');
+
+    const constantExported = /export const MAX_GP_DRIVER_POINTS\b/.test(constantsSource);
+    const participantImportsConstant = /import \{[^}]*MAX_GP_DRIVER_POINTS[^}]*\} from ["']@\/lib\/constants["'];/.test(participantSource);
+    const routeImportsConstant = /import \{[^}]*MAX_GP_DRIVER_POINTS[^}]*\} from ["']@\/lib\/constants["'];/.test(routeSource);
+    const localDefinitionsRemoved = !/const MAX_GP_DRIVER_POINTS\s*=/.test(participantSource) &&
+      !/const MAX_GP_DRIVER_POINTS\s*=/.test(routeSource);
+
+    log('TC-1098', constantExported && participantImportsConstant && routeImportsConstant && localDefinitionsRemoved ? 'PASS' : 'FAIL',
+      !constantExported ? 'MAX_GP_DRIVER_POINTS export missing from constants.ts'
+      : !participantImportsConstant ? 'participant page does not import MAX_GP_DRIVER_POINTS from constants'
+      : !routeImportsConstant ? 'report route does not import MAX_GP_DRIVER_POINTS from constants'
+      : !localDefinitionsRemoved ? 'page-local or route-local MAX_GP_DRIVER_POINTS definition remains'
+      : '');
+  } catch (err) {
+    log('TC-1098', 'FAIL', err instanceof Error ? err.message : 'GP 1098 failed');
+  }
 }
 
 async function prepareSharedGpPair(adminPage, { dualReport = false } = {}) {
@@ -1718,6 +1743,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
     },
     tests: [
       { name: 'TC-702', fn: runTc702 },
+      { name: 'TC-1098', fn: runTc1098 },
       { name: 'TC-707', fn: runTc707 },
       { name: 'TC-708', fn: runTc708 },
       { name: 'TC-701', fn: runTc701 },

--- a/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/gp/match/[matchId]/report/route.ts
@@ -33,7 +33,7 @@ import {
   type RecalculateStatsConfig,
 } from "@/lib/api-factories/score-report-helpers";
 import { validateGPRacePosition } from "@/lib/score-validation";
-import { COURSE_INFO, getDriverPoints, TOTAL_GP_RACES } from "@/lib/constants";
+import { COURSE_INFO, getDriverPoints, MAX_GP_DRIVER_POINTS, TOTAL_GP_RACES } from "@/lib/constants";
 import { isValidCupChoice } from "@/lib/event-types/gp-config";
 import {
   createErrorResponse,
@@ -47,8 +47,6 @@ import { checkRateLimit } from "@/lib/rate-limit";
 import { updateWithRetry, OptimisticLockError } from "@/lib/optimistic-locking";
 import { resolveTournamentId } from "@/lib/tournament-identifier";
 import { checkQualificationConfirmed } from "@/lib/qualification-confirmed-check";
-
-const MAX_GP_DRIVER_POINTS = 45;
 
 type ProcessedRace = {
   course: string;

--- a/smkc-score-app/src/app/tournaments/[id]/gp/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/participant/page.tsx
@@ -15,6 +15,7 @@ import { useParticipantMatches, type BaseMatch } from "@/lib/hooks/useParticipan
 import { ParticipantPageLayout } from "@/components/tournament/participant-page-layout";
 import { getMatchReportSuccessMessage } from "@/lib/participant-report-message";
 import { GP_DRIVER_POINTS_INPUT_PROPS } from "@/lib/gp-driver-points-input";
+import { MAX_GP_DRIVER_POINTS } from "@/lib/constants";
 
 /** GP Match extends BaseMatch with GP-specific fields */
 interface GPMatch extends BaseMatch {
@@ -32,8 +33,6 @@ interface DriverPointInput {
   points1: string;
   points2: string;
 }
-
-const MAX_GP_DRIVER_POINTS = 45;
 
 function isValidDriverPointInput(value: string): boolean {
   if (!/^\d+$/.test(value)) return false;

--- a/smkc-score-app/src/lib/constants.ts
+++ b/smkc-score-app/src/lib/constants.ts
@@ -180,6 +180,9 @@ export const OPTIMISTIC_LOCK_STATUS_CODE = 409;
  */
 export const DRIVER_POINTS = [0, 9, 6, 3, 1, 0, 0, 0, 0] as const;
 
+/** Maximum GP driver points a player can score in one qualification match. */
+export const MAX_GP_DRIVER_POINTS = DRIVER_POINTS[1] * TOTAL_GP_RACES;
+
 /** GP UI/API position options for normal race finishes. */
 export const GP_POSITION_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8] as const;
 


### PR DESCRIPTION
## Summary
- Export shared `MAX_GP_DRIVER_POINTS` from `src/lib/constants.ts`.
- Use the shared constant in GP participant input validation and the GP report API.
- Add TC-1098 scenario/E2E source guard plus Jest coverage for the shared limit.
- Make the TC-1098 source guard resilient to multiline imports and keep drift coverage behavior-focused.

## Issues
Closes #1098
Closes #1384
Closes #1385

## Validation
- `npm test -- --runTestsByPath __tests__/lib/gp-driver-points-limit.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `node --check e2e/tc-gp.js`
- `git diff --check`
- `npm run lint -- --quiet`
