### PR TITLE
test: harden TC1098 source guard

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -133,9 +133,11 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('gp/match/[matchId]/report/route.ts');
     expect(section).toContain('page-local / route-local');
     expect(tcGp).toContain("log('TC-1098'");
-    expect(tcGp).toContain('participantImportsConstant');
-    expect(tcGp).toContain('routeImportsConstant');
-    expect(tcGp).toContain('localDefinitionsRemoved');
+    expect(tcGp).toContain('importsMaxGpDriverPointsFromConstants');
+    expect(tcGp).toContain('[\\s\\S]*\\bMAX_GP_DRIVER_POINTS\\b[\\s\\S]*');
+    expect(tcGp).toContain('participant page does not import MAX_GP_DRIVER_POINTS from constants');
+    expect(tcGp).toContain('report route does not import MAX_GP_DRIVER_POINTS from constants');
+    expect(tcGp).toContain('page-local or route-local MAX_GP_DRIVER_POINTS definition remains');
   });
 
   it.each(['TC-DBG-01', 'TC-DBG-02', 'TC-DBG-03', 'TC-DBG-04'])(

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -60,6 +60,10 @@ const results = makeResults();
 const log = makeLog(results);
 let sharedFixture = null;
 
+function importsMaxGpDriverPointsFromConstants(source) {
+  return /import\s+\{[\s\S]*\bMAX_GP_DRIVER_POINTS\b[\s\S]*\}\s+from\s+["']@\/lib\/constants["'];/.test(source);
+}
+
 function sharedGpPlayers(count = 28) {
   if (!sharedFixture) throw new Error('Shared GP fixture is not initialized');
   return sharedFixture.players.slice(0, count);
@@ -78,8 +82,8 @@ async function runTc1098() {
     const routeSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'app', 'api', 'tournaments', '[id]', 'gp', 'match', '[matchId]', 'report', 'route.ts'), 'utf8');
 
     const constantExported = /export const MAX_GP_DRIVER_POINTS\b/.test(constantsSource);
-    const participantImportsConstant = /import \{[^}]*MAX_GP_DRIVER_POINTS[^}]*\} from ["']@\/lib\/constants["'];/.test(participantSource);
-    const routeImportsConstant = /import \{[^}]*MAX_GP_DRIVER_POINTS[^}]*\} from ["']@\/lib\/constants["'];/.test(routeSource);
+    const participantImportsConstant = importsMaxGpDriverPointsFromConstants(participantSource);
+    const routeImportsConstant = importsMaxGpDriverPointsFromConstants(routeSource);
     const localDefinitionsRemoved = !/const MAX_GP_DRIVER_POINTS\s*=/.test(participantSource) &&
       !/const MAX_GP_DRIVER_POINTS\s*=/.test(routeSource);
 


### PR DESCRIPTION
## Summary
- Harden TC-1098 source guard so multiline `@/lib/constants` imports still pass.
- Update the drift test to assert guard behavior/messages instead of internal variable names.

## Issues
Closes #1384
Closes #1385

## Validation
- `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts`
- `node --check e2e/tc-gp.js`
- `git diff --check`
- `npm run lint -- --quiet`
