### PR TITLE
test: avoid TC1098 import guard backtracking

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -134,7 +134,8 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('page-local / route-local');
     expect(tcGp).toContain("log('TC-1098'");
     expect(tcGp).toContain('importsMaxGpDriverPointsFromConstants');
-    expect(tcGp).toContain('[\\s\\S]*\\bMAX_GP_DRIVER_POINTS\\b[\\s\\S]*');
+    expect(tcGp).toContain(".split(';')");
+    expect(tcGp).toContain("statement.includes('MAX_GP_DRIVER_POINTS')");
     expect(tcGp).toContain('participant page does not import MAX_GP_DRIVER_POINTS from constants');
     expect(tcGp).toContain('report route does not import MAX_GP_DRIVER_POINTS from constants');
     expect(tcGp).toContain('page-local or route-local MAX_GP_DRIVER_POINTS definition remains');

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -61,7 +61,12 @@ const log = makeLog(results);
 let sharedFixture = null;
 
 function importsMaxGpDriverPointsFromConstants(source) {
-  return /import\s+\{[\s\S]*\bMAX_GP_DRIVER_POINTS\b[\s\S]*\}\s+from\s+["']@\/lib\/constants["'];/.test(source);
+  return source
+    .split(';')
+    .some((statement) =>
+      statement.includes('MAX_GP_DRIVER_POINTS') &&
+      /from\s+["']@\/lib\/constants["']/.test(statement)
+    );
 }
 
 function sharedGpPlayers(count = 28) {


### PR DESCRIPTION
## Summary
- Replace the TC-1098 import guard regex with semicolon-delimited import statement checks.
- Keep multiline import coverage while avoiding broad `[\s\S]*` matching.
- Update drift coverage to lock the lower-backtracking guard shape.

## Issues
Closes #1387

## Validation
- `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts`
- `node --check e2e/tc-gp.js`
- `git diff --check`
- `npm run lint -- --quiet`
