### PR TITLE
test: require import statement in TC1098 guard

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -135,6 +135,7 @@ describe('E2E case drift coverage', () => {
     expect(tcGp).toContain("log('TC-1098'");
     expect(tcGp).toContain('importsMaxGpDriverPointsFromConstants');
     expect(tcGp).toContain(".split(';')");
+    expect(tcGp).toContain('^\\s*import\\s');
     expect(tcGp).toContain("statement.includes('MAX_GP_DRIVER_POINTS')");
     expect(tcGp).toContain('participant page does not import MAX_GP_DRIVER_POINTS from constants');
     expect(tcGp).toContain('report route does not import MAX_GP_DRIVER_POINTS from constants');

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -64,6 +64,7 @@ function importsMaxGpDriverPointsFromConstants(source) {
   return source
     .split(';')
     .some((statement) =>
+      /^\s*import\s/.test(statement) &&
       statement.includes('MAX_GP_DRIVER_POINTS') &&
       /from\s+["']@\/lib\/constants["']/.test(statement)
     );


### PR DESCRIPTION
## Summary
- Require TC-1098 import guard chunks to begin as actual import statements.
- Preserve the lower-backtracking semicolon split guard while avoiding comment/import false positives.
- Update drift coverage to lock the import-statement check.

## Issues
Closes #1389

## Validation
- `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts`
- `node --check e2e/tc-gp.js`
- `git diff --check`
- `npm run lint -- --quiet`
