### PR TITLE
test: tighten GP driver point parser coverage

### DIFF
--- a/smkc-score-app/__tests__/lib/gp-driver-points-input.test.ts
+++ b/smkc-score-app/__tests__/lib/gp-driver-points-input.test.ts
@@ -23,6 +23,8 @@ describe("GP driver points input", () => {
     expect(parseGpDriverPointsInput("+1")).toBeNull();
     expect(parseGpDriverPointsInput("1e2")).toBeNull();
     expect(parseGpDriverPointsInput("abc")).toBeNull();
+    expect(parseGpDriverPointsInput("")).toBeNull();
+    expect(parseGpDriverPointsInput("   ")).toBeNull();
     expect(parseGpDriverPointsInput(String(Number.MAX_SAFE_INTEGER) + "0")).toBeNull();
     expect(parseGpDriverPointsInput(String(MAX_GP_DRIVER_POINTS + 1))).toBeNull();
   });

--- a/smkc-score-app/src/lib/gp-driver-points-input.ts
+++ b/smkc-score-app/src/lib/gp-driver-points-input.ts
@@ -1,4 +1,5 @@
 import { MAX_GP_DRIVER_POINTS } from "@/lib/constants";
+import { parseManualScore } from "@/lib/parse-manual-score";
 
 export const GP_DRIVER_POINTS_INPUT_PROPS = {
   type: "text",
@@ -8,9 +9,7 @@ export const GP_DRIVER_POINTS_INPUT_PROPS = {
 } as const;
 
 export function parseGpDriverPointsInput(input: string): number | null {
-  const trimmed = input.trim();
-  if (!/^\d+$/.test(trimmed)) return null;
-  const value = Number(trimmed);
-  if (!Number.isSafeInteger(value)) return null;
+  const value = parseManualScore(input);
+  if (value === null) return null;
   return value <= MAX_GP_DRIVER_POINTS ? value : null;
 }


### PR DESCRIPTION
Summary
- Delegated `parseGpDriverPointsInput` base integer parsing to `parseManualScore` to remove duplicated validation logic.
- Added explicit empty-string and whitespace-only unit coverage for cleared GP driver-point inputs.

Issues: Closes #1392, Closes #1393

Validation
- `npm test -- --runTestsByPath __tests__/lib/gp-driver-points-input.test.ts`
- `git diff --check HEAD~1..HEAD`
- `npm run lint -- --quiet`