### PR TITLE
fix: route 16-player QF losers into LR2 player1

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1580,6 +1580,16 @@
 - **期待結果**: Winners R1 M2 の敗者が M16 `player2Id` に反映され、`player1Id` を上書きしない
 - **スクリプト**: tc-mr.js TC-858
 
+## TC-1073: 16人決勝 Winners QF 敗者の Losers R2 1P 反映 (issue #1073)
+- **背景**: 16人決勝ブラケットでは、Winners QF から Losers R2 に落ちる敗者を 1P、Losers R1 から勝ち上がる選手を 2P に揃える必要がある。Losers R2 の対戦相手順は #1071 の B3/A4/A3/B4 順を維持する。
+- **手順**:
+  1. 16人決勝ブラケットを生成する
+  2. Winners QF M9-M12 の敗者ルーティングを取得する
+  3. Losers R1 M16-M19 の勝者ルーティングを取得する
+  4. Losers R2 M20-M23 で Winners QF 敗者が `player1`、Losers R1 勝者が `player2` に入ることを確認する
+- **期待結果**: M12→M20、M11→M21、M10→M22、M9→M23 の Winners QF 敗者がすべて 1P に入り、M16-M19 の Losers R1 勝者が対応する Losers R2 の 2P に入る
+- **スクリプト**: smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
+
 ## TC-611: BM/MR/GP予選確定 — スコアロック検証
 - **URL**: /api/tournaments/[temp-id]/mr (PUT), /api/tournaments/[temp-id]/mr/match/[matchId]/report (POST)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
@@ -1,0 +1,25 @@
+import { generateBracketStructure, getNextMatchInfo } from '@/lib/double-elimination';
+
+describe('TC-1073 16-player finals LR2 slot routing', () => {
+  it('keeps Winners QF losers in player1 slots and Losers R1 winners in player2 slots', () => {
+    const bracket = generateBracketStructure(16);
+
+    const lr2Expectations = [
+      { lr2: 20, qf: 12, lr1: 16 },
+      { lr2: 21, qf: 11, lr1: 17 },
+      { lr2: 22, qf: 10, lr1: 18 },
+      { lr2: 23, qf: 9, lr1: 19 },
+    ];
+
+    for (const { lr2, qf, lr1 } of lr2Expectations) {
+      expect(getNextMatchInfo(bracket, qf, false)).toEqual({
+        nextMatchNumber: lr2,
+        position: 1,
+      });
+      expect(getNextMatchInfo(bracket, lr1, true)).toEqual({
+        nextMatchNumber: lr2,
+        position: 2,
+      });
+    }
+  });
+});

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -236,10 +236,17 @@ describe('Finals Route Factory', () => {
       { matchNumber: 10, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 13, loserGoesTo: 22 },
       { matchNumber: 11, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 14, loserGoesTo: 21 },
       { matchNumber: 12, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 14, loserGoesTo: 20 },
-      ...Array.from({ length: 19 }, (_, i) => ({
-        matchNumber: i + 13,
-        round: i < 2 ? 'winners_sf' : i === 2 ? 'winners_final' : 'losers_r1',
-        bracket: i < 3 ? 'winners' : 'losers',
+      { matchNumber: 13, round: 'winners_sf', bracket: 'winners', winnerGoesTo: 15, loserGoesTo: 26, position: 1 },
+      { matchNumber: 14, round: 'winners_sf', bracket: 'winners', winnerGoesTo: 15, loserGoesTo: 27, position: 2 },
+      { matchNumber: 15, round: 'winners_final', bracket: 'winners', winnerGoesTo: 30, loserGoesTo: 29, position: 1 },
+      { matchNumber: 16, round: 'losers_r1', bracket: 'losers', winnerGoesTo: 20, position: 2 },
+      { matchNumber: 17, round: 'losers_r1', bracket: 'losers', winnerGoesTo: 21, position: 2 },
+      { matchNumber: 18, round: 'losers_r1', bracket: 'losers', winnerGoesTo: 22, position: 2 },
+      { matchNumber: 19, round: 'losers_r1', bracket: 'losers', winnerGoesTo: 23, position: 2 },
+      ...Array.from({ length: 12 }, (_, i) => ({
+        matchNumber: i + 20,
+        round: i < 4 ? 'losers_r2' : i < 6 ? 'losers_r3' : i < 8 ? 'losers_r4' : i === 8 ? 'losers_sf' : i === 9 ? 'losers_final' : i === 10 ? 'grand_final' : 'grand_final_reset',
+        bracket: i >= 10 ? 'grand_final' : 'losers',
       })),
     ];
 
@@ -1633,8 +1640,8 @@ describe('Finals Route Factory', () => {
       expect(mockGenerateBracketStructure).toHaveBeenCalledWith(16);
     });
 
-    it('should route 16-player QF loser to reversed L_R2 slot and player2Id', async () => {
-      // In 16-player bracket, QF losers enter L_R2 at position 2.
+    it('should route 16-player QF loser to reversed L_R2 slot and player1Id', async () => {
+      // In 16-player bracket, QF losers enter L_R2 at position 1.
       // M9 routes to M23 so the two-group LR2 order is B3/A4/A3/B4.
       const requestBody = createMockRequestBody();
       const mockMatch = createMockMatch({
@@ -1663,10 +1670,45 @@ describe('Finals Route Factory', () => {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
-      // In 16-player QF, loserPosition=2 → player2Id set
+      // In 16-player QF, loserPosition=1 → player1Id set
       expect((prisma.bMMatch as any).update).toHaveBeenCalledWith({
         where: { id: nextLoserMatch.id },
-        data: { player2Id: 'player-2' },
+        data: { player1Id: 'player-2' },
+      });
+    });
+
+    it('should route 16-player Losers R1 winner to L_R2 player2Id', async () => {
+      const requestBody = createMockRequestBody();
+      const mockMatch = createMockMatch({
+        matchNumber: 16, // losers_r1 in 16-player bracket
+        round: 'losers_r1',
+        player1Id: 'player-1',
+        player2Id: 'player-2',
+      });
+      const nextWinnerMatch = createMockMatch({ matchNumber: 20 }); // L_R2 in 16-player
+
+      (prisma.bMMatch as any).count.mockResolvedValue(31);
+      (prisma.bMMatch as any).findUnique.mockResolvedValue(mockMatch);
+      (prisma.bMMatch as any).update.mockResolvedValue(createMockMatch({ completed: true }));
+      (prisma.bMMatch as any).findFirst.mockImplementation((args: any) => {
+        if (args?.where?.matchNumber === 20) return Promise.resolve(nextWinnerMatch);
+        return Promise.resolve(null);
+      });
+
+      const config = createMockConfig();
+      const { PUT } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+      });
+      await PUT(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect((prisma.bMMatch as any).update).toHaveBeenCalledWith({
+        where: { id: nextWinnerMatch.id },
+        data: { player2Id: 'player-1' },
       });
     });
 

--- a/smkc-score-app/__tests__/lib/double-elimination.test.ts
+++ b/smkc-score-app/__tests__/lib/double-elimination.test.ts
@@ -520,7 +520,7 @@ describe('Double Elimination Bracket Structure', () => {
       });
     });
 
-    it('should route Winners QF losers into reversed Losers R2 slots', () => {
+    it('should route Winners QF losers into reversed Losers R2 player1 slots', () => {
       const matches16 = generateBracketStructure(16);
 
       [
@@ -531,6 +531,17 @@ describe('Double Elimination Bracket Structure', () => {
       ].forEach(([matchNumber, nextMatchNumber]) => {
         expect(getNextMatchInfo(matches16, matchNumber, false)).toEqual({
           nextMatchNumber,
+          position: 1,
+        });
+      });
+    });
+
+    it('should route Losers R1 winners into Losers R2 player2 slots', () => {
+      const matches16 = generateBracketStructure(16);
+
+      [16, 17, 18, 19].forEach((matchNumber, index) => {
+        expect(getNextMatchInfo(matches16, matchNumber, true)).toEqual({
+          nextMatchNumber: 20 + index,
           position: 2,
         });
       });

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -342,7 +342,7 @@ export function DoubleEliminationBracket({
    *
    * Loser position rules (same as getNextMatchInfo in double-elimination.ts):
    *   winners_r1:  (matchNumber - 1) % 2 + 1
-   *   winners_qf:  position 2 for 16-player; (matchNumber - 1) % 2 + 1 for 8-player
+   *   winners_qf:  position 1 for 16-player; (matchNumber - 1) % 2 + 1 for 8-player
    *   winners_sf:  always 1
    *   winners_final: always 2
    */
@@ -360,7 +360,7 @@ export function DoubleEliminationBracket({
         if (bm.round === 'winners_r1') {
           loserPos = ((bm.matchNumber - 1) % 2 + 1) as 1 | 2;
         } else if (bm.round === 'winners_qf') {
-          loserPos = is16Player ? 2 : ((bm.matchNumber - 1) % 2 + 1) as 1 | 2;
+          loserPos = is16Player ? 1 : ((bm.matchNumber - 1) % 2 + 1) as 1 | 2;
         } else if (bm.round === 'winners_sf') {
           loserPos = 1;
         } else if (bm.round === 'winners_final') {

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -2052,9 +2052,9 @@ export function createFinalsHandlers(config: FinalsConfig) {
            * Odd matchNumber (1,3,5,7) enters position 1; even (2,4,6,8) enters position 2. */
           loserPosition = (((matchNumber - 1) % 2) + 1) as 1 | 2;
         } else if (currentBracketMatch.round === 'winners_qf') {
-          /* 16-player: losers from QF enter L_R2 at position 2.
+          /* 16-player: losers from QF enter L_R2 at position 1.
            * 8-player: uses parity-based calculation ((matchNumber-1)%2 + 1). */
-          loserPosition = bracketSize === 16 ? 2 : (((matchNumber - 1) % 2) + 1) as 1 | 2;
+          loserPosition = bracketSize === 16 ? 1 : (((matchNumber - 1) % 2) + 1) as 1 | 2;
         } else if (currentBracketMatch.round === 'winners_sf') {
           loserPosition = 1;
         } else if (currentBracketMatch.round === 'winners_final') {

--- a/smkc-score-app/src/lib/double-elimination.ts
+++ b/smkc-score-app/src/lib/double-elimination.ts
@@ -296,7 +296,7 @@ function generate16PlayerBracket(): BracketMatch[] {
       round: "losers_r1",
       bracket: "losers",
       winnerGoesTo: 20 + i,
-      position: 1,
+      position: 2,
     });
     mn++;
   }
@@ -504,13 +504,13 @@ export function getNextMatchInfo(
         position: ((completedMatchNumber - 1) % 2 + 1) as 1 | 2,
       };
     } else if (match.round === "winners_qf") {
-      /* QF losers enter Losers R2 as position 2 (L_R1 winners enter as position 1).
+      /* QF losers enter Losers R2 as position 1 (L_R1 winners enter as position 2).
        * In 16-player bracket, QF matches 9-12 route to L_R2 matches 23-20.
        * In 8-player bracket, QF is matches 1-4 → position based on parity. */
       const is16Player = matches.length > 17;
       return {
         nextMatchNumber: match.loserGoesTo,
-        position: is16Player ? 2 : ((completedMatchNumber - 1) % 2 + 1) as 1 | 2,
+        position: is16Player ? 1 : ((completedMatchNumber - 1) % 2 + 1) as 1 | 2,
       };
     } else if (match.round === "winners_sf") {
       /* SF losers enter as player 1 (the "higher seed" position) */


### PR DESCRIPTION
## Summary
- Add TC-1073 E2E scenario coverage for 16-player Losers R2 slot routing.
- Route 16-player Winners QF losers into Losers R2 player1 slots and Losers R1 winners into player2 slots.
- Keep API progression and bracket TBD/source mapping aligned with the shared bracket helper.

## Issues
Closes #1073

## Validation
- npm test -- --runTestsByPath __tests__/e2e/tc-1073-16p-lr2-slots.test.ts __tests__/lib/double-elimination.test.ts __tests__/lib/api-factories/finals-route.test.ts --runInBand
- npm test -- --runTestsByPath __tests__/components/tournament/double-elimination-bracket.test.tsx --runInBand
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint
