### PR TITLE
refactor: centralize 16-player loser slots

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1590,6 +1590,16 @@
 - **期待結果**: M12→M20、M11→M21、M10→M22、M9→M23 の Winners QF 敗者がすべて 1P に入り、M16-M19 の Losers R1 勝者が対応する Losers R2 の 2P に入る
 - **スクリプト**: smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
 
+## TC-1396: 16人決勝 QF 敗者スロット定義の一元化 (issue #1396)
+- **背景**: TC-1073 の 16人決勝 QF 敗者スロットは、進行ロジック・API・ブラケット表示で同じ `BracketMatch.loserPosition` を参照し、個別の `loserPosition=1` ハードコードを増やさない
+- **手順**:
+  1. 16人決勝ブラケットを生成する
+  2. Winners QF M9-M12 の `loserGoesTo` と `loserPosition` を確認する
+  3. Losers R1 M16-M19 の winner `position` と比較する
+  4. API 進行処理が `BracketMatch.loserPosition` に従って敗者スロットを更新することを確認する
+- **期待結果**: QF 敗者はブラケットデータ上で M23/M22/M21/M20 の `loserPosition: 1` として定義され、API/表示側はそのフィールドを参照する
+- **スクリプト**: smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
+
 ## TC-611: BM/MR/GP予選確定 — スコアロック検証
 - **URL**: /api/tournaments/[temp-id]/mr (PUT), /api/tournaments/[temp-id]/mr/match/[matchId]/report (POST)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
@@ -94,7 +94,7 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
     mrMatch.findFirst.mockResolvedValue(null);
     mrMatch.createMany.mockResolvedValue({ count: 0 });
     (generateBracketStructure as jest.Mock).mockReturnValue([
-      { matchNumber: 1, round: 'winners_qf', player1Seed: 1, player2Seed: 8, winnerGoesTo: 5, loserGoesTo: 9, position: 1 },
+      { matchNumber: 1, round: 'winners_qf', player1Seed: 1, player2Seed: 8, winnerGoesTo: 5, loserGoesTo: 9, position: 1, loserPosition: 1 },
     ]);
   });
 
@@ -499,7 +499,7 @@ describe('MR Finals API Route - /api/tournaments/[id]/mr/finals', () => {
 
       (prisma.mRMatch.count as jest.Mock).mockResolvedValue(31);
       (generateBracketStructure as jest.Mock).mockReturnValue([
-        { matchNumber: 2, round: 'winners_r1', winnerGoesTo: 9, loserGoesTo: 16, position: 2 },
+        { matchNumber: 2, round: 'winners_r1', winnerGoesTo: 9, loserGoesTo: 16, position: 2, loserPosition: 2 },
       ]);
       (prisma.mRMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
       (prisma.mRMatch.update as jest.Mock).mockResolvedValue(mockUpdatedMatch);

--- a/smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
@@ -22,4 +22,23 @@ describe('TC-1073 16-player finals LR2 slot routing', () => {
       });
     }
   });
+
+  it('TC-1396 keeps QF loser slots in bracket data instead of recalculating them', () => {
+    const bracket = generateBracketStructure(16);
+
+    expect(
+      bracket
+        .filter((match) => match.round === 'winners_qf')
+        .map((match) => ({
+          matchNumber: match.matchNumber,
+          loserGoesTo: match.loserGoesTo,
+          loserPosition: match.loserPosition,
+        })),
+    ).toEqual([
+      { matchNumber: 9, loserGoesTo: 23, loserPosition: 1 },
+      { matchNumber: 10, loserGoesTo: 22, loserPosition: 1 },
+      { matchNumber: 11, loserGoesTo: 21, loserPosition: 1 },
+      { matchNumber: 12, loserGoesTo: 20, loserPosition: 1 },
+    ]);
+  });
 });

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -203,13 +203,13 @@ describe('Finals Route Factory', () => {
       // Grand Final Reset (match 18): played if losers bracket winner wins first GF
       // Note: Match 17 is not used - grand_final winnerGoesTo points to 18
       return [
-        { matchNumber: 1, round: 'winners_qf', bracket: 'winners', player1Seed: 1, player2Seed: 8, winnerGoesTo: 5, loserGoesTo: 9 },
-        { matchNumber: 2, round: 'winners_qf', bracket: 'winners', player1Seed: 4, player2Seed: 5, winnerGoesTo: 5, loserGoesTo: 10 },
-        { matchNumber: 3, round: 'winners_qf', bracket: 'winners', player1Seed: 2, player2Seed: 7, winnerGoesTo: 6, loserGoesTo: 10 },
-        { matchNumber: 4, round: 'winners_qf', bracket: 'winners', player1Seed: 3, player2Seed: 6, winnerGoesTo: 6, loserGoesTo: 9 },
-        { matchNumber: 5, round: 'winners_sf', bracket: 'winners', player1Seed: null, player2Seed: null, winnerGoesTo: 7, loserGoesTo: 13 },
-        { matchNumber: 6, round: 'winners_sf', bracket: 'winners', player1Seed: null, player2Seed: null, winnerGoesTo: 7, loserGoesTo: 14 },
-        { matchNumber: 7, round: 'winners_final', bracket: 'winners', player1Seed: null, player2Seed: null, winnerGoesTo: 16, loserGoesTo: 15 },
+        { matchNumber: 1, round: 'winners_qf', bracket: 'winners', player1Seed: 1, player2Seed: 8, winnerGoesTo: 5, loserGoesTo: 9, position: 1, loserPosition: 1 },
+        { matchNumber: 2, round: 'winners_qf', bracket: 'winners', player1Seed: 4, player2Seed: 5, winnerGoesTo: 5, loserGoesTo: 10, position: 2, loserPosition: 2 },
+        { matchNumber: 3, round: 'winners_qf', bracket: 'winners', player1Seed: 2, player2Seed: 7, winnerGoesTo: 6, loserGoesTo: 10, position: 1, loserPosition: 1 },
+        { matchNumber: 4, round: 'winners_qf', bracket: 'winners', player1Seed: 3, player2Seed: 6, winnerGoesTo: 6, loserGoesTo: 9, position: 2, loserPosition: 2 },
+        { matchNumber: 5, round: 'winners_sf', bracket: 'winners', player1Seed: null, player2Seed: null, winnerGoesTo: 7, loserGoesTo: 13, position: 1, loserPosition: 1 },
+        { matchNumber: 6, round: 'winners_sf', bracket: 'winners', player1Seed: null, player2Seed: null, winnerGoesTo: 7, loserGoesTo: 14, position: 2, loserPosition: 1 },
+        { matchNumber: 7, round: 'winners_final', bracket: 'winners', player1Seed: null, player2Seed: null, winnerGoesTo: 16, loserGoesTo: 15, position: 1, loserPosition: 2 },
         { matchNumber: 8, round: 'losers_r1', bracket: 'losers', player1Seed: null, player2Seed: null, winnerGoesTo: 11, loserGoesTo: undefined },
         { matchNumber: 9, round: 'losers_r1', bracket: 'losers', player1Seed: null, player2Seed: null, winnerGoesTo: 12, loserGoesTo: undefined },
         { matchNumber: 10, round: 'losers_r2', bracket: 'losers', player1Seed: null, player2Seed: null, winnerGoesTo: 11, loserGoesTo: undefined },
@@ -224,21 +224,21 @@ describe('Finals Route Factory', () => {
     };
 
     const create16PlayerBracketStructure = () => [
-      { matchNumber: 1, round: 'winners_r1', bracket: 'winners', player1Seed: 1, player2Seed: 16, winnerGoesTo: 9, loserGoesTo: 16 },
-      { matchNumber: 2, round: 'winners_r1', bracket: 'winners', player1Seed: 8, player2Seed: 9, winnerGoesTo: 9, loserGoesTo: 16 },
-      { matchNumber: 3, round: 'winners_r1', bracket: 'winners', player1Seed: 5, player2Seed: 12, winnerGoesTo: 10, loserGoesTo: 17 },
-      { matchNumber: 4, round: 'winners_r1', bracket: 'winners', player1Seed: 4, player2Seed: 13, winnerGoesTo: 10, loserGoesTo: 17 },
-      { matchNumber: 5, round: 'winners_r1', bracket: 'winners', player1Seed: 3, player2Seed: 14, winnerGoesTo: 11, loserGoesTo: 18 },
-      { matchNumber: 6, round: 'winners_r1', bracket: 'winners', player1Seed: 6, player2Seed: 11, winnerGoesTo: 11, loserGoesTo: 18 },
-      { matchNumber: 7, round: 'winners_r1', bracket: 'winners', player1Seed: 7, player2Seed: 10, winnerGoesTo: 12, loserGoesTo: 19 },
-      { matchNumber: 8, round: 'winners_r1', bracket: 'winners', player1Seed: 2, player2Seed: 15, winnerGoesTo: 12, loserGoesTo: 19 },
-      { matchNumber: 9, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 13, loserGoesTo: 23 },
-      { matchNumber: 10, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 13, loserGoesTo: 22 },
-      { matchNumber: 11, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 14, loserGoesTo: 21 },
-      { matchNumber: 12, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 14, loserGoesTo: 20 },
-      { matchNumber: 13, round: 'winners_sf', bracket: 'winners', winnerGoesTo: 15, loserGoesTo: 26, position: 1 },
-      { matchNumber: 14, round: 'winners_sf', bracket: 'winners', winnerGoesTo: 15, loserGoesTo: 27, position: 2 },
-      { matchNumber: 15, round: 'winners_final', bracket: 'winners', winnerGoesTo: 30, loserGoesTo: 29, position: 1 },
+      { matchNumber: 1, round: 'winners_r1', bracket: 'winners', player1Seed: 1, player2Seed: 16, winnerGoesTo: 9, loserGoesTo: 16, position: 1, loserPosition: 1 },
+      { matchNumber: 2, round: 'winners_r1', bracket: 'winners', player1Seed: 8, player2Seed: 9, winnerGoesTo: 9, loserGoesTo: 16, position: 2, loserPosition: 2 },
+      { matchNumber: 3, round: 'winners_r1', bracket: 'winners', player1Seed: 5, player2Seed: 12, winnerGoesTo: 10, loserGoesTo: 17, position: 1, loserPosition: 1 },
+      { matchNumber: 4, round: 'winners_r1', bracket: 'winners', player1Seed: 4, player2Seed: 13, winnerGoesTo: 10, loserGoesTo: 17, position: 2, loserPosition: 2 },
+      { matchNumber: 5, round: 'winners_r1', bracket: 'winners', player1Seed: 3, player2Seed: 14, winnerGoesTo: 11, loserGoesTo: 18, position: 1, loserPosition: 1 },
+      { matchNumber: 6, round: 'winners_r1', bracket: 'winners', player1Seed: 6, player2Seed: 11, winnerGoesTo: 11, loserGoesTo: 18, position: 2, loserPosition: 2 },
+      { matchNumber: 7, round: 'winners_r1', bracket: 'winners', player1Seed: 7, player2Seed: 10, winnerGoesTo: 12, loserGoesTo: 19, position: 1, loserPosition: 1 },
+      { matchNumber: 8, round: 'winners_r1', bracket: 'winners', player1Seed: 2, player2Seed: 15, winnerGoesTo: 12, loserGoesTo: 19, position: 2, loserPosition: 2 },
+      { matchNumber: 9, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 13, loserGoesTo: 23, position: 1, loserPosition: 1 },
+      { matchNumber: 10, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 13, loserGoesTo: 22, position: 2, loserPosition: 1 },
+      { matchNumber: 11, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 14, loserGoesTo: 21, position: 1, loserPosition: 1 },
+      { matchNumber: 12, round: 'winners_qf', bracket: 'winners', winnerGoesTo: 14, loserGoesTo: 20, position: 2, loserPosition: 1 },
+      { matchNumber: 13, round: 'winners_sf', bracket: 'winners', winnerGoesTo: 15, loserGoesTo: 26, position: 1, loserPosition: 1 },
+      { matchNumber: 14, round: 'winners_sf', bracket: 'winners', winnerGoesTo: 15, loserGoesTo: 27, position: 2, loserPosition: 1 },
+      { matchNumber: 15, round: 'winners_final', bracket: 'winners', winnerGoesTo: 30, loserGoesTo: 29, position: 1, loserPosition: 2 },
       { matchNumber: 16, round: 'losers_r1', bracket: 'losers', winnerGoesTo: 20, position: 2 },
       { matchNumber: 17, round: 'losers_r1', bracket: 'losers', winnerGoesTo: 21, position: 2 },
       { matchNumber: 18, round: 'losers_r1', bracket: 'losers', winnerGoesTo: 22, position: 2 },
@@ -1674,6 +1674,50 @@ describe('Finals Route Factory', () => {
       expect((prisma.bMMatch as any).update).toHaveBeenCalledWith({
         where: { id: nextLoserMatch.id },
         data: { player1Id: 'player-2' },
+      });
+    });
+
+    it('should use bracket-defined loserPosition for loser routing', async () => {
+      const requestBody = createMockRequestBody();
+      const mockMatch = createMockMatch({
+        matchNumber: 9,
+        round: 'winners_qf',
+        player1Id: 'player-1',
+        player2Id: 'player-2',
+      });
+      const nextLoserMatch = createMockMatch({ matchNumber: 23 });
+
+      (prisma.bMMatch as any).count.mockResolvedValue(31);
+      mockGenerateBracketStructure.mockReturnValue([
+        {
+          matchNumber: 9,
+          round: 'winners_qf',
+          bracket: 'winners',
+          loserGoesTo: 23,
+          loserPosition: 2,
+        },
+      ] as any);
+      (prisma.bMMatch as any).findUnique.mockResolvedValue(mockMatch);
+      (prisma.bMMatch as any).update.mockResolvedValue(createMockMatch({ completed: true }));
+      (prisma.bMMatch as any).findFirst.mockImplementation((args: any) => {
+        if (args?.where?.matchNumber === 23) return Promise.resolve(nextLoserMatch);
+        return Promise.resolve(null);
+      });
+
+      const config = createMockConfig();
+      const { PUT } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+      });
+      await PUT(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect((prisma.bMMatch as any).update).toHaveBeenCalledWith({
+        where: { id: nextLoserMatch.id },
+        data: { player2Id: 'player-2' },
       });
     });
 

--- a/smkc-score-app/__tests__/lib/double-elimination.test.ts
+++ b/smkc-score-app/__tests__/lib/double-elimination.test.ts
@@ -536,6 +536,21 @@ describe('Double Elimination Bracket Structure', () => {
       });
     });
 
+    it('should store 16-player Winners QF loser slots on the bracket matches', () => {
+      const matches16 = generateBracketStructure(16);
+
+      expect(
+        matches16
+          .filter((m) => m.round === 'winners_qf')
+          .map((m) => [m.matchNumber, m.loserGoesTo, m.loserPosition]),
+      ).toEqual([
+        [9, 23, 1],
+        [10, 22, 1],
+        [11, 21, 1],
+        [12, 20, 1],
+      ]);
+    });
+
     it('should route Losers R1 winners into Losers R2 player2 slots', () => {
       const matches16 = generateBracketStructure(16);
 

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -60,6 +60,8 @@ interface BracketMatch {
   loserGoesTo?: number;
   /** Position in the receiving match (1 or 2), used for winner routing */
   position?: 1 | 2;
+  /** Position in the receiving match (1 or 2), used for loser routing */
+  loserPosition?: 1 | 2;
 }
 
 /** Props for the main DoubleEliminationBracket component */
@@ -336,38 +338,20 @@ export function DoubleEliminationBracket({
    * Reverse routing map: `${matchNumber}-${slot}` → source match number.
    *
    * `bracketStructure` is always produced by `generateBracketStructure()` on the
-   * server, which guarantees `winnerGoesTo`, `loserGoesTo`, and `position` are
-   * populated for every non-terminal match. The map will therefore contain an
-   * entry for every non-seeded slot under normal circumstances.
-   *
-   * Loser position rules (same as getNextMatchInfo in double-elimination.ts):
-   *   winners_r1:  (matchNumber - 1) % 2 + 1
-   *   winners_qf:  position 1 for 16-player; (matchNumber - 1) % 2 + 1 for 8-player
-   *   winners_sf:  always 1
-   *   winners_final: always 2
+   * server, which guarantees `winnerGoesTo`, `loserGoesTo`, `position`, and
+   * `loserPosition` are populated for every non-terminal match. The map will
+   * therefore contain an entry for every non-seeded slot under normal
+   * circumstances.
    */
   const slotSourceMap = (() => {
     const map = new Map<string, number>();
-    /* 8-player bracket = 17 matches; 16-player = 31 matches. */
-    const is16Player = bracketStructure.length > 17;
     for (const bm of bracketStructure) {
       if (bm.winnerGoesTo) {
         const pos = bm.position ?? 1;
         map.set(`${bm.winnerGoesTo}-${pos}`, bm.matchNumber);
       }
       if (bm.loserGoesTo) {
-        let loserPos: 1 | 2;
-        if (bm.round === 'winners_r1') {
-          loserPos = ((bm.matchNumber - 1) % 2 + 1) as 1 | 2;
-        } else if (bm.round === 'winners_qf') {
-          loserPos = is16Player ? 1 : ((bm.matchNumber - 1) % 2 + 1) as 1 | 2;
-        } else if (bm.round === 'winners_sf') {
-          loserPos = 1;
-        } else if (bm.round === 'winners_final') {
-          loserPos = 2;
-        } else {
-          continue;
-        }
+        const loserPos = bm.loserPosition ?? 1;
         map.set(`${bm.loserGoesTo}-${loserPos}`, bm.matchNumber);
       }
     }

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -2046,20 +2046,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
           },
         });
 
-        let loserPosition: 1 | 2 = 1;
-        if (currentBracketMatch.round === 'winners_r1') {
-          /* 16-player: Winners R1 losers pair into adjacent Losers R1 slots.
-           * Odd matchNumber (1,3,5,7) enters position 1; even (2,4,6,8) enters position 2. */
-          loserPosition = (((matchNumber - 1) % 2) + 1) as 1 | 2;
-        } else if (currentBracketMatch.round === 'winners_qf') {
-          /* 16-player: losers from QF enter L_R2 at position 1.
-           * 8-player: uses parity-based calculation ((matchNumber-1)%2 + 1). */
-          loserPosition = bracketSize === 16 ? 1 : (((matchNumber - 1) % 2) + 1) as 1 | 2;
-        } else if (currentBracketMatch.round === 'winners_sf') {
-          loserPosition = 1;
-        } else if (currentBracketMatch.round === 'winners_final') {
-          loserPosition = 2;
-        }
+        const loserPosition = currentBracketMatch.loserPosition || 1;
 
         if (nextLoserMatch) {
           await model(prisma).update({

--- a/smkc-score-app/src/lib/double-elimination.ts
+++ b/smkc-score-app/src/lib/double-elimination.ts
@@ -81,6 +81,7 @@ export function generateBracketStructure(playerCount: number): BracketMatch[] {
       loserGoesTo: 8 + Math.floor(i / 2),
       // Position alternates 1,2,1,2 for the receiving semi-final match slots
       position: ((i % 2) + 1) as 1 | 2,
+      loserPosition: ((i % 2) + 1) as 1 | 2,
     });
     matchNumber++;
   }
@@ -98,6 +99,7 @@ export function generateBracketStructure(playerCount: number): BracketMatch[] {
       loserGoesTo: 12 + i,
       // Position 1 or 2 in the Winners Final
       position: (i + 1) as 1 | 2,
+      loserPosition: 1,
     });
     matchNumber++;
   }
@@ -113,6 +115,7 @@ export function generateBracketStructure(playerCount: number): BracketMatch[] {
     loserGoesTo: 15,
     // Enters Grand Final as player 1 (advantaged position for display)
     position: 1,
+    loserPosition: 2,
   });
   matchNumber++;
 
@@ -244,6 +247,7 @@ function generate16PlayerBracket(): BracketMatch[] {
       /* R1 losers → Losers R1: pairs of 2 map to one L_R1 match (16-19) */
       loserGoesTo: 16 + Math.floor(i / 2),
       position: ((i % 2) + 1) as 1 | 2,
+      loserPosition: ((i % 2) + 1) as 1 | 2,
     });
     mn++;
   }
@@ -260,6 +264,7 @@ function generate16PlayerBracket(): BracketMatch[] {
        * against B3, A4, A3, B4 instead of B4, A3, A4, B3. */
       loserGoesTo: 23 - i,
       position: ((i % 2) + 1) as 1 | 2,
+      loserPosition: 1,
     });
     mn++;
   }
@@ -274,6 +279,7 @@ function generate16PlayerBracket(): BracketMatch[] {
       /* SF losers → Losers R4 (26-27) */
       loserGoesTo: 26 + i,
       position: (i + 1) as 1 | 2,
+      loserPosition: 1,
     });
     mn++;
   }
@@ -286,6 +292,7 @@ function generate16PlayerBracket(): BracketMatch[] {
     winnerGoesTo: 30,
     loserGoesTo: 29,
     position: 1,
+    loserPosition: 2,
   });
   mn++;
 
@@ -495,36 +502,10 @@ export function getNextMatchInfo(
       position: match.position || 1,
     };
   } else if (!isWinner && match.loserGoesTo) {
-    // Loser drops down -- position depends on the round to maintain
-    // proper bracket placement and visual consistency
-    if (match.round === "winners_r1") {
-      /* 16-player R1 losers: position based on match number parity */
-      return {
-        nextMatchNumber: match.loserGoesTo,
-        position: ((completedMatchNumber - 1) % 2 + 1) as 1 | 2,
-      };
-    } else if (match.round === "winners_qf") {
-      /* QF losers enter Losers R2 as position 1 (L_R1 winners enter as position 2).
-       * In 16-player bracket, QF matches 9-12 route to L_R2 matches 23-20.
-       * In 8-player bracket, QF is matches 1-4 → position based on parity. */
-      const is16Player = matches.length > 17;
-      return {
-        nextMatchNumber: match.loserGoesTo,
-        position: is16Player ? 1 : ((completedMatchNumber - 1) % 2 + 1) as 1 | 2,
-      };
-    } else if (match.round === "winners_sf") {
-      /* SF losers enter as player 1 (the "higher seed" position) */
-      return {
-        nextMatchNumber: match.loserGoesTo,
-        position: 1,
-      };
-    } else if (match.round === "winners_final") {
-      /* Winners Final loser enters Losers Final as player 2 */
-      return {
-        nextMatchNumber: match.loserGoesTo,
-        position: 2,
-      };
-    }
+    return {
+      nextMatchNumber: match.loserGoesTo,
+      position: match.loserPosition || 1,
+    };
   }
 
   // No next match: player is eliminated or tournament is complete

--- a/smkc-score-app/src/types/bracket.ts
+++ b/smkc-score-app/src/types/bracket.ts
@@ -51,6 +51,8 @@ export interface BracketMatch {
   loserGoesTo?: number;
   /** Display position within the receiving match (1 or 2) */
   position?: 1 | 2;
+  /** Display position within the loser's receiving match (1 or 2) */
+  loserPosition?: 1 | 2;
   /**
    * For playoff matches only: the Upper-Bracket seed (1-16) the winner receives
    * when entering the 16-player double-elimination bracket. Only set on final


### PR DESCRIPTION
## Summary
- Add BracketMatch.loserPosition so loser-slot routing is stored in bracket data.
- Update getNextMatchInfo, finals API progression, and bracket TBD source mapping to read that field.
- Add TC-1396 documentation plus E2E/Jest/unit coverage for the centralized 16-player QF loser slot contract.

## Issues
Closes #1396

## Validation
- npm test -- --runTestsByPath __tests__/e2e/tc-1073-16p-lr2-slots.test.ts __tests__/lib/double-elimination.test.ts __tests__/lib/api-factories/finals-route.test.ts __tests__/app/api/tournaments/[id]/mr/finals/route.test.ts
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/components/tournament/double-elimination-bracket.test.tsx
- npm test -- --runTestsByPath __tests__/app/api/tournaments/[id]/bm/finals/route.test.ts __tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
- git diff --check
- npm run lint (exit 0; existing warnings only)
