### PR TITLE
test: address bracket contract review followups

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-1398-1399-bracket-contract.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-1398-1399-bracket-contract.test.ts
@@ -34,7 +34,7 @@ describe('TC-1398-1399 bracket contract E2E guard', () => {
       'double-elimination-bracket.tsx',
     );
 
-    expect(source).toContain('import type { BracketMatch, SeededPlayer } from "@/types/bracket";');
+    expect(source).toMatch(/import type \{[^}]*\bBracketMatch\b[^}]*\} from "@\/types\/bracket";/);
     expect(source).toContain('bracketStructure: BracketMatch[];');
     expect(source).not.toMatch(/interface\s+BracketMatch\s*{/);
   });

--- a/smkc-score-app/__tests__/types/bracket.test.ts
+++ b/smkc-score-app/__tests__/types/bracket.test.ts
@@ -72,18 +72,6 @@ describe('Bracket Types', () => {
       expect(match.position).toBe(1);
     });
 
-    it('should carry the shared loser routing slot field', () => {
-      const match: BracketMatch = {
-        matchNumber: 9,
-        round: 'winners_qf',
-        bracket: 'winners',
-        loserGoesTo: 23,
-        loserPosition: 1,
-      };
-
-      expect(match.loserPosition).toBe(1);
-    });
-
     it('should allow optional fields', () => {
       const match: BracketMatch = {
         matchNumber: 1,


### PR DESCRIPTION
Summary
- Make the TC-1398-1399 shared BracketMatch import guard tolerant of import member ordering.
- Remove the low-value runtime test that only echoed TypeScript field availability.

Issues: Closes #1401, Closes #1402

Validation
- npm test -- --runTestsByPath __tests__/e2e/tc-1398-1399-bracket-contract.test.ts __tests__/types/bracket.test.ts
- npm run lint -- __tests__/e2e/tc-1398-1399-bracket-contract.test.ts __tests__/types/bracket.test.ts
- git diff --check