### PR TITLE
test: cover seeded player bracket import guard

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-1398-1399-bracket-contract.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-1398-1399-bracket-contract.test.ts
@@ -35,6 +35,7 @@ describe('TC-1398-1399 bracket contract E2E guard', () => {
     );
 
     expect(source).toMatch(/import type \{[^}]*\bBracketMatch\b[^}]*\} from "@\/types\/bracket";/);
+    expect(source).toMatch(/import type \{[^}]*\bSeededPlayer\b[^}]*\} from "@\/types\/bracket";/);
     expect(source).toContain('bracketStructure: BracketMatch[];');
     expect(source).not.toMatch(/interface\s+BracketMatch\s*{/);
   });


### PR DESCRIPTION
Summary
- Add a dedicated order-tolerant import guard for SeededPlayer alongside BracketMatch in TC-1398-1399.

Issues: Closes #1404

Validation
- npm test -- --runTestsByPath __tests__/e2e/tc-1398-1399-bracket-contract.test.ts
- npm run lint -- __tests__/e2e/tc-1398-1399-bracket-contract.test.ts
- git diff --check