### PR TITLE
refactor: clarify finals target round helper

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1994,6 +1994,18 @@
 - **期待結果**: FT2は3カップ、FT3は5カップまでの固定フォーム数を最大カップ数ヘルパーで直接表現し、ページ内の薄いラッパーや重複した引数構築を経由しない
 - **スクリプト**: tc-gp.js TC-1109 (`npm run e2e:gp`, preview: `npm run e2e:preview:gp`)
 
+## TC-1100-1085: GP/MR決勝 — top-four target-wins helper の命名を実態に合わせる
+- **URL**: /tournaments/[temp-id]/gp/finals, /tournaments/[temp-id]/mr/finals
+- **authRequired**: true (admin)
+- **背景**: issues #1100, #1085。target-wins 共有ヘルパーは Winners Final / Losers Semi Final / Losers Final / Grand Final / Grand Final Reset を同じ上位4帯として扱う。`losers_sf` を含むため、`isFinalRound` という名前だと「決勝だけ」と誤読しやすい。
+- **手順**:
+  1. `finals-target-wins.ts` の共有ヘルパー名を確認する
+  2. helper 名が `isTopFourTargetRound` で、`losers_sf` を対象に含めていることを確認する
+  3. 古い `isFinalRound` helper 名が残っていないことを確認する
+  4. MR は上位4帯をFT9、GPは上位4帯をFT3として扱い、`winners_sf` はそれぞれFT7/FT2に残ることを確認する
+- **期待結果**: target-wins helper 名が `losers_sf` を含む実態を表し、MR/GPの上位4帯 target-wins 挙動は変わらない
+- **スクリプト**: __tests__/e2e/tc-1100-1085-finals-target-naming.test.ts, __tests__/lib/finals-target-wins.test.ts
+
 ## TC-727: GP決勝 — 取得カップ数がFT上限を超える保存を拒否する
 - **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/e2e/tc-1100-1085-finals-target-naming.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-1100-1085-finals-target-naming.test.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+
+const root = path.join(process.cwd(), '..');
+
+function readRepoFile(...parts: string[]) {
+  return fs.readFileSync(path.join(root, ...parts), 'utf8');
+}
+
+describe('TC-1100-1085 finals target naming E2E guard', () => {
+  it('documents the top-four target-wins naming scenario', () => {
+    const cases = readRepoFile('E2E_TEST_CASES.md');
+    const sectionStart = cases.indexOf('## TC-1100-1085:');
+    expect(sectionStart).toBeGreaterThanOrEqual(0);
+
+    const sectionEnd = cases.indexOf('\n## TC-', sectionStart + 1);
+    const section = cases.slice(
+      sectionStart,
+      sectionEnd === -1 ? cases.length : sectionEnd,
+    );
+
+    expect(section).toContain('issues #1100, #1085');
+    expect(section).toContain('isTopFourTargetRound');
+    expect(section).toContain('losers_sf');
+    expect(section).toContain('__tests__/e2e/tc-1100-1085-finals-target-naming.test.ts');
+  });
+
+  it('keeps the helper name aligned with the rounds it covers', () => {
+    const source = readRepoFile(
+      'smkc-score-app',
+      'src',
+      'lib',
+      'finals-target-wins.ts',
+    );
+
+    expect(source).toContain('function isTopFourTargetRound(round?: string | null): boolean');
+    expect(source).toContain("round === 'losers_sf'");
+    expect(source).not.toContain('function isFinalRound(');
+    expect(source).not.toContain('isFinalRound(context?.round)');
+  });
+});

--- a/smkc-score-app/__tests__/lib/finals-target-wins.test.ts
+++ b/smkc-score-app/__tests__/lib/finals-target-wins.test.ts
@@ -42,6 +42,24 @@ describe('finals-target-wins', () => {
     expect(getGpFinalsMaxCups({ round: 'grand_final' })).toBe(5);
   });
 
+  it('keeps the shared top-four target band explicit for MR and GP', () => {
+    const topFourRounds = [
+      'winners_final',
+      'losers_sf',
+      'losers_final',
+      'grand_final',
+      'grand_final_reset',
+    ];
+
+    for (const round of topFourRounds) {
+      expect(getMrFinalsTargetWins({ round })).toBe(9);
+      expect(getGpFinalsTargetWins({ round })).toBe(3);
+    }
+
+    expect(getMrFinalsTargetWins({ round: 'winners_sf' })).toBe(7);
+    expect(getGpFinalsTargetWins({ round: 'winners_sf' })).toBe(2);
+  });
+
   it('accepts match-shaped GP finals context objects for max cup counts', () => {
     const winnersMatch = { id: 'm1', round: 'winners_sf', stage: 'finals', player1Id: 'p1', player2Id: 'p2' };
     const grandFinalMatch = { id: 'm16', round: 'grand_final', stage: 'finals', player1Id: 'p1', player2Id: 'p2' };

--- a/smkc-score-app/src/lib/finals-target-wins.ts
+++ b/smkc-score-app/src/lib/finals-target-wins.ts
@@ -15,7 +15,7 @@ function isMidLowerRound(round?: string | null): boolean {
   return round === 'losers_r3' || round === 'losers_r4';
 }
 
-function isFinalRound(round?: string | null): boolean {
+function isTopFourTargetRound(round?: string | null): boolean {
   return round === 'winners_final'
     || round === 'losers_sf'
     || round === 'losers_final'
@@ -30,7 +30,7 @@ export function getBmFinalsTargetWins(context?: FinalsTargetContext): number {
   if (isEarlyUpperRound(context?.round) || isEarlyLowerRound(context?.round)) {
     return 5;
   }
-  if (context?.round === 'winners_sf' || isMidLowerRound(context?.round) || isFinalRound(context?.round)) {
+  if (context?.round === 'winners_sf' || isMidLowerRound(context?.round) || isTopFourTargetRound(context?.round)) {
     return 7;
   }
   return 5;
@@ -46,7 +46,7 @@ export function getMrFinalsTargetWins(context?: FinalsTargetContext): number {
   if (context?.round === 'winners_sf' || isMidLowerRound(context?.round)) {
     return 7;
   }
-  if (isFinalRound(context?.round)) {
+  if (isTopFourTargetRound(context?.round)) {
     return 9;
   }
   return 5;
@@ -56,7 +56,7 @@ export function getGpFinalsTargetWins(context?: FinalsTargetContext): number {
   if (context?.stage === 'playoff') {
     return 1;
   }
-  if (isFinalRound(context?.round)) {
+  if (isTopFourTargetRound(context?.round)) {
     return 3;
   }
   return 2;


### PR DESCRIPTION
Summary
- Rename the GP/MR finals target-wins helper from `isFinalRound` to `isTopFourTargetRound` so `losers_sf` inclusion is explicit.
- Add TC-1100-1085 scenario coverage plus a static E2E guard for the helper name.
- Add focused unit coverage that locks MR/GP top-four target wins while keeping `winners_sf` outside that band.

Issues: Closes #1100
Closes #1085

Validation
- `npm test -- --runTestsByPath __tests__/e2e/tc-1100-1085-finals-target-naming.test.ts __tests__/lib/finals-target-wins.test.ts --runInBand`
- `npm run lint -- src/lib/finals-target-wins.ts __tests__/lib/finals-target-wins.test.ts __tests__/e2e/tc-1100-1085-finals-target-naming.test.ts`
- `git diff --check`
