### PR TITLE
test: address finals target naming review followups

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2004,7 +2004,7 @@
   3. 古い `isFinalRound` helper 名が残っていないことを確認する
   4. MR は上位4帯をFT9、GPは上位4帯をFT3として扱い、`winners_sf` はそれぞれFT7/FT2に残ることを確認する
 - **期待結果**: target-wins helper 名が `losers_sf` を含む実態を表し、MR/GPの上位4帯 target-wins 挙動は変わらない
-- **スクリプト**: __tests__/e2e/tc-1100-1085-finals-target-naming.test.ts, __tests__/lib/finals-target-wins.test.ts
+- **スクリプト**: __tests__/static/tc-1100-1085-finals-target-naming.test.ts, __tests__/lib/finals-target-wins.test.ts
 
 ## TC-727: GP決勝 — 取得カップ数がFT上限を超える保存を拒否する
 - **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)

--- a/smkc-score-app/__tests__/lib/finals-target-wins.test.ts
+++ b/smkc-score-app/__tests__/lib/finals-target-wins.test.ts
@@ -42,7 +42,7 @@ describe('finals-target-wins', () => {
     expect(getGpFinalsMaxCups({ round: 'grand_final' })).toBe(5);
   });
 
-  it('keeps the shared top-four target band explicit for MR and GP', () => {
+  it('keeps the shared top-four target band explicit for BM, MR, and GP', () => {
     const topFourRounds = [
       'winners_final',
       'losers_sf',
@@ -52,10 +52,12 @@ describe('finals-target-wins', () => {
     ];
 
     for (const round of topFourRounds) {
+      expect(getBmFinalsTargetWins({ round })).toBe(7);
       expect(getMrFinalsTargetWins({ round })).toBe(9);
       expect(getGpFinalsTargetWins({ round })).toBe(3);
     }
 
+    expect(getBmFinalsTargetWins({ round: 'winners_sf' })).toBe(7);
     expect(getMrFinalsTargetWins({ round: 'winners_sf' })).toBe(7);
     expect(getGpFinalsTargetWins({ round: 'winners_sf' })).toBe(2);
   });

--- a/smkc-score-app/__tests__/static/tc-1100-1085-finals-target-naming.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1100-1085-finals-target-naming.test.ts
@@ -7,7 +7,7 @@ function readRepoFile(...parts: string[]) {
   return fs.readFileSync(path.join(root, ...parts), 'utf8');
 }
 
-describe('TC-1100-1085 finals target naming E2E guard', () => {
+describe('TC-1100-1085 finals target naming static guard', () => {
   it('documents the top-four target-wins naming scenario', () => {
     const cases = readRepoFile('E2E_TEST_CASES.md');
     const sectionStart = cases.indexOf('## TC-1100-1085:');
@@ -22,7 +22,7 @@ describe('TC-1100-1085 finals target naming E2E guard', () => {
     expect(section).toContain('issues #1100, #1085');
     expect(section).toContain('isTopFourTargetRound');
     expect(section).toContain('losers_sf');
-    expect(section).toContain('__tests__/e2e/tc-1100-1085-finals-target-naming.test.ts');
+    expect(section).toContain('__tests__/static/tc-1100-1085-finals-target-naming.test.ts');
   });
 
   it('keeps the helper name aligned with the rounds it covers', () => {
@@ -33,9 +33,9 @@ describe('TC-1100-1085 finals target naming E2E guard', () => {
       'finals-target-wins.ts',
     );
 
-    expect(source).toContain('function isTopFourTargetRound(round?: string | null): boolean');
+    expect(source).toMatch(/function\s+isTopFourTargetRound\b/);
     expect(source).toContain("round === 'losers_sf'");
-    expect(source).not.toContain('function isFinalRound(');
-    expect(source).not.toContain('isFinalRound(context?.round)');
+    expect(source).not.toMatch(/function\s+isFinalRound\b/);
+    expect(source).not.toMatch(/\bisFinalRound\s*\(/);
   });
 });


### PR DESCRIPTION
Summary
- Move the TC-1100-1085 static guard out of `__tests__/e2e/` and into `__tests__/static/`.
- Loosen the helper-name source guard so it checks the function name without hard-coding the full TypeScript signature.
- Extend finals target-wins unit coverage to include BM top-four rounds alongside MR and GP.

Issues: Closes #1407
Closes #1408

Validation
- `npm test -- --runTestsByPath __tests__/static/tc-1100-1085-finals-target-naming.test.ts __tests__/lib/finals-target-wins.test.ts --runInBand`
- `npm run lint -- __tests__/static/tc-1100-1085-finals-target-naming.test.ts __tests__/lib/finals-target-wins.test.ts`
- `git diff --check`
