### PR TITLE
fix: batch GP cup backfill by round

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1939,11 +1939,11 @@
   5. FT2 相当のラウンドでは `assignedCups` が3件以下かつ重複なしであることを確認
   6. FT3 相当のラウンドでは `assignedCups` が5件で、先頭4件が重複なしであることを確認
   7. legacy/divergent な `assignedCups` バックフィルが必要な場合、同数の valid sequence はラウンド内で最初に見つかった sequence を canonical とすることを単体テストで確認する
-  8. legacy/divergent な `assignedCups` バックフィルが必要な場合、GET はラウンド内の修復対象 update を逐次待ちせず並列に開始することを単体テストで確認する
-  9. 一部 update が失敗してもGETレスポンスは返し、失敗件数と理由を警告ログに残すことを単体テストで確認する
+  8. legacy/divergent な `assignedCups` バックフィルが必要な場合、GET は match ごとの `update()` ではなく round-scoped `updateMany()` を1ラウンド1回だけ実行することを単体テストで確認する
+  9. 一部 round-scoped update が失敗してもGETレスポンスは返し、失敗件数と理由を警告ログに残すことを単体テストで確認する
   10. 管理者スコア入力ダイアログを開き、FT2 は2カップ欄、FT3 は3カップ欄が最初から表示され、その自動表示分に削除ボタンがないことを確認
   11. クリーンアップ
-- **期待結果**: ラウンドをまたいだ同カップは許可されるが、同じラウンドのカップ組み合わせは FT3 の5件目を除いて重複しない。FT数ぶんの初期カップ欄は削除できず、追加したカップ欄だけ削除できる。legacy 修復時のDB updateは同数の valid sequence を first-seen で決定し、全件を開始してから完了待ちし、一部失敗しても閲覧レスポンスを継続する
+- **期待結果**: ラウンドをまたいだ同カップは許可されるが、同じラウンドのカップ組み合わせは FT3 の5件目を除いて重複しない。FT数ぶんの初期カップ欄は削除できず、追加したカップ欄だけ削除できる。legacy 修復時のDB updateは同数の valid sequence を first-seen で決定し、round-scoped `updateMany()` によって O(matches) ではなく O(rounds) の書き込みに収まる。一部失敗しても閲覧レスポンスを継続する
 - **スクリプト**: tc-gp.js TC-717
 - **補助検証**: `smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts`
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -98,6 +98,8 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
     gpMatch.count.mockResolvedValue(17);
     gpMatch.findFirst.mockResolvedValue(null);
     gpMatch.createMany.mockResolvedValue({ count: 0 });
+    gpMatch.update.mockResolvedValue({});
+    gpMatch.updateMany.mockResolvedValue({ count: 0 });
   });
 
   afterEach(() => {
@@ -227,7 +229,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         .mockResolvedValueOnce(mixedRoundMatches)
         .mockResolvedValueOnce([]);
 
-      (prisma.gPMatch.update as jest.Mock).mockResolvedValue({});
+      (prisma.gPMatch.updateMany as jest.Mock).mockResolvedValue({ count: 4 });
 
       (paginate as jest.Mock).mockResolvedValue({
         data: [],
@@ -240,36 +242,26 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const result = await GET(request, { params });
 
       expect(result.status).toBe(200);
-      const updateMock = (prisma.gPMatch as any).update as jest.Mock;
-      expect(updateMock).toHaveBeenCalledTimes(4);
-      expect(updateMock.mock.calls.map(([call]) => call.where.id).sort()).toEqual(['pm1', 'pm2', 'pm3', 'pm4']);
-      for (const [call] of updateMock.mock.calls) {
-        expect(call.data).toEqual({ cup: 'Flower', assignedCups: ['Flower'] });
-      }
+      expect(prisma.gPMatch.updateMany).toHaveBeenCalledTimes(1);
+      expect(prisma.gPMatch.updateMany).toHaveBeenCalledWith({
+        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r1' },
+        data: { cup: 'Flower', assignedCups: ['Flower'] },
+      });
+      expect(prisma.gPMatch.update).not.toHaveBeenCalled();
     });
 
-    it('should start all GP assigned cup backfill updates before waiting for completion', async () => {
+    it('should issue one GP assigned cup backfill updateMany per divergent round', async () => {
       const mixedRoundMatches = [
         { id: 'pm1', matchNumber: 1, round: 'playoff_r1', cup: 'Flower', player1: {}, player2: {} },
         { id: 'pm2', matchNumber: 2, round: 'playoff_r1', cup: 'Star',   player1: {}, player2: {} },
-        { id: 'pm3', matchNumber: 3, round: 'playoff_r1', cup: null,     player1: {}, player2: {} },
-        { id: 'pm4', matchNumber: 4, round: 'playoff_r1', cup: 'Special', player1: {}, player2: {} },
+        { id: 'pm3', matchNumber: 3, round: 'playoff_r2', cup: 'Mushroom', player1: {}, player2: {} },
+        { id: 'pm4', matchNumber: 4, round: 'playoff_r2', cup: 'Special', player1: {}, player2: {} },
       ];
       (prisma.gPMatch.findMany as jest.Mock)
         .mockResolvedValueOnce(mixedRoundMatches)
         .mockResolvedValueOnce([]);
 
-      const resolvers: Array<(value: unknown) => void> = [];
-      let firstUpdateStarted!: () => void;
-      const firstUpdateStartedPromise = new Promise<void>((resolve) => {
-        firstUpdateStarted = resolve;
-      });
-      (prisma.gPMatch as any).update = jest.fn().mockImplementation(() => (
-        new Promise((resolve) => {
-          resolvers.push(resolve);
-          if (resolvers.length === 1) firstUpdateStarted();
-        })
-      ));
+      (prisma.gPMatch.updateMany as jest.Mock).mockResolvedValue({ count: 2 });
 
       (paginate as jest.Mock).mockResolvedValue({
         data: [],
@@ -279,21 +271,22 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/finals');
       const params = Promise.resolve({ id: 't1' });
-      const resultPromise = GET(request, { params });
-
-      await firstUpdateStartedPromise;
-
-      const updateMock = (prisma.gPMatch as any).update as jest.Mock;
-      expect(updateMock).toHaveBeenCalledTimes(4);
-      expect(resolvers).toHaveLength(4);
-
-      resolvers.forEach((resolve) => resolve({}));
-      const result = await resultPromise;
+      const result = await GET(request, { params });
 
       expect(result.status).toBe(200);
+      expect(prisma.gPMatch.updateMany).toHaveBeenCalledTimes(2);
+      expect(prisma.gPMatch.updateMany).toHaveBeenNthCalledWith(1, {
+        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r1' },
+        data: { cup: 'Flower', assignedCups: ['Flower'] },
+      });
+      expect(prisma.gPMatch.updateMany).toHaveBeenNthCalledWith(2, {
+        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r2' },
+        data: { cup: 'Mushroom', assignedCups: ['Mushroom'] },
+      });
+      expect(prisma.gPMatch.update).not.toHaveBeenCalled();
     });
 
-    it('should keep returning finals data when one assigned cup backfill update fails', async () => {
+    it('should keep returning finals data when a round assigned cup backfill update fails', async () => {
       const mixedRoundMatches = [
         { id: 'pm1', matchNumber: 1, round: 'playoff_r1', cup: 'Flower', player1: {}, player2: {} },
         { id: 'pm2', matchNumber: 2, round: 'playoff_r1', cup: 'Star', player1: {}, player2: {} },
@@ -302,9 +295,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         .mockResolvedValueOnce(mixedRoundMatches)
         .mockResolvedValueOnce([]);
 
-      (prisma.gPMatch as any).update = jest.fn()
-        .mockResolvedValueOnce({})
-        .mockRejectedValueOnce(new Error('D1 update failed'));
+      (prisma.gPMatch.updateMany as jest.Mock).mockRejectedValueOnce(new Error('D1 update failed'));
 
       (paginate as jest.Mock).mockResolvedValue({
         data: [],
@@ -317,10 +308,10 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const result = await GET(request, { params });
 
       expect(result.status).toBe(200);
-      expect((prisma.gPMatch as any).update).toHaveBeenCalledTimes(2);
-      expect(logger.warn).toHaveBeenCalledWith('Failed to backfill some GP assigned cup rows', {
+      expect(prisma.gPMatch.updateMany).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledWith('Failed to backfill some GP assigned cup rounds', {
         failedWrites: 1,
-        totalWrites: 2,
+        totalWrites: 1,
         reasons: ['D1 update failed'],
       });
     });
@@ -340,7 +331,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         .mockResolvedValueOnce(nullRoundMatches)
         .mockResolvedValueOnce([]);
 
-      (prisma.gPMatch as any).update = jest.fn().mockResolvedValue({});
+      (prisma.gPMatch.updateMany as jest.Mock).mockResolvedValue({ count: 4 });
 
       (paginate as jest.Mock).mockResolvedValue({
         data: [],
@@ -354,15 +345,12 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
 
       expect(result.status).toBe(200);
 
-      const updateMock = (prisma.gPMatch as any).update as jest.Mock;
-      expect(updateMock).toHaveBeenCalledTimes(4);
-      const assigned = updateMock.mock.calls[0][0].data.assignedCups;
-      for (const [call] of updateMock.mock.calls) {
-        expect(call.data.assignedCups).toHaveLength(1);
-        expect(call.data.cup).toBe(call.data.assignedCups[0]);
-        expect(['Mushroom', 'Flower', 'Star', 'Special']).toContain(call.data.cup);
-        expect(call.data.assignedCups).toEqual(assigned);
-      }
+      expect(prisma.gPMatch.updateMany).toHaveBeenCalledTimes(1);
+      const updateCall = (prisma.gPMatch.updateMany as jest.Mock).mock.calls[0][0];
+      expect(updateCall.where).toEqual({ tournamentId: 't1', stage: 'playoff', round: 'playoff_r1' });
+      expect(updateCall.data.assignedCups).toHaveLength(1);
+      expect(updateCall.data.cup).toBe(updateCall.data.assignedCups[0]);
+      expect(['Mushroom', 'Flower', 'Star', 'Special']).toContain(updateCall.data.cup);
     });
 
     /**
@@ -378,7 +366,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         .mockResolvedValueOnce(normalized)
         .mockResolvedValueOnce([]);
 
-      (prisma.gPMatch as any).update = jest.fn();
+      (prisma.gPMatch.updateMany as jest.Mock).mockResolvedValue({ count: 2 });
 
       (paginate as jest.Mock).mockResolvedValue({
         data: [],
@@ -391,11 +379,12 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       await GET(request, { params });
 
 
-      expect((prisma.gPMatch as any).update).toHaveBeenCalledTimes(1);
-      expect((prisma.gPMatch as any).update).toHaveBeenCalledWith({
-        where: { id: 'pm2' },
+      expect(prisma.gPMatch.updateMany).toHaveBeenCalledTimes(1);
+      expect(prisma.gPMatch.updateMany).toHaveBeenCalledWith({
+        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r1' },
         data: { cup: 'Flower', assignedCups: ['Flower'] },
       });
+      expect(prisma.gPMatch.update).not.toHaveBeenCalled();
     });
 
     it('should tie-break equal valid playoff cup sequences by first seen order', async () => {
@@ -407,7 +396,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         .mockResolvedValueOnce(tiedSequences)
         .mockResolvedValueOnce([]);
 
-      (prisma.gPMatch as any).update = jest.fn().mockResolvedValue({});
+      (prisma.gPMatch.updateMany as jest.Mock).mockResolvedValue({ count: 2 });
 
       (paginate as jest.Mock).mockResolvedValue({
         data: [],
@@ -426,11 +415,12 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       expect(prisma.gPMatch.findMany).toHaveBeenNthCalledWith(2, expect.objectContaining({
         orderBy: { matchNumber: 'asc' },
       }));
-      expect(prisma.gPMatch.update).toHaveBeenCalledTimes(1);
-      expect(prisma.gPMatch.update).toHaveBeenCalledWith({
-        where: { id: 'pm2' },
+      expect(prisma.gPMatch.updateMany).toHaveBeenCalledTimes(1);
+      expect(prisma.gPMatch.updateMany).toHaveBeenCalledWith({
+        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r1' },
         data: { cup: 'Star', assignedCups: ['Star'] },
       });
+      expect(prisma.gPMatch.update).not.toHaveBeenCalled();
     });
 
     it('should not write when every playoff match in a round already shares a valid sequence', async () => {
@@ -442,7 +432,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         .mockResolvedValueOnce(normalized)
         .mockResolvedValueOnce([]);
 
-      (prisma.gPMatch as any).update = jest.fn();
+      (prisma.gPMatch.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
 
       (paginate as jest.Mock).mockResolvedValue({
         data: [],
@@ -454,7 +444,8 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const params = Promise.resolve({ id: 't1' });
       await GET(request, { params });
 
-      expect((prisma.gPMatch as any).update).not.toHaveBeenCalled();
+      expect(prisma.gPMatch.updateMany).not.toHaveBeenCalled();
+      expect(prisma.gPMatch.update).not.toHaveBeenCalled();
     });
   });
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -72,7 +72,8 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('FT2 相当');
     expect(section).toContain('FT3 相当');
     expect(section).toContain('first-seen');
-    expect(section).toContain('逐次待ちせず並列に開始');
+    expect(section).toContain('round-scoped `updateMany()`');
+    expect(section).toContain('O(rounds)');
     expect(section).toContain('一部失敗しても閲覧レスポンスを継続');
     expect(section).toContain('失敗件数と理由を警告ログ');
     expect(section).toContain('gp/finals/route.test.ts');

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -29,7 +29,6 @@ import { createErrorResponse, createSuccessResponse, handleValidationError, hand
 import { checkRateLimit } from '@/lib/rate-limit';
 import { getClientIdentifier } from '@/lib/request-utils';
 import { resolveTournament, resolveTournamentId } from '@/lib/tournament-identifier';
-import { checkQualificationConfirmed } from '@/lib/qualification-confirmed-check';
 import { computeQualificationRanks } from '@/lib/server-ranking';
 import { invalidateOverallRankingsCache } from '@/lib/points/overall-ranking';
 import { COURSES, CUPS, MAX_TV_NUMBER } from '@/lib/constants';
@@ -228,6 +227,7 @@ function isValidGpCupSequence(sequence: string[], maxCups: number): boolean {
 async function normalizeRoundCupsToSingleSequence(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   modelInstance: any,
+  tournamentId: string,
   stage: 'finals' | 'playoff',
   matches: Array<{ id: string; cup?: string | null; assignedCups?: unknown; round?: string | null }>,
   logger?: ReturnType<typeof createLogger>,
@@ -300,24 +300,22 @@ async function normalizeRoundCupsToSingleSequence(
     canonicalByRound.set(round, { cup: assignedCups[0], assignedCups });
   }
 
+  /* Collapse legacy GP repairs to one write per round. We intentionally do
+   * not add JSON equality predicates here: Prisma's JSON filters are brittle
+   * on D1/SQLite, and canonicalByRound only contains rounds that JS already
+   * proved need repair. */
   const writes: Array<Promise<unknown>> = [];
   for (const [round, data] of canonicalByRound) {
-    const canonicalKey = JSON.stringify(data.assignedCups);
-    for (const match of matchesByRound.get(round) ?? []) {
-      if (match.cup === data.cup && JSON.stringify(match.assignedCups) === canonicalKey) {
-        continue;
-      }
-      writes.push(modelInstance.update({
-        where: { id: match.id },
-        data,
-      }));
-    }
+    writes.push(modelInstance.updateMany({
+      where: { tournamentId, stage, round },
+      data,
+    }));
   }
 
   const writeResults = await Promise.allSettled(writes);
   const failedWrites = writeResults.filter((result): result is PromiseRejectedResult => result.status === 'rejected');
   if (failedWrites.length > 0) {
-    logger?.warn('Failed to backfill some GP assigned cup rows', {
+    logger?.warn('Failed to backfill some GP assigned cup rounds', {
       failedWrites: failedWrites.length,
       totalWrites: writes.length,
       reasons: failedWrites.map((result) => result.reason instanceof Error
@@ -919,6 +917,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
       if (config.assignGpCupByRound && playoffMatches.length > 0) {
         const cupResult = await normalizeRoundCupsToSingleSequence(
           model(prisma),
+          tournamentId,
           'playoff',
           playoffMatches,
           logger,
@@ -1054,6 +1053,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
         if (legacyFinals.length > 0) {
           await normalizeRoundCupsToSingleSequence(
             model(prisma),
+            tournamentId,
             'finals',
             legacyFinals,
             logger,


### PR DESCRIPTION
Summary
- Batch GP finals/playoff assignedCups legacy repair by bracket round using updateMany instead of per-match update calls.
- Keep first-seen canonical sequence behavior and in-memory response repair while preserving warning behavior for failed round writes.
- Update TC-717 scenario docs and focused route tests to cover O(rounds) repair behavior.

Issues: Closes #1103

Validation
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts' __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/api-factories/finals-route.test.ts --runInBand\n- npm run lint -- src/lib/api-factories/finals-route.ts '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts' __tests__/docs/e2e-cases-drift.test.ts