### PR TITLE
fix: scope GP cup backfill to stale rows

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1939,11 +1939,11 @@
   5. FT2 相当のラウンドでは `assignedCups` が3件以下かつ重複なしであることを確認
   6. FT3 相当のラウンドでは `assignedCups` が5件で、先頭4件が重複なしであることを確認
   7. legacy/divergent な `assignedCups` バックフィルが必要な場合、同数の valid sequence はラウンド内で最初に見つかった sequence を canonical とすることを単体テストで確認する
-  8. legacy/divergent な `assignedCups` バックフィルが必要な場合、GET は match ごとの `update()` ではなく round-scoped `updateMany()` を1ラウンド1回だけ実行することを単体テストで確認する
+  8. legacy/divergent な `assignedCups` バックフィルが必要な場合、GET は match ごとの `update()` ではなく round-scoped `updateMany()` を1ラウンド1回だけ実行し、`id IN (...)` で canonical と不一致の行だけを書き換えることを単体テストで確認する
   9. 一部 round-scoped update が失敗してもGETレスポンスは返し、失敗件数と理由を警告ログに残すことを単体テストで確認する
   10. 管理者スコア入力ダイアログを開き、FT2 は2カップ欄、FT3 は3カップ欄が最初から表示され、その自動表示分に削除ボタンがないことを確認
   11. クリーンアップ
-- **期待結果**: ラウンドをまたいだ同カップは許可されるが、同じラウンドのカップ組み合わせは FT3 の5件目を除いて重複しない。FT数ぶんの初期カップ欄は削除できず、追加したカップ欄だけ削除できる。legacy 修復時のDB updateは同数の valid sequence を first-seen で決定し、round-scoped `updateMany()` によって O(matches) ではなく O(rounds) の書き込みに収まる。一部失敗しても閲覧レスポンスを継続する
+- **期待結果**: ラウンドをまたいだ同カップは許可されるが、同じラウンドのカップ組み合わせは FT3 の5件目を除いて重複しない。FT数ぶんの初期カップ欄は削除できず、追加したカップ欄だけ削除できる。legacy 修復時のDB updateは同数の valid sequence を first-seen で決定し、round-scoped `updateMany()` によって O(matches) ではなく O(rounds) の書き込みに収まる。正規済み行は `id IN (...)` の対象から外し、一部失敗しても閲覧レスポンスを継続する
 - **スクリプト**: tc-gp.js TC-717
 - **補助検証**: `smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts`
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -244,7 +244,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       expect(result.status).toBe(200);
       expect(prisma.gPMatch.updateMany).toHaveBeenCalledTimes(1);
       expect(prisma.gPMatch.updateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r1' },
+        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r1', id: { in: ['pm1', 'pm2', 'pm3', 'pm4'] } },
         data: { cup: 'Flower', assignedCups: ['Flower'] },
       });
       expect(prisma.gPMatch.update).not.toHaveBeenCalled();
@@ -276,11 +276,11 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       expect(result.status).toBe(200);
       expect(prisma.gPMatch.updateMany).toHaveBeenCalledTimes(2);
       expect(prisma.gPMatch.updateMany).toHaveBeenNthCalledWith(1, {
-        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r1' },
+        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r1', id: { in: ['pm1', 'pm2'] } },
         data: { cup: 'Flower', assignedCups: ['Flower'] },
       });
       expect(prisma.gPMatch.updateMany).toHaveBeenNthCalledWith(2, {
-        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r2' },
+        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r2', id: { in: ['pm3', 'pm4'] } },
         data: { cup: 'Mushroom', assignedCups: ['Mushroom'] },
       });
       expect(prisma.gPMatch.update).not.toHaveBeenCalled();
@@ -347,7 +347,12 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
 
       expect(prisma.gPMatch.updateMany).toHaveBeenCalledTimes(1);
       const updateCall = (prisma.gPMatch.updateMany as jest.Mock).mock.calls[0][0];
-      expect(updateCall.where).toEqual({ tournamentId: 't1', stage: 'playoff', round: 'playoff_r1' });
+      expect(updateCall.where).toEqual({
+        tournamentId: 't1',
+        stage: 'playoff',
+        round: 'playoff_r1',
+        id: { in: ['pm1', 'pm2', 'pm3', 'pm4'] },
+      });
       expect(updateCall.data.assignedCups).toHaveLength(1);
       expect(updateCall.data.cup).toBe(updateCall.data.assignedCups[0]);
       expect(['Mushroom', 'Flower', 'Star', 'Special']).toContain(updateCall.data.cup);
@@ -381,7 +386,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
 
       expect(prisma.gPMatch.updateMany).toHaveBeenCalledTimes(1);
       expect(prisma.gPMatch.updateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r1' },
+        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r1', id: { in: ['pm2'] } },
         data: { cup: 'Flower', assignedCups: ['Flower'] },
       });
       expect(prisma.gPMatch.update).not.toHaveBeenCalled();
@@ -417,7 +422,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       }));
       expect(prisma.gPMatch.updateMany).toHaveBeenCalledTimes(1);
       expect(prisma.gPMatch.updateMany).toHaveBeenCalledWith({
-        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r1' },
+        where: { tournamentId: 't1', stage: 'playoff', round: 'playoff_r1', id: { in: ['pm2'] } },
         data: { cup: 'Star', assignedCups: ['Star'] },
       });
       expect(prisma.gPMatch.update).not.toHaveBeenCalled();

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -74,6 +74,7 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('first-seen');
     expect(section).toContain('round-scoped `updateMany()`');
     expect(section).toContain('O(rounds)');
+    expect(section).toContain('id IN (...)');
     expect(section).toContain('一部失敗しても閲覧レスポンスを継続');
     expect(section).toContain('失敗件数と理由を警告ログ');
     expect(section).toContain('gp/finals/route.test.ts');

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -300,14 +300,19 @@ async function normalizeRoundCupsToSingleSequence(
     canonicalByRound.set(round, { cup: assignedCups[0], assignedCups });
   }
 
-  /* Collapse legacy GP repairs to one write per round. We intentionally do
-   * not add JSON equality predicates here: Prisma's JSON filters are brittle
-   * on D1/SQLite, and canonicalByRound only contains rounds that JS already
-   * proved need repair. */
+  /* Collapse legacy GP repairs to one write per round. Keep JSON comparison in
+   * JS, then scope updateMany by id list instead of adding brittle Prisma JSON
+   * predicates on D1/SQLite. */
   const writes: Array<Promise<unknown>> = [];
   for (const [round, data] of canonicalByRound) {
+    const canonicalKey = JSON.stringify(data.assignedCups);
+    const staleIds = (matchesByRound.get(round) ?? [])
+      .filter((match) => match.cup !== data.cup || JSON.stringify(match.assignedCups) !== canonicalKey)
+      .map((match) => match.id);
+    if (staleIds.length === 0) continue;
+
     writes.push(modelInstance.updateMany({
-      where: { tournamentId, stage, round },
+      where: { tournamentId, stage, round, id: { in: staleIds } },
       data,
     }));
   }


### PR DESCRIPTION
Summary
- Keep GP assignedCups legacy repair batched by round while limiting each updateMany to stale match ids.
- Avoid D1 JSON predicates by comparing assignedCups in JS and using id IN for rows that actually need repair.
- Update TC-717 docs and route tests to assert both stale-row scope and already-canonical skip behavior.

Issues: Closes #1411, Closes #1413

Validation
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts' __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/api-factories/finals-route.test.ts --runInBand
- npm run lint -- src/lib/api-factories/finals-route.ts '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts' __tests__/docs/e2e-cases-drift.test.ts