### PR TITLE
test: simplify GP backfill skip comment

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -449,8 +449,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       const params = Promise.resolve({ id: 't1' });
       await GET(request, { params });
 
-      /* #1413: an already-canonical round must take the skip path and avoid
-       * issuing updateMany for rows that do not need repair. */
+      // #1413: canonical rounds must skip updateMany to avoid unnecessary repair writes.
       expect(prisma.gPMatch.updateMany).not.toHaveBeenCalled();
       expect(prisma.gPMatch.update).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
Summary
- Convert the GP backfill canonical-skip test comment to a one-line comment.
- Keep the existing assertion coverage unchanged.

Issues: Closes #1415

Validation
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts' --runInBand
- npm run lint -- '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts'