### PR TITLE
test: clarify home recommendation static guard

### DIFF
--- a/smkc-score-app/__tests__/static/tc-1417-home-recommendation.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1417-home-recommendation.test.ts
@@ -34,6 +34,7 @@ describe('TC-1417 home recommendation static guard', () => {
     );
 
     const sectionStart = source.indexOf('Sponsored recommendation block');
+    expect(sectionStart).toBeGreaterThanOrEqual(0);
     const sectionEnd = source.indexOf('\n    </div>', sectionStart);
     const section = source.slice(sectionStart, sectionEnd);
 


### PR DESCRIPTION
## Summary
- Add an explicit boundary assertion for the TC-1417 sponsored recommendation source slice.

## Issues
Closes #1423

## Validation
- npm test -- --runTestsByPath __tests__/static/tc-1417-home-recommendation.test.ts
- npm run lint

## Checklist
- [x] Summary only describes changes that are present in this PR diff.