### PR TITLE
test: guard home recommendation section end

### DIFF
--- a/smkc-score-app/__tests__/static/tc-1417-home-recommendation.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1417-home-recommendation.test.ts
@@ -36,6 +36,7 @@ describe('TC-1417 home recommendation static guard', () => {
     const sectionStart = source.indexOf('Sponsored recommendation block');
     expect(sectionStart).toBeGreaterThanOrEqual(0);
     const sectionEnd = source.indexOf('\n    </div>', sectionStart);
+    expect(sectionEnd).toBeGreaterThan(sectionStart);
     const section = source.slice(sectionStart, sectionEnd);
 
     expect(section).toContain('aria-labelledby="recommended-heading"');


### PR DESCRIPTION
## Summary
- Add an explicit sectionEnd assertion for the TC-1417 sponsored recommendation source slice.

## Issues
Closes #1425

## Validation
- npm test -- --runTestsByPath __tests__/static/tc-1417-home-recommendation.test.ts
- npm run lint

## Checklist
- [x] Summary only describes changes that are present in this PR diff.