### PR TITLE
test: unify home recommendation section slicing

### DIFF
--- a/smkc-score-app/__tests__/static/tc-1417-home-recommendation.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1417-home-recommendation.test.ts
@@ -7,17 +7,30 @@ function readRepoFile(...parts: string[]) {
   return fs.readFileSync(path.join(root, ...parts), 'utf8');
 }
 
+function sectionFor(
+  source: string,
+  startMarker: string,
+  endMarker: string,
+  { allowTerminal = false }: { allowTerminal?: boolean } = {},
+) {
+  const sectionStart = source.indexOf(startMarker);
+  expect(sectionStart).toBeGreaterThanOrEqual(0);
+
+  const sectionEndCandidate = source.indexOf(endMarker, sectionStart + startMarker.length);
+  if (!allowTerminal) {
+    expect(sectionEndCandidate).toBeGreaterThan(sectionStart);
+    return source.slice(sectionStart, sectionEndCandidate);
+  }
+
+  const sectionEnd = sectionEndCandidate === -1 ? source.length : sectionEndCandidate;
+  expect(sectionEnd).toBeGreaterThan(sectionStart);
+  return source.slice(sectionStart, sectionEnd);
+}
+
 describe('TC-1417 home recommendation static guard', () => {
   it('documents the sponsored recommendation scenario in the E2E case list', () => {
     const cases = readRepoFile('E2E_TEST_CASES.md');
-    const sectionStart = cases.indexOf('## TC-1417:');
-    expect(sectionStart).toBeGreaterThanOrEqual(0);
-
-    const sectionEnd = cases.indexOf('\n## TC-', sectionStart + 1);
-    const section = cases.slice(
-      sectionStart,
-      sectionEnd === -1 ? cases.length : sectionEnd,
-    );
+    const section = sectionFor(cases, '## TC-1417:', '\n## TC-', { allowTerminal: true });
 
     expect(section).toContain('issue #1417');
     expect(section).toContain('rel="sponsored noopener noreferrer"');
@@ -33,11 +46,7 @@ describe('TC-1417 home recommendation static guard', () => {
       'page.tsx',
     );
 
-    const sectionStart = source.indexOf('Sponsored recommendation block');
-    expect(sectionStart).toBeGreaterThanOrEqual(0);
-    const sectionEnd = source.indexOf('\n    </div>', sectionStart);
-    expect(sectionEnd).toBeGreaterThan(sectionStart);
-    const section = source.slice(sectionStart, sectionEnd);
+    const section = sectionFor(source, 'Sponsored recommendation block', '\n    </div>');
 
     expect(section).toContain('aria-labelledby="recommended-heading"');
     expect(section).toContain('id="recommended-heading"');


### PR DESCRIPTION
## Summary
- Share the TC-1417 static-test section slicing helper across the docs and source checks.
- Keep explicit start/end boundary assertions while allowing TC-1417 to remain the final E2E section.

## Issues
Closes #1427

## Validation
- npm test -- --runTestsByPath __tests__/static/tc-1417-home-recommendation.test.ts
- npm run lint

## Checklist
- [x] Summary only describes changes that are present in this PR diff.