### PR TITLE
test: clarify terminal section slicing

### DIFF
--- a/smkc-score-app/__tests__/static/tc-1417-home-recommendation.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1417-home-recommendation.test.ts
@@ -22,9 +22,12 @@ function sectionFor(
     return source.slice(sectionStart, sectionEndCandidate);
   }
 
-  const sectionEnd = sectionEndCandidate === -1 ? source.length : sectionEndCandidate;
-  expect(sectionEnd).toBeGreaterThan(sectionStart);
-  return source.slice(sectionStart, sectionEnd);
+  if (sectionEndCandidate === -1) {
+    return source.slice(sectionStart);
+  }
+
+  expect(sectionEndCandidate).toBeGreaterThan(sectionStart);
+  return source.slice(sectionStart, sectionEndCandidate);
 }
 
 describe('TC-1417 home recommendation static guard', () => {


### PR DESCRIPTION
## Summary
- Remove the redundant terminal-section assertion in the TC-1417 static-test helper.
- Keep end-marker assertions only when an end marker is actually present or required.

## Issues
Closes #1429

## Validation
- npm test -- --runTestsByPath __tests__/static/tc-1417-home-recommendation.test.ts
- npm run lint

## Checklist
- [x] Summary only describes changes that are present in this PR diff.