### PR TITLE
test: assert GP reported races JsonNull

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1675,8 +1675,10 @@
      `{ reportingPlayer: 1, points1: 45, points2: 0 }` を POST
   4. レスポンスに `autoConfirmed: true` が含まれること（`dualReportEnabled=false` のため即時確定）
   5. 管理者APIでマッチが completed、`points1=45, points2=0` で保存されていること
-  6. クリーンアップ
-- **期待結果**: GP participant 入力でdriver points合計送信→永続化が動作
+  6. issue #1099: driver points 直接入力時の `player1ReportedRaces` は `Prisma.JsonNull` として保存され、テストも `expect.any(Object)` に依存しないことを確認する
+  7. クリーンアップ
+- **期待結果**: GP participant 入力でdriver points合計送信→永続化が動作し、race breakdown がない直接入力は Prisma の JsonNull sentinel として扱われる
+- **スクリプト**: e2e/tc-gp.js TC-702
 
 ## TC-1098: GPドライバーズポイント上限を共有定数で参照する
 - **URL**: n/a (source guard)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts
@@ -71,6 +71,7 @@ import { auth } from '@/lib/auth';
 import { createLogger } from '@/lib/logger';
 import { updateWithRetry } from '@/lib/optimistic-locking';
 import { POST } from '@/app/api/tournaments/[id]/gp/match/[matchId]/report/route';
+import { Prisma } from '@prisma/client';
 
 const {
   createSuccessResponse,
@@ -231,7 +232,7 @@ describe('GP Score Report API Route - /api/tournaments/[id]/gp/match/[matchId]/r
         data: expect.objectContaining({
           player1ReportedPoints1: 37,
           player1ReportedPoints2: 24,
-          player1ReportedRaces: expect.any(Object),
+          player1ReportedRaces: Prisma.JsonNull,
         }),
       }));
       expect(prisma.scoreEntryLog.create).toHaveBeenCalledWith(expect.objectContaining({

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -36,6 +36,7 @@ describe('E2E case drift coverage', () => {
   it.each([
     ['TC-352', tcAll],
     ['TC-357', tcAll],
+    ['TC-702', tcGp],
     ['TC-717', tcGp],
     ['TC-722', tcGp],
     ['TC-1103', tcGp],
@@ -55,6 +56,21 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('**期待結果**');
     expect(section).toContain(`**スクリプト**:`);
     expect(scriptSource).toContain(`log('${tc}'`);
+  });
+
+  it('keeps TC-702 aligned with direct driver-points JsonNull reporting coverage', () => {
+    const section = sectionFor('TC-702');
+    const gpReportRouteTest = fs.readFileSync(
+      path.join(process.cwd(), '__tests__', 'app', 'api', 'tournaments', '[id]', 'gp', 'match', '[matchId]', 'report', 'route.test.ts'),
+      'utf8',
+    );
+
+    expect(section).toContain('issue #1099');
+    expect(section).toContain('`Prisma.JsonNull`');
+    expect(section).toContain('`expect.any(Object)`');
+    expect(tcGp).toContain("{ name: 'TC-702', fn: runTc702 }");
+    expect(gpReportRouteTest).toContain('player1ReportedRaces: Prisma.JsonNull');
+    expect(gpReportRouteTest).not.toContain('player1ReportedRaces: expect.any(Object)');
   });
 
   it('keeps TC-TA-FLOW-24 documented as the parent runnable for rank sub-coverage', () => {


### PR DESCRIPTION
## Summary
- Add TC-702 scenario coverage for direct GP driver-points JsonNull handling.
- Register TC-702 in the docs/runner drift guard and add a focused static regression for issue #1099.
- Replace the brittle player1ReportedRaces expect.any(Object) assertion with Prisma.JsonNull.

## Issues
Closes #1099

## Validation
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts' __tests__/docs/e2e-cases-drift.test.ts
- npm run lint -- '__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts' __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
