### PR TITLE
test: align TC-702 JsonNull E2E guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1675,7 +1675,7 @@
      `{ reportingPlayer: 1, points1: 45, points2: 0 }` を POST
   4. レスポンスに `autoConfirmed: true` が含まれること（`dualReportEnabled=false` のため即時確定）
   5. 管理者APIでマッチが completed、`points1=45, points2=0` で保存されていること
-  6. issue #1099: driver points 直接入力時の `player1ReportedRaces` は `Prisma.JsonNull` として保存され、テストも `expect.any(Object)` に依存しないことを確認する
+  6. issue #1099/#1437: driver points 直接入力時の `player1ReportedRaces` は `Prisma.JsonNull` として保存され、API 再取得では `null` として返ることを確認する
   7. クリーンアップ
 - **期待結果**: GP participant 入力でdriver points合計送信→永続化が動作し、race breakdown がない直接入力は Prisma の JsonNull sentinel として扱われる
 - **スクリプト**: e2e/tc-gp.js TC-702

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -60,17 +60,12 @@ describe('E2E case drift coverage', () => {
 
   it('keeps TC-702 aligned with direct driver-points JsonNull reporting coverage', () => {
     const section = sectionFor('TC-702');
-    const gpReportRouteTest = fs.readFileSync(
-      path.join(process.cwd(), '__tests__', 'app', 'api', 'tournaments', '[id]', 'gp', 'match', '[matchId]', 'report', 'route.test.ts'),
-      'utf8',
-    );
 
-    expect(section).toContain('issue #1099');
+    expect(section).toContain('issue #1099/#1437');
     expect(section).toContain('`Prisma.JsonNull`');
-    expect(section).toContain('`expect.any(Object)`');
+    expect(section).toContain('`null`');
     expect(tcGp).toContain("{ name: 'TC-702', fn: runTc702 }");
-    expect(gpReportRouteTest).toContain('player1ReportedRaces: Prisma.JsonNull');
-    expect(gpReportRouteTest).not.toContain('player1ReportedRaces: expect.any(Object)');
+    expect(tcGp).toContain('updated?.player1ReportedRaces === null');
   });
 
   it('keeps TC-TA-FLOW-24 documented as the parent runnable for rank sub-coverage', () => {

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -400,12 +400,14 @@ async function runTc702(adminPage) {
 
     const after = await apiFetchGp(adminPage, tournamentId);
     const updated = (after.matches || []).find((m) => m.id === match.id);
-    /* P1/P2 driver-point totals are persisted directly. */
-    const persisted = updated?.completed === true && updated.points1 === 45 && updated.points2 === 0;
+    /* P1/P2 driver-point totals are persisted directly; no race breakdown is stored. */
+    const directPointsPersisted = updated?.completed === true && updated.points1 === 45 && updated.points2 === 0;
+    const reportedRacesPersistedAsNull = updated?.player1ReportedRaces === null;
 
-    log('TC-702', confirmed && persisted ? 'PASS' : 'FAIL',
+    log('TC-702', confirmed && directPointsPersisted && reportedRacesPersistedAsNull ? 'PASS' : 'FAIL',
       !confirmed ? `report not confirmed: status=${reportRes.s}`
-      : !persisted ? `points: ${updated?.points1}-${updated?.points2} completed=${updated?.completed}`
+      : !directPointsPersisted ? `points: ${updated?.points1}-${updated?.points2} completed=${updated?.completed}`
+      : !reportedRacesPersistedAsNull ? `reportedRaces=${JSON.stringify(updated?.player1ReportedRaces)}`
       : '');
   } catch (err) {
     log('TC-702', 'FAIL', err instanceof Error ? err.message : 'GP 702 failed');


### PR DESCRIPTION
## Summary
- Extend TC-702 to verify direct GP driver-point reports return player1ReportedRaces as null after API refetch.
- Keep the E2E scenario aligned with the JsonNull persistence expectation from #1099/#1437.
- Narrow the drift guard to docs and E2E-script alignment instead of string-matching the unit test implementation.

## Issues
Closes #1437
Closes #1438

## Validation
- node --check e2e/tc-gp.js
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts '__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts'
- npm run lint -- __tests__/docs/e2e-cases-drift.test.ts '__tests__/app/api/tournaments/[id]/gp/match/[matchId]/report/route.test.ts'
- git diff --check
