### PR TITLE
fix: block locked finals bracket reset

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1007,15 +1007,16 @@
 ## TC-516: BM 予選ページの決勝ブラケット存在状態 + リセット
 - **URL**: /tournaments/[temp-id]/bm
 - **authRequired**: true (admin)
-- **背景**: 決勝ブラケット生成後に予選ページを再訪すると「View Tournament / トーナメントを見る」が表示される。危険操作である「Reset Bracket / ブラケットリセット」は予選ロック中は非表示で、予選ロック解除後のみ表示される
+- **背景**: 決勝ブラケット生成後に予選ページを再訪すると「View Tournament / トーナメントを見る」が表示される。危険操作である「Reset Bracket / ブラケットリセット」は予選ロック中は非表示で、直接 API リセットも 409 で拒否され、予選ロック解除後のみ表示される
 - **手順**:
   1. 28名予選完了状態のトーナメントで qualificationConfirmed=true にし、Top-8 ブラケットを生成する
   2. 予選ページ（`/bm`）を開き「View Tournament」が表示され、「Reset Bracket」が表示されないことを確認する
-  3. qualificationConfirmed=false にして予選ロックを解除し、「Reset Bracket」ボタンが表示されることを確認する
-  4. 「Reset Bracket」ボタンをクリックし、確認ダイアログで OK を選択する
-  5. リセット後は予選が未ロックのままなので、「Reset Bracket」と「Start Playoff / Generate Finals Bracket」が表示されないことを確認する
-  6. クリーンアップ
-- **期待結果**: ブラケット生成後は「View Tournament」のみ、予選ロック解除後だけ「Reset Bracket」が表示され、リセット後は再ロックまで生成ボタンも出ない
+  3. ロック中に `POST /api/tournaments/[id]/bm/finals { reset: true }` を直接呼び、409 `QUALIFICATION_LOCKED` が返ることを確認する
+  4. qualificationConfirmed=false にして予選ロックを解除し、「Reset Bracket」ボタンが表示されることを確認する
+  5. 「Reset Bracket」ボタンをクリックし、確認ダイアログで OK を選択する
+  6. リセット後は予選が未ロックのままなので、「Reset Bracket」と「Start Playoff / Generate Finals Bracket」が表示されないことを確認する
+  7. クリーンアップ
+- **期待結果**: ブラケット生成後は「View Tournament」のみ、予選ロック中の直接 API リセットは拒否され、予選ロック解除後だけ「Reset Bracket」が表示され、リセット後は再ロックまで生成ボタンも出ない
 
 ## TC-505: BM Grand Final → チャンピオン決定（28名予選後）
 - **URL**: /tournaments/[temp-id]/bm/finals
@@ -1493,15 +1494,16 @@
 ## TC-616: MR 予選ページの決勝ブラケット存在状態 + リセット
 - **URL**: /tournaments/[temp-id]/mr
 - **authRequired**: true (admin)
-- **背景**: BM TC-516 の MR 版。決勝ブラケット生成後に予選ページを再訪すると「View Tournament」が表示される。危険操作である「Reset Bracket」は予選ロック中は非表示で、予選ロック解除後のみ表示される
+- **背景**: BM TC-516 の MR 版。決勝ブラケット生成後に予選ページを再訪すると「View Tournament」が表示される。危険操作である「Reset Bracket」は予選ロック中は非表示で、直接 API リセットも 409 で拒否され、予選ロック解除後のみ表示される
 - **手順**:
   1. 28名予選完了状態のトーナメントで qualificationConfirmed=true にし、Top-8 ブラケットを生成する
   2. 予選ページ（`/mr`）を開き「View Tournament / トーナメントを見る」が表示され、「Reset Bracket / ブラケットリセット」が表示されないことを確認する
-  3. qualificationConfirmed=false にして予選ロックを解除し、「Reset Bracket / ブラケットリセット」ボタンが表示されることを確認する
-  4. 「Reset Bracket / ブラケットリセット」ボタンをクリックし、確認ダイアログで OK を選択する
-  5. リセット後は予選が未ロックのままなので、「Reset Bracket」と「Start Playoff / Generate Finals Bracket」が表示されないことを確認する
-  6. クリーンアップ
-- **期待結果**: ブラケット生成後は「View Tournament」のみ、予選ロック解除後だけ「Reset Bracket」が表示され、リセット後は再ロックまで生成ボタンも出ない
+  3. ロック中に `POST /api/tournaments/[id]/mr/finals { reset: true }` を直接呼び、409 `QUALIFICATION_LOCKED` が返ることを確認する
+  4. qualificationConfirmed=false にして予選ロックを解除し、「Reset Bracket / ブラケットリセット」ボタンが表示されることを確認する
+  5. 「Reset Bracket / ブラケットリセット」ボタンをクリックし、確認ダイアログで OK を選択する
+  6. リセット後は予選が未ロックのままなので、「Reset Bracket」と「Start Playoff / Generate Finals Bracket」が表示されないことを確認する
+  7. クリーンアップ
+- **期待結果**: ブラケット生成後は「View Tournament」のみ、予選ロック中の直接 API リセットは拒否され、予選ロック解除後だけ「Reset Bracket」が表示され、リセット後は再ロックまで生成ボタンも出ない
 
 ## TC-812: TA 予選同着解決 — 同タイムで average 課題ポイント
 - **URL**: /tournaments/[temp-id]/ta
@@ -2075,15 +2077,16 @@
 ## TC-716: GP 予選ページの決勝ブラケット存在状態 + リセット
 - **URL**: /tournaments/[temp-id]/gp
 - **authRequired**: true (admin)
-- **背景**: BM TC-516 / MR TC-616 の GP 版。決勝ブラケット生成後に予選ページを再訪すると「View Tournament」が表示される。危険操作である「Reset Bracket」は予選ロック中は非表示で、予選ロック解除後のみ表示される
+- **背景**: BM TC-516 / MR TC-616 の GP 版。決勝ブラケット生成後に予選ページを再訪すると「View Tournament」が表示される。危険操作である「Reset Bracket」は予選ロック中は非表示で、直接 API リセットも 409 で拒否され、予選ロック解除後のみ表示される
 - **手順**:
   1. 28名予選完了状態のトーナメントで qualificationConfirmed=true にし、Top-8 ブラケットを生成する
   2. 予選ページ（`/gp`）を開き「View Tournament / トーナメントを見る」が表示され、「Reset Bracket / ブラケットリセット」が表示されないことを確認する
-  3. qualificationConfirmed=false にして予選ロックを解除し、「Reset Bracket / ブラケットリセット」ボタンが表示されることを確認する
-  4. 「Reset Bracket / ブラケットリセット」ボタンをクリックし、確認ダイアログで OK を選択する
-  5. リセット後は予選が未ロックのままなので、「Reset Bracket」と「Start Playoff / Generate Finals Bracket」が表示されないことを確認する
-  6. クリーンアップ
-- **期待結果**: ブラケット生成後は「View Tournament」のみ、予選ロック解除後だけ「Reset Bracket」が表示され、リセット後は再ロックまで生成ボタンも出ない
+  3. ロック中に `POST /api/tournaments/[id]/gp/finals { reset: true }` を直接呼び、409 `QUALIFICATION_LOCKED` が返ることを確認する
+  4. qualificationConfirmed=false にして予選ロックを解除し、「Reset Bracket / ブラケットリセット」ボタンが表示されることを確認する
+  5. 「Reset Bracket / ブラケットリセット」ボタンをクリックし、確認ダイアログで OK を選択する
+  6. リセット後は予選が未ロックのままなので、「Reset Bracket」と「Start Playoff / Generate Finals Bracket」が表示されないことを確認する
+  7. クリーンアップ
+- **期待結果**: ブラケット生成後は「View Tournament」のみ、予選ロック中の直接 API リセットは拒否され、予選ロック解除後だけ「Reset Bracket」が表示され、リセット後は再ロックまで生成ボタンも出ない
 
 ## TC-719: GP 決勝 — 非 Grand Final マッチの同点カップ継続
 - **背景**: GP の Grand Final 以外のブラケットマッチでも、カップ内同点時はサドンデスではなく次カップへ進むこと

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -948,6 +948,44 @@ describe('Finals Route Factory', () => {
       expect((prisma.bMMatch as any).createMany).toHaveBeenCalledTimes(1);
     });
 
+    it.each([
+      ['bm', 'bMMatch', 'bMQualification', 'bmQualificationConfirmed'],
+      ['mr', 'mRMatch', 'mRQualification', 'mrQualificationConfirmed'],
+      ['gp', 'gPMatch', 'gPQualification', 'gpQualificationConfirmed'],
+    ] as const)('should reject %s bracket reset while qualification is locked', async (eventTypeCode, matchModel, qualificationModel, flag) => {
+      (prisma.tournament as any).findUnique.mockResolvedValue({
+        id: 'tournament-123',
+        bmQualificationConfirmed: false,
+        mrQualificationConfirmed: false,
+        gpQualificationConfirmed: false,
+        [flag]: true,
+      });
+
+      const config = createMockConfig({
+        eventTypeCode,
+        matchModel,
+        qualificationModel,
+      });
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ reset: true }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(409);
+      const json = await response.json();
+      expect(json).toMatchObject({
+        success: false,
+        error: 'Cannot reset bracket while qualification is locked',
+        code: 'QUALIFICATION_LOCKED',
+      });
+      expect((prisma[matchModel] as any).deleteMany).not.toHaveBeenCalled();
+    });
+
     it('should return 400 when topN is not 8', async () => {
       const config = createMockConfig();
       const { POST } = createFinalsHandlers(config);

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -825,6 +825,16 @@ async function runTc516(adminPage) {
       name: /Reset Bracket|ブラケットリセット/,
     });
     const resetHiddenWhileLocked = (await resetBtn.count()) === 0;
+    const resetApiLocked = await adminPage.evaluate(async (tid) => {
+      const r = await fetch(`/api/tournaments/${tid}/bm/finals`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ reset: true }),
+      });
+      return { s: r.status, body: await r.json().catch(() => ({})) };
+    }, tournamentId);
+    const resetApiBlockedWhileLocked = resetApiLocked.s === 409
+      && resetApiLocked.body?.code === 'QUALIFICATION_LOCKED';
 
     const unlockRes = await apiUpdateTournament(adminPage, tournamentId, { bmQualificationConfirmed: false });
     if (unlockRes.s !== 200) throw new Error(`Failed to unlock qualification (${unlockRes.s})`);
@@ -849,10 +859,11 @@ async function runTc516(adminPage) {
     const resetHiddenAfterReset = !postResetText.includes('Reset Bracket') && !postResetText.includes('ブラケットリセット');
     const generateHiddenWhileUnlocked = !postResetText.includes('Generate Finals Bracket') && !postResetText.includes('Generate Bracket') && !postResetText.includes('ブラケット生成') && !postResetText.includes('generateFinalsBracket') && !postResetText.includes('Start Playoff') && !postResetText.includes('バラッジ開始');
 
-    const ok = hasViewTournament && resetHiddenWhileLocked && hasViewTournamentUnlocked && hasResetBracketUnlocked && resetVisible && resetHiddenAfterReset && generateHiddenWhileUnlocked;
+    const ok = hasViewTournament && resetHiddenWhileLocked && resetApiBlockedWhileLocked && hasViewTournamentUnlocked && hasResetBracketUnlocked && resetVisible && resetHiddenAfterReset && generateHiddenWhileUnlocked;
     log('TC-516', ok ? 'PASS' : 'FAIL',
       !hasViewTournament ? 'View Tournament button missing after bracket creation'
       : !resetHiddenWhileLocked ? 'Reset Bracket visible while qualification is locked'
+      : !resetApiBlockedWhileLocked ? `Reset API allowed locked qualification (${resetApiLocked.s})`
       : !hasViewTournamentUnlocked ? 'View Tournament button missing after unlocking qualification'
       : !hasResetBracketUnlocked ? 'Reset Bracket button missing after qualification unlock'
       : !resetVisible ? 'Reset Bracket not found as button element'

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -1100,6 +1100,16 @@ async function runTc716(adminPage) {
       name: /Reset Bracket|ブラケットリセット/,
     });
     const resetHiddenWhileLocked = (await resetBtn.count()) === 0;
+    const resetApiLocked = await adminPage.evaluate(async (tid) => {
+      const r = await fetch(`/api/tournaments/${tid}/gp/finals`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ reset: true }),
+      });
+      return { s: r.status, body: await r.json().catch(() => ({})) };
+    }, tournamentId);
+    const resetApiBlockedWhileLocked = resetApiLocked.s === 409
+      && resetApiLocked.body?.code === 'QUALIFICATION_LOCKED';
 
     const unlockRes = await apiUpdateTournament(adminPage, tournamentId, { gpQualificationConfirmed: false });
     if (unlockRes.s !== 200) throw new Error(`Failed to unlock qualification (${unlockRes.s})`);
@@ -1126,10 +1136,11 @@ async function runTc716(adminPage) {
     const resetHiddenAfterReset = !postResetText.includes('Reset Bracket') && !postResetText.includes('ブラケットリセット');
     const generateHiddenWhileUnlocked = !postResetText.includes('Generate Finals Bracket') && !postResetText.includes('Generate Bracket') && !postResetText.includes('ブラケット生成') && !postResetText.includes('generateFinalsBracket') && !postResetText.includes('Start Playoff') && !postResetText.includes('バラッジ開始');
 
-    const ok = hasViewTournament && resetHiddenWhileLocked && hasViewTournamentUnlocked && hasResetBracketUnlocked && resetVisible && resetHiddenAfterReset && generateHiddenWhileUnlocked;
+    const ok = hasViewTournament && resetHiddenWhileLocked && resetApiBlockedWhileLocked && hasViewTournamentUnlocked && hasResetBracketUnlocked && resetVisible && resetHiddenAfterReset && generateHiddenWhileUnlocked;
     log('TC-716', ok ? 'PASS' : 'FAIL',
       !hasViewTournament ? 'View Tournament button missing after bracket creation'
       : !resetHiddenWhileLocked ? 'Reset Bracket visible while qualification is locked'
+      : !resetApiBlockedWhileLocked ? `Reset API allowed locked qualification (${resetApiLocked.s})`
       : !hasViewTournamentUnlocked ? 'View Tournament button missing after unlocking qualification'
       : !hasResetBracketUnlocked ? 'Reset Bracket button missing after qualification unlock'
       : !resetVisible ? 'Reset Bracket not found as button element'

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -1344,6 +1344,16 @@ async function runTc616(adminPage) {
       name: /Reset Bracket|ブラケットリセット/,
     });
     const resetHiddenWhileLocked = (await resetBtn.count()) === 0;
+    const resetApiLocked = await adminPage.evaluate(async (tid) => {
+      const r = await fetch(`/api/tournaments/${tid}/mr/finals`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ reset: true }),
+      });
+      return { s: r.status, body: await r.json().catch(() => ({})) };
+    }, tournamentId);
+    const resetApiBlockedWhileLocked = resetApiLocked.s === 409
+      && resetApiLocked.body?.code === 'QUALIFICATION_LOCKED';
 
     const unlockRes = await apiUpdateTournament(adminPage, tournamentId, { mrQualificationConfirmed: false });
     if (unlockRes.s !== 200) throw new Error(`Failed to unlock qualification (${unlockRes.s})`);
@@ -1370,10 +1380,11 @@ async function runTc616(adminPage) {
     const resetHiddenAfterReset = !postResetText.includes('Reset Bracket') && !postResetText.includes('ブラケットリセット');
     const generateHiddenWhileUnlocked = !postResetText.includes('Generate Finals Bracket') && !postResetText.includes('Generate Bracket') && !postResetText.includes('ブラケット生成') && !postResetText.includes('generateFinalsBracket') && !postResetText.includes('Start Playoff') && !postResetText.includes('バラッジ開始');
 
-    const ok = hasViewTournament && resetHiddenWhileLocked && hasViewTournamentUnlocked && hasResetBracketUnlocked && resetVisible && resetHiddenAfterReset && generateHiddenWhileUnlocked;
+    const ok = hasViewTournament && resetHiddenWhileLocked && resetApiBlockedWhileLocked && hasViewTournamentUnlocked && hasResetBracketUnlocked && resetVisible && resetHiddenAfterReset && generateHiddenWhileUnlocked;
     log('TC-616', ok ? 'PASS' : 'FAIL',
       !hasViewTournament ? 'View Tournament button missing after bracket creation'
       : !resetHiddenWhileLocked ? 'Reset Bracket visible while qualification is locked'
+      : !resetApiBlockedWhileLocked ? `Reset API allowed locked qualification (${resetApiLocked.s})`
       : !hasViewTournamentUnlocked ? 'View Tournament button missing after unlocking qualification'
       : !hasResetBracketUnlocked ? 'Reset Bracket button missing after qualification unlock'
       : !resetVisible ? 'Reset Bracket not found as button element'

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -48,6 +48,15 @@ const BRACKET_SIZE_THRESHOLD = 20;
  */
 const PLAYOFF_ENTRANT_COUNT = 12;
 
+type QualificationConfirmedField =
+  | 'bmQualificationConfirmed'
+  | 'mrQualificationConfirmed'
+  | 'gpQualificationConfirmed';
+
+function getQualificationConfirmedField(eventTypeCode: 'bm' | 'mr' | 'gp'): QualificationConfirmedField {
+  return `${eventTypeCode}QualificationConfirmed` as QualificationConfirmedField;
+}
+
 interface FinalsMatchResult {
   winnerId?: string;
   loserId?: string;
@@ -869,10 +878,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
     // the mode-specific qualificationConfirmed flag, so the projection stays
     // tight. Using per-mode flags (issue #696) prevents BM confirmation from
     // locking MR/GP bracket creation.
-    const modeField = `${config.eventTypeCode}QualificationConfirmed` as
-      | 'bmQualificationConfirmed'
-      | 'mrQualificationConfirmed'
-      | 'gpQualificationConfirmed';
+    const modeField = getQualificationConfirmedField(config.eventTypeCode);
     // Select all three flags explicitly to avoid computed-key type inference issues with Prisma generics.
     let tournament;
     try {
@@ -1254,6 +1260,27 @@ export function createFinalsHandlers(config: FinalsConfig) {
        * start over from qualification. Triggered by a dedicated reset button
        * on the qualification page. */
       if (reset) {
+        const modeField = getQualificationConfirmedField(config.eventTypeCode);
+        const tournament = await prisma.tournament.findUnique({
+          where: { id: tournamentId },
+          select: {
+            bmQualificationConfirmed: true,
+            mrQualificationConfirmed: true,
+            gpQualificationConfirmed: true,
+          },
+        });
+
+        if (!tournament) {
+          return createErrorResponse('Tournament not found', 404, 'NOT_FOUND');
+        }
+        if (tournament[modeField]) {
+          return createErrorResponse(
+            'Cannot reset bracket while qualification is locked',
+            409,
+            'QUALIFICATION_LOCKED',
+          );
+        }
+
         await model(prisma).deleteMany({
           where: { tournamentId, stage: { in: ['playoff', 'finals'] } },
         });


### PR DESCRIPTION
## Summary
- block BM/MR/GP finals bracket reset requests while the matching qualification flag is locked
- extend TC-516/616/716 E2E scenarios and scripts to assert locked reset POST returns 409
- add factory-level coverage for BM/MR/GP locked reset guards

## Issues
Closes #1077

## Validation
- `npm test -- --runTestsByPath __tests__/lib/api-factories/finals-route.test.ts --runInBand`
- `node --check e2e/tc-bm.js && node --check e2e/tc-mr.js && node --check e2e/tc-gp.js`
- `git diff --check`
- `npx eslint src/lib/api-factories/finals-route.ts __tests__/lib/api-factories/finals-route.test.ts e2e/tc-bm.js e2e/tc-mr.js e2e/tc-gp.js` (exit 0; existing warnings only)
