### PR TITLE
test: share locked reset e2e helper

### DIFF
--- a/smkc-score-app/__tests__/lib/e2e-reset-api-helper.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-reset-api-helper.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+type E2ECommon = typeof import('../../e2e/lib/common');
+
+function loadCommon() {
+  let loaded: E2ECommon | undefined;
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    loaded = require('../../e2e/lib/common') as E2ECommon;
+  });
+  if (!loaded) throw new Error('Failed to load e2e common helpers');
+  return loaded;
+}
+
+describe('assertResetApiBlocked', () => {
+  it('posts reset=true to the selected finals route and accepts the locked response', async () => {
+    const common = loadCommon();
+    const page = {
+      evaluate: jest.fn(async (_fn, args) => {
+        expect(args).toEqual(['tournament-1', 'mr']);
+        return { s: 409, b: { code: 'QUALIFICATION_LOCKED' } };
+      }),
+    };
+
+    await expect(common.assertResetApiBlocked(page, 'tournament-1', 'mr')).resolves.toEqual({
+      s: 409,
+      b: { code: 'QUALIFICATION_LOCKED' },
+    });
+  });
+
+  it('throws a diagnostic error when reset is not blocked', async () => {
+    const common = loadCommon();
+    const page = {
+      evaluate: jest.fn(async () => ({ s: 200, b: { message: 'Bracket reset' } })),
+    };
+
+    await expect(common.assertResetApiBlocked(page, 'tournament-1', 'gp')).rejects.toThrow(
+      'GP reset API allowed locked qualification (200)',
+    );
+  });
+});

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -762,6 +762,27 @@ async function apiGenerateGpFinals(page, tournamentId, topN = 8) {
   { label: `GP finals POST` });
 }
 
+async function assertResetApiBlocked(page, tournamentId, mode) {
+  if (!['bm', 'mr', 'gp'].includes(mode)) {
+    throw new Error(`Unsupported finals reset mode: ${mode}`);
+  }
+
+  const result = await page.evaluate(async ([tid, eventMode]) => {
+    const r = await fetch(`/api/tournaments/${tid}/${eventMode}/finals`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reset: true }),
+    });
+    return { s: r.status, b: await r.json().catch(() => ({})) };
+  }, [tournamentId, mode]);
+
+  if (result.s !== 409 || result.b?.code !== 'QUALIFICATION_LOCKED') {
+    throw new Error(`${mode.toUpperCase()} reset API allowed locked qualification (${result.s})`);
+  }
+
+  return result;
+}
+
 /** GP finals uses 'paginated' GET style: { success: true, data: { data: [...], meta: {...} } }.
  *  Aggregate up to 5 pages of 50 entries (17 finals matches always fit in 1 page).
  *  Note: createSuccessResponse wraps the paginated result, so json.data = { data, meta }.
@@ -2654,6 +2675,7 @@ module.exports = {
   assertQualificationPointsColumn,
   assertCombinedStandingsTab,
   assertGpCombinedStandingsHeaders,
+  assertResetApiBlocked,
   /* BM */
   apiSetupBmGroup,
   apiFetchBm,

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -57,6 +57,7 @@ const {
   launchPersistentChromiumContext,
   assertQualificationPointsColumn,
   assertCombinedStandingsTab,
+  assertResetApiBlocked,
   BASE,
 } = require('./lib/common');
 const { createSharedE2eFixture, setupModePlayersViaUi, ensurePlayerPassword } = require('./lib/fixtures');
@@ -825,16 +826,7 @@ async function runTc516(adminPage) {
       name: /Reset Bracket|ブラケットリセット/,
     });
     const resetHiddenWhileLocked = (await resetBtn.count()) === 0;
-    const resetApiLocked = await adminPage.evaluate(async (tid) => {
-      const r = await fetch(`/api/tournaments/${tid}/bm/finals`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ reset: true }),
-      });
-      return { s: r.status, body: await r.json().catch(() => ({})) };
-    }, tournamentId);
-    const resetApiBlockedWhileLocked = resetApiLocked.s === 409
-      && resetApiLocked.body?.code === 'QUALIFICATION_LOCKED';
+    await assertResetApiBlocked(adminPage, tournamentId, 'bm');
 
     const unlockRes = await apiUpdateTournament(adminPage, tournamentId, { bmQualificationConfirmed: false });
     if (unlockRes.s !== 200) throw new Error(`Failed to unlock qualification (${unlockRes.s})`);
@@ -859,11 +851,10 @@ async function runTc516(adminPage) {
     const resetHiddenAfterReset = !postResetText.includes('Reset Bracket') && !postResetText.includes('ブラケットリセット');
     const generateHiddenWhileUnlocked = !postResetText.includes('Generate Finals Bracket') && !postResetText.includes('Generate Bracket') && !postResetText.includes('ブラケット生成') && !postResetText.includes('generateFinalsBracket') && !postResetText.includes('Start Playoff') && !postResetText.includes('バラッジ開始');
 
-    const ok = hasViewTournament && resetHiddenWhileLocked && resetApiBlockedWhileLocked && hasViewTournamentUnlocked && hasResetBracketUnlocked && resetVisible && resetHiddenAfterReset && generateHiddenWhileUnlocked;
+    const ok = hasViewTournament && resetHiddenWhileLocked && hasViewTournamentUnlocked && hasResetBracketUnlocked && resetVisible && resetHiddenAfterReset && generateHiddenWhileUnlocked;
     log('TC-516', ok ? 'PASS' : 'FAIL',
       !hasViewTournament ? 'View Tournament button missing after bracket creation'
       : !resetHiddenWhileLocked ? 'Reset Bracket visible while qualification is locked'
-      : !resetApiBlockedWhileLocked ? `Reset API allowed locked qualification (${resetApiLocked.s})`
       : !hasViewTournamentUnlocked ? 'View Tournament button missing after unlocking qualification'
       : !hasResetBracketUnlocked ? 'Reset Bracket button missing after qualification unlock'
       : !resetVisible ? 'Reset Bracket not found as button element'

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -50,6 +50,7 @@ const {
   resolveAllTies,
   assertQualificationPointsColumn,
   assertCombinedStandingsTab,
+  assertResetApiBlocked,
 } = require('./lib/common');
 const { createSharedE2eFixture, setupModePlayersViaUi, ensurePlayerPassword } = require('./lib/fixtures');
 const { runSuite } = require('./lib/runner');
@@ -1100,16 +1101,7 @@ async function runTc716(adminPage) {
       name: /Reset Bracket|ブラケットリセット/,
     });
     const resetHiddenWhileLocked = (await resetBtn.count()) === 0;
-    const resetApiLocked = await adminPage.evaluate(async (tid) => {
-      const r = await fetch(`/api/tournaments/${tid}/gp/finals`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ reset: true }),
-      });
-      return { s: r.status, body: await r.json().catch(() => ({})) };
-    }, tournamentId);
-    const resetApiBlockedWhileLocked = resetApiLocked.s === 409
-      && resetApiLocked.body?.code === 'QUALIFICATION_LOCKED';
+    await assertResetApiBlocked(adminPage, tournamentId, 'gp');
 
     const unlockRes = await apiUpdateTournament(adminPage, tournamentId, { gpQualificationConfirmed: false });
     if (unlockRes.s !== 200) throw new Error(`Failed to unlock qualification (${unlockRes.s})`);
@@ -1136,11 +1128,10 @@ async function runTc716(adminPage) {
     const resetHiddenAfterReset = !postResetText.includes('Reset Bracket') && !postResetText.includes('ブラケットリセット');
     const generateHiddenWhileUnlocked = !postResetText.includes('Generate Finals Bracket') && !postResetText.includes('Generate Bracket') && !postResetText.includes('ブラケット生成') && !postResetText.includes('generateFinalsBracket') && !postResetText.includes('Start Playoff') && !postResetText.includes('バラッジ開始');
 
-    const ok = hasViewTournament && resetHiddenWhileLocked && resetApiBlockedWhileLocked && hasViewTournamentUnlocked && hasResetBracketUnlocked && resetVisible && resetHiddenAfterReset && generateHiddenWhileUnlocked;
+    const ok = hasViewTournament && resetHiddenWhileLocked && hasViewTournamentUnlocked && hasResetBracketUnlocked && resetVisible && resetHiddenAfterReset && generateHiddenWhileUnlocked;
     log('TC-716', ok ? 'PASS' : 'FAIL',
       !hasViewTournament ? 'View Tournament button missing after bracket creation'
       : !resetHiddenWhileLocked ? 'Reset Bracket visible while qualification is locked'
-      : !resetApiBlockedWhileLocked ? `Reset API allowed locked qualification (${resetApiLocked.s})`
       : !hasViewTournamentUnlocked ? 'View Tournament button missing after unlocking qualification'
       : !hasResetBracketUnlocked ? 'Reset Bracket button missing after qualification unlock'
       : !resetVisible ? 'Reset Bracket not found as button element'

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -55,6 +55,7 @@ const {
   resolveAllTies,
   assertQualificationPointsColumn,
   assertCombinedStandingsTab,
+  assertResetApiBlocked,
 } = require('./lib/common');
 const { createSharedE2eFixture, setupModePlayersViaUi, ensurePlayerPassword } = require('./lib/fixtures');
 const { runSuite } = require('./lib/runner');
@@ -1344,16 +1345,7 @@ async function runTc616(adminPage) {
       name: /Reset Bracket|ブラケットリセット/,
     });
     const resetHiddenWhileLocked = (await resetBtn.count()) === 0;
-    const resetApiLocked = await adminPage.evaluate(async (tid) => {
-      const r = await fetch(`/api/tournaments/${tid}/mr/finals`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ reset: true }),
-      });
-      return { s: r.status, body: await r.json().catch(() => ({})) };
-    }, tournamentId);
-    const resetApiBlockedWhileLocked = resetApiLocked.s === 409
-      && resetApiLocked.body?.code === 'QUALIFICATION_LOCKED';
+    await assertResetApiBlocked(adminPage, tournamentId, 'mr');
 
     const unlockRes = await apiUpdateTournament(adminPage, tournamentId, { mrQualificationConfirmed: false });
     if (unlockRes.s !== 200) throw new Error(`Failed to unlock qualification (${unlockRes.s})`);
@@ -1380,11 +1372,10 @@ async function runTc616(adminPage) {
     const resetHiddenAfterReset = !postResetText.includes('Reset Bracket') && !postResetText.includes('ブラケットリセット');
     const generateHiddenWhileUnlocked = !postResetText.includes('Generate Finals Bracket') && !postResetText.includes('Generate Bracket') && !postResetText.includes('ブラケット生成') && !postResetText.includes('generateFinalsBracket') && !postResetText.includes('Start Playoff') && !postResetText.includes('バラッジ開始');
 
-    const ok = hasViewTournament && resetHiddenWhileLocked && resetApiBlockedWhileLocked && hasViewTournamentUnlocked && hasResetBracketUnlocked && resetVisible && resetHiddenAfterReset && generateHiddenWhileUnlocked;
+    const ok = hasViewTournament && resetHiddenWhileLocked && hasViewTournamentUnlocked && hasResetBracketUnlocked && resetVisible && resetHiddenAfterReset && generateHiddenWhileUnlocked;
     log('TC-616', ok ? 'PASS' : 'FAIL',
       !hasViewTournament ? 'View Tournament button missing after bracket creation'
       : !resetHiddenWhileLocked ? 'Reset Bracket visible while qualification is locked'
-      : !resetApiBlockedWhileLocked ? `Reset API allowed locked qualification (${resetApiLocked.s})`
       : !hasViewTournamentUnlocked ? 'View Tournament button missing after unlocking qualification'
       : !hasResetBracketUnlocked ? 'Reset Bracket button missing after qualification unlock'
       : !resetVisible ? 'Reset Bracket not found as button element'


### PR DESCRIPTION
## Summary
- move the locked finals reset API assertion into a shared E2E helper
- replace duplicated TC-516/616/716 fetch blocks with the helper
- add focused unit coverage for the helper success and diagnostic failure paths

## Issues
Closes #1441

## Validation
- `npm test -- --runTestsByPath __tests__/lib/e2e-reset-api-helper.test.ts --runInBand`
- `node --check e2e/lib/common.js && node --check e2e/tc-bm.js && node --check e2e/tc-mr.js && node --check e2e/tc-gp.js`
- `git diff --check`
- `npx eslint e2e/lib/common.js e2e/tc-bm.js e2e/tc-mr.js e2e/tc-gp.js __tests__/lib/e2e-reset-api-helper.test.ts` (exit 0; E2E files are ignored by config and reported as warnings)
