### PR TITLE
test: cover reset helper invalid mode

### DIFF
--- a/smkc-score-app/__tests__/lib/e2e-reset-api-helper.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-reset-api-helper.test.ts
@@ -38,4 +38,16 @@ describe('assertResetApiBlocked', () => {
       'GP reset API allowed locked qualification (200)',
     );
   });
+
+  it('throws for an unsupported mode before calling the browser page', async () => {
+    const common = loadCommon();
+    const page = {
+      evaluate: jest.fn(),
+    };
+
+    await expect(common.assertResetApiBlocked(page, 'tournament-1', 'ta')).rejects.toThrow(
+      'Unsupported finals reset mode: ta',
+    );
+    expect(page.evaluate).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- cover the unsupported-mode guard in assertResetApiBlocked
- assert the helper fails before invoking the browser page when mode is invalid

## Issues
Closes #1443

## Validation
- `npm test -- --runTestsByPath __tests__/lib/e2e-reset-api-helper.test.ts --runInBand`
- `npx eslint __tests__/lib/e2e-reset-api-helper.test.ts`
- `git diff --check`
