### PR TITLE
test: harden overall ranking match coverage

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -826,6 +826,17 @@
 - **期待結果**: 4モード対応の総合ランキングが返り、ページも正常に表示される
 - **スクリプト**: tc-all.js TC-402
 
+## TC-1090-1091: 総合ランキング — match model 網羅性と TA 空エントリ検証
+- **URL**: /api/tournaments/[id]/overall-ranking
+- **authRequired**: true (admin)
+- **背景**: issue #1090/#1091。BM/MR/GP の real qualification match 検出は `gPMatch` を暗黙 default にせず、`Record<MatchQualificationModel, ...>` で網羅する。TA は TTEntry ベースで BREAK match を生成しないため、BREAK-like な `times=null` / `{}` entry が総合ランキングへ加点されないことを確認する。
+- **手順**:
+  1. `hasCompletedRealQualificationMatch` が `bMMatch` / `mRMatch` / `gPMatch` を exhaustive map で選択することを static guard で確認する
+  2. TA qualification の `times=null` / `{}` entry を overall ranking の TA qualification 集計へ渡す
+  3. 空 entry が 0 点として playerId に map され、BM/MR/GP の BREAK-only ガードとは別経路で扱われることを確認する
+- **期待結果**: 新しい match model 追加時は TypeScript の `Record<MatchQualificationModel, ...>` が未対応を検出し、TA の空エントリは総合ランキングに正のポイントを発生させない
+- **スクリプト**: n/a (static/unit coverage) — `smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts`, `smkc-score-app/__tests__/lib/points/overall-ranking.test.ts`
+
 ## TC-320: BM/MR/GP マッチリスト行レベルのスコア入力リンク非表示化 ✅ FIXED (PR #407)
 - **URL**: /tournaments/[temp-id]/bm, /mr, /gp → Matches タブ
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -195,6 +195,7 @@ describe('E2E case drift coverage', () => {
     ['TC-111', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts'],
     ['TC-726', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-finals-assigned-cups.test.ts'],
     ['TC-728', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-ranking.test.ts'],
+    ['TC-1090-1091', 'n/a (static/unit coverage)', 'smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts'],
     ['TC-803', 'TC-318 でカバー済み', 'TC-318'],
     ['TC-943', '.github/pull_request_template.md', '__tests__/docs/pr-template.test.ts'],
   ])('keeps %s explicitly classified outside standalone browser runner registration', (tc, marker, coverage) => {
@@ -202,6 +203,15 @@ describe('E2E case drift coverage', () => {
 
     expect(section).toContain(marker);
     expect(section).toContain(coverage);
+  });
+
+  it('keeps TC-1090-1091 aligned with overall-ranking static and unit coverage', () => {
+    const section = sectionFor('TC-1090-1091');
+
+    expect(section).toContain('issue #1090/#1091');
+    expect(section).toContain('Record<MatchQualificationModel');
+    expect(section).toContain('BREAK-like');
+    expect(section).toContain('__tests__/lib/points/overall-ranking.test.ts');
   });
 
   it('keeps TC-111 aligned with the preview D1 columns that fail GP finals before browser launch', () => {

--- a/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
+++ b/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
@@ -156,6 +156,31 @@ describe('Overall Ranking module', () => {
         })
       );
     });
+
+    it('keeps BREAK-like empty TA qualification entries at 0 overall points', async () => {
+      mockPrisma.tTEntry.findMany.mockResolvedValue([
+        { id: 'empty-null', playerId: 'p1', times: null, player: PLAYER_P1 },
+        { id: 'empty-object', playerId: 'p2', times: {}, player: PLAYER_P2 },
+      ]);
+      getMockCalculateAllCourseScores().mockReturnValue(
+        new Map([
+          ['empty-null', { courseScores: {}, qualificationPoints: 0 }],
+          ['empty-object', { courseScores: {}, qualificationPoints: 0 }],
+        ]),
+      );
+
+      const result = await calculateTAQualificationPointsFromDB(
+        mockPrisma as any,
+        TOURNAMENT_ID,
+      );
+
+      expect(result.get('p1')?.totalPoints).toBe(0);
+      expect(result.get('p2')?.totalPoints).toBe(0);
+      expect(getMockCalculateAllCourseScores()).toHaveBeenCalledWith([
+        { id: 'empty-null', times: null },
+        { id: 'empty-object', times: {} },
+      ]);
+    });
   });
 
   // =========================================================================

--- a/smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+
+const root = path.join(process.cwd(), '..');
+
+function readRepoFile(...parts: string[]) {
+  return fs.readFileSync(path.join(root, ...parts), 'utf8');
+}
+
+function sectionFor(source: string, tc: string) {
+  const heading = new RegExp(`^## ${tc}:`, 'm');
+  const match = heading.exec(source);
+  expect(match).toBeTruthy();
+
+  const start = match!.index;
+  const next = source.slice(start + 1).search(/\n## TC-/);
+  const end = next === -1 ? source.length : start + 1 + next;
+  return source.slice(start, end);
+}
+
+describe('TC-1090-1091 overall-ranking static guard', () => {
+  it('documents the overall-ranking follow-up scenario', () => {
+    const section = sectionFor(readRepoFile('E2E_TEST_CASES.md'), 'TC-1090-1091');
+
+    expect(section).toContain('issue #1090/#1091');
+    expect(section).toContain('hasCompletedRealQualificationMatch');
+    expect(section).toContain('Record<MatchQualificationModel');
+    expect(section).toContain('BREAK-like');
+    expect(section).toContain('__tests__/lib/points/overall-ranking.test.ts');
+  });
+
+  it('keeps match-model lookup exhaustive instead of defaulting to GP', () => {
+    const source = readRepoFile('smkc-score-app', 'src', 'lib', 'points', 'overall-ranking.ts');
+    const helperStart = source.indexOf('async function hasCompletedRealQualificationMatch');
+    expect(helperStart).toBeGreaterThanOrEqual(0);
+    const helperEnd = source.indexOf('\nfunction qualificationResultsByPlayer', helperStart);
+    expect(helperEnd).toBeGreaterThan(helperStart);
+    const helper = source.slice(helperStart, helperEnd);
+
+    expect(helper).toContain('Record<MatchQualificationModel');
+    expect(helper).toContain('bMMatch: () => prisma.bMMatch.findMany');
+    expect(helper).toContain('mRMatch: () => prisma.mRMatch.findMany');
+    expect(helper).toContain('gPMatch: () => prisma.gPMatch.findMany');
+    expect(helper).not.toContain(': await prisma.gPMatch.findMany');
+  });
+});

--- a/smkc-score-app/src/lib/points/overall-ranking.ts
+++ b/smkc-score-app/src/lib/points/overall-ranking.ts
@@ -559,11 +559,12 @@ async function hasCompletedRealQualificationMatch(
   const select = { id: true };
   const take = 1;
 
-  const matches = matchModel === "bMMatch"
-    ? await prisma.bMMatch.findMany({ where, select, take })
-    : matchModel === "mRMatch"
-      ? await prisma.mRMatch.findMany({ where, select, take })
-      : await prisma.gPMatch.findMany({ where, select, take });
+  const finders: Record<MatchQualificationModel, () => Promise<Array<{ id: string }>>> = {
+    bMMatch: () => prisma.bMMatch.findMany({ where, select, take }),
+    mRMatch: () => prisma.mRMatch.findMany({ where, select, take }),
+    gPMatch: () => prisma.gPMatch.findMany({ where, select, take }),
+  };
+  const matches = await finders[matchModel]();
 
   return matches.length > 0;
 }


### PR DESCRIPTION
## Summary
- Document TC-1090-1091 for overall-ranking match-model exhaustiveness and TA empty-entry scoring.
- Replace the implicit GP fallback in hasCompletedRealQualificationMatch with a Record<MatchQualificationModel, ...> finder map.
- Add static and unit coverage for the exhaustive finder contract and TA BREAK-like empty entries staying at 0 points.

## Issues
Closes #1090
Closes #1091

## Validation
- npm test -- --runTestsByPath __tests__/lib/points/overall-ranking.test.ts __tests__/static/tc-1090-1091-overall-ranking.test.ts __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
- npm run lint -- --quiet