### PR TITLE
test: share e2e case section helper

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -837,6 +837,17 @@
 - **期待結果**: 新しい match model 追加時は TypeScript の `Record<MatchQualificationModel, ...>` が未対応を検出し、TA の空エントリは総合ランキングに正のポイントを発生させない
 - **スクリプト**: n/a (static/unit coverage) — `smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts`, `smkc-score-app/__tests__/lib/points/overall-ranking.test.ts`
 
+## TC-1451-1452: E2E case helper — static guard の重複と脆さを抑える
+- **URL**: n/a
+- **authRequired**: false
+- **背景**: issue #1451/#1452。TC-1090-1091 追加時に static test と drift test が E2E case section parser を重複定義し、さらに overall-ranking 実装の具体的な finder 文字列に依存していた。
+- **手順**:
+  1. `__tests__/helpers/e2e-cases.ts` の共通 helper から E2E case section を取得する
+  2. `tc-1090-1091-overall-ranking.test.ts` と `e2e-cases-drift.test.ts` が同じ helper を使うことを確認する
+  3. static guard は `Record<MatchQualificationModel, ...>` と暗黙 default の不在を確認し、個別 finder の実装文字列には依存しない
+- **期待結果**: E2E case parsing の仕様が1か所に集約され、formatter や finder 分割のような安全な実装変更で static guard が不要に失敗しない
+- **スクリプト**: n/a (static/doc coverage) — `smkc-score-app/__tests__/helpers/e2e-cases.ts`, `smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts`, `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-320: BM/MR/GP マッチリスト行レベルのスコア入力リンク非表示化 ✅ FIXED (PR #407)
 - **URL**: /tournaments/[temp-id]/bm, /mr, /gp → Matches タブ
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1,27 +1,12 @@
-import fs from 'fs';
-import path from 'path';
 import * as gpFinalsValidatorExports from '../../e2e/lib/gp-finals-validators';
-
-const root = path.join(process.cwd(), '..');
-const casesPath = path.join(root, 'E2E_TEST_CASES.md');
-const cases = fs.readFileSync(casesPath, 'utf8');
+import { e2eCaseSection, readRepoFile } from '../helpers/e2e-cases';
 
 function readE2eScript(script: string) {
-  return fs.readFileSync(path.join(process.cwd(), 'e2e', script), 'utf8');
+  return readRepoFile('smkc-score-app', 'e2e', script);
 }
 
 function readE2eLib(script: string) {
-  return fs.readFileSync(path.join(process.cwd(), 'e2e', 'lib', script), 'utf8');
-}
-
-function sectionFor(tc: string) {
-  const heading = new RegExp(`^#{2,3} ${tc}:`, 'm');
-  const match = heading.exec(cases);
-  const start = match?.index ?? -1;
-  if (start === -1) throw new Error(`${tc} section not found`);
-  const next = cases.slice(start + 1).search(/\n#{2,3} TC-/);
-  const end = next === -1 ? cases.length : start + 1 + next;
-  return cases.slice(start, end);
+  return readRepoFile('smkc-score-app', 'e2e', 'lib', script);
 }
 
 describe('E2E case drift coverage', () => {
@@ -50,7 +35,7 @@ describe('E2E case drift coverage', () => {
     ['TC-926', tcOverlay],
     ['TC-TA-FLOW-24', tcTaFlow],
   ])('keeps %s documented and registered in its runnable E2E script', (tc, scriptSource) => {
-    const section = sectionFor(tc);
+    const section = e2eCaseSection(tc);
 
     expect(section).toContain('**手順**');
     expect(section).toContain('**期待結果**');
@@ -59,7 +44,7 @@ describe('E2E case drift coverage', () => {
   });
 
   it('keeps TC-702 aligned with direct driver-points JsonNull reporting coverage', () => {
-    const section = sectionFor('TC-702');
+    const section = e2eCaseSection('TC-702');
 
     expect(section).toContain('issue #1099/#1437');
     expect(section).toContain('`Prisma.JsonNull`');
@@ -69,7 +54,7 @@ describe('E2E case drift coverage', () => {
   });
 
   it('keeps TC-TA-FLOW-24 documented as the parent runnable for rank sub-coverage', () => {
-    const section = sectionFor('TC-TA-FLOW-24');
+    const section = e2eCaseSection('TC-TA-FLOW-24');
 
     expect(section).toContain('24名 TA');
     expect(section).toContain('TC-TA-FLOW-24-RANK');
@@ -78,7 +63,7 @@ describe('E2E case drift coverage', () => {
   });
 
   it('keeps TC-717 aligned with the assignedCups scenario', () => {
-    const section = sectionFor('TC-717');
+    const section = e2eCaseSection('TC-717');
 
     expect(section).toContain('assignedCups');
     expect(section).toContain('FT2 相当');
@@ -101,7 +86,7 @@ describe('E2E case drift coverage', () => {
   });
 
   it('keeps TC-1087 aligned with finite positive round-number guards', () => {
-    const section = sectionFor('TC-1087');
+    const section = e2eCaseSection('TC-1087');
 
     expect(section).toContain('有限な正の1始まり整数');
     expect(section).toContain('NaN');
@@ -112,7 +97,7 @@ describe('E2E case drift coverage', () => {
   });
 
   it('keeps TC-722 from duplicating GP finals target-wins logic in E2E', () => {
-    const section = sectionFor('TC-722');
+    const section = e2eCaseSection('TC-722');
 
     expect(section).toContain('completed=true');
     expect(section).toContain('FT数を再計算せず');
@@ -125,7 +110,7 @@ describe('E2E case drift coverage', () => {
   });
 
   it('keeps TC-1109 aligned with direct GP max-cups usage', () => {
-    const section = sectionFor('TC-1109');
+    const section = e2eCaseSection('TC-1109');
 
     expect(section).toContain('getGpFinalsMaxCups');
     expect(section).toContain('getLockedCupCountForMatch');
@@ -140,7 +125,7 @@ describe('E2E case drift coverage', () => {
   });
 
   it('keeps TC-1098 aligned with shared GP driver-points max usage', () => {
-    const section = sectionFor('TC-1098');
+    const section = e2eCaseSection('TC-1098');
 
     expect(section).toContain('MAX_GP_DRIVER_POINTS');
     expect(section).toContain('src/lib/constants.ts');
@@ -158,7 +143,7 @@ describe('E2E case drift coverage', () => {
   });
 
   it('keeps TC-1106 aligned with GP manual driver-points input bounds', () => {
-    const section = sectionFor('TC-1106');
+    const section = e2eCaseSection('TC-1106');
 
     expect(section).toContain('parseGpDriverPointsInput');
     expect(section).toContain('MAX_GP_DRIVER_POINTS');
@@ -176,7 +161,7 @@ describe('E2E case drift coverage', () => {
   it.each(['TC-DBG-01', 'TC-DBG-02', 'TC-DBG-03', 'TC-DBG-04'])(
     'keeps %s documented as runnable focused debug-fill coverage',
     (tc) => {
-      const section = sectionFor(tc);
+      const section = e2eCaseSection(tc);
 
       expect(section).toContain(`tc-debug-fill.js ${tc}`);
       expect(section).toContain('npm run e2e:preview:debug-fill');
@@ -196,17 +181,18 @@ describe('E2E case drift coverage', () => {
     ['TC-726', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-finals-assigned-cups.test.ts'],
     ['TC-728', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-ranking.test.ts'],
     ['TC-1090-1091', 'n/a (static/unit coverage)', 'smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts'],
+    ['TC-1451-1452', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-803', 'TC-318 でカバー済み', 'TC-318'],
     ['TC-943', '.github/pull_request_template.md', '__tests__/docs/pr-template.test.ts'],
   ])('keeps %s explicitly classified outside standalone browser runner registration', (tc, marker, coverage) => {
-    const section = sectionFor(tc);
+    const section = e2eCaseSection(tc);
 
     expect(section).toContain(marker);
     expect(section).toContain(coverage);
   });
 
   it('keeps TC-1090-1091 aligned with overall-ranking static and unit coverage', () => {
-    const section = sectionFor('TC-1090-1091');
+    const section = e2eCaseSection('TC-1090-1091');
 
     expect(section).toContain('issue #1090/#1091');
     expect(section).toContain('Record<MatchQualificationModel');
@@ -214,8 +200,16 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('__tests__/lib/points/overall-ranking.test.ts');
   });
 
+  it('keeps TC-1451-1452 aligned with the shared E2E case helper coverage', () => {
+    const section = e2eCaseSection('TC-1451-1452');
+
+    expect(section).toContain('issue #1451/#1452');
+    expect(section).toContain('__tests__/helpers/e2e-cases.ts');
+    expect(section).toContain('個別 finder の実装文字列には依存しない');
+  });
+
   it('keeps TC-111 aligned with the preview D1 columns that fail GP finals before browser launch', () => {
-    const section = sectionFor('TC-111');
+    const section = e2eCaseSection('TC-111');
 
     expect(section).toContain('Tournament.publicModes');
     expect(section).toContain('GPMatch.assignedCups');
@@ -225,7 +219,7 @@ describe('E2E case drift coverage', () => {
   });
 
   it('documents TC-534 as BM Top-24 unresolved winner warning coverage', () => {
-    const section = sectionFor('TC-534');
+    const section = e2eCaseSection('TC-534');
 
     expect(section).toContain('playoff_r2');
     expect(section).toContain('winner 不定');
@@ -237,7 +231,7 @@ describe('E2E case drift coverage', () => {
   });
 
   it('documents TC-535 as BM Top-24 qualification label coverage', () => {
-    const section = sectionFor('TC-535');
+    const section = e2eCaseSection('TC-535');
 
     expect(section).toContain('qualificationRankLabel');
     expect(section).toContain('buildQualificationRankLabelMap');

--- a/smkc-score-app/__tests__/helpers/e2e-cases.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+
+const repoRoot = path.join(process.cwd(), '..');
+
+export function readRepoFile(...parts: string[]) {
+  return fs.readFileSync(path.join(repoRoot, ...parts), 'utf8');
+}
+
+export function sectionBetween(
+  source: string,
+  startMarker: string,
+  endMarker: string,
+  { allowTerminal = false }: { allowTerminal?: boolean } = {},
+) {
+  const sectionStart = source.indexOf(startMarker);
+  expect(sectionStart).toBeGreaterThanOrEqual(0);
+
+  const sectionEndCandidate = source.indexOf(endMarker, sectionStart + startMarker.length);
+  if (!allowTerminal) {
+    expect(sectionEndCandidate).toBeGreaterThan(sectionStart);
+    return source.slice(sectionStart, sectionEndCandidate);
+  }
+
+  if (sectionEndCandidate === -1) {
+    if (source.length <= sectionStart + startMarker.length) {
+      throw new Error(`terminal section for marker "${startMarker}" has no content`);
+    }
+    return source.slice(sectionStart);
+  }
+
+  expect(sectionEndCandidate).toBeGreaterThan(sectionStart);
+  return source.slice(sectionStart, sectionEndCandidate);
+}
+
+export function e2eCaseSection(tc: string, source = readRepoFile('E2E_TEST_CASES.md')) {
+  const heading = new RegExp(`^#{2,3} ${tc}:`, 'm');
+  const match = heading.exec(source);
+  if (!match) throw new Error(`${tc} section not found`);
+
+  const start = match.index;
+  const next = source.slice(start + 1).search(/\n#{2,3} TC-/);
+  const end = next === -1 ? source.length : start + 1 + next;
+  return source.slice(start, end);
+}

--- a/smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts
@@ -1,26 +1,8 @@
-import fs from 'fs';
-import path from 'path';
-
-const root = path.join(process.cwd(), '..');
-
-function readRepoFile(...parts: string[]) {
-  return fs.readFileSync(path.join(root, ...parts), 'utf8');
-}
-
-function sectionFor(source: string, tc: string) {
-  const heading = new RegExp(`^## ${tc}:`, 'm');
-  const match = heading.exec(source);
-  expect(match).toBeTruthy();
-
-  const start = match!.index;
-  const next = source.slice(start + 1).search(/\n## TC-/);
-  const end = next === -1 ? source.length : start + 1 + next;
-  return source.slice(start, end);
-}
+import { e2eCaseSection, readRepoFile, sectionBetween } from '../helpers/e2e-cases';
 
 describe('TC-1090-1091 overall-ranking static guard', () => {
   it('documents the overall-ranking follow-up scenario', () => {
-    const section = sectionFor(readRepoFile('E2E_TEST_CASES.md'), 'TC-1090-1091');
+    const section = e2eCaseSection('TC-1090-1091');
 
     expect(section).toContain('issue #1090/#1091');
     expect(section).toContain('hasCompletedRealQualificationMatch');
@@ -31,16 +13,14 @@ describe('TC-1090-1091 overall-ranking static guard', () => {
 
   it('keeps match-model lookup exhaustive instead of defaulting to GP', () => {
     const source = readRepoFile('smkc-score-app', 'src', 'lib', 'points', 'overall-ranking.ts');
-    const helperStart = source.indexOf('async function hasCompletedRealQualificationMatch');
-    expect(helperStart).toBeGreaterThanOrEqual(0);
-    const helperEnd = source.indexOf('\nfunction qualificationResultsByPlayer', helperStart);
-    expect(helperEnd).toBeGreaterThan(helperStart);
-    const helper = source.slice(helperStart, helperEnd);
+    const helper = sectionBetween(
+      source,
+      'async function hasCompletedRealQualificationMatch',
+      '\nfunction qualificationResultsByPlayer',
+    );
 
     expect(helper).toContain('Record<MatchQualificationModel');
-    expect(helper).toContain('bMMatch: () => prisma.bMMatch.findMany');
-    expect(helper).toContain('mRMatch: () => prisma.mRMatch.findMany');
-    expect(helper).toContain('gPMatch: () => prisma.gPMatch.findMany');
+    expect(helper).toContain('const finders');
     expect(helper).not.toContain(': await prisma.gPMatch.findMany');
   });
 });

--- a/smkc-score-app/__tests__/static/tc-1417-home-recommendation.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1417-home-recommendation.test.ts
@@ -1,42 +1,9 @@
-import fs from 'fs';
-import path from 'path';
-
-const root = path.join(process.cwd(), '..');
-
-function readRepoFile(...parts: string[]) {
-  return fs.readFileSync(path.join(root, ...parts), 'utf8');
-}
-
-function sectionFor(
-  source: string,
-  startMarker: string,
-  endMarker: string,
-  { allowTerminal = false }: { allowTerminal?: boolean } = {},
-) {
-  const sectionStart = source.indexOf(startMarker);
-  expect(sectionStart).toBeGreaterThanOrEqual(0);
-
-  const sectionEndCandidate = source.indexOf(endMarker, sectionStart + startMarker.length);
-  if (!allowTerminal) {
-    expect(sectionEndCandidate).toBeGreaterThan(sectionStart);
-    return source.slice(sectionStart, sectionEndCandidate);
-  }
-
-  if (sectionEndCandidate === -1) {
-    if (source.length <= sectionStart + startMarker.length) {
-      throw new Error(`terminal section for marker "${startMarker}" has no content`);
-    }
-    return source.slice(sectionStart);
-  }
-
-  expect(sectionEndCandidate).toBeGreaterThan(sectionStart);
-  return source.slice(sectionStart, sectionEndCandidate);
-}
+import { readRepoFile, sectionBetween } from '../helpers/e2e-cases';
 
 describe('TC-1417 home recommendation static guard', () => {
   it('documents the sponsored recommendation scenario in the E2E case list', () => {
     const cases = readRepoFile('E2E_TEST_CASES.md');
-    const section = sectionFor(cases, '## TC-1417:', '\n## TC-', { allowTerminal: true });
+    const section = sectionBetween(cases, '## TC-1417:', '\n## TC-', { allowTerminal: true });
 
     expect(section).toContain('issue #1417');
     expect(section).toContain('rel="sponsored noopener noreferrer"');
@@ -45,7 +12,7 @@ describe('TC-1417 home recommendation static guard', () => {
   });
 
   it('keeps terminal sections from silently accepting empty slices with a marker-specific error', () => {
-    expect(() => sectionFor('prefix ## TC-1417:', '## TC-1417:', '\n## TC-', { allowTerminal: true }))
+    expect(() => sectionBetween('prefix ## TC-1417:', '## TC-1417:', '\n## TC-', { allowTerminal: true }))
       .toThrow('terminal section for marker "## TC-1417:" has no content');
   });
 
@@ -57,7 +24,7 @@ describe('TC-1417 home recommendation static guard', () => {
       'page.tsx',
     );
 
-    const section = sectionFor(source, 'Sponsored recommendation block', '\n    </div>');
+    const section = sectionBetween(source, 'Sponsored recommendation block', '\n    </div>');
 
     expect(section).toContain('aria-labelledby="recommended-heading"');
     expect(section).toContain('id="recommended-heading"');


### PR DESCRIPTION
## Summary
- Add TC-1451-1452 for the review follow-ups around E2E case helper reuse and static guard brittleness.
- Extract shared E2E case helpers into __tests__/helpers/e2e-cases.ts and reuse them from drift/static tests.
- Reduce the TC-1090-1091 static guard so it no longer depends on every concrete finder string.

## Issues
Closes #1451
Closes #1452

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/static/tc-1090-1091-overall-ranking.test.ts __tests__/static/tc-1417-home-recommendation.test.ts
- git diff --check
- npm run lint -- --quiet