### PR TITLE
test: tighten e2e case helper behavior

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -848,6 +848,17 @@
 - **期待結果**: E2E case parsing の仕様が1か所に集約され、formatter や finder 分割のような安全な実装変更で static guard が不要に失敗しない
 - **スクリプト**: n/a (static/doc coverage) — `smkc-score-app/__tests__/helpers/e2e-cases.ts`, `smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts`, `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-1454-1455: E2E case helper — キャッシュと明確な section error
+- **URL**: n/a
+- **authRequired**: false
+- **背景**: issue #1454/#1455。共通化した E2E case helper が `E2E_TEST_CASES.md` を呼び出しごとに読み込み、`sectionBetween` 内で直接 `expect()` していたため、不要な IO と読みにくい失敗位置が残っていた。
+- **手順**:
+  1. `e2eCaseSection` が module-level cache された E2E cases をデフォルト source として使うことを確認する
+  2. `sectionBetween` が helper 内で `expect()` を呼ばず、marker 名入りの例外を返すことを確認する
+  3. 既存の drift/static tests が同じ helper 経由で通ることを確認する
+- **期待結果**: E2E case section 取得は不要なファイル再読み込みを避け、section 抽出失敗時は marker 名のあるエラーで原因を特定できる
+- **スクリプト**: n/a (static/doc coverage) — `smkc-score-app/__tests__/helpers/e2e-cases.ts`, `smkc-score-app/__tests__/static/tc-1417-home-recommendation.test.ts`, `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-320: BM/MR/GP マッチリスト行レベルのスコア入力リンク非表示化 ✅ FIXED (PR #407)
 - **URL**: /tournaments/[temp-id]/bm, /mr, /gp → Matches タブ
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -182,6 +182,7 @@ describe('E2E case drift coverage', () => {
     ['TC-728', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-ranking.test.ts'],
     ['TC-1090-1091', 'n/a (static/unit coverage)', 'smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts'],
     ['TC-1451-1452', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
+    ['TC-1454-1455', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-803', 'TC-318 でカバー済み', 'TC-318'],
     ['TC-943', '.github/pull_request_template.md', '__tests__/docs/pr-template.test.ts'],
   ])('keeps %s explicitly classified outside standalone browser runner registration', (tc, marker, coverage) => {
@@ -206,6 +207,14 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #1451/#1452');
     expect(section).toContain('__tests__/helpers/e2e-cases.ts');
     expect(section).toContain('個別 finder の実装文字列には依存しない');
+  });
+
+  it('keeps TC-1454-1455 aligned with helper cache and error coverage', () => {
+    const section = e2eCaseSection('TC-1454-1455');
+
+    expect(section).toContain('issue #1454/#1455');
+    expect(section).toContain('module-level cache');
+    expect(section).toContain('helper 内で `expect()` を呼ばず');
   });
 
   it('keeps TC-111 aligned with the preview D1 columns that fail GP finals before browser launch', () => {

--- a/smkc-score-app/__tests__/helpers/e2e-cases.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 const repoRoot = path.join(process.cwd(), '..');
+const e2eCases = readRepoFile('E2E_TEST_CASES.md');
 
 export function readRepoFile(...parts: string[]) {
   return fs.readFileSync(path.join(repoRoot, ...parts), 'utf8');
@@ -14,11 +15,15 @@ export function sectionBetween(
   { allowTerminal = false }: { allowTerminal?: boolean } = {},
 ) {
   const sectionStart = source.indexOf(startMarker);
-  expect(sectionStart).toBeGreaterThanOrEqual(0);
+  if (sectionStart === -1) {
+    throw new Error(`section start marker not found: "${startMarker}"`);
+  }
 
   const sectionEndCandidate = source.indexOf(endMarker, sectionStart + startMarker.length);
   if (!allowTerminal) {
-    expect(sectionEndCandidate).toBeGreaterThan(sectionStart);
+    if (sectionEndCandidate <= sectionStart) {
+      throw new Error(`section end marker not found after "${startMarker}": "${endMarker}"`);
+    }
     return source.slice(sectionStart, sectionEndCandidate);
   }
 
@@ -29,11 +34,13 @@ export function sectionBetween(
     return source.slice(sectionStart);
   }
 
-  expect(sectionEndCandidate).toBeGreaterThan(sectionStart);
+  if (sectionEndCandidate <= sectionStart) {
+    throw new Error(`section end marker not found after "${startMarker}": "${endMarker}"`);
+  }
   return source.slice(sectionStart, sectionEndCandidate);
 }
 
-export function e2eCaseSection(tc: string, source = readRepoFile('E2E_TEST_CASES.md')) {
+export function e2eCaseSection(tc: string, source = e2eCases) {
   const heading = new RegExp(`^#{2,3} ${tc}:`, 'm');
   const match = heading.exec(source);
   if (!match) throw new Error(`${tc} section not found`);


### PR DESCRIPTION
## Summary
- Add TC-1454-1455 for the e2e-cases helper cache and section error follow-ups.
- Cache E2E_TEST_CASES.md once in the shared helper instead of rereading it for each e2eCaseSection call.
- Replace helper-local expect() calls in sectionBetween with marker-specific errors.

## Issues
Closes #1454
Closes #1455

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/static/tc-1090-1091-overall-ranking.test.ts __tests__/static/tc-1417-home-recommendation.test.ts
- git diff --check
- npm run lint -- --quiet