### PR TITLE
test: order e2e case helper cache after reader

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -859,6 +859,16 @@
 - **期待結果**: E2E case section 取得は不要なファイル再読み込みを避け、section 抽出失敗時は marker 名のあるエラーで原因を特定できる
 - **スクリプト**: n/a (static/doc coverage) — `smkc-score-app/__tests__/helpers/e2e-cases.ts`, `smkc-score-app/__tests__/static/tc-1417-home-recommendation.test.ts`, `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-1457: E2E case helper — readRepoFile 定義後に cache 初期化する
+- **URL**: n/a
+- **authRequired**: false
+- **背景**: issue #1457。`readRepoFile` は関数宣言として hoist されるが、module cache 初期化より後に定義されていると、上から読んだときに未定義関数を呼んでいるように見える。
+- **手順**:
+  1. `__tests__/helpers/e2e-cases.ts` で `readRepoFile` 定義が `const e2eCases = readRepoFile(...)` より前にあることを確認する
+  2. 既存の E2E case drift/static tests が helper 経由で通ることを確認する
+- **期待結果**: helper の module-level cache は読みやすい宣言順で初期化され、既存の E2E case section 取得挙動は変わらない
+- **スクリプト**: n/a (static/doc coverage) — `smkc-score-app/__tests__/helpers/e2e-cases.ts`, `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-320: BM/MR/GP マッチリスト行レベルのスコア入力リンク非表示化 ✅ FIXED (PR #407)
 - **URL**: /tournaments/[temp-id]/bm, /mr, /gp → Matches タブ
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -183,6 +183,7 @@ describe('E2E case drift coverage', () => {
     ['TC-1090-1091', 'n/a (static/unit coverage)', 'smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts'],
     ['TC-1451-1452', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-1454-1455', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
+    ['TC-1457', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-803', 'TC-318 でカバー済み', 'TC-318'],
     ['TC-943', '.github/pull_request_template.md', '__tests__/docs/pr-template.test.ts'],
   ])('keeps %s explicitly classified outside standalone browser runner registration', (tc, marker, coverage) => {
@@ -215,6 +216,14 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #1454/#1455');
     expect(section).toContain('module-level cache');
     expect(section).toContain('helper 内で `expect()` を呼ばず');
+  });
+
+  it('keeps TC-1457 aligned with the readRepoFile/cache declaration order', () => {
+    const section = e2eCaseSection('TC-1457');
+
+    expect(section).toContain('issue #1457');
+    expect(section).toContain('readRepoFile` 定義が `const e2eCases');
+    expect(section).toContain('__tests__/helpers/e2e-cases.ts');
   });
 
   it('keeps TC-111 aligned with the preview D1 columns that fail GP finals before browser launch', () => {

--- a/smkc-score-app/__tests__/helpers/e2e-cases.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.ts
@@ -2,11 +2,12 @@ import fs from 'fs';
 import path from 'path';
 
 const repoRoot = path.join(process.cwd(), '..');
-const e2eCases = readRepoFile('E2E_TEST_CASES.md');
 
 export function readRepoFile(...parts: string[]) {
   return fs.readFileSync(path.join(repoRoot, ...parts), 'utf8');
 }
+
+const e2eCases = readRepoFile('E2E_TEST_CASES.md');
 
 export function sectionBetween(
   source: string,


### PR DESCRIPTION
## Summary
- Add TC-1457 for the e2e-cases helper declaration-order follow-up.
- Move the E2E_TEST_CASES.md module cache initialization after readRepoFile is declared.
- Keep existing helper-based drift/static tests passing.

## Issues
Closes #1457

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/static/tc-1090-1091-overall-ranking.test.ts __tests__/static/tc-1417-home-recommendation.test.ts
- git diff --check
- npm run lint -- --quiet