### PR TITLE
test: document GP round-robin round count

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1973,6 +1973,17 @@
 - **期待結果**: E2E の GP 予選生成経路は有限な `roundNumber >= 1` のみを返し、`0` / `-1` / `1.5` / `NaN` / `Infinity` 入力時の例外は `qualification-route.test.ts` でカバーする
 - **スクリプト**: tc-gp.js TC-1087
 
+## TC-1088: GP 予選単体テスト — 4人ラウンドロビンの3ラウンド前提を明記する
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #1088。`qualification-route.test.ts` の `matchesByRound.size === 3` は、4人ラウンドロビンでは各プレイヤーが3ラウンド走るという組み合わせ前提を表す。コメントなしでは単なるマジックナンバーに見えるため、テスト内で前提を明示する。
+- **手順**:
+  1. `qualification-route.test.ts` の GP 予選同一ラウンド cup テストを確認する
+  2. `matchesByRound.size` の直前に4人ラウンドロビンの3ラウンド前提コメントがあることを確認する
+  3. コメントが `C(4,2)/2` の組み合わせ根拠を含むことを確認する
+- **期待結果**: 4人 GP 予選で3ラウンドになる理由が単体テスト上で読み取れ、将来の fixture 変更時に前提の更新漏れを検知できる
+- **スクリプト**: smkc-score-app/__tests__/static/tc-1088-qualification-route-comment.test.ts
+
 ## TC-717: GP決勝 — ラウンドごとのカップ組み合わせがFT3の5カップ目以外で重複しない
 - **URL**: /api/tournaments/[temp-id]/gp/finals (GET)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -96,6 +96,22 @@ describe('E2E case drift coverage', () => {
     expect(tcGp).toContain('Number.isInteger(match.roundNumber)');
   });
 
+  it('keeps TC-1088 aligned with the GP round-robin unit-test comment', () => {
+    const section = e2eCaseSection('TC-1088');
+    const qualificationRouteTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'lib',
+      'api-factories',
+      'qualification-route.test.ts',
+    );
+
+    expect(section).toContain('issue #1088');
+    expect(section).toContain('C(4,2)/2');
+    expect(qualificationRouteTest).toContain('4-player round-robin => 3 rounds (C(4,2)/2)');
+    expect(qualificationRouteTest).toContain('expect(matchesByRound.size).toBe(3)');
+  });
+
   it('keeps TC-722 from duplicating GP finals target-wins logic in E2E', () => {
     const section = e2eCaseSection('TC-722');
 
@@ -180,6 +196,7 @@ describe('E2E case drift coverage', () => {
     ['TC-111', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts'],
     ['TC-726', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-finals-assigned-cups.test.ts'],
     ['TC-728', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-ranking.test.ts'],
+    ['TC-1088', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1088-qualification-route-comment.test.ts'],
     ['TC-1090-1091', 'n/a (static/unit coverage)', 'smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts'],
     ['TC-1451-1452', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-1454-1455', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -1001,6 +1001,7 @@ describe('Qualification Route Factory', () => {
         matchesByRound.set(match.roundNumber, cups);
       }
 
+      // 4-player round-robin => 3 rounds (C(4,2)/2), with two matches per round.
       expect(matchesByRound.size).toBe(3);
       for (const cups of matchesByRound.values()) {
         expect(cups).toHaveLength(2);

--- a/smkc-score-app/__tests__/static/tc-1088-qualification-route-comment.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1088-qualification-route-comment.test.ts
@@ -1,0 +1,30 @@
+import { e2eCaseSection, readRepoFile, sectionBetween } from '../helpers/e2e-cases';
+
+describe('TC-1088 qualification-route round-robin comment guard', () => {
+  it('documents the review follow-up scenario', () => {
+    const section = e2eCaseSection('TC-1088');
+
+    expect(section).toContain('issue #1088');
+    expect(section).toContain('4人ラウンドロビン');
+    expect(section).toContain('C(4,2)/2');
+    expect(section).toContain('__tests__/static/tc-1088-qualification-route-comment.test.ts');
+  });
+
+  it('keeps the 3-round GP fixture assertion explained at the unit-test site', () => {
+    const source = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'lib',
+      'api-factories',
+      'qualification-route.test.ts',
+    );
+    const testBlock = sectionBetween(
+      source,
+      "it('should assign the same GP cup to all real matches in the same round'",
+      "it('rejects non-positive GP round numbers before cup assignment",
+    );
+
+    expect(testBlock).toContain('4-player round-robin => 3 rounds (C(4,2)/2)');
+    expect(testBlock).toContain('expect(matchesByRound.size).toBe(3)');
+  });
+});


### PR DESCRIPTION
## Summary
- Add TC-1088 scenario coverage for the GP qualification round-robin comment follow-up.
- Document why the 4-player GP fixture produces three round-robin rounds before the `matchesByRound.size` assertion.
- Add static/docs guards so the comment and scenario stay aligned.

## Issues
Closes #1088

## Validation
- `npm test -- --runTestsByPath __tests__/lib/api-factories/qualification-route.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/static/tc-1088-qualification-route-comment.test.ts`
- `npx eslint __tests__/lib/api-factories/qualification-route.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/static/tc-1088-qualification-route-comment.test.ts` (passes with existing warnings in `qualification-route.test.ts`)
- `git diff --check`
