### PR TITLE
test: dedupe TC-1088 drift coverage

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -96,22 +96,6 @@ describe('E2E case drift coverage', () => {
     expect(tcGp).toContain('Number.isInteger(match.roundNumber)');
   });
 
-  it('keeps TC-1088 aligned with the GP round-robin unit-test comment', () => {
-    const section = e2eCaseSection('TC-1088');
-    const qualificationRouteTest = readRepoFile(
-      'smkc-score-app',
-      '__tests__',
-      'lib',
-      'api-factories',
-      'qualification-route.test.ts',
-    );
-
-    expect(section).toContain('issue #1088');
-    expect(section).toContain('C(4,2)/2');
-    expect(qualificationRouteTest).toContain('4-player round-robin => 3 rounds (C(4,2)/2)');
-    expect(qualificationRouteTest).toContain('expect(matchesByRound.size).toBe(3)');
-  });
-
   it('keeps TC-722 from duplicating GP finals target-wins logic in E2E', () => {
     const section = e2eCaseSection('TC-722');
 


### PR DESCRIPTION
## Summary
- Remove the duplicated TC-1088 detailed assertions from `e2e-cases-drift.test.ts`.
- Keep drift coverage focused on the existing doc-to-static-test classification entry.
- Leave the detailed comment/content checks in the dedicated TC-1088 static test.

## Issues
Closes #1460

## Validation
- `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/static/tc-1088-qualification-route-comment.test.ts`
- `npx eslint __tests__/docs/e2e-cases-drift.test.ts __tests__/static/tc-1088-qualification-route-comment.test.ts`
- `git diff --check`
