### PR TITLE
feat: add MR participant score correction flow

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1374,6 +1374,19 @@
   8. 一時トーナメントと一時プレイヤーを削除する
 - **期待結果**: MRのparticipant入力フォームからレース結果を送信でき、結果が永続化される
 
+## TC-1083: MR participant 過去報告表示とスコア修正フロー
+- **URL**: /tournaments/[temp-id]/mr/participant
+- **authRequired**: true (player)
+- **背景**: issue #1083。BM participant は確定済み試合で過去報告を表示し、「Correct Score」から参加者自身が修正できる。MR participant も同じデータフィールド (`player1ReportedPoints*` / `player2ReportedPoints*`) と correction API を持つため、UI でも同等の確認・訂正導線が必要。
+- **手順**:
+  1. 管理者セッションでMR予選2名マッチを作成する
+  2. player1 として `/mr/participant` にログインし、3-1 を送信する
+  3. 試合確定後、過去報告と `Correct Score` ボタンが表示されることを確認する
+  4. `Correct Score` を開き、3-1 から 2-2 に修正して `Submit Correction` を送信する
+  5. 管理者APIで対象マッチが completed のまま score1=2, score2=2 に更新されていることを確認する
+- **期待結果**: MR participant で過去報告を確認でき、確定済みスコアを参加者自身が修正できる
+- **スクリプト**: `tc-mr.js TC-1083`
+
 ## TC-603: MR引き分け(2-2)スコアの受理確認
 - **URL**: /api/tournaments/[temp-id]/mr (PUT)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
@@ -81,7 +81,7 @@ import prisma from '@/lib/prisma';
 import { auth } from '@/lib/auth';
 import { createLogger } from '@/lib/logger';
 import { getClientIdentifier, getUserAgent } from '@/lib/request-utils';
-import { checkScoreReportAuth, createScoreEntryLog, createCharacterUsageLog, isDualReportEnabled, validateCharacter } from '@/lib/api-factories/score-report-helpers';
+import { checkScoreReportAuth, createScoreEntryLog, createCharacterUsageLog, isDualReportEnabled, validateCharacter, recalculatePlayersStats } from '@/lib/api-factories/score-report-helpers';
 import { POST } from '@/app/api/tournaments/[id]/mr/match/[matchId]/report/route';
 
 const {
@@ -304,6 +304,59 @@ describe('MR Score Report API Route - /api/tournaments/[id]/mr/match/[matchId]/r
       expect(result).toEqual({
         data: { match: finalMatch, autoConfirmed: true },
         message: 'Scores confirmed and match completed',
+        status: 200,
+      });
+    });
+
+    it('should save a participant correction for a completed MR match', async () => {
+      const completedMatch = {
+        id: 'm1',
+        tournamentId: 't1',
+        version: 3,
+        completed: true,
+        score1: 3,
+        score2: 1,
+        player1Id: 'p1',
+        player2Id: 'p2',
+        player1ReportedPoints1: 3,
+        player1ReportedPoints2: 1,
+        player2ReportedPoints1: null,
+        player2ReportedPoints2: null,
+        player1: { id: 'p1', userId: 'u1' },
+        player2: { id: 'p2', userId: 'u2' },
+      };
+      const correctedMatch = {
+        ...completedMatch,
+        version: 4,
+        score1: 2,
+        score2: 2,
+        player1ReportedPoints1: 2,
+        player1ReportedPoints2: 2,
+      };
+
+      (prisma.mRMatch.findUnique as jest.Mock)
+        .mockResolvedValueOnce(completedMatch)
+        .mockResolvedValueOnce({ version: completedMatch.version });
+      (prisma.mRMatch.update as jest.Mock).mockResolvedValue(correctedMatch);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/match/m1/report', { reportingPlayer: 1, score1: 2, score2: 2 });
+      const params = Promise.resolve({ id: 't1', matchId: 'm1' });
+      const result = await POST(request, { params });
+
+      expect(prisma.mRMatch.update).toHaveBeenCalledWith(expect.objectContaining({
+        where: { id: 'm1', version: completedMatch.version },
+        data: expect.objectContaining({
+          score1: 2,
+          score2: 2,
+          completed: true,
+          player1ReportedPoints1: 2,
+          player1ReportedPoints2: 2,
+        }),
+      }));
+      expect(recalculatePlayersStats).toHaveBeenCalledWith(expect.any(Object), 't1', ['p1', 'p2']);
+      expect(result).toEqual({
+        data: { match: correctedMatch, corrected: true },
+        message: 'Score correction saved',
         status: 200,
       });
     });

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -12,6 +12,7 @@ function readE2eLib(script: string) {
 describe('E2E case drift coverage', () => {
   const tcAll = readE2eScript('tc-all.js');
   const tcBm = readE2eScript('tc-bm.js');
+  const tcMr = readE2eScript('tc-mr.js');
   const tcGp = readE2eScript('tc-gp.js');
   const tcOverlay = readE2eScript('tc-overlay.js');
   const tcDebugFill = readE2eScript('tc-debug-fill.js');
@@ -31,6 +32,7 @@ describe('E2E case drift coverage', () => {
     ['TC-1417', tcAll],
     ['TC-725', tcGp],
     ['TC-1087', tcGp],
+    ['TC-1083', tcMr],
     ['TC-729', tcGp],
     ['TC-926', tcOverlay],
     ['TC-TA-FLOW-24', tcTaFlow],
@@ -94,6 +96,18 @@ describe('E2E case drift coverage', () => {
     expect(tcGp).toContain('Keep the finite check explicit to cover NaN/Infinity edge cases tested in TC-1087.');
     expect(tcGp).toContain('Number.isFinite(match.roundNumber)');
     expect(tcGp).toContain('Number.isInteger(match.roundNumber)');
+  });
+
+  it('keeps TC-1083 aligned with MR participant correction coverage', () => {
+    const section = e2eCaseSection('TC-1083');
+
+    expect(section).toContain('issue #1083');
+    expect(section).toContain('Correct Score');
+    expect(section).toContain('Submit Correction');
+    expect(section).toContain('player1ReportedPoints');
+    expect(tcMr).toContain("log('TC-1083'");
+    expect(tcMr).toContain('Previous Reports');
+    expect(tcMr).toContain('apiFetchMr');
   });
 
   it('keeps TC-722 from duplicating GP finals target-wins logic in E2E', () => {

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -10,6 +10,7 @@
  *
  *  TC-601  28-player qualification full flow + standings + course assignment
  *  TC-602  MR participant score entry (UI, 2 players)
+ *  TC-1083 MR participant previous reports + correction (UI, 2 players)
  *  TC-603  MR draw 2-2 score (admin PUT, 2 players)
  *  TC-604  28-player full + finals bracket gen + race-format UI score entry
  *  TC-605  28-player full + finals bracket reset
@@ -37,7 +38,7 @@
  * Run: node e2e/tc-mr.js  (from smkc-score-app/)
  */
 const {
-  makeResults, makeLog, nav,
+  makeResults, makeLog, nav, escapeRegex,
   matchUpdateUsesLeanPayload,
   uiCreatePlayer: createPlayer,
   uiCreateTournament: createTournament,
@@ -319,6 +320,63 @@ async function runTc602(adminPage) {
       : `completed=${updatedMatch?.completed} score=${updatedMatch?.score1}-${updatedMatch?.score2}`);
   } catch (err) {
     log('TC-602', 'FAIL', err instanceof Error ? err.message : 'MR participant flow failed');
+  } finally {
+    if (playerBrowser) await playerBrowser.close().catch(() => {});
+  }
+}
+
+/**
+ * TC-1083: MR participant previous reports + correction (UI)
+ *
+ * Submit 3-1, verify the completed participant card exposes previous reports
+ * and the "Correct Score" affordance, then correct the score to 2-2.
+ */
+async function runTc1083(adminPage) {
+  let playerBrowser = null;
+
+  try {
+    const { tournamentId, p1, match } = await prepareSharedMrPair(adminPage);
+    const p1Label = match.player1.nickname;
+    const p2Label = match.player2.nickname;
+
+    const ctx = await loginSharedPlayer(adminPage, p1);
+    playerBrowser = ctx.browser;
+    const playerPage = ctx.page;
+    await nav(playerPage, `/tournaments/${tournamentId}/mr/participant`);
+
+    for (let i = 0; i < 3; i++) {
+      await playerPage.getByRole('button', { name: new RegExp(`${escapeRegex(p1Label)} \\+1`) }).click();
+    }
+    await playerPage.getByRole('button', { name: new RegExp(`${escapeRegex(p2Label)} \\+1`) }).click();
+
+    playerPage.once('dialog', (d) => d.accept());
+    await playerPage.getByRole('button', { name: /スコア送信|Submit Scores/ }).click();
+    await playerPage.waitForFunction(() => {
+      const text = document.body.innerText;
+      return text.includes('前回の報告') || text.includes('Previous Reports');
+    }, null, { timeout: 15000 });
+    await playerPage.getByRole('button', { name: /スコアを修正|Correct Score/ }).click();
+
+    await playerPage.getByRole('button', { name: new RegExp(`${escapeRegex(p1Label)} -1`) }).click();
+    await playerPage.getByRole('button', { name: new RegExp(`${escapeRegex(p2Label)} \\+1`) }).click();
+
+    playerPage.once('dialog', (d) => d.accept());
+    await playerPage.getByRole('button', { name: /修正を送信|Submit Correction/ }).click();
+    await playerPage.waitForTimeout(3000);
+
+    const correctedMr = await apiFetchMr(adminPage, tournamentId);
+    const correctedMatch = (correctedMr.matches || []).find((m) => m.id === match.id);
+    const ok =
+      correctedMatch?.completed === true &&
+      correctedMatch.score1 === 2 &&
+      correctedMatch.score2 === 2;
+
+    log('TC-1083', ok ? 'PASS' : 'FAIL',
+      ok ? ''
+      : !correctedMatch ? 'Corrected MR match not found'
+      : `completed=${correctedMatch.completed} score=${correctedMatch.score1}-${correctedMatch.score2}`);
+  } catch (err) {
+    log('TC-1083', 'FAIL', err instanceof Error ? err.message : 'MR correction flow failed');
   } finally {
     if (playerBrowser) await playerBrowser.close().catch(() => {});
   }
@@ -1636,6 +1694,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
     },
     tests: [
       { name: 'TC-602', fn: runTc602 },
+      { name: 'TC-1083', fn: runTc1083 },
       { name: 'TC-603', fn: runTc603 },
       { name: 'TC-608', fn: runTc608 },
       { name: 'TC-609', fn: runTc609 },

--- a/smkc-score-app/src/app/tournaments/[id]/mr/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/participant/page.tsx
@@ -43,6 +43,7 @@ export default function MatchRaceParticipantPage({
   const [reportingScores, setReportingScores] = useState<
     Record<string, { score1: number; score2: number }>
   >({});
+  const [editingCorrections, setEditingCorrections] = useState<Record<string, boolean>>({});
 
   const getInitialScores = (match: MRMatch) => {
     const isPlayer1 = match.player1.id === ctx.playerId;
@@ -101,6 +102,7 @@ export default function MatchRaceParticipantPage({
         delete next[match.id];
         return next;
       });
+      setEditingCorrections((prev) => ({ ...prev, [match.id]: false }));
       alert(getScoreReportSuccessMessage(data, {
         correctionSubmittedSuccess: tPart("correctionSubmittedSuccess"),
         scoresReportedSuccess: tPart("scoresReportedSuccess"),
@@ -108,6 +110,89 @@ export default function MatchRaceParticipantPage({
         scoresMismatchSubmitted: tPart("scoresMismatchSubmitted"),
       }));
     }
+  };
+
+  const renderScoreEditor = (match: MRMatch, title: string, submitLabel: string) => {
+    const scores = reportingScores[match.id] ?? getInitialScores(match);
+    const totalValid = scores.score1 + scores.score2 === 4;
+
+    return (
+      <div className="border-t pt-4">
+        <h4 className="font-medium mb-3">{title}</h4>
+        <div className="flex items-center justify-center gap-3 mb-4">
+          <div className="text-center min-w-0 max-w-[120px]">
+            <p className="text-sm mb-2 truncate">{match.player1.nickname}</p>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-10 w-10 text-lg"
+                aria-label={`${match.player1.nickname} -1`}
+                onClick={() => adjustScore(match, "score1", -1)}
+              >
+                -
+              </Button>
+              <span className="text-3xl font-bold w-10 text-center">
+                {scores.score1}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-10 w-10 text-lg"
+                aria-label={`${match.player1.nickname} +1`}
+                onClick={() => adjustScore(match, "score1", 1)}
+              >
+                +
+              </Button>
+            </div>
+          </div>
+          <span className="text-xl mt-6">-</span>
+          <div className="text-center min-w-0 max-w-[120px]">
+            <p className="text-sm mb-2 truncate">{match.player2.nickname}</p>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-10 w-10 text-lg"
+                aria-label={`${match.player2.nickname} -1`}
+                onClick={() => adjustScore(match, "score2", -1)}
+              >
+                -
+              </Button>
+              <span className="text-3xl font-bold w-10 text-center">
+                {scores.score2}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-10 w-10 text-lg"
+                aria-label={`${match.player2.nickname} +1`}
+                onClick={() => adjustScore(match, "score2", 1)}
+              >
+                +
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <p className={`text-sm text-center mb-3 ${
+          !totalValid && (scores.score1 > 0 || scores.score2 > 0)
+            ? 'text-yellow-600' : 'invisible'
+        }`}>
+          {tMatch("totalMustEqual4")}
+        </p>
+
+        <Button
+          onClick={() => handleSubmitScore(match)}
+          disabled={ctx.submitting === match.id || !totalValid}
+          className="w-full"
+        >
+          {ctx.submitting === match.id
+            ? tMatch("submitting")
+            : submitLabel}
+        </Button>
+      </div>
+    );
   };
 
   return (
@@ -129,110 +214,77 @@ export default function MatchRaceParticipantPage({
       submitting={ctx.submitting}
       qualificationConfirmed={ctx.qualificationConfirmed}
       renderMatchForm={(match) => {
-        const scores = reportingScores[match.id] ?? getInitialScores(match);
-        const totalValid = scores.score1 + scores.score2 === 4;
-
+        return renderScoreEditor(
+          match,
+          hasOwnReport(match) ? tPart("editYourReport") : tPart("reportMatchResult"),
+          hasOwnReport(match) ? tPart("submitCorrection") : tPart("submitScores")
+        );
+      }}
+      renderPreviousReports={(match) => {
+        const p1reported = match.player1ReportedPoints1 != null;
+        const p2reported = match.player2ReportedPoints1 != null;
+        if (!p1reported && !p2reported && !match.completed) return null;
         return (
           <div className="border-t pt-4">
-            <h4 className="font-medium mb-3">
-              {hasOwnReport(match) ? tPart("editYourReport") : tPart("reportMatchResult")}
-            </h4>
-            <div className="flex items-center justify-center gap-3 mb-4">
-              <div className="text-center min-w-0 max-w-[120px]">
-                <p className="text-sm mb-2 truncate">{match.player1.nickname}</p>
-                <div className="flex items-center gap-1">
+            {(p1reported || p2reported) && (
+              <>
+                <h4 className="font-medium mb-2">{tPart("previousReports")}</h4>
+                <div className="space-y-2 text-sm">
+                  {p1reported && (
+                    <div className="flex justify-between p-2 bg-gray-50 rounded">
+                      <span>{tPart("playerReported", { player: match.player1.nickname })}</span>
+                      <span className="font-mono">{match.player1ReportedPoints1} - {match.player1ReportedPoints2}</span>
+                    </div>
+                  )}
+                  {p2reported && (
+                    <div className="flex justify-between p-2 bg-gray-50 rounded">
+                      <span>{tPart("playerReported", { player: match.player2.nickname })}</span>
+                      <span className="font-mono">{match.player2ReportedPoints1} - {match.player2ReportedPoints2}</span>
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+            {match.completed && (
+              editingCorrections[match.id] ? (
+                <div className="mt-4 space-y-3">
+                  {renderScoreEditor(match, tPart("correctScore"), tPart("submitCorrection"))}
                   <Button
+                    type="button"
                     variant="outline"
-                    size="sm"
-                    className="h-10 w-10 text-lg"
-                    aria-label={`${match.player1.nickname} -1`}
-                    onClick={() => adjustScore(match, "score1", -1)}
+                    className="w-full"
+                    onClick={() => {
+                      setEditingCorrections((prev) => ({ ...prev, [match.id]: false }));
+                      setReportingScores((prev) => {
+                        const next = { ...prev };
+                        delete next[match.id];
+                        return next;
+                      });
+                    }}
                   >
-                    -
-                  </Button>
-                  <span className="text-3xl font-bold w-10 text-center">
-                    {scores.score1}
-                  </span>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-10 w-10 text-lg"
-                    aria-label={`${match.player1.nickname} +1`}
-                    onClick={() => adjustScore(match, "score1", 1)}
-                  >
-                    +
+                    {tPart("cancelCorrection")}
                   </Button>
                 </div>
-              </div>
-              <span className="text-xl mt-6">-</span>
-              <div className="text-center min-w-0 max-w-[120px]">
-                <p className="text-sm mb-2 truncate">{match.player2.nickname}</p>
-                <div className="flex items-center gap-1">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-10 w-10 text-lg"
-                    aria-label={`${match.player2.nickname} -1`}
-                    onClick={() => adjustScore(match, "score2", -1)}
-                  >
-                    -
-                  </Button>
-                  <span className="text-3xl font-bold w-10 text-center">
-                    {scores.score2}
-                  </span>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-10 w-10 text-lg"
-                    aria-label={`${match.player2.nickname} +1`}
-                    onClick={() => adjustScore(match, "score2", 1)}
-                  >
-                    +
-                  </Button>
-                </div>
-              </div>
-            </div>
-
-            <p className={`text-sm text-center mb-3 ${
-              !totalValid && (scores.score1 > 0 || scores.score2 > 0)
-                ? 'text-yellow-600' : 'invisible'
-            }`}>
-              {tMatch("totalMustEqual4")}
-            </p>
-
-            <Button
-              onClick={() => handleSubmitScore(match)}
-              disabled={ctx.submitting === match.id || !totalValid}
-              className="w-full"
-            >
-              {ctx.submitting === match.id
-                ? tMatch("submitting")
-                : hasOwnReport(match) ? tPart("submitCorrection") : tPart("submitScores")}
-            </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full mt-4"
+                  onClick={() => {
+                    setReportingScores((prev) => ({
+                      ...prev,
+                      [match.id]: getInitialScores(match),
+                    }));
+                    setEditingCorrections((prev) => ({ ...prev, [match.id]: true }));
+                  }}
+                >
+                  {tPart("correctScore")}
+                </Button>
+              )
+            )}
           </div>
         );
       }}
-      renderPreviousReports={(match) =>
-        match.player1ReportedPoints1 !== undefined || match.player2ReportedPoints1 !== undefined ? (
-          <div className="border-t pt-4">
-            <h4 className="font-medium mb-2">{tPart("previousReports")}</h4>
-            <div className="space-y-2 text-sm">
-              {match.player1ReportedPoints1 !== undefined && (
-                <div className="flex justify-between p-2 bg-gray-50 rounded">
-                  <span>{tPart("playerReported", { player: match.player1.nickname })}</span>
-                  <span className="font-mono">{match.player1ReportedPoints1} - {match.player1ReportedPoints2}</span>
-                </div>
-              )}
-              {match.player2ReportedPoints1 !== undefined && (
-                <div className="flex justify-between p-2 bg-gray-50 rounded">
-                  <span>{tPart("playerReported", { player: match.player2.nickname })}</span>
-                  <span className="font-mono">{match.player2ReportedPoints1} - {match.player2ReportedPoints2}</span>
-                </div>
-              )}
-            </div>
-          </div>
-        ) : null
-      }
     />
   );
 }


### PR DESCRIPTION
## Summary
- Add TC-1083 scenario coverage for MR participant previous reports and correction flow.
- Add MR focused E2E coverage for submitting 3-1, opening Correct Score, and correcting to 2-2.
- Mirror BM's completed-match correction UI on the MR participant page and cover the MR report API correction path.

## Issues
Closes #1083

## Validation
- `node --check smkc-score-app/e2e/tc-mr.js`
- `npm test -- --runTestsByPath '__tests__/docs/e2e-cases-drift.test.ts' '__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts'`
- `npx eslint 'src/app/tournaments/[id]/mr/participant/page.tsx' '__tests__/docs/e2e-cases-drift.test.ts' '__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts'`
- `npm run lint` (passes with existing warnings)
- `git diff --check`
