### PR TITLE
test: tighten MR correction followups

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1378,6 +1378,7 @@
 - **URL**: /tournaments/[temp-id]/mr/participant
 - **authRequired**: true (player)
 - **背景**: issue #1083。BM participant は確定済み試合で過去報告を表示し、「Correct Score」から参加者自身が修正できる。MR participant も同じデータフィールド (`player1ReportedPoints*` / `player2ReportedPoints*`) と correction API を持つため、UI でも同等の確認・訂正導線が必要。
+- **回帰チェック**: issue #1463/#1464。修正送信後は固定 sleep ではなく更新済みスコアを条件待機し、MR スコアエディタは `MrScoreEditor` コンポーネントとしてページ外に切り出して再利用する。
 - **手順**:
   1. 管理者セッションでMR予選2名マッチを作成する
   2. player1 として `/mr/participant` にログインし、3-1 を送信する

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1,5 +1,5 @@
 import * as gpFinalsValidatorExports from '../../e2e/lib/gp-finals-validators';
-import { e2eCaseSection, readRepoFile } from '../helpers/e2e-cases';
+import { e2eCaseSection, readRepoFile, sectionBetween } from '../helpers/e2e-cases';
 
 function readE2eScript(script: string) {
   return readRepoFile('smkc-score-app', 'e2e', script);
@@ -100,14 +100,18 @@ describe('E2E case drift coverage', () => {
 
   it('keeps TC-1083 aligned with MR participant correction coverage', () => {
     const section = e2eCaseSection('TC-1083');
+    const tc1083 = sectionBetween(tcMr, 'async function runTc1083', '/**\n * TC-603');
 
     expect(section).toContain('issue #1083');
+    expect(section).toContain('issue #1463/#1464');
     expect(section).toContain('Correct Score');
     expect(section).toContain('Submit Correction');
     expect(section).toContain('player1ReportedPoints');
-    expect(tcMr).toContain("log('TC-1083'");
-    expect(tcMr).toContain('Previous Reports');
-    expect(tcMr).toContain('apiFetchMr');
+    expect(section).toContain('MrScoreEditor');
+    expect(tc1083).toContain("log('TC-1083'");
+    expect(tc1083).toContain('Previous Reports');
+    expect(tc1083).toContain('apiFetchMr');
+    expect(tc1083).not.toContain('waitForTimeout(3000)');
   });
 
   it('keeps TC-722 from duplicating GP finals target-wins logic in E2E', () => {

--- a/smkc-score-app/__tests__/static/tc-1463-1464-mr-correction-followups.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1463-1464-mr-correction-followups.test.ts
@@ -1,0 +1,42 @@
+import { e2eCaseSection, readRepoFile, sectionBetween } from '../helpers/e2e-cases';
+
+describe('TC-1463-1464 MR correction follow-up guards', () => {
+  it('documents the condition wait and extracted MR score editor follow-ups', () => {
+    const section = e2eCaseSection('TC-1083');
+
+    expect(section).toContain('issue #1463/#1464');
+    expect(section).toContain('固定 sleep ではなく更新済みスコアを条件待機');
+    expect(section).toContain('MrScoreEditor');
+  });
+
+  it('keeps TC-1083 correction wait tied to the updated MR score instead of a fixed sleep', () => {
+    const source = readRepoFile('smkc-score-app', 'e2e', 'tc-mr.js');
+    const tc1083 = sectionBetween(
+      source,
+      'async function runTc1083',
+      '/**\n * TC-603',
+    );
+
+    expect(tc1083).toContain('waitForFunction(async');
+    expect(tc1083).toContain('updated.score1 === 2 && updated.score2 === 2');
+    expect(tc1083).not.toContain('waitForTimeout(3000)');
+  });
+
+  it('keeps the MR score editor as a page-level component reused by normal and correction forms', () => {
+    const source = readRepoFile(
+      'smkc-score-app',
+      'src',
+      'app',
+      'tournaments',
+      '[id]',
+      'mr',
+      'participant',
+      'page.tsx',
+    );
+
+    expect(source).toContain('function MrScoreEditor({');
+    expect(source).toContain('interface MrScoreEditorProps');
+    expect(source.match(/<MrScoreEditor/g)?.length).toBe(2);
+    expect(source).not.toContain('const renderScoreEditor');
+  });
+});

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -362,7 +362,13 @@ async function runTc1083(adminPage) {
 
     playerPage.once('dialog', (d) => d.accept());
     await playerPage.getByRole('button', { name: /修正を送信|Submit Correction/ }).click();
-    await playerPage.waitForTimeout(3000);
+    await playerPage.waitForFunction(async ({ tournamentId: tid, matchId }) => {
+      const response = await fetch(`/api/tournaments/${tid}/mr`);
+      const json = await response.json();
+      const data = json.data ?? json;
+      const updated = (data.matches || []).find((m) => m.id === matchId);
+      return updated?.completed === true && updated.score1 === 2 && updated.score2 === 2;
+    }, { tournamentId, matchId: match.id }, { timeout: 15000 });
 
     const correctedMr = await apiFetchMr(adminPage, tournamentId);
     const correctedMatch = (correctedMr.matches || []).find((m) => m.id === match.id);

--- a/smkc-score-app/src/app/tournaments/[id]/mr/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/participant/page.tsx
@@ -29,6 +29,108 @@ interface MRMatch extends BaseMatch {
   player2ReportedPoints2?: number;
 }
 
+interface MrScoreEditorProps {
+  match: MRMatch;
+  title: string;
+  submitLabel: string;
+  submitting: boolean;
+  submittingLabel: string;
+  totalMessage: string;
+  scores: { score1: number; score2: number };
+  onAdjustScore: (match: MRMatch, field: "score1" | "score2", delta: number) => void;
+  onSubmit: (match: MRMatch) => void;
+}
+
+function MrScoreEditor({
+  match,
+  title,
+  submitLabel,
+  submitting,
+  submittingLabel,
+  totalMessage,
+  scores,
+  onAdjustScore,
+  onSubmit,
+}: MrScoreEditorProps) {
+  const totalValid = scores.score1 + scores.score2 === 4;
+
+  return (
+    <div className="border-t pt-4">
+      <h4 className="font-medium mb-3">{title}</h4>
+      <div className="flex items-center justify-center gap-3 mb-4">
+        <div className="text-center min-w-0 max-w-[120px]">
+          <p className="text-sm mb-2 truncate">{match.player1.nickname}</p>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-10 w-10 text-lg"
+              aria-label={`${match.player1.nickname} -1`}
+              onClick={() => onAdjustScore(match, "score1", -1)}
+            >
+              -
+            </Button>
+            <span className="text-3xl font-bold w-10 text-center">
+              {scores.score1}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-10 w-10 text-lg"
+              aria-label={`${match.player1.nickname} +1`}
+              onClick={() => onAdjustScore(match, "score1", 1)}
+            >
+              +
+            </Button>
+          </div>
+        </div>
+        <span className="text-xl mt-6">-</span>
+        <div className="text-center min-w-0 max-w-[120px]">
+          <p className="text-sm mb-2 truncate">{match.player2.nickname}</p>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-10 w-10 text-lg"
+              aria-label={`${match.player2.nickname} -1`}
+              onClick={() => onAdjustScore(match, "score2", -1)}
+            >
+              -
+            </Button>
+            <span className="text-3xl font-bold w-10 text-center">
+              {scores.score2}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-10 w-10 text-lg"
+              aria-label={`${match.player2.nickname} +1`}
+              onClick={() => onAdjustScore(match, "score2", 1)}
+            >
+              +
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <p className={`text-sm text-center mb-3 ${
+        !totalValid && (scores.score1 > 0 || scores.score2 > 0)
+          ? 'text-yellow-600' : 'invisible'
+      }`}>
+        {totalMessage}
+      </p>
+
+      <Button
+        onClick={() => onSubmit(match)}
+        disabled={submitting || !totalValid}
+        className="w-full"
+      >
+        {submitting ? submittingLabel : submitLabel}
+      </Button>
+    </div>
+  );
+}
+
 export default function MatchRaceParticipantPage({
   params,
 }: {
@@ -112,87 +214,19 @@ export default function MatchRaceParticipantPage({
     }
   };
 
-  const renderScoreEditor = (match: MRMatch, title: string, submitLabel: string) => {
+  const scoreEditorProps = (match: MRMatch, title: string, submitLabel: string) => {
     const scores = reportingScores[match.id] ?? getInitialScores(match);
-    const totalValid = scores.score1 + scores.score2 === 4;
-
-    return (
-      <div className="border-t pt-4">
-        <h4 className="font-medium mb-3">{title}</h4>
-        <div className="flex items-center justify-center gap-3 mb-4">
-          <div className="text-center min-w-0 max-w-[120px]">
-            <p className="text-sm mb-2 truncate">{match.player1.nickname}</p>
-            <div className="flex items-center gap-1">
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-10 w-10 text-lg"
-                aria-label={`${match.player1.nickname} -1`}
-                onClick={() => adjustScore(match, "score1", -1)}
-              >
-                -
-              </Button>
-              <span className="text-3xl font-bold w-10 text-center">
-                {scores.score1}
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-10 w-10 text-lg"
-                aria-label={`${match.player1.nickname} +1`}
-                onClick={() => adjustScore(match, "score1", 1)}
-              >
-                +
-              </Button>
-            </div>
-          </div>
-          <span className="text-xl mt-6">-</span>
-          <div className="text-center min-w-0 max-w-[120px]">
-            <p className="text-sm mb-2 truncate">{match.player2.nickname}</p>
-            <div className="flex items-center gap-1">
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-10 w-10 text-lg"
-                aria-label={`${match.player2.nickname} -1`}
-                onClick={() => adjustScore(match, "score2", -1)}
-              >
-                -
-              </Button>
-              <span className="text-3xl font-bold w-10 text-center">
-                {scores.score2}
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-10 w-10 text-lg"
-                aria-label={`${match.player2.nickname} +1`}
-                onClick={() => adjustScore(match, "score2", 1)}
-              >
-                +
-              </Button>
-            </div>
-          </div>
-        </div>
-
-        <p className={`text-sm text-center mb-3 ${
-          !totalValid && (scores.score1 > 0 || scores.score2 > 0)
-            ? 'text-yellow-600' : 'invisible'
-        }`}>
-          {tMatch("totalMustEqual4")}
-        </p>
-
-        <Button
-          onClick={() => handleSubmitScore(match)}
-          disabled={ctx.submitting === match.id || !totalValid}
-          className="w-full"
-        >
-          {ctx.submitting === match.id
-            ? tMatch("submitting")
-            : submitLabel}
-        </Button>
-      </div>
-    );
+    return {
+      match,
+      title,
+      submitLabel,
+      scores,
+      submitting: ctx.submitting === match.id,
+      submittingLabel: tMatch("submitting"),
+      totalMessage: tMatch("totalMustEqual4"),
+      onAdjustScore: adjustScore,
+      onSubmit: handleSubmitScore,
+    };
   };
 
   return (
@@ -214,10 +248,14 @@ export default function MatchRaceParticipantPage({
       submitting={ctx.submitting}
       qualificationConfirmed={ctx.qualificationConfirmed}
       renderMatchForm={(match) => {
-        return renderScoreEditor(
-          match,
-          hasOwnReport(match) ? tPart("editYourReport") : tPart("reportMatchResult"),
-          hasOwnReport(match) ? tPart("submitCorrection") : tPart("submitScores")
+        return (
+          <MrScoreEditor
+            {...scoreEditorProps(
+              match,
+              hasOwnReport(match) ? tPart("editYourReport") : tPart("reportMatchResult"),
+              hasOwnReport(match) ? tPart("submitCorrection") : tPart("submitScores")
+            )}
+          />
         );
       }}
       renderPreviousReports={(match) => {
@@ -248,7 +286,9 @@ export default function MatchRaceParticipantPage({
             {match.completed && (
               editingCorrections[match.id] ? (
                 <div className="mt-4 space-y-3">
-                  {renderScoreEditor(match, tPart("correctScore"), tPart("submitCorrection"))}
+                  <MrScoreEditor
+                    {...scoreEditorProps(match, tPart("correctScore"), tPart("submitCorrection"))}
+                  />
                   <Button
                     type="button"
                     variant="outline"


### PR DESCRIPTION
## Summary
- Replace TC-1083 correction submit fixed sleep with a condition wait against the updated MR API score.
- Extract the MR participant score editor into a page-level MrScoreEditor component reused by normal and correction forms.
- Add static/doc drift coverage for the follow-up guards.

## Issues
Closes #1463
Closes #1464

## Validation
- `node --check smkc-score-app/e2e/tc-mr.js`
- `npm test -- --runTestsByPath '__tests__/docs/e2e-cases-drift.test.ts' '__tests__/static/tc-1463-1464-mr-correction-followups.test.ts'`
- `npx eslint 'src/app/tournaments/[id]/mr/participant/page.tsx' '__tests__/docs/e2e-cases-drift.test.ts' '__tests__/static/tc-1463-1464-mr-correction-followups.test.ts'`
- `npm run lint` (passes with existing warnings)
- `git diff --check`
