### PR TITLE
test: dedupe MR correction drift assertions

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1378,7 +1378,7 @@
 - **URL**: /tournaments/[temp-id]/mr/participant
 - **authRequired**: true (player)
 - **背景**: issue #1083。BM participant は確定済み試合で過去報告を表示し、「Correct Score」から参加者自身が修正できる。MR participant も同じデータフィールド (`player1ReportedPoints*` / `player2ReportedPoints*`) と correction API を持つため、UI でも同等の確認・訂正導線が必要。
-- **回帰チェック**: issue #1463/#1464。修正送信後は固定 sleep ではなく更新済みスコアを条件待機し、MR スコアエディタは `MrScoreEditor` コンポーネントとしてページ外に切り出して再利用する。
+- **回帰チェック**: issue #1463/#1464/#1466。修正送信後は固定 sleep ではなく更新済みスコアを条件待機し、MR スコアエディタは `MrScoreEditor` コンポーネントとしてページ外に切り出して再利用する。ドキュメント確認は drift test に一本化し、static test は実装ガードに集中する。
 - **手順**:
   1. 管理者セッションでMR予選2名マッチを作成する
   2. player1 として `/mr/participant` にログインし、3-1 を送信する

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -103,7 +103,8 @@ describe('E2E case drift coverage', () => {
     const tc1083 = sectionBetween(tcMr, 'async function runTc1083', '/**\n * TC-603');
 
     expect(section).toContain('issue #1083');
-    expect(section).toContain('issue #1463/#1464');
+    expect(section).toContain('issue #1463/#1464/#1466');
+    expect(section).toContain('ドキュメント確認は drift test に一本化');
     expect(section).toContain('Correct Score');
     expect(section).toContain('Submit Correction');
     expect(section).toContain('player1ReportedPoints');

--- a/smkc-score-app/__tests__/static/tc-1463-1464-mr-correction-followups.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1463-1464-mr-correction-followups.test.ts
@@ -1,14 +1,6 @@
-import { e2eCaseSection, readRepoFile, sectionBetween } from '../helpers/e2e-cases';
+import { readRepoFile, sectionBetween } from '../helpers/e2e-cases';
 
 describe('TC-1463-1464 MR correction follow-up guards', () => {
-  it('documents the condition wait and extracted MR score editor follow-ups', () => {
-    const section = e2eCaseSection('TC-1083');
-
-    expect(section).toContain('issue #1463/#1464');
-    expect(section).toContain('固定 sleep ではなく更新済みスコアを条件待機');
-    expect(section).toContain('MrScoreEditor');
-  });
-
   it('keeps TC-1083 correction wait tied to the updated MR score instead of a fixed sleep', () => {
     const source = readRepoFile('smkc-score-app', 'e2e', 'tc-mr.js');
     const tc1083 = sectionBetween(


### PR DESCRIPTION
## Summary
- Move TC-1463/1464 documentation assertions solely into the drift test.
- Remove the duplicate documentation-only static test block so static coverage focuses on implementation guards.

## Issues
Closes #1466

## Validation
- `npm test -- --runTestsByPath '__tests__/docs/e2e-cases-drift.test.ts' '__tests__/static/tc-1463-1464-mr-correction-followups.test.ts'`
- `npx eslint '__tests__/docs/e2e-cases-drift.test.ts' '__tests__/static/tc-1463-1464-mr-correction-followups.test.ts'`
- `git diff --check`
