### PR TITLE
refactor: share BM MR participant score input

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1388,6 +1388,17 @@
 - **期待結果**: MR participant で過去報告を確認でき、確定済みスコアを参加者自身が修正できる
 - **スクリプト**: `tc-mr.js TC-1083`
 
+## TC-1082: BM/MR participant スコア入力ロジック共通化
+- **URL**: /tournaments/[temp-id]/bm/participant, /tournaments/[temp-id]/mr/participant
+- **authRequired**: true (player)
+- **背景**: issue #1082。BM/MR participant ページの `getInitialScores` / `hasOwnReport` / `adjustScore` / `handleSubmitScore` は同じ入力ルールを持つ。BM は `player*ReportedScore*`、MR は `player*ReportedPoints*` を読む差分だけを page 側に残し、共通処理は `useParticipantScoreInput` に集約する。
+- **回帰チェック**:
+  1. BM と MR の participant ページはいずれも `useParticipantScoreInput` を使い、ページ内に重複した初期スコア計算・送信処理を持たない
+  2. 未編集の確定済み試合を送信する場合、BM/MR とも `getInitialScores(match)` の completed score fallback を使う
+  3. 既存 UI シナリオは BM `TC-322` と MR `TC-1083` が担当し、共通化の構造は static/unit test で固定する
+- **期待結果**: BM/MR participant のスコア入力ロジックが共通フックで維持され、mode-specific な報告フィールド差分だけが各ページに残る
+- **スクリプト**: static guard `__tests__/static/tc-1082-shared-score-input.test.ts` + unit `__tests__/lib/hooks/useParticipantScoreInput.test.ts`
+
 ## TC-603: MR引き分け(2-2)スコアの受理確認
 - **URL**: /api/tournaments/[temp-id]/mr (PUT)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -115,6 +115,37 @@ describe('E2E case drift coverage', () => {
     expect(tc1083).not.toContain('waitForTimeout(3000)');
   });
 
+  it('keeps TC-1082 aligned with shared BM/MR participant score input coverage', () => {
+    const section = e2eCaseSection('TC-1082');
+    const bmPage = readRepoFile(
+      'smkc-score-app',
+      'src',
+      'app',
+      'tournaments',
+      '[id]',
+      'bm',
+      'participant',
+      'page.tsx',
+    );
+    const mrPage = readRepoFile(
+      'smkc-score-app',
+      'src',
+      'app',
+      'tournaments',
+      '[id]',
+      'mr',
+      'participant',
+      'page.tsx',
+    );
+
+    expect(section).toContain('issue #1082');
+    expect(section).toContain('useParticipantScoreInput');
+    expect(section).toContain('TC-322');
+    expect(section).toContain('TC-1083');
+    expect(bmPage).toContain('useParticipantScoreInput<BMMatch>');
+    expect(mrPage).toContain('useParticipantScoreInput<MRMatch>');
+  });
+
   it('keeps TC-722 from duplicating GP finals target-wins logic in E2E', () => {
     const section = e2eCaseSection('TC-722');
 

--- a/smkc-score-app/__tests__/lib/hooks/useParticipantScoreInput.test.ts
+++ b/smkc-score-app/__tests__/lib/hooks/useParticipantScoreInput.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+import { useParticipantScoreInput, type ParticipantScoreInputMatch } from '@/lib/hooks/useParticipantScoreInput';
+
+interface TestMatch extends ParticipantScoreInputMatch {
+  player1ReportedScore1?: number | null;
+  player1ReportedScore2?: number | null;
+  player2ReportedScore1?: number | null;
+  player2ReportedScore2?: number | null;
+}
+
+const makeMatch = (overrides: Partial<TestMatch> = {}): TestMatch => ({
+  id: 'match-1',
+  matchNumber: 1,
+  stage: 'qualification',
+  player1: { id: 'player-1', name: 'Player 1', nickname: 'P1' },
+  player1Side: 1,
+  player2: { id: 'player-2', name: 'Player 2', nickname: 'P2' },
+  player2Side: 2,
+  completed: false,
+  score1: 0,
+  score2: 0,
+  ...overrides,
+});
+
+function renderScoreInput(options: {
+  playerId?: string;
+  submitReport?: jest.Mock;
+  setError?: jest.Mock;
+  onSubmitSuccess?: jest.Mock;
+} = {}) {
+  const submitReport = options.submitReport ?? jest.fn().mockResolvedValue({ ok: true });
+  const setError = options.setError ?? jest.fn();
+  const onSubmitSuccess = options.onSubmitSuccess ?? jest.fn();
+
+  const hook = renderHook(() =>
+    useParticipantScoreInput<TestMatch>({
+      playerId: options.playerId ?? 'player-1',
+      getReportedScores: (match, isPlayer1) => ({
+        score1: isPlayer1 ? match.player1ReportedScore1 : match.player2ReportedScore1,
+        score2: isPlayer1 ? match.player1ReportedScore2 : match.player2ReportedScore2,
+      }),
+      submitReport,
+      setError,
+      totalMustEqualMessage: 'total must equal 4',
+      onSubmitSuccess,
+    })
+  );
+
+  return { ...hook, submitReport, setError, onSubmitSuccess };
+}
+
+describe('useParticipantScoreInput', () => {
+  it('uses the current player report before completed match scores', () => {
+    const { result } = renderScoreInput();
+    const match = makeMatch({
+      completed: true,
+      score1: 4,
+      score2: 0,
+      player1ReportedScore1: 3,
+      player1ReportedScore2: 1,
+    });
+
+    expect(result.current.getInitialScores(match)).toEqual({ score1: 3, score2: 1 });
+    expect(result.current.hasOwnReport(match)).toBe(true);
+  });
+
+  it('uses completed scores as the shared submit fallback', async () => {
+    const { result, submitReport, setError, onSubmitSuccess } = renderScoreInput();
+    const match = makeMatch({ completed: true, score1: 3, score2: 1 });
+
+    await act(async () => {
+      await result.current.handleSubmitScore(match);
+    });
+
+    expect(setError).toHaveBeenCalledWith(null);
+    expect(submitReport).toHaveBeenCalledWith('match-1', {
+      reportingPlayer: 1,
+      score1: 3,
+      score2: 1,
+    });
+    expect(onSubmitSuccess).toHaveBeenCalledWith({ ok: true }, match);
+  });
+
+  it('clamps adjusted scores and blocks invalid totals', async () => {
+    const { result, submitReport, setError } = renderScoreInput();
+    const match = makeMatch();
+
+    act(() => {
+      result.current.adjustScore(match, 'score1', 5);
+      result.current.adjustScore(match, 'score2', -1);
+    });
+
+    expect(result.current.reportingScores[match.id]).toEqual({ score1: 4, score2: 0 });
+
+    act(() => {
+      result.current.adjustScore(match, 'score1', -2);
+    });
+
+    await act(async () => {
+      await result.current.handleSubmitScore(match);
+    });
+
+    expect(setError).toHaveBeenCalledWith('total must equal 4');
+    expect(submitReport).not.toHaveBeenCalled();
+  });
+
+  it('submits as player2 when the logged-in player owns player2', async () => {
+    const { result, submitReport } = renderScoreInput({ playerId: 'player-2' });
+    const match = makeMatch({
+      player2ReportedScore1: 1,
+      player2ReportedScore2: 3,
+    });
+
+    await act(async () => {
+      await result.current.handleSubmitScore(match);
+    });
+
+    expect(result.current.hasOwnReport(match)).toBe(true);
+    expect(submitReport).toHaveBeenCalledWith('match-1', {
+      reportingPlayer: 2,
+      score1: 1,
+      score2: 3,
+    });
+  });
+});

--- a/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
@@ -1,0 +1,49 @@
+import { readRepoFile } from '../helpers/e2e-cases';
+
+describe('TC-1082 shared BM/MR participant score input guards', () => {
+  it('keeps BM and MR participant pages on the shared score input hook', () => {
+    const bmPage = readRepoFile(
+      'smkc-score-app',
+      'src',
+      'app',
+      'tournaments',
+      '[id]',
+      'bm',
+      'participant',
+      'page.tsx',
+    );
+    const mrPage = readRepoFile(
+      'smkc-score-app',
+      'src',
+      'app',
+      'tournaments',
+      '[id]',
+      'mr',
+      'participant',
+      'page.tsx',
+    );
+    const hook = readRepoFile('smkc-score-app', 'src', 'lib', 'hooks', 'useParticipantScoreInput.ts');
+
+    expect(bmPage).toContain('useParticipantScoreInput<BMMatch>');
+    expect(mrPage).toContain('useParticipantScoreInput<MRMatch>');
+    expect(bmPage).not.toContain('const getInitialScores =');
+    expect(mrPage).not.toContain('const getInitialScores =');
+    expect(hook).toContain('const getInitialScores = useCallback');
+    expect(hook).toContain('const handleSubmitScore = useCallback');
+  });
+
+  it('documents TC-1082 as the BM/MR shared participant score-input scenario', () => {
+    const cases = readRepoFile('E2E_TEST_CASES.md');
+    const driftTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'docs',
+      'e2e-cases-drift.test.ts',
+    );
+
+    expect(cases).toContain('## TC-1082: BM/MR participant スコア入力ロジック共通化');
+    expect(cases).toContain('issue #1082');
+    expect(cases).toContain('useParticipantScoreInput');
+    expect(driftTest).toContain("e2eCaseSection('TC-1082')");
+  });
+});

--- a/smkc-score-app/src/app/tournaments/[id]/bm/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/participant/page.tsx
@@ -9,11 +9,12 @@
  */
 "use client";
 
-import { useState, use } from "react";
+import { use, useCallback, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Trophy } from "lucide-react";
 import { useParticipantMatches, type BaseMatch } from "@/lib/hooks/useParticipantMatches";
+import { useParticipantScoreInput } from "@/lib/hooks/useParticipantScoreInput";
 import { ParticipantPageLayout } from "@/components/tournament/participant-page-layout";
 import { getScoreReportSuccessMessage } from "@/lib/participant-report-message";
 
@@ -40,71 +41,10 @@ export default function BattleModeParticipantPage({
   /* Shared hook for session, data fetching, polling, match filtering */
   const ctx = useParticipantMatches<BMMatch>({ tournamentId, mode: "bm" });
 
-  /* BM-specific: score entry form state (number-based for +/- button UI) */
-  const [reportingScores, setReportingScores] = useState<
-    Record<string, { score1: number; score2: number }>
-  >({});
   const [editingCorrections, setEditingCorrections] = useState<Record<string, boolean>>({});
 
-  const getInitialScores = (match: BMMatch) => {
-    const isPlayer1 = match.player1.id === ctx.playerId;
-    const ownScore1 = isPlayer1 ? match.player1ReportedScore1 : match.player2ReportedScore1;
-    const ownScore2 = isPlayer1 ? match.player1ReportedScore2 : match.player2ReportedScore2;
-
-    if (ownScore1 != null && ownScore2 != null) {
-      return { score1: ownScore1, score2: ownScore2 };
-    }
-
-    if (match.completed) {
-      return { score1: match.score1 ?? 0, score2: match.score2 ?? 0 };
-    }
-
-    return { score1: 0, score2: 0 };
-  };
-
-  const hasOwnReport = (match: BMMatch) => {
-    const isPlayer1 = match.player1.id === ctx.playerId;
-    return isPlayer1
-      ? match.player1ReportedScore1 != null
-      : match.player2ReportedScore1 != null;
-  };
-
-  /** Increment or decrement a score field, clamped to [0, 4] */
-  const adjustScore = (
-    match: BMMatch,
-    field: "score1" | "score2",
-    delta: number
-  ) => {
-    setReportingScores((prev) => {
-      const current = prev[match.id] ?? getInitialScores(match);
-      const clamped = Math.max(0, Math.min(4, current[field] + delta));
-      return { ...prev, [match.id]: { ...current, [field]: clamped } };
-    });
-  };
-
-  /** BM validation: total must equal 4 (ties allowed per §4.1) */
-  const handleSubmitScore = async (match: BMMatch) => {
-    const scores = reportingScores[match.id] ?? { score1: 0, score2: 0 };
-    const reportingPlayer = match.player1.id === ctx.playerId ? 1 : 2;
-
-    if (scores.score1 + scores.score2 !== 4) {
-      ctx.setError(tMatch("totalMustEqual4"));
-      return;
-    }
-
-    const data = await ctx.submitReport(match.id, {
-      reportingPlayer,
-      score1: scores.score1,
-      score2: scores.score2,
-    });
-
-    if (data) {
-      /* Clear form for this match on success */
-      setReportingScores((prev) => {
-        const next = { ...prev };
-        delete next[match.id];
-        return next;
-      });
+  const handleScoreSubmitSuccess = useCallback(
+    (data: Record<string, unknown>, match: BMMatch) => {
       setEditingCorrections((prev) => ({ ...prev, [match.id]: false }));
       alert(getScoreReportSuccessMessage(data, {
         correctionSubmittedSuccess: tPart("correctionSubmittedSuccess"),
@@ -112,8 +52,28 @@ export default function BattleModeParticipantPage({
         scoresConfirmedSuccess: tPart("scoresConfirmedSuccess"),
         scoresMismatchSubmitted: tPart("scoresMismatchSubmitted"),
       }));
-    }
-  };
+    },
+    [tPart]
+  );
+
+  const {
+    reportingScores,
+    setReportingScores,
+    getInitialScores,
+    hasOwnReport,
+    adjustScore,
+    handleSubmitScore,
+  } = useParticipantScoreInput<BMMatch>({
+    playerId: ctx.playerId,
+    getReportedScores: (match, isPlayer1) => ({
+      score1: isPlayer1 ? match.player1ReportedScore1 : match.player2ReportedScore1,
+      score2: isPlayer1 ? match.player1ReportedScore2 : match.player2ReportedScore2,
+    }),
+    submitReport: ctx.submitReport,
+    setError: ctx.setError,
+    totalMustEqualMessage: tMatch("totalMustEqual4"),
+    onSubmitSuccess: handleScoreSubmitSuccess,
+  });
 
   const renderScoreEditor = (match: BMMatch, title: string, submitLabel: string) => {
     const scores = reportingScores[match.id] ?? getInitialScores(match);

--- a/smkc-score-app/src/app/tournaments/[id]/mr/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/participant/page.tsx
@@ -9,11 +9,12 @@
  */
 "use client";
 
-import { useState, use } from "react";
+import { use, useCallback, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Flag } from "lucide-react";
 import { useParticipantMatches, type BaseMatch } from "@/lib/hooks/useParticipantMatches";
+import { useParticipantScoreInput } from "@/lib/hooks/useParticipantScoreInput";
 import { ParticipantPageLayout } from "@/components/tournament/participant-page-layout";
 import { getScoreReportSuccessMessage } from "@/lib/participant-report-message";
 
@@ -142,68 +143,10 @@ export default function MatchRaceParticipantPage({
 
   const ctx = useParticipantMatches<MRMatch>({ tournamentId, mode: "mr" });
 
-  const [reportingScores, setReportingScores] = useState<
-    Record<string, { score1: number; score2: number }>
-  >({});
   const [editingCorrections, setEditingCorrections] = useState<Record<string, boolean>>({});
 
-  const getInitialScores = (match: MRMatch) => {
-    const isPlayer1 = match.player1.id === ctx.playerId;
-    const ownScore1 = isPlayer1 ? match.player1ReportedPoints1 : match.player2ReportedPoints1;
-    const ownScore2 = isPlayer1 ? match.player1ReportedPoints2 : match.player2ReportedPoints2;
-
-    if (ownScore1 != null && ownScore2 != null) {
-      return { score1: ownScore1, score2: ownScore2 };
-    }
-
-    if (match.completed) {
-      return { score1: match.score1 ?? 0, score2: match.score2 ?? 0 };
-    }
-
-    return { score1: 0, score2: 0 };
-  };
-
-  const hasOwnReport = (match: MRMatch) => {
-    const isPlayer1 = match.player1.id === ctx.playerId;
-    return isPlayer1
-      ? match.player1ReportedPoints1 != null
-      : match.player2ReportedPoints1 != null;
-  };
-
-  const adjustScore = (
-    match: MRMatch,
-    field: "score1" | "score2",
-    delta: number
-  ) => {
-    setReportingScores((prev) => {
-      const current = prev[match.id] ?? getInitialScores(match);
-      const clamped = Math.max(0, Math.min(4, current[field] + delta));
-      return { ...prev, [match.id]: { ...current, [field]: clamped } };
-    });
-  };
-
-  const handleSubmitScore = async (match: MRMatch) => {
-    const scores = reportingScores[match.id] ?? getInitialScores(match);
-    const reportingPlayer = match.player1.id === ctx.playerId ? 1 : 2;
-
-    if (scores.score1 + scores.score2 !== 4) {
-      ctx.setError(tMatch("totalMustEqual4"));
-      return;
-    }
-
-    ctx.setError(null);
-    const data = await ctx.submitReport(match.id, {
-      reportingPlayer,
-      score1: scores.score1,
-      score2: scores.score2,
-    });
-
-    if (data) {
-      setReportingScores((prev) => {
-        const next = { ...prev };
-        delete next[match.id];
-        return next;
-      });
+  const handleScoreSubmitSuccess = useCallback(
+    (data: Record<string, unknown>, match: MRMatch) => {
       setEditingCorrections((prev) => ({ ...prev, [match.id]: false }));
       alert(getScoreReportSuccessMessage(data, {
         correctionSubmittedSuccess: tPart("correctionSubmittedSuccess"),
@@ -211,8 +154,28 @@ export default function MatchRaceParticipantPage({
         scoresConfirmedSuccess: tPart("scoresConfirmedSuccess"),
         scoresMismatchSubmitted: tPart("scoresMismatchSubmitted"),
       }));
-    }
-  };
+    },
+    [tPart]
+  );
+
+  const {
+    reportingScores,
+    setReportingScores,
+    getInitialScores,
+    hasOwnReport,
+    adjustScore,
+    handleSubmitScore,
+  } = useParticipantScoreInput<MRMatch>({
+    playerId: ctx.playerId,
+    getReportedScores: (match, isPlayer1) => ({
+      score1: isPlayer1 ? match.player1ReportedPoints1 : match.player2ReportedPoints1,
+      score2: isPlayer1 ? match.player1ReportedPoints2 : match.player2ReportedPoints2,
+    }),
+    submitReport: ctx.submitReport,
+    setError: ctx.setError,
+    totalMustEqualMessage: tMatch("totalMustEqual4"),
+    onSubmitSuccess: handleScoreSubmitSuccess,
+  });
 
   const scoreEditorProps = (match: MRMatch, title: string, submitLabel: string) => {
     const scores = reportingScores[match.id] ?? getInitialScores(match);

--- a/smkc-score-app/src/lib/hooks/useParticipantScoreInput.ts
+++ b/smkc-score-app/src/lib/hooks/useParticipantScoreInput.ts
@@ -1,0 +1,137 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { BaseMatch } from "@/lib/hooks/useParticipantMatches";
+
+export interface ParticipantScorePair {
+  score1: number;
+  score2: number;
+}
+
+export interface ParticipantScoreInputMatch extends BaseMatch {
+  score1?: number | null;
+  score2?: number | null;
+}
+
+interface UseParticipantScoreInputOptions<TMatch extends ParticipantScoreInputMatch> {
+  playerId: string | undefined;
+  getReportedScores: (
+    match: TMatch,
+    isPlayer1: boolean
+  ) => {
+    score1: number | null | undefined;
+    score2: number | null | undefined;
+  };
+  submitReport: (
+    matchId: string,
+    body: Record<string, unknown>
+  ) => Promise<Record<string, unknown> | null>;
+  setError: (error: string | null) => void;
+  totalMustEqualMessage: string;
+  onSubmitSuccess?: (data: Record<string, unknown>, match: TMatch) => void;
+}
+
+export function useParticipantScoreInput<TMatch extends ParticipantScoreInputMatch>({
+  playerId,
+  getReportedScores,
+  submitReport,
+  setError,
+  totalMustEqualMessage,
+  onSubmitSuccess,
+}: UseParticipantScoreInputOptions<TMatch>) {
+  const [reportingScores, setReportingScores] = useState<
+    Record<string, ParticipantScorePair>
+  >({});
+
+  const isPlayer1ForMatch = useCallback(
+    (match: TMatch) => match.player1.id === playerId,
+    [playerId]
+  );
+
+  const getInitialScores = useCallback(
+    (match: TMatch): ParticipantScorePair => {
+      const reported = getReportedScores(match, isPlayer1ForMatch(match));
+
+      if (reported.score1 != null && reported.score2 != null) {
+        return { score1: reported.score1, score2: reported.score2 };
+      }
+
+      if (match.completed) {
+        return { score1: match.score1 ?? 0, score2: match.score2 ?? 0 };
+      }
+
+      return { score1: 0, score2: 0 };
+    },
+    [getReportedScores, isPlayer1ForMatch]
+  );
+
+  const hasOwnReport = useCallback(
+    (match: TMatch) => getReportedScores(match, isPlayer1ForMatch(match)).score1 != null,
+    [getReportedScores, isPlayer1ForMatch]
+  );
+
+  const clearScores = useCallback((matchId: string) => {
+    setReportingScores((prev) => {
+      const next = { ...prev };
+      delete next[matchId];
+      return next;
+    });
+  }, []);
+
+  const adjustScore = useCallback(
+    (match: TMatch, field: keyof ParticipantScorePair, delta: number) => {
+      setReportingScores((prev) => {
+        const current = prev[match.id] ?? getInitialScores(match);
+        const clamped = Math.max(0, Math.min(4, current[field] + delta));
+        return { ...prev, [match.id]: { ...current, [field]: clamped } };
+      });
+    },
+    [getInitialScores]
+  );
+
+  const handleSubmitScore = useCallback(
+    async (match: TMatch) => {
+      const scores = reportingScores[match.id] ?? getInitialScores(match);
+      const reportingPlayer = isPlayer1ForMatch(match) ? 1 : 2;
+
+      if (scores.score1 + scores.score2 !== 4) {
+        setError(totalMustEqualMessage);
+        return null;
+      }
+
+      setError(null);
+      const data = await submitReport(match.id, {
+        reportingPlayer,
+        score1: scores.score1,
+        score2: scores.score2,
+      });
+
+      if (data) {
+        clearScores(match.id);
+        onSubmitSuccess?.(data, match);
+      }
+
+      return data;
+    },
+    [
+      clearScores,
+      getInitialScores,
+      isPlayer1ForMatch,
+      onSubmitSuccess,
+      reportingScores,
+      setError,
+      submitReport,
+      totalMustEqualMessage,
+    ]
+  );
+
+  return {
+    reportingScores,
+    setReportingScores,
+    getInitialScores,
+    hasOwnReport,
+    adjustScore,
+    clearScores,
+    handleSubmitScore,
+  };
+}


### PR DESCRIPTION
Summary
- Add TC-1082 scenario docs and drift/static guards for shared BM/MR participant score input coverage.
- Extract shared BM/MR participant score input state, initial score fallback, report detection, score adjustment, and submit handling into `useParticipantScoreInput`.
- Keep BM/MR field mapping mode-specific while aligning BM completed-match submit fallback with MR via `getInitialScores(match)`.

Issues: Closes #1082

Validation
- `npm test -- --runInBand __tests__/lib/hooks/useParticipantScoreInput.test.ts __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npx eslint src/lib/hooks/useParticipantScoreInput.ts 'src/app/tournaments/[id]/bm/participant/page.tsx' 'src/app/tournaments/[id]/mr/participant/page.tsx' __tests__/lib/hooks/useParticipantScoreInput.test.ts __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npm run lint` (passes with existing warnings)
- `git diff --check`
