### PR TITLE
test: tighten participant score input hook API

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1395,7 +1395,8 @@
 - **回帰チェック**:
   1. BM と MR の participant ページはいずれも `useParticipantScoreInput` を使い、ページ内に重複した初期スコア計算・送信処理を持たない
   2. 未編集の確定済み試合を送信する場合、BM/MR とも `getInitialScores(match)` の completed score fallback を使う
-  3. 既存 UI シナリオは BM `TC-322` と MR `TC-1083` が担当し、共通化の構造は static/unit test で固定する
+  3. issue #1469/#1470 の再発防止として、クランプ値は `maxScorePerSide`、合計値は `requiredTotalScore` で揃えられ、`clearScores` は public hook API として公開されない
+  4. 既存 UI シナリオは BM `TC-322` と MR `TC-1083` が担当し、共通化の構造は static/unit test で固定する
 - **期待結果**: BM/MR participant のスコア入力ロジックが共通フックで維持され、mode-specific な報告フィールド差分だけが各ページに残る
 - **スクリプト**: static guard `__tests__/static/tc-1082-shared-score-input.test.ts` + unit `__tests__/lib/hooks/useParticipantScoreInput.test.ts`
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -139,7 +139,10 @@ describe('E2E case drift coverage', () => {
     );
 
     expect(section).toContain('issue #1082');
+    expect(section).toContain('issue #1469/#1470');
     expect(section).toContain('useParticipantScoreInput');
+    expect(section).toContain('requiredTotalScore');
+    expect(section).toContain('maxScorePerSide');
     expect(section).toContain('TC-322');
     expect(section).toContain('TC-1083');
     expect(bmPage).toContain('useParticipantScoreInput<BMMatch>');

--- a/smkc-score-app/__tests__/lib/hooks/useParticipantScoreInput.test.ts
+++ b/smkc-score-app/__tests__/lib/hooks/useParticipantScoreInput.test.ts
@@ -30,6 +30,8 @@ function renderScoreInput(options: {
   submitReport?: jest.Mock;
   setError?: jest.Mock;
   onSubmitSuccess?: jest.Mock;
+  requiredTotalScore?: number;
+  maxScorePerSide?: number;
 } = {}) {
   const submitReport = options.submitReport ?? jest.fn().mockResolvedValue({ ok: true });
   const setError = options.setError ?? jest.fn();
@@ -45,6 +47,8 @@ function renderScoreInput(options: {
       submitReport,
       setError,
       totalMustEqualMessage: 'total must equal 4',
+      requiredTotalScore: options.requiredTotalScore,
+      maxScorePerSide: options.maxScorePerSide,
       onSubmitSuccess,
     })
   );
@@ -105,6 +109,38 @@ describe('useParticipantScoreInput', () => {
 
     expect(setError).toHaveBeenCalledWith('total must equal 4');
     expect(submitReport).not.toHaveBeenCalled();
+  });
+
+  it('allows callers to align the max score clamp with a non-default required total', async () => {
+    const { result, submitReport } = renderScoreInput({
+      requiredTotalScore: 7,
+      maxScorePerSide: 7,
+    });
+    const match = makeMatch();
+
+    act(() => {
+      result.current.adjustScore(match, 'score1', 8);
+      result.current.adjustScore(match, 'score2', 2);
+      result.current.adjustScore(match, 'score1', -2);
+    });
+
+    expect(result.current.reportingScores[match.id]).toEqual({ score1: 5, score2: 2 });
+
+    await act(async () => {
+      await result.current.handleSubmitScore(match);
+    });
+
+    expect(submitReport).toHaveBeenCalledWith('match-1', {
+      reportingPlayer: 1,
+      score1: 5,
+      score2: 2,
+    });
+  });
+
+  it('does not expose clearScores as a public hook API', () => {
+    const { result } = renderScoreInput();
+
+    expect(Object.prototype.hasOwnProperty.call(result.current, 'clearScores')).toBe(false);
   });
 
   it('submits as player2 when the logged-in player owns player2', async () => {

--- a/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
@@ -30,6 +30,8 @@ describe('TC-1082 shared BM/MR participant score input guards', () => {
     expect(mrPage).not.toContain('const getInitialScores =');
     expect(hook).toContain('const getInitialScores = useCallback');
     expect(hook).toContain('const handleSubmitScore = useCallback');
+    expect(hook).toContain('maxScorePerSide = requiredTotalScore');
+    expect(hook).toContain('requiredTotalScore = 4');
   });
 
   it('documents TC-1082 as the BM/MR shared participant score-input scenario', () => {

--- a/smkc-score-app/src/lib/hooks/useParticipantScoreInput.ts
+++ b/smkc-score-app/src/lib/hooks/useParticipantScoreInput.ts
@@ -28,6 +28,8 @@ interface UseParticipantScoreInputOptions<TMatch extends ParticipantScoreInputMa
   ) => Promise<Record<string, unknown> | null>;
   setError: (error: string | null) => void;
   totalMustEqualMessage: string;
+  requiredTotalScore?: number;
+  maxScorePerSide?: number;
   onSubmitSuccess?: (data: Record<string, unknown>, match: TMatch) => void;
 }
 
@@ -37,6 +39,8 @@ export function useParticipantScoreInput<TMatch extends ParticipantScoreInputMat
   submitReport,
   setError,
   totalMustEqualMessage,
+  requiredTotalScore = 4,
+  maxScorePerSide = requiredTotalScore,
   onSubmitSuccess,
 }: UseParticipantScoreInputOptions<TMatch>) {
   const [reportingScores, setReportingScores] = useState<
@@ -82,11 +86,11 @@ export function useParticipantScoreInput<TMatch extends ParticipantScoreInputMat
     (match: TMatch, field: keyof ParticipantScorePair, delta: number) => {
       setReportingScores((prev) => {
         const current = prev[match.id] ?? getInitialScores(match);
-        const clamped = Math.max(0, Math.min(4, current[field] + delta));
+        const clamped = Math.max(0, Math.min(maxScorePerSide, current[field] + delta));
         return { ...prev, [match.id]: { ...current, [field]: clamped } };
       });
     },
-    [getInitialScores]
+    [getInitialScores, maxScorePerSide]
   );
 
   const handleSubmitScore = useCallback(
@@ -94,7 +98,7 @@ export function useParticipantScoreInput<TMatch extends ParticipantScoreInputMat
       const scores = reportingScores[match.id] ?? getInitialScores(match);
       const reportingPlayer = isPlayer1ForMatch(match) ? 1 : 2;
 
-      if (scores.score1 + scores.score2 !== 4) {
+      if (scores.score1 + scores.score2 !== requiredTotalScore) {
         setError(totalMustEqualMessage);
         return null;
       }
@@ -119,6 +123,7 @@ export function useParticipantScoreInput<TMatch extends ParticipantScoreInputMat
       isPlayer1ForMatch,
       onSubmitSuccess,
       reportingScores,
+      requiredTotalScore,
       setError,
       submitReport,
       totalMustEqualMessage,
@@ -131,7 +136,6 @@ export function useParticipantScoreInput<TMatch extends ParticipantScoreInputMat
     getInitialScores,
     hasOwnReport,
     adjustScore,
-    clearScores,
     handleSubmitScore,
   };
 }


### PR DESCRIPTION
Summary
- Add configurable `requiredTotalScore` and `maxScorePerSide` options so the shared participant score hook keeps validation and clamp limits aligned.
- Keep the default BM/MR qualification behavior at 4 while adding regression coverage for non-default totals.
- Remove `clearScores` from the public hook return API and guard that it stays internal.

Issues: Closes #1469, Closes #1470

Validation
- `npm test -- --runInBand __tests__/lib/hooks/useParticipantScoreInput.test.ts __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npx eslint src/lib/hooks/useParticipantScoreInput.ts __tests__/lib/hooks/useParticipantScoreInput.test.ts __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `git diff --check`