### PR TITLE
test: align score input total validation

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1396,7 +1396,8 @@
   1. BM と MR の participant ページはいずれも `useParticipantScoreInput` を使い、ページ内に重複した初期スコア計算・送信処理を持たない
   2. 未編集の確定済み試合を送信する場合、BM/MR とも `getInitialScores(match)` の completed score fallback を使う
   3. issue #1469/#1470 の再発防止として、クランプ値は `maxScorePerSide`、合計値は `requiredTotalScore` で揃えられ、`clearScores` は public hook API として公開されない
-  4. 既存 UI シナリオは BM `TC-322` と MR `TC-1083` が担当し、共通化の構造は static/unit test で固定する
+  4. issue #1472/#1473 の再発防止として、呼び出し元 UI の `totalValid` も hook から返る `requiredTotalScore` を参照し、`maxScorePerSide < requiredTotalScore` の valid/invalid 境界を unit test で固定する
+  5. 既存 UI シナリオは BM `TC-322` と MR `TC-1083` が担当し、共通化の構造は static/unit test で固定する
 - **期待結果**: BM/MR participant のスコア入力ロジックが共通フックで維持され、mode-specific な報告フィールド差分だけが各ページに残る
 - **スクリプト**: static guard `__tests__/static/tc-1082-shared-score-input.test.ts` + unit `__tests__/lib/hooks/useParticipantScoreInput.test.ts`
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -140,6 +140,7 @@ describe('E2E case drift coverage', () => {
 
     expect(section).toContain('issue #1082');
     expect(section).toContain('issue #1469/#1470');
+    expect(section).toContain('issue #1472/#1473');
     expect(section).toContain('useParticipantScoreInput');
     expect(section).toContain('requiredTotalScore');
     expect(section).toContain('maxScorePerSide');

--- a/smkc-score-app/__tests__/lib/hooks/useParticipantScoreInput.test.ts
+++ b/smkc-score-app/__tests__/lib/hooks/useParticipantScoreInput.test.ts
@@ -135,6 +135,47 @@ describe('useParticipantScoreInput', () => {
       score1: 5,
       score2: 2,
     });
+    expect(result.current.requiredTotalScore).toBe(7);
+    expect(result.current.maxScorePerSide).toBe(7);
+  });
+
+  it('supports best-of-nine style totals where each side is capped below the required total', async () => {
+    const { result, submitReport, setError } = renderScoreInput({
+      requiredTotalScore: 9,
+      maxScorePerSide: 5,
+    });
+    const match = makeMatch();
+
+    act(() => {
+      result.current.adjustScore(match, 'score1', 6);
+      result.current.adjustScore(match, 'score2', 4);
+    });
+
+    expect(result.current.reportingScores[match.id]).toEqual({ score1: 5, score2: 4 });
+
+    await act(async () => {
+      await result.current.handleSubmitScore(match);
+    });
+
+    expect(submitReport).toHaveBeenCalledWith('match-1', {
+      reportingPlayer: 1,
+      score1: 5,
+      score2: 4,
+    });
+
+    act(() => {
+      result.current.adjustScore(match, 'score1', 6);
+      result.current.adjustScore(match, 'score2', 6);
+    });
+
+    expect(result.current.reportingScores[match.id]).toEqual({ score1: 5, score2: 5 });
+
+    await act(async () => {
+      await result.current.handleSubmitScore(match);
+    });
+
+    expect(setError).toHaveBeenLastCalledWith('total must equal 4');
+    expect(submitReport).toHaveBeenCalledTimes(1);
   });
 
   it('does not expose clearScores as a public hook API', () => {

--- a/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
@@ -32,6 +32,9 @@ describe('TC-1082 shared BM/MR participant score input guards', () => {
     expect(hook).toContain('const handleSubmitScore = useCallback');
     expect(hook).toContain('maxScorePerSide = requiredTotalScore');
     expect(hook).toContain('requiredTotalScore = 4');
+    expect(hook).toContain('requiredTotalScore,');
+    expect(bmPage).toContain('scores.score1 + scores.score2 === requiredTotalScore');
+    expect(mrPage).toContain('scores.score1 + scores.score2 === requiredTotalScore');
   });
 
   it('documents TC-1082 as the BM/MR shared participant score-input scenario', () => {

--- a/smkc-score-app/src/app/tournaments/[id]/bm/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/participant/page.tsx
@@ -59,6 +59,7 @@ export default function BattleModeParticipantPage({
   const {
     reportingScores,
     setReportingScores,
+    requiredTotalScore,
     getInitialScores,
     hasOwnReport,
     adjustScore,
@@ -77,7 +78,7 @@ export default function BattleModeParticipantPage({
 
   const renderScoreEditor = (match: BMMatch, title: string, submitLabel: string) => {
     const scores = reportingScores[match.id] ?? getInitialScores(match);
-    const totalValid = scores.score1 + scores.score2 === 4;
+    const totalValid = scores.score1 + scores.score2 === requiredTotalScore;
 
     return (
       <div className="border-t pt-4">

--- a/smkc-score-app/src/app/tournaments/[id]/mr/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/participant/page.tsx
@@ -37,6 +37,7 @@ interface MrScoreEditorProps {
   submitting: boolean;
   submittingLabel: string;
   totalMessage: string;
+  requiredTotalScore: number;
   scores: { score1: number; score2: number };
   onAdjustScore: (match: MRMatch, field: "score1" | "score2", delta: number) => void;
   onSubmit: (match: MRMatch) => void;
@@ -49,11 +50,12 @@ function MrScoreEditor({
   submitting,
   submittingLabel,
   totalMessage,
+  requiredTotalScore,
   scores,
   onAdjustScore,
   onSubmit,
 }: MrScoreEditorProps) {
-  const totalValid = scores.score1 + scores.score2 === 4;
+  const totalValid = scores.score1 + scores.score2 === requiredTotalScore;
 
   return (
     <div className="border-t pt-4">
@@ -161,6 +163,7 @@ export default function MatchRaceParticipantPage({
   const {
     reportingScores,
     setReportingScores,
+    requiredTotalScore,
     getInitialScores,
     hasOwnReport,
     adjustScore,
@@ -187,6 +190,7 @@ export default function MatchRaceParticipantPage({
       submitting: ctx.submitting === match.id,
       submittingLabel: tMatch("submitting"),
       totalMessage: tMatch("totalMustEqual4"),
+      requiredTotalScore,
       onAdjustScore: adjustScore,
       onSubmit: handleSubmitScore,
     };

--- a/smkc-score-app/src/lib/hooks/useParticipantScoreInput.ts
+++ b/smkc-score-app/src/lib/hooks/useParticipantScoreInput.ts
@@ -133,6 +133,8 @@ export function useParticipantScoreInput<TMatch extends ParticipantScoreInputMat
   return {
     reportingScores,
     setReportingScores,
+    requiredTotalScore,
+    maxScorePerSide,
     getInitialScores,
     hasOwnReport,
     adjustScore,


### PR DESCRIPTION
Summary
- Return `requiredTotalScore` and `maxScorePerSide` from `useParticipantScoreInput` so participant UI validation can use the same total as submit validation.
- Update BM/MR participant score editors to compute `totalValid` from the hook-returned required total instead of hardcoded 4.
- Add unit coverage for `maxScorePerSide < requiredTotalScore` with both 5-4 valid and 5-5 invalid boundaries.

Issues: Closes #1472, Closes #1473

Validation
- `npm test -- --runInBand __tests__/lib/hooks/useParticipantScoreInput.test.ts __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npx eslint src/lib/hooks/useParticipantScoreInput.ts 'src/app/tournaments/[id]/bm/participant/page.tsx' 'src/app/tournaments/[id]/mr/participant/page.tsx' __tests__/lib/hooks/useParticipantScoreInput.test.ts __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `git diff --check`