### PR TITLE
test: narrow score input hook API

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1397,7 +1397,8 @@
   2. 未編集の確定済み試合を送信する場合、BM/MR とも `getInitialScores(match)` の completed score fallback を使う
   3. issue #1469/#1470 の再発防止として、クランプ値は `maxScorePerSide`、合計値は `requiredTotalScore` で揃えられ、`clearScores` は public hook API として公開されない
   4. issue #1472/#1473 の再発防止として、呼び出し元 UI の `totalValid` も hook から返る `requiredTotalScore` を参照し、`maxScorePerSide < requiredTotalScore` の valid/invalid 境界を unit test で固定する
-  5. 既存 UI シナリオは BM `TC-322` と MR `TC-1083` が担当し、共通化の構造は static/unit test で固定する
+  5. issue #1475/#1476 の再発防止として、テストヘルパーの `totalMustEqualMessage` は可変にし、`maxScorePerSide` は未使用の public return API として公開しない
+  6. 既存 UI シナリオは BM `TC-322` と MR `TC-1083` が担当し、共通化の構造は static/unit test で固定する
 - **期待結果**: BM/MR participant のスコア入力ロジックが共通フックで維持され、mode-specific な報告フィールド差分だけが各ページに残る
 - **スクリプト**: static guard `__tests__/static/tc-1082-shared-score-input.test.ts` + unit `__tests__/lib/hooks/useParticipantScoreInput.test.ts`
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -141,6 +141,7 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #1082');
     expect(section).toContain('issue #1469/#1470');
     expect(section).toContain('issue #1472/#1473');
+    expect(section).toContain('issue #1475/#1476');
     expect(section).toContain('useParticipantScoreInput');
     expect(section).toContain('requiredTotalScore');
     expect(section).toContain('maxScorePerSide');

--- a/smkc-score-app/__tests__/lib/hooks/useParticipantScoreInput.test.ts
+++ b/smkc-score-app/__tests__/lib/hooks/useParticipantScoreInput.test.ts
@@ -32,6 +32,7 @@ function renderScoreInput(options: {
   onSubmitSuccess?: jest.Mock;
   requiredTotalScore?: number;
   maxScorePerSide?: number;
+  totalMustEqualMessage?: string;
 } = {}) {
   const submitReport = options.submitReport ?? jest.fn().mockResolvedValue({ ok: true });
   const setError = options.setError ?? jest.fn();
@@ -46,7 +47,7 @@ function renderScoreInput(options: {
       }),
       submitReport,
       setError,
-      totalMustEqualMessage: 'total must equal 4',
+      totalMustEqualMessage: options.totalMustEqualMessage ?? 'total must equal 4',
       requiredTotalScore: options.requiredTotalScore,
       maxScorePerSide: options.maxScorePerSide,
       onSubmitSuccess,
@@ -136,13 +137,13 @@ describe('useParticipantScoreInput', () => {
       score2: 2,
     });
     expect(result.current.requiredTotalScore).toBe(7);
-    expect(result.current.maxScorePerSide).toBe(7);
   });
 
   it('supports best-of-nine style totals where each side is capped below the required total', async () => {
     const { result, submitReport, setError } = renderScoreInput({
       requiredTotalScore: 9,
       maxScorePerSide: 5,
+      totalMustEqualMessage: 'total must equal 9',
     });
     const match = makeMatch();
 
@@ -174,7 +175,7 @@ describe('useParticipantScoreInput', () => {
       await result.current.handleSubmitScore(match);
     });
 
-    expect(setError).toHaveBeenLastCalledWith('total must equal 4');
+    expect(setError).toHaveBeenLastCalledWith('total must equal 9');
     expect(submitReport).toHaveBeenCalledTimes(1);
   });
 

--- a/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
@@ -33,6 +33,7 @@ describe('TC-1082 shared BM/MR participant score input guards', () => {
     expect(hook).toContain('maxScorePerSide = requiredTotalScore');
     expect(hook).toContain('requiredTotalScore = 4');
     expect(hook).toContain('requiredTotalScore,');
+    expect(hook).not.toContain('    maxScorePerSide,');
     expect(bmPage).toContain('scores.score1 + scores.score2 === requiredTotalScore');
     expect(mrPage).toContain('scores.score1 + scores.score2 === requiredTotalScore');
   });

--- a/smkc-score-app/src/lib/hooks/useParticipantScoreInput.ts
+++ b/smkc-score-app/src/lib/hooks/useParticipantScoreInput.ts
@@ -134,7 +134,6 @@ export function useParticipantScoreInput<TMatch extends ParticipantScoreInputMat
     reportingScores,
     setReportingScores,
     requiredTotalScore,
-    maxScorePerSide,
     getInitialScores,
     hasOwnReport,
     adjustScore,


### PR DESCRIPTION
Summary
- Let the score-input hook test helper accept `totalMustEqualMessage` so non-default total tests assert the correct error copy.
- Remove unused `maxScorePerSide` from the hook return API while keeping it as an internal clamp option.
- Extend TC-1082 docs/static drift guards for the narrowed public API.

Issues: Closes #1475, Closes #1476

Validation
- `npm test -- --runInBand __tests__/lib/hooks/useParticipantScoreInput.test.ts __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npx eslint src/lib/hooks/useParticipantScoreInput.ts __tests__/lib/hooks/useParticipantScoreInput.test.ts __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `git diff --check`