### PR TITLE
test: harden score input static guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1397,7 +1397,7 @@
   2. 未編集の確定済み試合を送信する場合、BM/MR とも `getInitialScores(match)` の completed score fallback を使う
   3. issue #1469/#1470 の再発防止として、クランプ値は `maxScorePerSide`、合計値は `requiredTotalScore` で揃えられ、`clearScores` は public hook API として公開されない
   4. issue #1472/#1473 の再発防止として、呼び出し元 UI の `totalValid` も hook から返る `requiredTotalScore` を参照し、`maxScorePerSide < requiredTotalScore` の valid/invalid 境界を unit test で固定する
-  5. issue #1475/#1476 の再発防止として、テストヘルパーの `totalMustEqualMessage` は可変にし、`maxScorePerSide` は未使用の public return API として公開しない
+  5. issue #1475/#1476/#1478 の再発防止として、テストヘルパーの `totalMustEqualMessage` は可変にし、`maxScorePerSide` は未使用の public return API として公開しない。static guard は return object を正規表現で検証し、インデントに依存しない
   6. 既存 UI シナリオは BM `TC-322` と MR `TC-1083` が担当し、共通化の構造は static/unit test で固定する
 - **期待結果**: BM/MR participant のスコア入力ロジックが共通フックで維持され、mode-specific な報告フィールド差分だけが各ページに残る
 - **スクリプト**: static guard `__tests__/static/tc-1082-shared-score-input.test.ts` + unit `__tests__/lib/hooks/useParticipantScoreInput.test.ts`

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -141,7 +141,7 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #1082');
     expect(section).toContain('issue #1469/#1470');
     expect(section).toContain('issue #1472/#1473');
-    expect(section).toContain('issue #1475/#1476');
+    expect(section).toContain('issue #1475/#1476/#1478');
     expect(section).toContain('useParticipantScoreInput');
     expect(section).toContain('requiredTotalScore');
     expect(section).toContain('maxScorePerSide');

--- a/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
@@ -33,7 +33,7 @@ describe('TC-1082 shared BM/MR participant score input guards', () => {
     expect(hook).toContain('maxScorePerSide = requiredTotalScore');
     expect(hook).toContain('requiredTotalScore = 4');
     expect(hook).toContain('requiredTotalScore,');
-    expect(hook).not.toContain('    maxScorePerSide,');
+    expect(hook).not.toMatch(/return\s*\{[^}]*\bmaxScorePerSide\b/s);
     expect(bmPage).toContain('scores.score1 + scores.score2 === requiredTotalScore');
     expect(mrPage).toContain('scores.score1 + scores.score2 === requiredTotalScore');
   });


### PR DESCRIPTION
Summary
- Replace the indentation-sensitive static guard with a regex over the hook return object.
- Update TC-1082 docs and drift coverage to record the #1478 regression guard.

Issues: Closes #1478

Validation
- `npm test -- --runInBand __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npx eslint __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `git diff --check`