### PR TITLE
test: harden score input return guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1398,7 +1398,8 @@
   3. issue #1469/#1470 の再発防止として、クランプ値は `maxScorePerSide`、合計値は `requiredTotalScore` で揃えられ、`clearScores` は public hook API として公開されない
   4. issue #1472/#1473 の再発防止として、呼び出し元 UI の `totalValid` も hook から返る `requiredTotalScore` を参照し、`maxScorePerSide < requiredTotalScore` の valid/invalid 境界を unit test で固定する
   5. issue #1475/#1476/#1478 の再発防止として、テストヘルパーの `totalMustEqualMessage` は可変にし、`maxScorePerSide` は未使用の public return API として公開しない。static guard は return object を正規表現で検証し、インデントに依存しない
-  6. 既存 UI シナリオは BM `TC-322` と MR `TC-1083` が担当し、共通化の構造は static/unit test で固定する
+  6. issue #1480 の再発防止として、static guard は `return { ... }` 内にネストしたオブジェクトリテラルが先に来ても後続プロパティを見落とさないよう、TypeScript AST で hook の最上位 return object を抽出して検証する
+  7. 既存 UI シナリオは BM `TC-322` と MR `TC-1083` が担当し、共通化の構造は static/unit test で固定する
 - **期待結果**: BM/MR participant のスコア入力ロジックが共通フックで維持され、mode-specific な報告フィールド差分だけが各ページに残る
 - **スクリプト**: static guard `__tests__/static/tc-1082-shared-score-input.test.ts` + unit `__tests__/lib/hooks/useParticipantScoreInput.test.ts`
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -142,6 +142,8 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #1469/#1470');
     expect(section).toContain('issue #1472/#1473');
     expect(section).toContain('issue #1475/#1476/#1478');
+    expect(section).toContain('issue #1480');
+    expect(section).toContain('TypeScript AST');
     expect(section).toContain('useParticipantScoreInput');
     expect(section).toContain('requiredTotalScore');
     expect(section).toContain('maxScorePerSide');

--- a/smkc-score-app/__tests__/helpers/e2e-cases.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import ts from 'typescript';
 
 const repoRoot = path.join(process.cwd(), '..');
 
@@ -50,4 +51,47 @@ export function e2eCaseSection(tc: string, source = e2eCases) {
   const next = source.slice(start + 1).search(/\n#{2,3} TC-/);
   const end = next === -1 ? source.length : start + 1 + next;
   return source.slice(start, end);
+}
+
+export function functionReturnObjectLiteral(source: string, functionName: string) {
+  const sourceFile = ts.createSourceFile(
+    'source.tsx',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+  let returnObject: ts.ObjectLiteralExpression | null = null;
+
+  function visit(node: ts.Node) {
+    if (
+      ts.isFunctionDeclaration(node) &&
+      node.name?.text === functionName &&
+      node.body
+    ) {
+      for (const statement of [...node.body.statements].reverse()) {
+        if (
+          ts.isReturnStatement(statement) &&
+          statement.expression &&
+          ts.isObjectLiteralExpression(statement.expression)
+        ) {
+          returnObject = statement.expression;
+          return;
+        }
+      }
+    }
+
+    if (!returnObject) {
+      ts.forEachChild(node, visit);
+    }
+  }
+
+  visit(sourceFile);
+
+  if (!returnObject) {
+    throw new Error(`return object not found for function: ${functionName}`);
+  }
+
+  return returnObject.getText(sourceFile);
 }

--- a/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
@@ -1,4 +1,7 @@
-import { readRepoFile } from '../helpers/e2e-cases';
+import {
+  functionReturnObjectLiteral,
+  readRepoFile,
+} from '../helpers/e2e-cases';
 
 describe('TC-1082 shared BM/MR participant score input guards', () => {
   it('keeps BM and MR participant pages on the shared score input hook', () => {
@@ -23,6 +26,7 @@ describe('TC-1082 shared BM/MR participant score input guards', () => {
       'page.tsx',
     );
     const hook = readRepoFile('smkc-score-app', 'src', 'lib', 'hooks', 'useParticipantScoreInput.ts');
+    const hookReturnObject = functionReturnObjectLiteral(hook, 'useParticipantScoreInput');
 
     expect(bmPage).toContain('useParticipantScoreInput<BMMatch>');
     expect(mrPage).toContain('useParticipantScoreInput<MRMatch>');
@@ -32,10 +36,26 @@ describe('TC-1082 shared BM/MR participant score input guards', () => {
     expect(hook).toContain('const handleSubmitScore = useCallback');
     expect(hook).toContain('maxScorePerSide = requiredTotalScore');
     expect(hook).toContain('requiredTotalScore = 4');
-    expect(hook).toContain('requiredTotalScore,');
-    expect(hook).not.toMatch(/return\s*\{[^}]*\bmaxScorePerSide\b/s);
+    expect(hookReturnObject).toContain('requiredTotalScore');
+    expect(hookReturnObject).not.toContain('maxScorePerSide');
     expect(bmPage).toContain('scores.score1 + scores.score2 === requiredTotalScore');
     expect(mrPage).toContain('scores.score1 + scores.score2 === requiredTotalScore');
+  });
+
+  it('keeps the return-object guard stable when nested object literals appear first', () => {
+    const returnObject = functionReturnObjectLiteral(`
+      export function useParticipantScoreInput() {
+        const nested = true;
+        return {
+          diagnostics: { nested },
+          requiredTotalScore: 4,
+          maxScorePerSide: 4,
+        };
+      }
+    `, 'useParticipantScoreInput');
+
+    expect(returnObject).toContain('diagnostics: { nested }');
+    expect(returnObject).toContain('maxScorePerSide');
   });
 
   it('documents TC-1082 as the BM/MR shared participant score-input scenario', () => {
@@ -49,6 +69,7 @@ describe('TC-1082 shared BM/MR participant score input guards', () => {
 
     expect(cases).toContain('## TC-1082: BM/MR participant スコア入力ロジック共通化');
     expect(cases).toContain('issue #1082');
+    expect(cases).toContain('issue #1480');
     expect(cases).toContain('useParticipantScoreInput');
     expect(driftTest).toContain("e2eCaseSection('TC-1082')");
   });


### PR DESCRIPTION
## Summary
- Add TC-1082 scenario coverage for issue #1480's nested return-object static guard risk
- Replace the shallow return-object regex with a TypeScript AST helper that extracts the hook's top-level return object
- Add regression coverage proving nested object literals do not hide later return properties from the guard

## Issues
Closes #1480

## Validation
- npm test -- --runTestsByPath __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm test -- --runTestsByPath __tests__/lib/hooks/useParticipantScoreInput.test.ts --runInBand
- npx eslint __tests__/helpers/e2e-cases.ts __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts
- git diff --check

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
