### PR TITLE
test: support expression score guard helpers

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1399,7 +1399,8 @@
   4. issue #1472/#1473 の再発防止として、呼び出し元 UI の `totalValid` も hook から返る `requiredTotalScore` を参照し、`maxScorePerSide < requiredTotalScore` の valid/invalid 境界を unit test で固定する
   5. issue #1475/#1476/#1478 の再発防止として、テストヘルパーの `totalMustEqualMessage` は可変にし、`maxScorePerSide` は未使用の public return API として公開しない。static guard は return object を正規表現で検証し、インデントに依存しない
   6. issue #1480 の再発防止として、static guard は `return { ... }` 内にネストしたオブジェクトリテラルが先に来ても後続プロパティを見落とさないよう、TypeScript AST で hook の最上位 return object を抽出して検証する
-  7. 既存 UI シナリオは BM `TC-322` と MR `TC-1083` が担当し、共通化の構造は static/unit test で固定する
+  7. issue #1482 の再発防止として、return object helper は function declaration だけでなく arrow function と function expression の hook 形式も検査できる
+  8. 既存 UI シナリオは BM `TC-322` と MR `TC-1083` が担当し、共通化の構造は static/unit test で固定する
 - **期待結果**: BM/MR participant のスコア入力ロジックが共通フックで維持され、mode-specific な報告フィールド差分だけが各ページに残る
 - **スクリプト**: static guard `__tests__/static/tc-1082-shared-score-input.test.ts` + unit `__tests__/lib/hooks/useParticipantScoreInput.test.ts`
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -143,6 +143,7 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #1472/#1473');
     expect(section).toContain('issue #1475/#1476/#1478');
     expect(section).toContain('issue #1480');
+    expect(section).toContain('issue #1482');
     expect(section).toContain('TypeScript AST');
     expect(section).toContain('useParticipantScoreInput');
     expect(section).toContain('requiredTotalScore');

--- a/smkc-score-app/__tests__/helpers/e2e-cases.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.ts
@@ -64,22 +64,47 @@ export function functionReturnObjectLiteral(source: string, functionName: string
 
   let returnObject: ts.ObjectLiteralExpression | null = null;
 
+  function objectLiteralFromBody(body: ts.ConciseBody) {
+    if (ts.isObjectLiteralExpression(body)) {
+      return body;
+    }
+
+    if (!ts.isBlock(body)) {
+      return null;
+    }
+
+    for (const statement of [...body.statements].reverse()) {
+      if (
+        ts.isReturnStatement(statement) &&
+        statement.expression &&
+        ts.isObjectLiteralExpression(statement.expression)
+      ) {
+        return statement.expression;
+      }
+    }
+
+    return null;
+  }
+
   function visit(node: ts.Node) {
     if (
       ts.isFunctionDeclaration(node) &&
       node.name?.text === functionName &&
       node.body
     ) {
-      for (const statement of [...node.body.statements].reverse()) {
-        if (
-          ts.isReturnStatement(statement) &&
-          statement.expression &&
-          ts.isObjectLiteralExpression(statement.expression)
-        ) {
-          returnObject = statement.expression;
-          return;
-        }
-      }
+      returnObject = objectLiteralFromBody(node.body);
+      return;
+    }
+
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === functionName &&
+      node.initializer &&
+      (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer))
+    ) {
+      returnObject = objectLiteralFromBody(node.initializer.body);
+      return;
     }
 
     if (!returnObject) {

--- a/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
@@ -58,6 +58,28 @@ describe('TC-1082 shared BM/MR participant score input guards', () => {
     expect(returnObject).toContain('maxScorePerSide');
   });
 
+  it('can inspect arrow-function and function-expression hook forms', () => {
+    const arrowReturnObject = functionReturnObjectLiteral(`
+      export const useParticipantScoreInput = () => {
+        return {
+          diagnostics: { source: 'arrow' },
+          requiredTotalScore: 4,
+        };
+      };
+    `, 'useParticipantScoreInput');
+    const functionExpressionReturnObject = functionReturnObjectLiteral(`
+      export const useParticipantScoreInput = function() {
+        return {
+          diagnostics: { source: 'function expression' },
+          requiredTotalScore: 4,
+        };
+      };
+    `, 'useParticipantScoreInput');
+
+    expect(arrowReturnObject).toContain("source: 'arrow'");
+    expect(functionExpressionReturnObject).toContain("source: 'function expression'");
+  });
+
   it('documents TC-1082 as the BM/MR shared participant score-input scenario', () => {
     const cases = readRepoFile('E2E_TEST_CASES.md');
     const driftTest = readRepoFile(
@@ -70,6 +92,7 @@ describe('TC-1082 shared BM/MR participant score input guards', () => {
     expect(cases).toContain('## TC-1082: BM/MR participant スコア入力ロジック共通化');
     expect(cases).toContain('issue #1082');
     expect(cases).toContain('issue #1480');
+    expect(cases).toContain('issue #1482');
     expect(cases).toContain('useParticipantScoreInput');
     expect(driftTest).toContain("e2eCaseSection('TC-1082')");
   });


### PR DESCRIPTION
## Summary
- Extend the TC-1082 return-object helper to inspect arrow-function and function-expression hook declarations
- Add regression fixtures covering both non-declaration hook forms
- Document issue #1482 in the TC-1082 scenario and drift guard

## Issues
Closes #1482

## Validation
- npm test -- --runTestsByPath __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm test -- --runTestsByPath __tests__/lib/hooks/useParticipantScoreInput.test.ts --runInBand
- npx eslint __tests__/helpers/e2e-cases.ts __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts
- git diff --check

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
