### PR TITLE
test: cover concise arrow return helper

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1399,7 +1399,7 @@
   4. issue #1472/#1473 の再発防止として、呼び出し元 UI の `totalValid` も hook から返る `requiredTotalScore` を参照し、`maxScorePerSide < requiredTotalScore` の valid/invalid 境界を unit test で固定する
   5. issue #1475/#1476/#1478 の再発防止として、テストヘルパーの `totalMustEqualMessage` は可変にし、`maxScorePerSide` は未使用の public return API として公開しない。static guard は return object を正規表現で検証し、インデントに依存しない
   6. issue #1480 の再発防止として、static guard は `return { ... }` 内にネストしたオブジェクトリテラルが先に来ても後続プロパティを見落とさないよう、TypeScript AST で hook の最上位 return object を抽出して検証する
-  7. issue #1482 の再発防止として、return object helper は function declaration だけでなく arrow function と function expression の hook 形式も検査できる
+  7. issue #1482 と issue #1484 の再発防止として、return object helper は function declaration だけでなく block-body arrow function、concise-body arrow function、function expression の hook 形式も検査できる
   8. 既存 UI シナリオは BM `TC-322` と MR `TC-1083` が担当し、共通化の構造は static/unit test で固定する
 - **期待結果**: BM/MR participant のスコア入力ロジックが共通フックで維持され、mode-specific な報告フィールド差分だけが各ページに残る
 - **スクリプト**: static guard `__tests__/static/tc-1082-shared-score-input.test.ts` + unit `__tests__/lib/hooks/useParticipantScoreInput.test.ts`

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -144,6 +144,7 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #1475/#1476/#1478');
     expect(section).toContain('issue #1480');
     expect(section).toContain('issue #1482');
+    expect(section).toContain('issue #1484');
     expect(section).toContain('TypeScript AST');
     expect(section).toContain('useParticipantScoreInput');
     expect(section).toContain('requiredTotalScore');

--- a/smkc-score-app/__tests__/helpers/e2e-cases.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.ts
@@ -65,15 +65,20 @@ export function functionReturnObjectLiteral(source: string, functionName: string
   let returnObject: ts.ObjectLiteralExpression | null = null;
 
   function objectLiteralFromBody(body: ts.ConciseBody) {
-    if (ts.isObjectLiteralExpression(body)) {
-      return body;
+    let expression = body;
+    while (ts.isParenthesizedExpression(expression)) {
+      expression = expression.expression;
     }
 
-    if (!ts.isBlock(body)) {
+    if (ts.isObjectLiteralExpression(expression)) {
+      return expression;
+    }
+
+    if (!ts.isBlock(expression)) {
       return null;
     }
 
-    for (const statement of [...body.statements].reverse()) {
+    for (const statement of [...expression.statements].reverse()) {
       if (
         ts.isReturnStatement(statement) &&
         statement.expression &&

--- a/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1082-shared-score-input.test.ts
@@ -75,9 +75,16 @@ describe('TC-1082 shared BM/MR participant score input guards', () => {
         };
       };
     `, 'useParticipantScoreInput');
+    const conciseArrowReturnObject = functionReturnObjectLiteral(`
+      export const useParticipantScoreInput = () => ({
+        diagnostics: { source: 'concise arrow' },
+        requiredTotalScore: 4,
+      });
+    `, 'useParticipantScoreInput');
 
     expect(arrowReturnObject).toContain("source: 'arrow'");
     expect(functionExpressionReturnObject).toContain("source: 'function expression'");
+    expect(conciseArrowReturnObject).toContain("source: 'concise arrow'");
   });
 
   it('documents TC-1082 as the BM/MR shared participant score-input scenario', () => {
@@ -93,6 +100,7 @@ describe('TC-1082 shared BM/MR participant score input guards', () => {
     expect(cases).toContain('issue #1082');
     expect(cases).toContain('issue #1480');
     expect(cases).toContain('issue #1482');
+    expect(cases).toContain('issue #1484');
     expect(cases).toContain('useParticipantScoreInput');
     expect(driftTest).toContain("e2eCaseSection('TC-1082')");
   });


### PR DESCRIPTION
## Summary
- Add TC-1082 fixture coverage for concise-body arrow hook return objects
- Unwrap parenthesized concise arrow bodies in the return-object helper
- Document issue #1484 in the TC-1082 scenario and drift guard

## Issues
Closes #1484

## Validation
- npm test -- --runTestsByPath __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm test -- --runTestsByPath __tests__/lib/hooks/useParticipantScoreInput.test.ts --runInBand
- npx eslint __tests__/helpers/e2e-cases.ts __tests__/static/tc-1082-shared-score-input.test.ts __tests__/docs/e2e-cases-drift.test.ts
- git diff --check

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
