### PR TITLE
test: clarify group seeding follow-ups

### DIFF
--- a/smkc-score-app/__tests__/lib/group-utils.test.ts
+++ b/smkc-score-app/__tests__/lib/group-utils.test.ts
@@ -45,7 +45,7 @@ describe('assignGroupsBySeeding', () => {
     expect(result.filter(p => p.group === 'D').map(p => p.seeding)).toEqual([4, 5, 12, 13]);
   });
 
-  it('should place seed 5 in group D when 8 players are split into 4 groups', () => {
+  it('should distribute 8 players into 4 groups using serpentine seeding', () => {
     const players: SetupPlayer[] = Array.from({ length: 8 }, (_, i) => ({
       playerId: `p${i + 1}`,
       group: 'A',

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -1545,10 +1545,11 @@ async function setupModePlayersViaUi(page, mode, tournamentId, players, options 
     await selectGroupPlayer(dialog, player);
   }
 
+  /* Force product-default group count of 2 for normal multi-player setup unless
+   * the caller explicitly exercises another setup shape. Skip the click for
+   * small pair tests with no explicit groupCount: those rely on the dialog
+   * default group rather than a split A/B setup. */
   if (players.length >= 4 || options.groupCount !== undefined) {
-    /* Force product-default group count of 2 unless the caller is explicitly
-     * exercising another setup shape. Pair tests with 2 players rely on the
-     * dialog default group rather than a split A/B setup. */
     await dialog.getByRole('button', { name: new RegExp(`^${targetGroupCount}$`) }).click();
   }
 


### PR DESCRIPTION
Summary
- Move the setupModePlayersViaUi group-count note so the skip/click behavior is easier to read.
- Rename the 8-player serpentine unit test so it describes the whole 1-8 distribution, not only seed 5.

Issues: Closes #1487, Closes #1488

Validation
- node --check smkc-score-app/e2e/lib/common.js
- node --check smkc-score-app/e2e/tc-all.js
- npm test -- --runTestsByPath __tests__/lib/group-utils.test.ts
