### PR TITLE
test: document MR round size assertion

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2026,6 +2026,17 @@
 - **期待結果**: 4人 GP 予選で3ラウンドになる理由が単体テスト上で読み取れ、将来の fixture 変更時に前提の更新漏れを検知できる
 - **スクリプト**: smkc-score-app/__tests__/static/tc-1088-qualification-route-comment.test.ts
 
+## TC-1080: MR 予選単体テスト — 8人ラウンドロビンの4試合/ラウンド前提を明記する
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #1080。`qualification-route.test.ts` の `roundMatches` に対する `toHaveLength(4)` は、8人グループのラウンドロビンでは各ラウンドが `n/2 = 8/2 = 4` 試合になるという前提を表す。fixture の人数が変わった時に失敗理由が分かるよう、単体テスト内で前提を明示する。
+- **手順**:
+  1. `qualification-route.test.ts` の MR raw insert assignedCourses テストを確認する
+  2. `expect(roundMatches).toHaveLength(4)` の直前に8人ラウンドロビンの4試合前提コメントがあることを確認する
+  3. コメントが `8/2 = 4` の人数根拠を含むことを確認する
+- **期待結果**: 8人 MR 予選で各ラウンドが4試合になる理由が単体テスト上で読み取れ、将来の fixture 変更時に前提の更新漏れを検知できる
+- **スクリプト**: smkc-score-app/__tests__/static/tc-1080-qualification-route-comment.test.ts
+
 ## TC-717: GP決勝 — ラウンドごとのカップ組み合わせがFT3の5カップ目以外で重複しない
 - **URL**: /api/tournaments/[temp-id]/gp/finals (GET)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -239,6 +239,7 @@ describe('E2E case drift coverage', () => {
     ['TC-111', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts'],
     ['TC-726', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-finals-assigned-cups.test.ts'],
     ['TC-728', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-ranking.test.ts'],
+    ['TC-1080', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1080-qualification-route-comment.test.ts'],
     ['TC-1088', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1088-qualification-route-comment.test.ts'],
     ['TC-1090-1091', 'n/a (static/unit coverage)', 'smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts'],
     ['TC-1451-1452', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -402,6 +402,7 @@ describe('Qualification Route Factory', () => {
         return acc;
       }, {});
       Object.values(realMatchesByRound).forEach((roundMatches: any[]) => {
+        // 8-player round-robin: each round has 4 real matches (8 / 2 = 4).
         expect(roundMatches).toHaveLength(4);
         const expectedCourses = roundMatches[0].assignedCourses;
         expect(expectedCourses).toHaveLength(4);

--- a/smkc-score-app/__tests__/static/tc-1080-qualification-route-comment.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1080-qualification-route-comment.test.ts
@@ -1,0 +1,31 @@
+import { e2eCaseSection, readRepoFile, sectionBetween } from '../helpers/e2e-cases';
+
+describe('TC-1080 qualification-route MR round size comment guard', () => {
+  it('documents the review follow-up scenario', () => {
+    const section = e2eCaseSection('TC-1080');
+
+    expect(section).toContain('issue #1080');
+    expect(section).toContain('8人ラウンドロビン');
+    expect(section).toContain('8/2 = 4');
+    expect(section).toContain('__tests__/static/tc-1080-qualification-route-comment.test.ts');
+  });
+
+  it('keeps the 8-player MR round-size assertion explained at the unit-test site', () => {
+    const source = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'lib',
+      'api-factories',
+      'qualification-route.test.ts',
+    );
+    const testBlock = sectionBetween(
+      source,
+      "it('should use the MR raw insert mapping for large qualification setup'",
+      "it('should use the GP raw insert mapping for large qualification setup'",
+    );
+
+    expect(testBlock).toContain('8-player round-robin');
+    expect(testBlock).toContain('8 / 2 = 4');
+    expect(testBlock).toContain('expect(roundMatches).toHaveLength(4)');
+  });
+});


### PR DESCRIPTION
Summary
- Add TC-1080 to the E2E scenario catalog for the MR 8-player round-size assertion.
- Add a static guard that keeps the scenario, coverage classification, and unit-test comment aligned.
- Document why the MR raw insert test expects 4 real matches per round.

Issues: Closes #1080

Validation
- npm test -- --runTestsByPath __tests__/static/tc-1080-qualification-route-comment.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm test -- --runTestsByPath __tests__/lib/api-factories/qualification-route.test.ts --runInBand
- git diff --check
