### PR TITLE
test: guard MR round course assignment

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1372,6 +1372,18 @@
   8. クリーンアップ
 - **期待結果**: 28名4グループのMR予選がシード・自動振り分けで正しく設定・実行・集計される
 
+## TC-1079: MR予選コース割り当て — roundNumber は正の1始まりだけを使う
+- **URL**: /tournaments/[temp-id]/mr
+- **authRequired**: true (admin)
+- **背景**: MR 予選コース選択は `(roundNumber - 1) * 4` でシャッフル済みコースデッキを参照する。`roundNumber <= 0` や `NaN` / `Infinity` が混入すると round 1 と同じコースへサイレントにフォールバックし、呼び出し元のバグを隠す可能性がある。
+- **手順**:
+  1. 28名 MR 予選を作成し、全予選試合にスコアを投入する
+  2. BYE を除いた全マッチの `roundNumber` が有限な正の整数であることを確認する
+  3. 同じ `roundNumber` のマッチが同じ4コースの `assignedCourses` を持つことを確認する
+  4. `0` / `-1` / `1.5` / `NaN` / `Infinity` 入力時の例外を `qualification-route.test.ts` で確認する
+- **期待結果**: E2E の MR 予選生成経路は有限な `roundNumber >= 1` のみを返し、単体ガードは不正な roundNumber を round 1 に丸めず例外にする
+- **スクリプト**: tc-mr.js TC-601 内で検証
+
 ## TC-602: MR予選プレイヤーログインからスコア入力・送信まで
 - **URL**: /auth/signin -> /tournaments/[temp-id]/mr/participant
 - **authRequired**: true (player)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -98,6 +98,18 @@ describe('E2E case drift coverage', () => {
     expect(tcGp).toContain('Number.isInteger(match.roundNumber)');
   });
 
+  it('keeps TC-1079 aligned with MR finite positive round-number guards', () => {
+    const section = e2eCaseSection('TC-1079');
+
+    expect(section).toContain('MR 予選コース選択');
+    expect(section).toContain('NaN');
+    expect(section).toContain('Infinity');
+    expect(section).toContain('tc-mr.js TC-601 内で検証');
+    expect(tcMr).toContain('Keep the finite check explicit to cover NaN/Infinity edge cases tested in TC-1079.');
+    expect(tcMr).toContain('Number.isFinite(match.roundNumber)');
+    expect(tcMr).toContain('Number.isInteger(match.roundNumber)');
+  });
+
   it('keeps TC-1083 aligned with MR participant correction coverage', () => {
     const section = e2eCaseSection('TC-1083');
     const tc1083 = sectionBetween(tcMr, 'async function runTc1083', '/**\n * TC-603');

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -32,7 +32,11 @@
  */
 // @ts-nocheck - This test file uses complex mock types that are difficult to type correctly
 
-import { createQualificationHandlers, getAssignedCupForRound } from '@/lib/api-factories/qualification-route';
+import {
+  createQualificationHandlers,
+  getAssignedCoursesForRound,
+  getAssignedCupForRound,
+} from '@/lib/api-factories/qualification-route';
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { NextRequest } from 'next/server';
 import { EventTypeConfig } from '@/lib/event-types/types';
@@ -906,6 +910,18 @@ describe('Qualification Route Factory', () => {
         expect(secondDeck).not.toEqual(firstDeck);
       } finally {
         randomSpy.mockRestore();
+      }
+    });
+
+    it('should reject invalid MR qualification round numbers before assigning courses', () => {
+      const shuffledCourses = COURSES.concat(COURSES, COURSES, COURSES);
+
+      expect(getAssignedCoursesForRound(shuffledCourses, 1)).toEqual(COURSES.slice(0, 4));
+      expect(getAssignedCoursesForRound(shuffledCourses, 2)).toEqual(COURSES.slice(4, 8));
+      for (const invalidRoundNumber of [0, -1, 1.5, NaN, Infinity]) {
+        expect(() => getAssignedCoursesForRound(shuffledCourses, invalidRoundNumber)).toThrow(
+          `MR qualification roundNumber must be a positive integer: ${invalidRoundNumber}`,
+        );
       }
     });
 

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -24,6 +24,7 @@
  *  TC-612  GP race position validation (no-tie + double-game-over)
  *  TC-820  MR match/[matchId] page view-only
  *  TC-822  SKIP — feature not implemented
+ *  TC-1079 MR qualification course assignment rejects invalid roundNumber before fallback
  *  TC-617  MR finals same-courses-per-round enforcement (PR #585 normalizer)
  *  TC-618  MR finals admin manual total-score override (PR #585 manual form)
  *  TC-620  MR qualification tie resolution (tie warning → resolveAllTies)
@@ -233,6 +234,10 @@ async function runTc601(adminPage) {
     const postScoreData = await apiFetchMr(adminPage, tournamentId);
     const postScoreMatches = postScoreData.matches || [];
     const realMatches = postScoreMatches.filter((m) => !m.isBye);
+    const invalidRoundMatches = realMatches.filter((match) => (
+      // Keep the finite check explicit to cover NaN/Infinity edge cases tested in TC-1079.
+      !Number.isFinite(match.roundNumber) || !Number.isInteger(match.roundNumber) || match.roundNumber < 1
+    ));
     const roundCourseVariants = new Map();
     for (const match of realMatches) {
       const roundNumber = match.roundNumber;
@@ -247,7 +252,7 @@ async function runTc601(adminPage) {
       return variants.size === 1 && Array.isArray(courses) && courses.length === 4;
     });
 
-    const allPassed = hasExpectedMatches && allScoresOk && hasStandings && qualificationPointsOk && standingsSorted && coursesSharedByRound;
+    const allPassed = hasExpectedMatches && allScoresOk && hasStandings && qualificationPointsOk && standingsSorted && invalidRoundMatches.length === 0 && coursesSharedByRound;
     log('TC-601', allPassed ? 'PASS' : 'FAIL',
       !allPassed
         ? (!hasExpectedMatches ? `Expected 182 non-bye matches, got ${nonByeMatches.length}`
@@ -255,6 +260,7 @@ async function runTc601(adminPage) {
            : !hasStandings ? 'Standings page did not render properly'
            : !qualificationPointsOk ? `qualification points rows=${qualificationPoints.length} expected>=28`
            : !standingsSorted ? 'Standings not sorted correctly'
+           : invalidRoundMatches.length > 0 ? `invalid roundNumber matches=${invalidRoundMatches.map((m) => m.matchNumber).join(',')}`
            : !coursesSharedByRound ? 'MR assignedCourses are not shared by round'
            : '')
         : '');

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -117,8 +117,11 @@ function generateShuffledCupList(
  * @param roundNumber - One-based round/day number in the round-robin schedule
  * @returns Array of TOTAL_MR_RACES (4) course abbreviations
  */
-function getAssignedCoursesForRound(shuffled: string[], roundNumber: number): string[] {
-  const roundIndex = Math.max(0, roundNumber - 1);
+export function getAssignedCoursesForRound(shuffled: string[], roundNumber: number): string[] {
+  if (!Number.isInteger(roundNumber) || roundNumber < 1) {
+    throw new Error(`MR qualification roundNumber must be a positive integer: ${roundNumber}`);
+  }
+  const roundIndex = roundNumber - 1;
   return Array.from({ length: TOTAL_MR_RACES }, (_, i) =>
     shuffled[(roundIndex * TOTAL_MR_RACES + i) % shuffled.length]
   );


### PR DESCRIPTION
## Summary
- Add TC-1079 to the E2E scenario list for MR qualification round-number validation.
- Extend the MR E2E TC-601 guard to fail if generated non-BYE matches have non-finite, non-integer, or non-positive roundNumber values.
- Export and validate getAssignedCoursesForRound so invalid MR roundNumber values throw instead of falling back to round 1, with focused unit coverage.

## Issues
Closes #1079

## Validation
- node --check e2e/tc-mr.js
- npm test -- --runTestsByPath __tests__/lib/api-factories/qualification-route.test.ts __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
