### PR TITLE
test: simplify MR roundNumber guard follow-ups

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1378,7 +1378,7 @@
 - **背景**: MR 予選コース選択は `(roundNumber - 1) * 4` でシャッフル済みコースデッキを参照する。`roundNumber <= 0` や `NaN` / `Infinity` が混入すると round 1 と同じコースへサイレントにフォールバックし、呼び出し元のバグを隠す可能性がある。
 - **手順**:
   1. 28名 MR 予選を作成し、全予選試合にスコアを投入する
-  2. BYE を除いた全マッチの `roundNumber` が有限な正の整数であることを確認する
+  2. BYE を除いた全マッチの `roundNumber` が `Number.isInteger` で検証できる正の1始まり整数であることを確認する
   3. 同じ `roundNumber` のマッチが同じ4コースの `assignedCourses` を持つことを確認する
   4. `0` / `-1` / `1.5` / `NaN` / `Infinity` 入力時の例外を `qualification-route.test.ts` で確認する
 - **期待結果**: E2E の MR 予選生成経路は有限な `roundNumber >= 1` のみを返し、単体ガードは不正な roundNumber を round 1 に丸めず例外にする

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -105,9 +105,9 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('NaN');
     expect(section).toContain('Infinity');
     expect(section).toContain('tc-mr.js TC-601 内で検証');
-    expect(tcMr).toContain('Keep the finite check explicit to cover NaN/Infinity edge cases tested in TC-1079.');
-    expect(tcMr).toContain('Number.isFinite(match.roundNumber)');
     expect(tcMr).toContain('Number.isInteger(match.roundNumber)');
+    expect(tcMr).toContain('match.roundNumber < 1');
+    expect(tcMr).not.toContain('Number.isFinite(match.roundNumber)');
   });
 
   it('keeps TC-1083 aligned with MR participant correction coverage', () => {

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -913,7 +913,7 @@ describe('Qualification Route Factory', () => {
       }
     });
 
-    it('should reject invalid MR qualification round numbers before assigning courses', () => {
+    it('should reject non-positive, fractional, and non-finite MR qualification round numbers before assigning courses', () => {
       const shuffledCourses = COURSES.concat(COURSES, COURSES, COURSES);
 
       expect(getAssignedCoursesForRound(shuffledCourses, 1)).toEqual(COURSES.slice(0, 4));

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -235,8 +235,7 @@ async function runTc601(adminPage) {
     const postScoreMatches = postScoreData.matches || [];
     const realMatches = postScoreMatches.filter((m) => !m.isBye);
     const invalidRoundMatches = realMatches.filter((match) => (
-      // Keep the finite check explicit to cover NaN/Infinity edge cases tested in TC-1079.
-      !Number.isFinite(match.roundNumber) || !Number.isInteger(match.roundNumber) || match.roundNumber < 1
+      !Number.isInteger(match.roundNumber) || match.roundNumber < 1
     ));
     const roundCourseVariants = new Map();
     for (const match of realMatches) {


### PR DESCRIPTION
## Summary
- simplify the MR TC-601 roundNumber guard by relying on Number.isInteger for NaN/Infinity rejection
- remove the brittle TC-1079 static test assertion against an exact comment string
- keep the scenario/static/unit coverage aligned with the integer-positive roundNumber contract

## Issues
Closes #1492
Closes #1493

## Validation
- node --check smkc-score-app/e2e/tc-mr.js
- git diff --check
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/api-factories/qualification-route.test.ts
