### PR TITLE
test: cover broadcast null win clearing

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -774,7 +774,8 @@
   3. 管理者として PUT `{ player1Name: '1P-Alice', player2Name: '2P-Bob', matchLabel: 'QF1', player1Wins: 2, player2Wins: 1, matchFt: 5, layout: { ...座標 } }` → 200
   4. GET → PUT した値が永続化されていること
   5. PUT `{ matchLabel: null }` → フィールドがクリアされること（200）
-  6. OBS 1920×1080 キャンバス外の `layout` 座標は 400 で拒否されること
+  6. PUT `{ player1Wins: null, player2Wins: null }` → 1P/2P 勝利数が null にクリアされること（200）
+  7. OBS 1920×1080 キャンバス外の `layout` 座標は 400 で拒否されること
 - **期待結果**: GET は正しい形状を返し、PUT は値を永続化・クリアできる
 - **スクリプト**: tc-all.js TC-354
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
@@ -203,6 +203,32 @@ describe('PUT /api/tournaments/[id]/broadcast', () => {
     );
   });
 
+  it('clears player1 wins when null is passed', async () => {
+    await PUT(
+      mockReq({ player1Wins: null }),
+      mockParams('t1'),
+    );
+
+    expect(prisma.tournament.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ overlayPlayer1Wins: null }),
+      }),
+    );
+  });
+
+  it('clears player2 wins when null is passed', async () => {
+    await PUT(
+      mockReq({ player2Wins: null }),
+      mockParams('t1'),
+    );
+
+    expect(prisma.tournament.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ overlayPlayer2Wins: null }),
+      }),
+    );
+  });
+
   it('trims whitespace from player names', async () => {
     await PUT(
       mockReq({ player1Name: '  Alice  ' }),

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3838,6 +3838,28 @@ async function main() {
       }, tc354TournamentId);
       const clearOk = putClear.s === 200;
 
+      // PUT with null clears both score fields.
+      const putClearWins = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/broadcast`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ player1Wins: null, player2Wins: null }),
+        });
+        return { s: r.status };
+      }, tc354TournamentId);
+
+      const getAfterClearWins = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/broadcast`);
+        const j = await r.json().catch(() => ({}));
+        return { s: r.status, data: j.data ?? j };
+      }, tc354TournamentId);
+      const clearWinsOk = (
+        putClearWins.s === 200 &&
+        getAfterClearWins.s === 200 &&
+        getAfterClearWins.data.player1Wins === null &&
+        getAfterClearWins.data.player2Wins === null
+      );
+
       // Invalid layout coordinates outside the OBS 1920x1080 canvas are rejected.
       const putInvalidLayout = await page.evaluate(async (tid) => {
         const r = await fetch(`/api/tournaments/${tid}/broadcast`, {
@@ -3876,9 +3898,9 @@ async function main() {
       }
       const nonAdminBlocked = nonAdminPutStatus === 401 || nonAdminPutStatus === 403;
 
-      const ok = hasShape && putOk && getOk && clearOk && invalidLayoutBlocked && nonAdminBlocked;
+      const ok = hasShape && putOk && getOk && clearOk && clearWinsOk && invalidLayoutBlocked && nonAdminBlocked;
       log('TC-354', ok ? 'PASS' : 'FAIL',
-        `shape=${hasShape} put=${putOk} persist=${getOk} clear=${clearOk} invalidLayoutBlocked=${invalidLayoutBlocked} nonAdminBlocked=${nonAdminBlocked}(${nonAdminPutStatus})`);
+        `shape=${hasShape} put=${putOk} persist=${getOk} clear=${clearOk} clearWins=${clearWinsOk} invalidLayoutBlocked=${invalidLayoutBlocked} nonAdminBlocked=${nonAdminBlocked}(${nonAdminPutStatus})`);
     } catch (err) {
       log('TC-354', 'FAIL', err instanceof Error ? err.message : 'broadcast API test failed');
     } finally {


### PR DESCRIPTION
## Summary
- document TC-354 coverage for clearing broadcast player win counts with null
- extend tc-all.js TC-354 to PUT null wins and verify GET returns null for both players
- add API unit tests for player1Wins/player2Wins null clearing

## Issues
Closes #1070

## Validation
- npm test -- __tests__/docs/e2e-cases-drift.test.ts
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/broadcast/route.test.ts'
- node --check smkc-score-app/e2e/tc-all.js
- git diff --check
