### PR TITLE
test: assert broadcast null win response

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -774,7 +774,7 @@
   3. 管理者として PUT `{ player1Name: '1P-Alice', player2Name: '2P-Bob', matchLabel: 'QF1', player1Wins: 2, player2Wins: 1, matchFt: 5, layout: { ...座標 } }` → 200
   4. GET → PUT した値が永続化されていること
   5. PUT `{ matchLabel: null }` → フィールドがクリアされること（200）
-  6. PUT `{ player1Wins: null, player2Wins: null }` → 1P/2P 勝利数が null にクリアされること（200）
+  6. PUT `{ player1Wins: null, player2Wins: null }` → レスポンス body と再取得 GET の両方で 1P/2P 勝利数が null にクリアされること（200）
   7. OBS 1920×1080 キャンバス外の `layout` 座標は 400 で拒否されること
 - **期待結果**: GET は正しい形状を返し、PUT は値を永続化・クリアできる
 - **スクリプト**: tc-all.js TC-354

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
@@ -214,6 +214,10 @@ describe('PUT /api/tournaments/[id]/broadcast', () => {
         data: expect.objectContaining({ overlayPlayer1Wins: null }),
       }),
     );
+    expect(NextResponse.json).toHaveBeenCalledWith({
+      success: true,
+      data: expect.objectContaining({ player1Wins: null }),
+    });
   });
 
   it('clears player2 wins when null is passed', async () => {
@@ -227,6 +231,10 @@ describe('PUT /api/tournaments/[id]/broadcast', () => {
         data: expect.objectContaining({ overlayPlayer2Wins: null }),
       }),
     );
+    expect(NextResponse.json).toHaveBeenCalledWith({
+      success: true,
+      data: expect.objectContaining({ player2Wins: null }),
+    });
   });
 
   it('trims whitespace from player names', async () => {

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3845,7 +3845,8 @@ async function main() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ player1Wins: null, player2Wins: null }),
         });
-        return { s: r.status };
+        const j = await r.json().catch(() => ({}));
+        return { s: r.status, data: j.data ?? j };
       }, tc354TournamentId);
 
       const getAfterClearWins = await page.evaluate(async (tid) => {
@@ -3855,6 +3856,8 @@ async function main() {
       }, tc354TournamentId);
       const clearWinsOk = (
         putClearWins.s === 200 &&
+        putClearWins.data.player1Wins === null &&
+        putClearWins.data.player2Wins === null &&
         getAfterClearWins.s === 200 &&
         getAfterClearWins.data.player1Wins === null &&
         getAfterClearWins.data.player2Wins === null


### PR DESCRIPTION
## Summary
- Update TC-354 to require null win clears in the PUT response body as well as the refetched GET payload.
- Assert broadcast route unit-test responses include `player1Wins: null` / `player2Wins: null` when each score is cleared.

## Issues
Closes #1499

## Validation
- `node --check e2e/tc-all.js`
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/broadcast/route.test.ts' __tests__/docs/e2e-cases-drift.test.ts`
- `git diff --check`
- `npx eslint e2e/tc-all.js '__tests__/app/api/tournaments/[id]/broadcast/route.test.ts'` (exit 0; tc-all.js is ignored by repo config)

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
