### PR TITLE
fix: keep broadcast response public

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -771,10 +771,10 @@
 - **手順**:
   1. 新規トーナメントを作成
   2. GET → `{ player1Name, player2Name, matchLabel, player1Wins, player2Wins, matchFt, layout }` の形状が返ること（初期値は空文字/null/default 座標）
-  3. 管理者として PUT `{ player1Name: '1P-Alice', player2Name: '2P-Bob', matchLabel: 'QF1', player1Wins: 2, player2Wins: 1, matchFt: 5, layout: { ...座標 } }` → 200
+  3. 管理者として PUT `{ player1Name: '1P-Alice', player2Name: '2P-Bob', matchLabel: 'QF1', player1Wins: 2, player2Wins: 1, matchFt: 5, layout: { ...座標 } }` → 200。レスポンス body は API 向け `player1Wins/player2Wins` のみを返し、DB カラム名 `overlayPlayer1Wins/overlayPlayer2Wins` を含まないこと
   4. GET → PUT した値が永続化されていること
   5. PUT `{ matchLabel: null }` → フィールドがクリアされること（200）
-  6. PUT `{ player1Wins: null, player2Wins: null }` → レスポンス body と再取得 GET の両方で 1P/2P 勝利数が null にクリアされること（200）
+  6. PUT `{ player1Wins: null, player2Wins: null }` → レスポンス body と再取得 GET の両方で 1P/2P 勝利数が null にクリアされ、レスポンス body に `overlayPlayer1Wins/overlayPlayer2Wins` が含まれないこと（200）
   7. OBS 1920×1080 キャンバス外の `layout` 座標は 400 で拒否されること
 - **期待結果**: GET は正しい形状を返し、PUT は値を永続化・クリアできる
 - **スクリプト**: tc-all.js TC-354

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
@@ -47,6 +47,12 @@ const mockReq = (body?: unknown) =>
   }) as unknown as NextRequest;
 
 const mockResolveTournament = resolveTournament as jest.Mock;
+const expectNoInternalBroadcastFields = (data: Record<string, unknown>) => {
+  expect(data).not.toHaveProperty('overlayPlayer1Wins');
+  expect(data).not.toHaveProperty('overlayPlayer2Wins');
+  expect(data).not.toHaveProperty('overlayMatchLabel');
+  expect(data).not.toHaveProperty('overlayMatchFt');
+};
 
 describe('GET /api/tournaments/[id]/broadcast', () => {
   beforeEach(() => {
@@ -188,6 +194,27 @@ describe('PUT /api/tournaments/[id]/broadcast', () => {
       }),
     );
     expect((NextResponse.json as jest.Mock).mock.calls[0][1]?.status ?? 200).toBe(200);
+    expect(NextResponse.json).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        player1Name: 'Alice',
+        player2Name: 'Bob',
+        player1NoCamera: true,
+        player2NoCamera: false,
+        matchLabel: 'QF1',
+        player1Wins: 2,
+        player2Wins: 1,
+        matchFt: 5,
+        layout: {
+          player1Name: { x: 120, y: 500 },
+          player1Score: { x: 140, y: 540 },
+          player2Name: { x: 120, y: 890 },
+          player2Score: { x: 140, y: 930 },
+          footer: { x: 180, y: 990 },
+        },
+      },
+    });
+    expectNoInternalBroadcastFields((NextResponse.json as jest.Mock).mock.calls[0][0].data);
   });
 
   it('clears a field when null is passed', async () => {
@@ -196,11 +223,10 @@ describe('PUT /api/tournaments/[id]/broadcast', () => {
       mockParams('t1'),
     );
 
-    expect(prisma.tournament.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ overlayMatchLabel: null }),
-      }),
-    );
+    expect(NextResponse.json).toHaveBeenCalledWith({
+      success: true,
+      data: { matchLabel: null },
+    });
   });
 
   it('clears player1 wins when null is passed', async () => {
@@ -216,8 +242,9 @@ describe('PUT /api/tournaments/[id]/broadcast', () => {
     );
     expect(NextResponse.json).toHaveBeenCalledWith({
       success: true,
-      data: expect.objectContaining({ player1Wins: null }),
+      data: { player1Wins: null },
     });
+    expectNoInternalBroadcastFields((NextResponse.json as jest.Mock).mock.calls[0][0].data);
   });
 
   it('clears player2 wins when null is passed', async () => {
@@ -233,8 +260,9 @@ describe('PUT /api/tournaments/[id]/broadcast', () => {
     );
     expect(NextResponse.json).toHaveBeenCalledWith({
       success: true,
-      data: expect.objectContaining({ player2Wins: null }),
+      data: { player2Wins: null },
     });
+    expectNoInternalBroadcastFields((NextResponse.json as jest.Mock).mock.calls[0][0].data);
   });
 
   it('trims whitespace from player names', async () => {

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3806,6 +3806,12 @@ async function main() {
 
       // Persistence is verified by the subsequent GET; body shape varies by implementation
       const putOk = putResp.s === 200;
+      const putResponsePublicShape = (
+        !('overlayPlayer1Wins' in putResp.data) &&
+        !('overlayPlayer2Wins' in putResp.data) &&
+        putResp.data.player1Wins === 2 &&
+        putResp.data.player2Wins === 1
+      );
 
       // GET after PUT: persisted values returned
       const getAfter = await page.evaluate(async (tid) => {
@@ -3858,6 +3864,8 @@ async function main() {
         putClearWins.s === 200 &&
         putClearWins.data.player1Wins === null &&
         putClearWins.data.player2Wins === null &&
+        !('overlayPlayer1Wins' in putClearWins.data) &&
+        !('overlayPlayer2Wins' in putClearWins.data) &&
         getAfterClearWins.s === 200 &&
         getAfterClearWins.data.player1Wins === null &&
         getAfterClearWins.data.player2Wins === null
@@ -3901,9 +3909,9 @@ async function main() {
       }
       const nonAdminBlocked = nonAdminPutStatus === 401 || nonAdminPutStatus === 403;
 
-      const ok = hasShape && putOk && getOk && clearOk && clearWinsOk && invalidLayoutBlocked && nonAdminBlocked;
+      const ok = hasShape && putOk && putResponsePublicShape && getOk && clearOk && clearWinsOk && invalidLayoutBlocked && nonAdminBlocked;
       log('TC-354', ok ? 'PASS' : 'FAIL',
-        `shape=${hasShape} put=${putOk} persist=${getOk} clear=${clearOk} clearWins=${clearWinsOk} invalidLayoutBlocked=${invalidLayoutBlocked} nonAdminBlocked=${nonAdminBlocked}(${nonAdminPutStatus})`);
+        `shape=${hasShape} put=${putOk} putPublicShape=${putResponsePublicShape} persist=${getOk} clear=${clearOk} clearWins=${clearWinsOk} invalidLayoutBlocked=${invalidLayoutBlocked} nonAdminBlocked=${nonAdminBlocked}(${nonAdminPutStatus})`);
     } catch (err) {
       log('TC-354', 'FAIL', err instanceof Error ? err.message : 'broadcast API test failed');
     } finally {

--- a/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
@@ -31,6 +31,17 @@ import {
 import type { Prisma } from "@prisma/client";
 
 const MAX_NAME_LENGTH = 50;
+type BroadcastUpdateResponse = Partial<{
+  player1Name: string;
+  player2Name: string;
+  player1NoCamera: boolean;
+  player2NoCamera: boolean;
+  matchLabel: string | null;
+  player1Wins: number | null;
+  player2Wins: number | null;
+  matchFt: number | null;
+  layout: OverlayBroadcastLayout;
+}>;
 
 /**
  * GET /api/tournaments/[id]/broadcast
@@ -208,33 +219,44 @@ export async function PUT(
       data: updateData,
     });
 
-    return createSuccessResponse({
-      player1Name: updateData.overlayPlayer1Name !== undefined
-        ? (updateData.overlayPlayer1Name ?? "")
-        : undefined,
-      player2Name: updateData.overlayPlayer2Name !== undefined
-        ? (updateData.overlayPlayer2Name ?? "")
-        : undefined,
-      player1NoCamera: updateData.overlayPlayer1NoCamera !== undefined
-        ? Boolean(updateData.overlayPlayer1NoCamera)
-        : undefined,
-      player2NoCamera: updateData.overlayPlayer2NoCamera !== undefined
-        ? Boolean(updateData.overlayPlayer2NoCamera)
-        : undefined,
-      matchLabel: updateData.overlayMatchLabel !== undefined
-        ? (updateData.overlayMatchLabel ?? null)
-        : undefined,
-      player1Wins: updateData.overlayPlayer1Wins !== undefined
-        ? (updateData.overlayPlayer1Wins ?? null)
-        : undefined,
-      player2Wins: updateData.overlayPlayer2Wins !== undefined
-        ? (updateData.overlayPlayer2Wins ?? null)
-        : undefined,
-      matchFt: updateData.overlayMatchFt !== undefined
-        ? (updateData.overlayMatchFt ?? null)
-        : undefined,
-      layout: normalizedLayout,
-    });
+    const responseData: BroadcastUpdateResponse = {};
+    if (updateData.overlayPlayer1Name !== undefined) {
+      responseData.player1Name = String(updateData.overlayPlayer1Name ?? "");
+    }
+    if (updateData.overlayPlayer2Name !== undefined) {
+      responseData.player2Name = String(updateData.overlayPlayer2Name ?? "");
+    }
+    if (updateData.overlayPlayer1NoCamera !== undefined) {
+      responseData.player1NoCamera = Boolean(updateData.overlayPlayer1NoCamera);
+    }
+    if (updateData.overlayPlayer2NoCamera !== undefined) {
+      responseData.player2NoCamera = Boolean(updateData.overlayPlayer2NoCamera);
+    }
+    if (updateData.overlayMatchLabel !== undefined) {
+      responseData.matchLabel = typeof updateData.overlayMatchLabel === "string"
+        ? updateData.overlayMatchLabel
+        : null;
+    }
+    if (updateData.overlayPlayer1Wins !== undefined) {
+      responseData.player1Wins = typeof updateData.overlayPlayer1Wins === "number"
+        ? updateData.overlayPlayer1Wins
+        : null;
+    }
+    if (updateData.overlayPlayer2Wins !== undefined) {
+      responseData.player2Wins = typeof updateData.overlayPlayer2Wins === "number"
+        ? updateData.overlayPlayer2Wins
+        : null;
+    }
+    if (updateData.overlayMatchFt !== undefined) {
+      responseData.matchFt = typeof updateData.overlayMatchFt === "number"
+        ? updateData.overlayMatchFt
+        : null;
+    }
+    if (normalizedLayout !== undefined) {
+      responseData.layout = normalizedLayout;
+    }
+
+    return createSuccessResponse(responseData);
   } catch (error) {
     logger.error("Failed to update broadcast state", { error, tournamentId: id });
     return createErrorResponse("Failed to update broadcast state", 500);


### PR DESCRIPTION
Summary
- Keep PUT /broadcast responses on the public API field names only.
- Strengthen broadcast route unit assertions for exact success responses and absence of internal overlay DB field names.
- Extend TC-354 scenario and runner coverage for public response shape on set and clear flows.

Issues: Closes #1501, Closes #1502

Validation
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/broadcast/route.test.ts' --runInBand
- node --check e2e/tc-all.js
- git diff --check
- npx eslint 'src/app/api/tournaments/[id]/broadcast/route.ts' '__tests__/app/api/tournaments/[id]/broadcast/route.test.ts' 'e2e/tc-all.js' (exit 0; e2e/tc-all.js is ignored by eslint config)
- npm run lint -- --no-warn-ignored (exit 0; existing warnings only)

Note
- npx tsc --noEmit --pretty false still fails on pre-existing E2E/helper typing issues unrelated to this change.
