### PR TITLE
fix: tighten broadcast update response coverage

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -771,10 +771,10 @@
 - **手順**:
   1. 新規トーナメントを作成
   2. GET → `{ player1Name, player2Name, matchLabel, player1Wins, player2Wins, matchFt, layout }` の形状が返ること（初期値は空文字/null/default 座標）
-  3. 管理者として PUT `{ player1Name: '1P-Alice', player2Name: '2P-Bob', matchLabel: 'QF1', player1Wins: 2, player2Wins: 1, matchFt: 5, layout: { ...座標 } }` → 200。レスポンス body は API 向け `player1Wins/player2Wins` のみを返し、DB カラム名 `overlayPlayer1Wins/overlayPlayer2Wins` を含まないこと
+  3. 管理者として PUT `{ player1Name: '1P-Alice', player2Name: '2P-Bob', matchLabel: 'QF1', player1Wins: 2, player2Wins: 1, matchFt: 5, layout: { ...座標 } }` → 200。レスポンス body は API 向け `matchLabel/player1Wins/player2Wins/matchFt` のみを返し、DB カラム名 `overlayMatchLabel/overlayPlayer1Wins/overlayPlayer2Wins/overlayMatchFt` を含まないこと
   4. GET → PUT した値が永続化されていること
-  5. PUT `{ matchLabel: null }` → フィールドがクリアされること（200）
-  6. PUT `{ player1Wins: null, player2Wins: null }` → レスポンス body と再取得 GET の両方で 1P/2P 勝利数が null にクリアされ、レスポンス body に `overlayPlayer1Wins/overlayPlayer2Wins` が含まれないこと（200）
+  5. PUT `{ matchLabel: null }` → フィールドがクリアされ、レスポンス body に `overlayMatchLabel/overlayMatchFt` を含まないこと（200）
+  6. PUT `{ player1Wins: null, player2Wins: null }` → レスポンス body と再取得 GET の両方で 1P/2P 勝利数が null にクリアされ、レスポンス body に `overlayMatchLabel/overlayPlayer1Wins/overlayPlayer2Wins/overlayMatchFt` が含まれないこと（200）
   7. OBS 1920×1080 キャンバス外の `layout` 座標は 400 で拒否されること
 - **期待結果**: GET は正しい形状を返し、PUT は値を永続化・クリアできる
 - **スクリプト**: tc-all.js TC-354

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
@@ -223,10 +223,16 @@ describe('PUT /api/tournaments/[id]/broadcast', () => {
       mockParams('t1'),
     );
 
+    expect(prisma.tournament.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ overlayMatchLabel: null }),
+      }),
+    );
     expect(NextResponse.json).toHaveBeenCalledWith({
       success: true,
       data: { matchLabel: null },
     });
+    expectNoInternalBroadcastFields((NextResponse.json as jest.Mock).mock.calls[0][0].data);
   });
 
   it('clears player1 wins when null is passed', async () => {

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3806,9 +3806,15 @@ async function main() {
 
       // Persistence is verified by the subsequent GET; body shape varies by implementation
       const putOk = putResp.s === 200;
+      const hasNoInternalBroadcastFields = (data) => (
+        data &&
+        !('overlayMatchLabel' in data) &&
+        !('overlayPlayer1Wins' in data) &&
+        !('overlayPlayer2Wins' in data) &&
+        !('overlayMatchFt' in data)
+      );
       const putResponsePublicShape = (
-        !('overlayPlayer1Wins' in putResp.data) &&
-        !('overlayPlayer2Wins' in putResp.data) &&
+        hasNoInternalBroadcastFields(putResp.data) &&
         putResp.data.player1Wins === 2 &&
         putResp.data.player2Wins === 1
       );
@@ -3840,9 +3846,14 @@ async function main() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ matchLabel: null }),
         });
-        return { s: r.status };
+        const j = await r.json().catch(() => ({}));
+        return { s: r.status, data: j.data ?? j };
       }, tc354TournamentId);
-      const clearOk = putClear.s === 200;
+      const clearOk = (
+        putClear.s === 200 &&
+        putClear.data.matchLabel === null &&
+        hasNoInternalBroadcastFields(putClear.data)
+      );
 
       // PUT with null clears both score fields.
       const putClearWins = await page.evaluate(async (tid) => {
@@ -3864,8 +3875,7 @@ async function main() {
         putClearWins.s === 200 &&
         putClearWins.data.player1Wins === null &&
         putClearWins.data.player2Wins === null &&
-        !('overlayPlayer1Wins' in putClearWins.data) &&
-        !('overlayPlayer2Wins' in putClearWins.data) &&
+        hasNoInternalBroadcastFields(putClearWins.data) &&
         getAfterClearWins.s === 200 &&
         getAfterClearWins.data.player1Wins === null &&
         getAfterClearWins.data.player2Wins === null

--- a/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
@@ -220,40 +220,65 @@ export async function PUT(
     });
 
     const responseData: BroadcastUpdateResponse = {};
-    if (updateData.overlayPlayer1Name !== undefined) {
-      responseData.player1Name = String(updateData.overlayPlayer1Name ?? "");
-    }
-    if (updateData.overlayPlayer2Name !== undefined) {
-      responseData.player2Name = String(updateData.overlayPlayer2Name ?? "");
-    }
-    if (updateData.overlayPlayer1NoCamera !== undefined) {
-      responseData.player1NoCamera = Boolean(updateData.overlayPlayer1NoCamera);
-    }
-    if (updateData.overlayPlayer2NoCamera !== undefined) {
-      responseData.player2NoCamera = Boolean(updateData.overlayPlayer2NoCamera);
-    }
-    if (updateData.overlayMatchLabel !== undefined) {
-      responseData.matchLabel = typeof updateData.overlayMatchLabel === "string"
-        ? updateData.overlayMatchLabel
-        : null;
-    }
-    if (updateData.overlayPlayer1Wins !== undefined) {
-      responseData.player1Wins = typeof updateData.overlayPlayer1Wins === "number"
-        ? updateData.overlayPlayer1Wins
-        : null;
-    }
-    if (updateData.overlayPlayer2Wins !== undefined) {
-      responseData.player2Wins = typeof updateData.overlayPlayer2Wins === "number"
-        ? updateData.overlayPlayer2Wins
-        : null;
-    }
-    if (updateData.overlayMatchFt !== undefined) {
-      responseData.matchFt = typeof updateData.overlayMatchFt === "number"
-        ? updateData.overlayMatchFt
-        : null;
-    }
-    if (normalizedLayout !== undefined) {
-      responseData.layout = normalizedLayout;
+    const responseFieldMappers = [
+      {
+        source: "overlayPlayer1Name",
+        apply: (value: unknown) => {
+          responseData.player1Name = typeof value === "string" ? value : "";
+        },
+      },
+      {
+        source: "overlayPlayer2Name",
+        apply: (value: unknown) => {
+          responseData.player2Name = typeof value === "string" ? value : "";
+        },
+      },
+      {
+        source: "overlayPlayer1NoCamera",
+        apply: (value: unknown) => {
+          responseData.player1NoCamera = value === true;
+        },
+      },
+      {
+        source: "overlayPlayer2NoCamera",
+        apply: (value: unknown) => {
+          responseData.player2NoCamera = value === true;
+        },
+      },
+      {
+        source: "overlayMatchLabel",
+        apply: (value: unknown) => {
+          responseData.matchLabel = typeof value === "string" ? value : null;
+        },
+      },
+      {
+        source: "overlayPlayer1Wins",
+        apply: (value: unknown) => {
+          responseData.player1Wins = typeof value === "number" ? value : null;
+        },
+      },
+      {
+        source: "overlayPlayer2Wins",
+        apply: (value: unknown) => {
+          responseData.player2Wins = typeof value === "number" ? value : null;
+        },
+      },
+      {
+        source: "overlayMatchFt",
+        apply: (value: unknown) => {
+          responseData.matchFt = typeof value === "number" ? value : null;
+        },
+      },
+      {
+        source: "overlayLayout",
+        apply: () => {
+          if (normalizedLayout !== undefined) responseData.layout = normalizedLayout;
+        },
+      },
+    ] as const;
+
+    for (const { source, apply } of responseFieldMappers) {
+      if (updateData[source] !== undefined) apply(updateData[source]);
     }
 
     return createSuccessResponse(responseData);


### PR DESCRIPTION
Summary
- Replace broadcast PUT response if-blocks with a declarative field mapper and remove redundant String() casts.
- Extend TC-354 scenario/runtime checks to reject all internal broadcast field names in PUT responses.
- Restore the matchLabel null DB write assertion in the broadcast route unit test.

Issues: Closes #1504, Closes #1505, Closes #1506, Closes #1507

Validation
- node --check smkc-score-app/e2e/tc-all.js
- npm test -- --runTestsByPath __tests__/app/api/tournaments/[id]/broadcast/route.test.ts
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts
- npx eslint src/app/api/tournaments/[id]/broadcast/route.ts __tests__/app/api/tournaments/[id]/broadcast/route.test.ts --no-warn-ignored
- git diff --check
- npm run lint -- --no-warn-ignored (exit 0; existing warnings only)