### PR TITLE
refactor: simplify broadcast response fields

### DIFF
--- a/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
@@ -220,65 +220,32 @@ export async function PUT(
     });
 
     const responseData: BroadcastUpdateResponse = {};
-    const responseFieldMappers = [
-      {
-        source: "overlayPlayer1Name",
-        apply: (value: unknown) => {
-          responseData.player1Name = typeof value === "string" ? value : "";
-        },
-      },
-      {
-        source: "overlayPlayer2Name",
-        apply: (value: unknown) => {
-          responseData.player2Name = typeof value === "string" ? value : "";
-        },
-      },
-      {
-        source: "overlayPlayer1NoCamera",
-        apply: (value: unknown) => {
-          responseData.player1NoCamera = value === true;
-        },
-      },
-      {
-        source: "overlayPlayer2NoCamera",
-        apply: (value: unknown) => {
-          responseData.player2NoCamera = value === true;
-        },
-      },
-      {
-        source: "overlayMatchLabel",
-        apply: (value: unknown) => {
-          responseData.matchLabel = typeof value === "string" ? value : null;
-        },
-      },
-      {
-        source: "overlayPlayer1Wins",
-        apply: (value: unknown) => {
-          responseData.player1Wins = typeof value === "number" ? value : null;
-        },
-      },
-      {
-        source: "overlayPlayer2Wins",
-        apply: (value: unknown) => {
-          responseData.player2Wins = typeof value === "number" ? value : null;
-        },
-      },
-      {
-        source: "overlayMatchFt",
-        apply: (value: unknown) => {
-          responseData.matchFt = typeof value === "number" ? value : null;
-        },
-      },
-      {
-        source: "overlayLayout",
-        apply: () => {
-          if (normalizedLayout !== undefined) responseData.layout = normalizedLayout;
-        },
-      },
-    ] as const;
-
-    for (const { source, apply } of responseFieldMappers) {
-      if (updateData[source] !== undefined) apply(updateData[source]);
+    if (updateData.overlayPlayer1Name !== undefined) {
+      responseData.player1Name = typeof updateData.overlayPlayer1Name === "string" ? updateData.overlayPlayer1Name : "";
+    }
+    if (updateData.overlayPlayer2Name !== undefined) {
+      responseData.player2Name = typeof updateData.overlayPlayer2Name === "string" ? updateData.overlayPlayer2Name : "";
+    }
+    if (updateData.overlayPlayer1NoCamera !== undefined) {
+      responseData.player1NoCamera = updateData.overlayPlayer1NoCamera === true;
+    }
+    if (updateData.overlayPlayer2NoCamera !== undefined) {
+      responseData.player2NoCamera = updateData.overlayPlayer2NoCamera === true;
+    }
+    if (updateData.overlayMatchLabel !== undefined) {
+      responseData.matchLabel = typeof updateData.overlayMatchLabel === "string" ? updateData.overlayMatchLabel : null;
+    }
+    if (updateData.overlayPlayer1Wins !== undefined) {
+      responseData.player1Wins = typeof updateData.overlayPlayer1Wins === "number" ? updateData.overlayPlayer1Wins : null;
+    }
+    if (updateData.overlayPlayer2Wins !== undefined) {
+      responseData.player2Wins = typeof updateData.overlayPlayer2Wins === "number" ? updateData.overlayPlayer2Wins : null;
+    }
+    if (updateData.overlayMatchFt !== undefined) {
+      responseData.matchFt = typeof updateData.overlayMatchFt === "number" ? updateData.overlayMatchFt : null;
+    }
+    if (normalizedLayout !== undefined) {
+      responseData.layout = normalizedLayout;
     }
 
     return createSuccessResponse(responseData);


### PR DESCRIPTION
Summary
- Replace responseFieldMappers callback loop with direct response assignments.
- Keep layout response handling outside the field mapper path so it only depends on normalizedLayout.
- Preserve public broadcast response names added in PR #1508.

Issues: Closes #1509, Closes #1510

Validation
- npm test -- --runTestsByPath __tests__/app/api/tournaments/[id]/broadcast/route.test.ts
- npx eslint src/app/api/tournaments/[id]/broadcast/route.ts --no-warn-ignored
- git diff --check
- npm run lint -- --no-warn-ignored (exit 0; existing warnings only)