### PR TITLE
test: cover broadcast partial layout response

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
@@ -235,6 +235,26 @@ describe('PUT /api/tournaments/[id]/broadcast', () => {
     expectNoInternalBroadcastFields((NextResponse.json as jest.Mock).mock.calls[0][0].data);
   });
 
+  it('omits layout from partial update responses when layout is not sent', async () => {
+    await PUT(
+      mockReq({ matchLabel: 'SF1' }),
+      mockParams('t1'),
+    );
+
+    expect(prisma.tournament.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.not.objectContaining({ overlayLayout: expect.anything() }),
+      }),
+    );
+    expect(NextResponse.json).toHaveBeenCalledWith({
+      success: true,
+      data: { matchLabel: 'SF1' },
+    });
+    const responseData = (NextResponse.json as jest.Mock).mock.calls[0][0].data;
+    expect(responseData).not.toHaveProperty('layout');
+    expectNoInternalBroadcastFields(responseData);
+  });
+
   it('clears player1 wins when null is passed', async () => {
     await PUT(
       mockReq({ player1Wins: null }),


### PR DESCRIPTION
Summary
- Add a broadcast PUT unit test for partial updates that do not send layout.
- Assert the DB write does not include overlayLayout and the public response omits layout.

Issues: Closes #1512

Validation
- npm test -- --runTestsByPath __tests__/app/api/tournaments/[id]/broadcast/route.test.ts
- npx eslint __tests__/app/api/tournaments/[id]/broadcast/route.test.ts --no-warn-ignored
- git diff --check