### PR TITLE
test: simplify broadcast layout assertion

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
@@ -250,9 +250,7 @@ describe('PUT /api/tournaments/[id]/broadcast', () => {
       success: true,
       data: { matchLabel: 'SF1' },
     });
-    const responseData = (NextResponse.json as jest.Mock).mock.calls[0][0].data;
-    expect(responseData).not.toHaveProperty('layout');
-    expectNoInternalBroadcastFields(responseData);
+    expectNoInternalBroadcastFields((NextResponse.json as jest.Mock).mock.calls[0][0].data);
   });
 
   it('clears player1 wins when null is passed', async () => {


### PR DESCRIPTION
Summary
- Remove the redundant explicit layout absence assertion from the broadcast partial-update test.
- Keep the exact response shape and internal-field checks.

Issues: Closes #1514

Validation
- npm test -- --runTestsByPath __tests__/app/api/tournaments/[id]/broadcast/route.test.ts
- npx eslint __tests__/app/api/tournaments/[id]/broadcast/route.test.ts --no-warn-ignored
- git diff --check