### PR TITLE
fix: validate broadcast score inputs

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -775,7 +775,8 @@
   4. GET → PUT した値が永続化されていること
   5. PUT `{ matchLabel: null }` → フィールドがクリアされ、レスポンス body に `overlayMatchLabel/overlayMatchFt` を含まないこと（200）
   6. PUT `{ player1Wins: null, player2Wins: null }` → レスポンス body と再取得 GET の両方で 1P/2P 勝利数が null にクリアされ、レスポンス body に `overlayMatchLabel/overlayPlayer1Wins/overlayPlayer2Wins/overlayMatchFt` が含まれないこと（200）
-  7. OBS 1920×1080 キャンバス外の `layout` 座標は 400 で拒否されること
+  7. 小数・負数の `player1Wins/player2Wins/matchFt` は 400 で拒否されること
+  8. OBS 1920×1080 キャンバス外の `layout` 座標は 400 で拒否されること
 - **期待結果**: GET は正しい形状を返し、PUT は値を永続化・クリアできる
 - **スクリプト**: tc-all.js TC-354
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/broadcast/route.test.ts
@@ -353,6 +353,17 @@ describe('PUT /api/tournaments/[id]/broadcast', () => {
     expect((NextResponse.json as jest.Mock).mock.calls[0][1]?.status).toBe(400);
   });
 
+  it.each([
+    ['player1Wins', 1.5],
+    ['player2Wins', -1],
+    ['matchFt', 2.25],
+  ])('returns 400 when %s is not a non-negative integer', async (field, value) => {
+    await PUT(mockReq({ [field]: value }), mockParams('t1'));
+
+    expect((NextResponse.json as jest.Mock).mock.calls[0][1]?.status).toBe(400);
+    expect(prisma.tournament.update).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when layout contains unsupported coordinate slots', async () => {
     await PUT(mockReq({ layout: { player3Name: { x: 1, y: 2 } } }), mockParams('t1'));
 

--- a/smkc-score-app/__tests__/lib/broadcast-input.test.ts
+++ b/smkc-score-app/__tests__/lib/broadcast-input.test.ts
@@ -1,0 +1,17 @@
+import { nullableBroadcastIntegerInput } from '@/lib/broadcast-input';
+
+describe('nullableBroadcastIntegerInput', () => {
+  it.each([
+    ['', null],
+    ['   ', null],
+    ['3', 3],
+    [' 04 ', 4],
+    ['1.9', 1],
+    ['0.5', 0],
+    ['-1', 0],
+    ['abc', null],
+    ['Infinity', null],
+  ])('parses "%s" to %s', (value, expected) => {
+    expect(nullableBroadcastIntegerInput(value)).toBe(expected);
+  });
+});

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3881,6 +3881,25 @@ async function main() {
         getAfterClearWins.data.player2Wins === null
       );
 
+      // Score fields are integer counters; decimals and negatives must not persist.
+      const putDecimalWins = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/broadcast`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ player1Wins: 1.5 }),
+        });
+        return { s: r.status };
+      }, tc354TournamentId);
+      const putNegativeFt = await page.evaluate(async (tid) => {
+        const r = await fetch(`/api/tournaments/${tid}/broadcast`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ matchFt: -1 }),
+        });
+        return { s: r.status };
+      }, tc354TournamentId);
+      const invalidScoresBlocked = putDecimalWins.s === 400 && putNegativeFt.s === 400;
+
       // Invalid layout coordinates outside the OBS 1920x1080 canvas are rejected.
       const putInvalidLayout = await page.evaluate(async (tid) => {
         const r = await fetch(`/api/tournaments/${tid}/broadcast`, {
@@ -3919,9 +3938,9 @@ async function main() {
       }
       const nonAdminBlocked = nonAdminPutStatus === 401 || nonAdminPutStatus === 403;
 
-      const ok = hasShape && putOk && putResponsePublicShape && getOk && clearOk && clearWinsOk && invalidLayoutBlocked && nonAdminBlocked;
+      const ok = hasShape && putOk && putResponsePublicShape && getOk && clearOk && clearWinsOk && invalidScoresBlocked && invalidLayoutBlocked && nonAdminBlocked;
       log('TC-354', ok ? 'PASS' : 'FAIL',
-        `shape=${hasShape} put=${putOk} putPublicShape=${putResponsePublicShape} persist=${getOk} clear=${clearOk} clearWins=${clearWinsOk} invalidLayoutBlocked=${invalidLayoutBlocked} nonAdminBlocked=${nonAdminBlocked}(${nonAdminPutStatus})`);
+        `shape=${hasShape} put=${putOk} putPublicShape=${putResponsePublicShape} persist=${getOk} clear=${clearOk} clearWins=${clearWinsOk} invalidScoresBlocked=${invalidScoresBlocked} invalidLayoutBlocked=${invalidLayoutBlocked} nonAdminBlocked=${nonAdminBlocked}(${nonAdminPutStatus})`);
     } catch (err) {
       log('TC-354', 'FAIL', err instanceof Error ? err.message : 'broadcast API test failed');
     } finally {

--- a/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
@@ -92,6 +92,12 @@ export async function GET(
 }
 
 const MAX_LABEL_LENGTH = 50;
+const isNonNegativeInteger = (value: unknown) => (
+  typeof value === "number" &&
+  Number.isFinite(value) &&
+  Number.isInteger(value) &&
+  value >= 0
+);
 
 /**
  * PUT /api/tournaments/[id]/broadcast
@@ -154,14 +160,14 @@ export async function PUT(
     if (typeof matchLabel === "string" && matchLabel.length > MAX_LABEL_LENGTH) {
       return handleValidationError(`matchLabel must be at most ${MAX_LABEL_LENGTH} characters`, "matchLabel");
     }
-    if (player1Wins !== undefined && player1Wins !== null && typeof player1Wins !== "number") {
-      return handleValidationError("player1Wins must be a number", "player1Wins");
+    if (player1Wins !== undefined && player1Wins !== null && !isNonNegativeInteger(player1Wins)) {
+      return handleValidationError("player1Wins must be a non-negative integer", "player1Wins");
     }
-    if (player2Wins !== undefined && player2Wins !== null && typeof player2Wins !== "number") {
-      return handleValidationError("player2Wins must be a number", "player2Wins");
+    if (player2Wins !== undefined && player2Wins !== null && !isNonNegativeInteger(player2Wins)) {
+      return handleValidationError("player2Wins must be a non-negative integer", "player2Wins");
     }
-    if (matchFt !== undefined && matchFt !== null && typeof matchFt !== "number") {
-      return handleValidationError("matchFt must be a number", "matchFt");
+    if (matchFt !== undefined && matchFt !== null && !isNonNegativeInteger(matchFt)) {
+      return handleValidationError("matchFt must be a non-negative integer", "matchFt");
     }
     if (layout !== undefined && layout !== null && !isOverlayBroadcastLayoutInput(layout)) {
       return handleValidationError(

--- a/smkc-score-app/src/app/tournaments/[id]/broadcast/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/broadcast/page.tsx
@@ -32,6 +32,7 @@ import {
   normalizeOverlayBroadcastLayout,
   type OverlayBroadcastLayout,
 } from "@/lib/overlay/layout";
+import { nullableBroadcastIntegerInput } from "@/lib/broadcast-input";
 
 interface Player {
   id: string;
@@ -45,14 +46,13 @@ interface BroadcastState {
   player2Name: string;
   player1NoCamera: boolean;
   player2NoCamera: boolean;
-  matchLabel: string;
+  matchLabel: string | null;
   player1Wins: number | null;
   player2Wins: number | null;
   matchFt: number | null;
   layout: OverlayBroadcastLayout;
 }
 
-const nullableNumberInput = (value: string) => value.trim() === "" ? null : Number(value);
 const coordinateInput = (value: string, fallback: number) => {
   const next = Number(value);
   return Number.isFinite(next) ? next : fallback;
@@ -155,9 +155,9 @@ export default function BroadcastPage({
           player1NoCamera: player1?.noCamera === true,
           player2NoCamera: player2?.noCamera === true,
           matchLabel: matchLabelInput.trim(),
-          player1Wins: nullableNumberInput(player1WinsInput),
-          player2Wins: nullableNumberInput(player2WinsInput),
-          matchFt: nullableNumberInput(matchFtInput),
+          player1Wins: nullableBroadcastIntegerInput(player1WinsInput),
+          player2Wins: nullableBroadcastIntegerInput(player2WinsInput),
+          matchFt: nullableBroadcastIntegerInput(matchFtInput),
           layout: layoutInput,
         }),
       });

--- a/smkc-score-app/src/lib/broadcast-input.ts
+++ b/smkc-score-app/src/lib/broadcast-input.ts
@@ -1,0 +1,9 @@
+export function nullableBroadcastIntegerInput(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) return null;
+
+  return Math.max(0, Math.trunc(parsed));
+}


### PR DESCRIPTION
## Summary
- add TC-354 scenario/runtime coverage for rejecting decimal and negative broadcast score values
- validate broadcast score fields as non-negative integers in the PUT API
- extract and test the broadcast page nullable integer input parser, and allow matchLabel to be null in page state

## Issues
Closes #1021
Closes #1022
Closes #1023

## Validation
- node --check smkc-score-app/e2e/tc-all.js
- npm test -- --runTestsByPath __tests__/lib/broadcast-input.test.ts __tests__/app/api/tournaments/[id]/broadcast/route.test.ts __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
- npx eslint src/lib/broadcast-input.ts src/app/tournaments/[id]/broadcast/page.tsx src/app/api/tournaments/[id]/broadcast/route.ts __tests__/lib/broadcast-input.test.ts __tests__/app/api/tournaments/[id]/broadcast/route.test.ts --no-warn-ignored
- npm run lint -- --no-warn-ignored (exit 0; existing warnings only)