### PR TITLE
fix: surface broadcast score input errors

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -776,7 +776,8 @@
   5. PUT `{ matchLabel: null }` → フィールドがクリアされ、レスポンス body に `overlayMatchLabel/overlayMatchFt` を含まないこと（200）
   6. PUT `{ player1Wins: null, player2Wins: null }` → レスポンス body と再取得 GET の両方で 1P/2P 勝利数が null にクリアされ、レスポンス body に `overlayMatchLabel/overlayPlayer1Wins/overlayPlayer2Wins/overlayMatchFt` が含まれないこと（200）
   7. 小数・負数の `player1Wins/player2Wins/matchFt` は 400 で拒否されること
-  8. OBS 1920×1080 キャンバス外の `layout` 座標は 400 で拒否されること
+  8. 配信管理ページで点数欄に小数を入力して「配信に反映」を押すと、送信前に 0 以上の整数エラーが表示されること
+  9. OBS 1920×1080 キャンバス外の `layout` 座標は 400 で拒否されること
 - **期待結果**: GET は正しい形状を返し、PUT は値を永続化・クリアできる
 - **スクリプト**: tc-all.js TC-354
 

--- a/smkc-score-app/__tests__/lib/broadcast-input.test.ts
+++ b/smkc-score-app/__tests__/lib/broadcast-input.test.ts
@@ -1,4 +1,7 @@
-import { nullableBroadcastIntegerInput } from '@/lib/broadcast-input';
+import {
+  isBroadcastIntegerInputValid,
+  nullableBroadcastIntegerInput,
+} from '@/lib/broadcast-input';
 
 describe('nullableBroadcastIntegerInput', () => {
   it.each([
@@ -6,12 +9,26 @@ describe('nullableBroadcastIntegerInput', () => {
     ['   ', null],
     ['3', 3],
     [' 04 ', 4],
-    ['1.9', 1],
-    ['0.5', 0],
-    ['-1', 0],
+    ['1.9', null],
+    ['0.5', null],
+    ['-1', null],
     ['abc', null],
     ['Infinity', null],
   ])('parses "%s" to %s', (value, expected) => {
     expect(nullableBroadcastIntegerInput(value)).toBe(expected);
+  });
+});
+
+describe('isBroadcastIntegerInputValid', () => {
+  it.each([
+    ['', true],
+    ['4', true],
+    [' 04 ', true],
+    ['1.9', false],
+    ['-1', false],
+    ['abc', false],
+    ['Infinity', false],
+  ])('reports "%s" validity as %s', (value, expected) => {
+    expect(isBroadcastIntegerInputValid(value)).toBe(expected);
   });
 });

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3900,6 +3900,11 @@ async function main() {
       }, tc354TournamentId);
       const invalidScoresBlocked = putDecimalWins.s === 400 && putNegativeFt.s === 400;
 
+      await page.goto(`${BASE}/tournaments/${tc354TournamentId}/broadcast`);
+      await page.locator('#broadcast-player1-wins').fill('1.5');
+      await page.getByRole('button', { name: '配信に反映' }).click();
+      const uiInvalidScoreVisible = await page.getByText('1P 点数は0以上の整数で入力してください。').isVisible().catch(() => false);
+
       // Invalid layout coordinates outside the OBS 1920x1080 canvas are rejected.
       const putInvalidLayout = await page.evaluate(async (tid) => {
         const r = await fetch(`/api/tournaments/${tid}/broadcast`, {
@@ -3938,9 +3943,9 @@ async function main() {
       }
       const nonAdminBlocked = nonAdminPutStatus === 401 || nonAdminPutStatus === 403;
 
-      const ok = hasShape && putOk && putResponsePublicShape && getOk && clearOk && clearWinsOk && invalidScoresBlocked && invalidLayoutBlocked && nonAdminBlocked;
+      const ok = hasShape && putOk && putResponsePublicShape && getOk && clearOk && clearWinsOk && invalidScoresBlocked && uiInvalidScoreVisible && invalidLayoutBlocked && nonAdminBlocked;
       log('TC-354', ok ? 'PASS' : 'FAIL',
-        `shape=${hasShape} put=${putOk} putPublicShape=${putResponsePublicShape} persist=${getOk} clear=${clearOk} clearWins=${clearWinsOk} invalidScoresBlocked=${invalidScoresBlocked} invalidLayoutBlocked=${invalidLayoutBlocked} nonAdminBlocked=${nonAdminBlocked}(${nonAdminPutStatus})`);
+        `shape=${hasShape} put=${putOk} putPublicShape=${putResponsePublicShape} persist=${getOk} clear=${clearOk} clearWins=${clearWinsOk} invalidScoresBlocked=${invalidScoresBlocked} uiInvalidScoreVisible=${uiInvalidScoreVisible} invalidLayoutBlocked=${invalidLayoutBlocked} nonAdminBlocked=${nonAdminBlocked}(${nonAdminPutStatus})`);
     } catch (err) {
       log('TC-354', 'FAIL', err instanceof Error ? err.message : 'broadcast API test failed');
     } finally {

--- a/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/broadcast/route.ts
@@ -94,7 +94,6 @@ export async function GET(
 const MAX_LABEL_LENGTH = 50;
 const isNonNegativeInteger = (value: unknown) => (
   typeof value === "number" &&
-  Number.isFinite(value) &&
   Number.isInteger(value) &&
   value >= 0
 );

--- a/smkc-score-app/src/app/tournaments/[id]/broadcast/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/broadcast/page.tsx
@@ -32,7 +32,10 @@ import {
   normalizeOverlayBroadcastLayout,
   type OverlayBroadcastLayout,
 } from "@/lib/overlay/layout";
-import { nullableBroadcastIntegerInput } from "@/lib/broadcast-input";
+import {
+  isBroadcastIntegerInputValid,
+  nullableBroadcastIntegerInput,
+} from "@/lib/broadcast-input";
 
 interface Player {
   id: string;
@@ -92,6 +95,15 @@ export default function BroadcastPage({
   const [saving, setSaving] = useState(false);
   const [savedFlash, setSavedFlash] = useState(false);
 
+  const invalidScoreField = [
+    { label: "1P 点数", value: player1WinsInput },
+    { label: "2P 点数", value: player2WinsInput },
+    { label: "FT", value: matchFtInput },
+  ].find(({ value }) => !isBroadcastIntegerInputValid(value));
+  const scoreInputError = invalidScoreField
+    ? `${invalidScoreField.label}は0以上の整数で入力してください。`
+    : "";
+
   const fetchBroadcastState = useCallback(async () => {
     try {
       const res = await fetch(`/api/tournaments/${tournamentId}/broadcast`);
@@ -142,6 +154,8 @@ export default function BroadcastPage({
 
   const handleSave = async () => {
     if (!isAdmin) return;
+    if (scoreInputError) return;
+
     setSaving(true);
     const player1 = players.find((p) => p.nickname === player1Input.trim());
     const player2 = players.find((p) => p.nickname === player2Input.trim());
@@ -362,6 +376,7 @@ export default function BroadcastPage({
                   inputMode="numeric"
                   min={0}
                   step={1}
+                  aria-invalid={!isBroadcastIntegerInputValid(player1WinsInput)}
                   placeholder="0"
                 />
               </div>
@@ -375,6 +390,7 @@ export default function BroadcastPage({
                   inputMode="numeric"
                   min={0}
                   step={1}
+                  aria-invalid={!isBroadcastIntegerInputValid(player2WinsInput)}
                   placeholder="0"
                 />
               </div>
@@ -388,10 +404,16 @@ export default function BroadcastPage({
                   inputMode="numeric"
                   min={0}
                   step={1}
+                  aria-invalid={!isBroadcastIntegerInputValid(matchFtInput)}
                   placeholder="任意"
                 />
               </div>
             </div>
+            {scoreInputError && (
+              <p className="text-sm font-semibold text-destructive" role="alert">
+                {scoreInputError}
+              </p>
+            )}
             <div className="border-t border-foreground/10 pt-4 space-y-3">
               <div>
                 <p className="text-sm font-semibold">表示位置を調整</p>

--- a/smkc-score-app/src/lib/broadcast-input.ts
+++ b/smkc-score-app/src/lib/broadcast-input.ts
@@ -1,9 +1,17 @@
+export function isBroadcastIntegerInputValid(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed === "") return true;
+
+  const parsed = Number(trimmed);
+  return Number.isInteger(parsed) && parsed >= 0;
+}
+
 export function nullableBroadcastIntegerInput(value: string): number | null {
   const trimmed = value.trim();
   if (trimmed === "") return null;
 
   const parsed = Number(trimmed);
-  if (!Number.isFinite(parsed)) return null;
+  if (!isBroadcastIntegerInputValid(trimmed)) return null;
 
-  return Math.max(0, Math.trunc(parsed));
+  return parsed;
 }


### PR DESCRIPTION
## Summary
- add TC-354 scenario/runtime coverage for the broadcast page invalid score message
- stop silently truncating/clamping decimal and negative broadcast score inputs before save
- remove the redundant Number.isFinite check from the API integer guard

## Issues
Closes #1517
Closes #1518

## Validation
- node --check smkc-score-app/e2e/tc-all.js
- npm test -- --runTestsByPath __tests__/lib/broadcast-input.test.ts __tests__/app/api/tournaments/[id]/broadcast/route.test.ts __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
- npx eslint src/lib/broadcast-input.ts src/app/tournaments/[id]/broadcast/page.tsx src/app/api/tournaments/[id]/broadcast/route.ts __tests__/lib/broadcast-input.test.ts __tests__/app/api/tournaments/[id]/broadcast/route.test.ts --no-warn-ignored
- npm run lint -- --no-warn-ignored (exit 0; existing warnings only)