### PR TITLE
fix: show all broadcast score input errors

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -776,7 +776,7 @@
   5. PUT `{ matchLabel: null }` → フィールドがクリアされ、レスポンス body に `overlayMatchLabel/overlayMatchFt` を含まないこと（200）
   6. PUT `{ player1Wins: null, player2Wins: null }` → レスポンス body と再取得 GET の両方で 1P/2P 勝利数が null にクリアされ、レスポンス body に `overlayMatchLabel/overlayPlayer1Wins/overlayPlayer2Wins/overlayMatchFt` が含まれないこと（200）
   7. 小数・負数の `player1Wins/player2Wins/matchFt` は 400 で拒否されること
-  8. 配信管理ページで点数欄に小数を入力して「配信に反映」を押すと、送信前に 0 以上の整数エラーが表示されること
+  8. 配信管理ページで複数の点数欄に小数・負数を入力して「配信に反映」を押すと、送信前に対象欄を列挙した 0 以上の整数エラーと赤枠表示が出ること
   9. OBS 1920×1080 キャンバス外の `layout` 座標は 400 で拒否されること
 - **期待結果**: GET は正しい形状を返し、PUT は値を永続化・クリアできる
 - **スクリプト**: tc-all.js TC-354

--- a/smkc-score-app/__tests__/lib/broadcast-input.test.ts
+++ b/smkc-score-app/__tests__/lib/broadcast-input.test.ts
@@ -1,4 +1,5 @@
 import {
+  invalidBroadcastIntegerInputLabels,
   isBroadcastIntegerInputValid,
   nullableBroadcastIntegerInput,
 } from '@/lib/broadcast-input';
@@ -30,5 +31,15 @@ describe('isBroadcastIntegerInputValid', () => {
     ['Infinity', false],
   ])('reports "%s" validity as %s', (value, expected) => {
     expect(isBroadcastIntegerInputValid(value)).toBe(expected);
+  });
+});
+
+describe('invalidBroadcastIntegerInputLabels', () => {
+  it('returns all invalid field labels in display order', () => {
+    expect(invalidBroadcastIntegerInputLabels([
+      { label: '1P 点数', value: '1.5' },
+      { label: '2P 点数', value: '-1' },
+      { label: 'FT', value: '3' },
+    ])).toEqual(['1P 点数', '2P 点数']);
   });
 });

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3902,8 +3902,13 @@ async function main() {
 
       await page.goto(`${BASE}/tournaments/${tc354TournamentId}/broadcast`);
       await page.locator('#broadcast-player1-wins').fill('1.5');
+      await page.locator('#broadcast-player2-wins').fill('-1');
       await page.getByRole('button', { name: '配信に反映' }).click();
-      const uiInvalidScoreVisible = await page.getByText('1P 点数は0以上の整数で入力してください。').isVisible().catch(() => false);
+      const uiInvalidScoreVisible = await page.getByText('1P 点数、2P 点数は0以上の整数で入力してください。').isVisible().catch(() => false);
+      const uiInvalidScoreStyled = await page.locator('#broadcast-player1-wins').evaluate((el) => (
+        el.getAttribute('aria-invalid') === 'true' &&
+        el.className.includes('border-destructive')
+      )).catch(() => false);
 
       // Invalid layout coordinates outside the OBS 1920x1080 canvas are rejected.
       const putInvalidLayout = await page.evaluate(async (tid) => {
@@ -3943,9 +3948,9 @@ async function main() {
       }
       const nonAdminBlocked = nonAdminPutStatus === 401 || nonAdminPutStatus === 403;
 
-      const ok = hasShape && putOk && putResponsePublicShape && getOk && clearOk && clearWinsOk && invalidScoresBlocked && uiInvalidScoreVisible && invalidLayoutBlocked && nonAdminBlocked;
+      const ok = hasShape && putOk && putResponsePublicShape && getOk && clearOk && clearWinsOk && invalidScoresBlocked && uiInvalidScoreVisible && uiInvalidScoreStyled && invalidLayoutBlocked && nonAdminBlocked;
       log('TC-354', ok ? 'PASS' : 'FAIL',
-        `shape=${hasShape} put=${putOk} putPublicShape=${putResponsePublicShape} persist=${getOk} clear=${clearOk} clearWins=${clearWinsOk} invalidScoresBlocked=${invalidScoresBlocked} uiInvalidScoreVisible=${uiInvalidScoreVisible} invalidLayoutBlocked=${invalidLayoutBlocked} nonAdminBlocked=${nonAdminBlocked}(${nonAdminPutStatus})`);
+        `shape=${hasShape} put=${putOk} putPublicShape=${putResponsePublicShape} persist=${getOk} clear=${clearOk} clearWins=${clearWinsOk} invalidScoresBlocked=${invalidScoresBlocked} uiInvalidScoreVisible=${uiInvalidScoreVisible} uiInvalidScoreStyled=${uiInvalidScoreStyled} invalidLayoutBlocked=${invalidLayoutBlocked} nonAdminBlocked=${nonAdminBlocked}(${nonAdminPutStatus})`);
     } catch (err) {
       log('TC-354', 'FAIL', err instanceof Error ? err.message : 'broadcast API test failed');
     } finally {

--- a/smkc-score-app/src/app/tournaments/[id]/broadcast/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/broadcast/page.tsx
@@ -33,6 +33,7 @@ import {
   type OverlayBroadcastLayout,
 } from "@/lib/overlay/layout";
 import {
+  invalidBroadcastIntegerInputLabels,
   isBroadcastIntegerInputValid,
   nullableBroadcastIntegerInput,
 } from "@/lib/broadcast-input";
@@ -95,14 +96,15 @@ export default function BroadcastPage({
   const [saving, setSaving] = useState(false);
   const [savedFlash, setSavedFlash] = useState(false);
 
-  const invalidScoreField = [
+  const invalidScoreLabels = invalidBroadcastIntegerInputLabels([
     { label: "1P 点数", value: player1WinsInput },
     { label: "2P 点数", value: player2WinsInput },
     { label: "FT", value: matchFtInput },
-  ].find(({ value }) => !isBroadcastIntegerInputValid(value));
-  const scoreInputError = invalidScoreField
-    ? `${invalidScoreField.label}は0以上の整数で入力してください。`
+  ]);
+  const scoreInputError = invalidScoreLabels.length > 0
+    ? `${invalidScoreLabels.join("、")}は0以上の整数で入力してください。`
     : "";
+  const invalidScoreClassName = "border-destructive focus-visible:ring-destructive";
 
   const fetchBroadcastState = useCallback(async () => {
     try {
@@ -377,6 +379,7 @@ export default function BroadcastPage({
                   min={0}
                   step={1}
                   aria-invalid={!isBroadcastIntegerInputValid(player1WinsInput)}
+                  className={!isBroadcastIntegerInputValid(player1WinsInput) ? invalidScoreClassName : undefined}
                   placeholder="0"
                 />
               </div>
@@ -391,6 +394,7 @@ export default function BroadcastPage({
                   min={0}
                   step={1}
                   aria-invalid={!isBroadcastIntegerInputValid(player2WinsInput)}
+                  className={!isBroadcastIntegerInputValid(player2WinsInput) ? invalidScoreClassName : undefined}
                   placeholder="0"
                 />
               </div>
@@ -405,6 +409,7 @@ export default function BroadcastPage({
                   min={0}
                   step={1}
                   aria-invalid={!isBroadcastIntegerInputValid(matchFtInput)}
+                  className={!isBroadcastIntegerInputValid(matchFtInput) ? invalidScoreClassName : undefined}
                   placeholder="任意"
                 />
               </div>

--- a/smkc-score-app/src/lib/broadcast-input.ts
+++ b/smkc-score-app/src/lib/broadcast-input.ts
@@ -6,6 +6,14 @@ export function isBroadcastIntegerInputValid(value: string): boolean {
   return Number.isInteger(parsed) && parsed >= 0;
 }
 
+export function invalidBroadcastIntegerInputLabels(
+  fields: Array<{ label: string; value: string }>,
+): string[] {
+  return fields
+    .filter(({ value }) => !isBroadcastIntegerInputValid(value))
+    .map(({ label }) => label);
+}
+
 export function nullableBroadcastIntegerInput(value: string): number | null {
   const trimmed = value.trim();
   if (trimmed === "") return null;


### PR DESCRIPTION
## Summary
- list every invalid broadcast score field in the page error message
- apply destructive border/focus styling to invalid score inputs
- extend TC-354 scenario/runtime coverage and unit coverage for multiple invalid fields

## Issues
Closes #1520
Closes #1521

## Validation
- node --check smkc-score-app/e2e/tc-all.js
- npm test -- --runTestsByPath __tests__/lib/broadcast-input.test.ts __tests__/app/api/tournaments/[id]/broadcast/route.test.ts __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
- npx eslint src/lib/broadcast-input.ts src/app/tournaments/[id]/broadcast/page.tsx __tests__/lib/broadcast-input.test.ts --no-warn-ignored
- npm run lint -- --no-warn-ignored (exit 0; existing warnings only)