### PR TITLE
test: cover broadcast input label cases

### DIFF
--- a/smkc-score-app/__tests__/lib/broadcast-input.test.ts
+++ b/smkc-score-app/__tests__/lib/broadcast-input.test.ts
@@ -35,6 +35,22 @@ describe('isBroadcastIntegerInputValid', () => {
 });
 
 describe('invalidBroadcastIntegerInputLabels', () => {
+  it('returns no labels when all fields are valid or empty', () => {
+    expect(invalidBroadcastIntegerInputLabels([
+      { label: '1P 点数', value: '' },
+      { label: '2P 点数', value: '0' },
+      { label: 'FT', value: '3' },
+    ])).toEqual([]);
+  });
+
+  it('returns the single invalid field label', () => {
+    expect(invalidBroadcastIntegerInputLabels([
+      { label: '1P 点数', value: '2' },
+      { label: '2P 点数', value: '-1' },
+      { label: 'FT', value: '' },
+    ])).toEqual(['2P 点数']);
+  });
+
   it('returns all invalid field labels in display order', () => {
     expect(invalidBroadcastIntegerInputLabels([
       { label: '1P 点数', value: '1.5' },


### PR DESCRIPTION
## Summary
- add unit coverage for all-valid and single-invalid broadcast input label cases
- keep empty score inputs covered as valid/no-error fields

## Issues
Closes #1523

## Validation
- npm test -- --runTestsByPath __tests__/lib/broadcast-input.test.ts
- npx eslint __tests__/lib/broadcast-input.test.ts --no-warn-ignored
- git diff --check