### PR TITLE
test: simplify LR2 pairing coverage

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1682,6 +1682,16 @@
 - **期待結果**: Winners R1 M2 の敗者が M16 `player2Id` に反映され、`player1Id` を上書きしない
 - **スクリプト**: tc-mr.js TC-858
 
+## TC-1072: 16人決勝 LR2 ペアリング検証の単純化 (issue #1072)
+- **背景**: 16人決勝の Losers R2 ペアリング検証は、テスト内で参加者ラベルを再構成せず、ブラケット定義が持つ `loserGoesTo` を直接確認する。これにより #1071 で決めた B3/A4/A3/B4 順の保証を、余計なテスト側変換ロジックなしで読み取れるようにする。
+- **手順**:
+  1. 16人決勝ブラケットを生成する
+  2. Winners QF M9-M12 を上から順に取得する
+  3. 各 match の `loserGoesTo` を直接読み取る
+  4. Losers R2 M23/M22/M21/M20 へ逆順に落ちることを確認する
+- **期待結果**: Winners QF の `loserGoesTo` は `[23, 22, 21, 20]` で、テストは LR2 ラベル変換用の Map や `find()` を使わずに意図を検証する
+- **スクリプト**: smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
+
 ## TC-1073: 16人決勝 Winners QF 敗者の Losers R2 1P 反映 (issue #1073)
 - **背景**: 16人決勝ブラケットでは、Winners QF から Losers R2 に落ちる敗者を 1P、Losers R1 から勝ち上がる選手を 2P に揃える必要がある。Losers R2 の対戦相手順は #1071 の B3/A4/A3/B4 順を維持する。
 - **手順**:

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -19,6 +19,7 @@ describe('E2E case drift coverage', () => {
   const tcTa = readE2eScript('tc-ta.js');
   const tcTaFlow = readE2eScript('tc-ta-flow.js');
   const gpFinalsValidators = readE2eLib('gp-finals-validators.js');
+  const tc1073Lr2Slots = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'tc-1073-16p-lr2-slots.test.ts');
 
   it.each([
     ['TC-352', tcAll],
@@ -166,6 +167,20 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('TC-1083');
     expect(bmPage).toContain('useParticipantScoreInput<BMMatch>');
     expect(mrPage).toContain('useParticipantScoreInput<MRMatch>');
+  });
+
+  it('keeps TC-1072 aligned with direct LR2 loserGoesTo coverage', () => {
+    const section = e2eCaseSection('TC-1072');
+
+    expect(section).toContain('issue #1072');
+    expect(section).toContain('`loserGoesTo`');
+    expect(section).toContain('[23, 22, 21, 20]');
+    expect(section).toContain('Map');
+    expect(section).toContain('find()');
+    expect(section).toContain('tc-1073-16p-lr2-slots.test.ts');
+    expect(tc1073Lr2Slots).toContain('TC-1072 keeps LR2 pairing coverage on direct loserGoesTo values');
+    expect(tc1073Lr2Slots).toContain('.map((match) => match.loserGoesTo)');
+    expect(tc1073Lr2Slots).toContain(').toEqual([23, 22, 21, 20])');
   });
 
   it('keeps TC-722 from duplicating GP finals target-wins logic in E2E', () => {

--- a/smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
@@ -1,6 +1,16 @@
 import { generateBracketStructure, getNextMatchInfo } from '@/lib/double-elimination';
 
 describe('TC-1073 16-player finals LR2 slot routing', () => {
+  it('TC-1072 keeps LR2 pairing coverage on direct loserGoesTo values', () => {
+    const bracket = generateBracketStructure(16);
+
+    expect(
+      bracket
+        .filter((match) => match.round === 'winners_qf')
+        .map((match) => match.loserGoesTo),
+    ).toEqual([23, 22, 21, 20]);
+  });
+
   it('keeps Winners QF losers in player1 slots and Losers R1 winners in player2 slots', () => {
     const bracket = generateBracketStructure(16);
 

--- a/smkc-score-app/__tests__/lib/double-elimination.test.ts
+++ b/smkc-score-app/__tests__/lib/double-elimination.test.ts
@@ -580,31 +580,11 @@ describe('Double Elimination Bracket Structure', () => {
 
     it('should pair two-group LR2 matches in the requested top-to-bottom order', () => {
       const matches16 = generateBracketStructure(16);
-      const qfLoserLabelsByMatch = new Map([
-        [9, 'B4'],
-        [10, 'A3'],
-        [11, 'A4'],
-        [12, 'B3'],
-      ]);
 
-      const lr2PairLabels = matches16
-        .filter((m) => m.round === 'losers_r2')
-        .map((lr2Match) => {
-          const lr1Source = matches16.find(
-            (m) => m.round === 'losers_r1' && m.winnerGoesTo === lr2Match.matchNumber,
-          );
-          const qfSource = matches16.find(
-            (m) => m.round === 'winners_qf' && m.loserGoesTo === lr2Match.matchNumber,
-          );
-          return [`W${lr1Source?.matchNumber}`, qfLoserLabelsByMatch.get(qfSource?.matchNumber ?? 0)];
-        });
-
-      expect(lr2PairLabels).toEqual([
-        ['W16', 'B3'],
-        ['W17', 'A4'],
-        ['W18', 'A3'],
-        ['W19', 'B4'],
-      ]);
+      expect(matches16
+        .filter((m) => m.round === 'winners_qf')
+        .map((m) => m.loserGoesTo),
+      ).toEqual([23, 22, 21, 20]);
     });
   });
 


### PR DESCRIPTION
Summary
- Document TC-1072 for the LR2 pairing test simplification follow-up.
- Add direct E2E/static coverage that checks Winners QF `loserGoesTo` values.
- Simplify the unit test by removing the label Map/find reconstruction and asserting the routing values directly.

Issues: Closes #1072

Validation
- npm test -- --runTestsByPath __tests__/e2e/tc-1073-16p-lr2-slots.test.ts __tests__/lib/double-elimination.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint (passes with existing warnings)
