### PR TITLE
test: cover LR2 follow-up routing checks

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1689,7 +1689,7 @@
   2. Winners QF M9-M12 を上から順に取得する
   3. 各 match の `loserGoesTo` を直接読み取る
   4. Losers R2 M23/M22/M21/M20 へ逆順に落ちることを確認する
-- **期待結果**: Winners QF の `loserGoesTo` は `[23, 22, 21, 20]` で、テストは LR2 ラベル変換用の Map や `find()` を使わずに意図を検証する
+- **期待結果**: Winners QF の `loserGoesTo` は `[23, 22, 21, 20]` で、テストは LR2 ラベル変換用の辞書化や探索処理を使わずに意図を検証する
 - **スクリプト**: smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
 
 ## TC-1073: 16人決勝 Winners QF 敗者の Losers R2 1P 反映 (issue #1073)
@@ -1700,6 +1700,16 @@
   3. Losers R1 M16-M19 の勝者ルーティングを取得する
   4. Losers R2 M20-M23 で Winners QF 敗者が `player1`、Losers R1 勝者が `player2` に入ることを確認する
 - **期待結果**: M12→M20、M11→M21、M10→M22、M9→M23 の Winners QF 敗者がすべて 1P に入り、M16-M19 の Losers R1 勝者が対応する Losers R2 の 2P に入る
+- **スクリプト**: smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
+
+## TC-1534-1535: 16人決勝 LR2 ルーティング follow-up 検証 (issues #1534, #1535)
+- **背景**: TC-1072/TC-1073 の LR2 検証は、ドキュメント文言に含まれる単語ではなく、実際のテスト本体が補助的な変換・探索ロジックを持たないことと、QF 敗者・LR1 勝者の両ルートを直接読むことを保証する。
+- **手順**:
+  1. 16人決勝ブラケットを生成する
+  2. Winners QF M9-M12 の `loserGoesTo` と `loserPosition` を確認する
+  3. Losers R1 M16-M19 の `winnerGoesTo` と `position` を確認する
+  4. static drift test で LR2 検証ファイルに補助的な変換・探索呼び出しが混入していないことを確認する
+- **期待結果**: Winners QF 側は M23/M22/M21/M20 の 1P、Losers R1 側は M20/M21/M22/M23 の 2P に直接ルーティングされ、テスト本体はルーティング値を直接検証する
 - **スクリプト**: smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
 
 ## TC-1396: 16人決勝 QF 敗者スロット定義の一元化 (issue #1396)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -175,12 +175,24 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #1072');
     expect(section).toContain('`loserGoesTo`');
     expect(section).toContain('[23, 22, 21, 20]');
-    expect(section).toContain('Map');
-    expect(section).toContain('find()');
     expect(section).toContain('tc-1073-16p-lr2-slots.test.ts');
     expect(tc1073Lr2Slots).toContain('TC-1072 keeps LR2 pairing coverage on direct loserGoesTo values');
     expect(tc1073Lr2Slots).toContain('.map((match) => match.loserGoesTo)');
     expect(tc1073Lr2Slots).toContain(').toEqual([23, 22, 21, 20])');
+  });
+
+  it('keeps TC-1534-1535 aligned with direct LR2 source route coverage', () => {
+    const section = e2eCaseSection('TC-1534-1535');
+
+    expect(section).toContain('issues #1534, #1535');
+    expect(section).toContain('`winnerGoesTo`');
+    expect(section).toContain('`position`');
+    expect(section).toContain('tc-1073-16p-lr2-slots.test.ts');
+    expect(tc1073Lr2Slots).toContain('TC-1535 keeps LR2 source routes explicit on both bracket sides');
+    expect(tc1073Lr2Slots).toContain(".filter((match) => match.round === 'losers_r1')");
+    expect(tc1073Lr2Slots).toContain('.map((match) => match.winnerGoesTo)');
+    expect(tc1073Lr2Slots).not.toContain('new Map(');
+    expect(tc1073Lr2Slots).not.toContain('.find(');
   });
 
   it('keeps TC-722 from duplicating GP finals target-wins logic in E2E', () => {

--- a/smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-1073-16p-lr2-slots.test.ts
@@ -11,6 +11,51 @@ describe('TC-1073 16-player finals LR2 slot routing', () => {
     ).toEqual([23, 22, 21, 20]);
   });
 
+  it('TC-1535 keeps LR2 source routes explicit on both bracket sides', () => {
+    const bracket = generateBracketStructure(16);
+
+    expect(
+      bracket
+        .filter((match) => match.round === 'winners_qf')
+        .map((match) => match.loserGoesTo),
+    ).toEqual([23, 22, 21, 20]);
+    expect(
+      bracket
+        .filter((match) => match.round === 'losers_r1')
+        .map((match) => match.winnerGoesTo),
+    ).toEqual([20, 21, 22, 23]);
+
+    expect(
+      bracket
+        .filter((match) => match.round === 'winners_qf')
+        .map((match) => ({
+          matchNumber: match.matchNumber,
+          loserGoesTo: match.loserGoesTo,
+          loserPosition: match.loserPosition,
+        })),
+    ).toEqual([
+      { matchNumber: 9, loserGoesTo: 23, loserPosition: 1 },
+      { matchNumber: 10, loserGoesTo: 22, loserPosition: 1 },
+      { matchNumber: 11, loserGoesTo: 21, loserPosition: 1 },
+      { matchNumber: 12, loserGoesTo: 20, loserPosition: 1 },
+    ]);
+
+    expect(
+      bracket
+        .filter((match) => match.round === 'losers_r1')
+        .map((match) => ({
+          matchNumber: match.matchNumber,
+          winnerGoesTo: match.winnerGoesTo,
+          position: match.position,
+        })),
+    ).toEqual([
+      { matchNumber: 16, winnerGoesTo: 20, position: 2 },
+      { matchNumber: 17, winnerGoesTo: 21, position: 2 },
+      { matchNumber: 18, winnerGoesTo: 22, position: 2 },
+      { matchNumber: 19, winnerGoesTo: 23, position: 2 },
+    ]);
+  });
+
   it('keeps Winners QF losers in player1 slots and Losers R1 winners in player2 slots', () => {
     const bracket = generateBracketStructure(16);
 

--- a/smkc-score-app/__tests__/lib/double-elimination.test.ts
+++ b/smkc-score-app/__tests__/lib/double-elimination.test.ts
@@ -578,13 +578,17 @@ describe('Double Elimination Bracket Structure', () => {
       });
     });
 
-    it('should pair two-group LR2 matches in the requested top-to-bottom order', () => {
+    it('should pair two-group LR2 matches from both source rounds in the requested order', () => {
       const matches16 = generateBracketStructure(16);
 
       expect(matches16
         .filter((m) => m.round === 'winners_qf')
         .map((m) => m.loserGoesTo),
       ).toEqual([23, 22, 21, 20]);
+      expect(matches16
+        .filter((m) => m.round === 'losers_r1')
+        .map((m) => m.winnerGoesTo),
+      ).toEqual([20, 21, 22, 23]);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add TC-1534-1535 scenario coverage for LR2 follow-up assertions.
- Move the Map/find guard to the E2E test source instead of relying on brittle TC-1072 wording.
- Restore explicit LR1 winnerGoesTo coverage in both static E2E and double-elimination unit tests.

## Issues
Closes #1534
Closes #1535

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/tc-1073-16p-lr2-slots.test.ts __tests__/lib/double-elimination.test.ts --runInBand
- npm test -- --runInBand
- npm run lint (passes with existing warnings)
