### PR TITLE
test: cover orphan TA eliminated entries

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2495,6 +2495,18 @@
   5. 最後に脱落したプレイヤーの `taFinalsPoints` が、最初に脱落したプレイヤーの `taFinalsPoints` より大きいことを確認
 - **期待結果**: 総合ランキングの TA Finals 配点が「最後まで生き残った順」を反映する。早期脱落者が後期脱落者を上回ることはない
 
+## TC-1068: TA Finals の orphan eliminated entry は末尾に並ぶ (issue #1068)
+- **URL**: /api/tournaments/[temp-id]/ta/phases?phase=phase3
+- **authRequired**: true (admin)
+- **背景**: `eliminated: true` だが Phase 3 の `rounds[].eliminatedIds` に存在しない legacy/orphan entry は、脱落ラウンドを復元できないため、round-backed の脱落者より低い順位として扱う。
+- **手順**:
+  1. Phase 3 entries に active player、round 1 脱落者、round 2 脱落者、`eliminated=true` だが `eliminatedIds` 未登録の orphan player を用意する
+  2. `/api/tournaments/[temp-id]/ta/phases?phase=phase3` の表示用 entries 並び順を取得する
+  3. active player が先頭、round 2 脱落者、round 1 脱落者、orphan player の順になることを確認する
+  4. orphan player の速い qualification time や rank が round-backed 脱落者を追い越さないことを確認する
+- **期待結果**: `eliminatedIds` に履歴がない eliminated entry は fallback round `-1` として扱われ、すべての round-backed 脱落者の後ろに表示される
+- **スクリプト**: smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
+
 ## TC-809: TA Phase 1 で未提出ラウンドをキャンセルできる
 - **URL**: /tournaments/[temp-id]/ta/phase1
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
@@ -623,6 +623,89 @@ describe('GET /api/tournaments/[id]/ta/phases', () => {
       ]);
     });
 
+    it('keeps orphaned eliminated entries after round-backed eliminations', async () => {
+      (prisma.tTEntry.findMany as jest.Mock).mockResolvedValue([
+        {
+          ...mockEntries[0],
+          id: 'entry-orphan-eliminated',
+          playerId: 'player-orphan-eliminated',
+          lives: 0,
+          eliminated: true,
+          totalTime: 45000,
+          rank: 1,
+          player: { ...mockEntries[0].player, id: 'player-orphan-eliminated', nickname: 'orphan-out' },
+        },
+        {
+          ...mockEntries[0],
+          id: 'entry-eliminated-early',
+          playerId: 'player-eliminated-early',
+          lives: 0,
+          eliminated: true,
+          totalTime: 50000,
+          rank: 2,
+          player: { ...mockEntries[0].player, id: 'player-eliminated-early', nickname: 'early-out' },
+        },
+        {
+          ...mockEntries[0],
+          id: 'entry-eliminated-late',
+          playerId: 'player-eliminated-late',
+          lives: 0,
+          eliminated: true,
+          totalTime: 90000,
+          rank: 4,
+          player: { ...mockEntries[0].player, id: 'player-eliminated-late', nickname: 'late-out' },
+        },
+        {
+          ...mockEntries[0],
+          id: 'entry-active',
+          playerId: 'player-active',
+          lives: 2,
+          eliminated: false,
+          totalTime: 80000,
+          rank: 3,
+          player: { ...mockEntries[0].player, id: 'player-active', nickname: 'active' },
+        },
+      ]);
+      (prisma.tTPhaseRound.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'round-1',
+          phase: 'phase3',
+          roundNumber: 1,
+          course: 'MC1',
+          results: [
+            { playerId: 'player-eliminated-early', timeMs: 95000, isRetry: false },
+            { playerId: 'player-eliminated-late', timeMs: 85000, isRetry: false },
+          ],
+          eliminatedIds: ['player-eliminated-early'],
+          livesReset: false,
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+        {
+          id: 'round-2',
+          phase: 'phase3',
+          roundNumber: 2,
+          course: 'DP1',
+          results: [
+            { playerId: 'player-eliminated-early', timeMs: 75000, isRetry: false },
+            { playerId: 'player-eliminated-late', timeMs: 96000, isRetry: false },
+          ],
+          eliminatedIds: ['player-eliminated-late'],
+          livesReset: false,
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+      ]);
+
+      await phasesRoute.GET(createRequest('?phase=phase3'), { params: mockParams });
+
+      const call = NextResponse.json.mock.calls[0][0];
+      expect(call.data.entries.map((entry: { playerId: string }) => entry.playerId)).toEqual([
+        'player-active',
+        'player-eliminated-late',
+        'player-eliminated-early',
+        'player-orphan-eliminated',
+      ]);
+    });
+
     it('should query rounds with correct phase filter', async () => {
       await phasesRoute.GET(createRequest('?phase=phase3'), { params: mockParams });
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -20,6 +20,17 @@ describe('E2E case drift coverage', () => {
   const tcTaFlow = readE2eScript('tc-ta-flow.js');
   const gpFinalsValidators = readE2eLib('gp-finals-validators.js');
   const tc1073Lr2Slots = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'tc-1073-16p-lr2-slots.test.ts');
+  const taPhasesRouteTest = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'app',
+    'api',
+    'tournaments',
+    '[id]',
+    'ta',
+    'phases',
+    'route.test.ts',
+  );
 
   it.each([
     ['TC-352', tcAll],
@@ -64,6 +75,21 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('TC-TA-FLOW-24-RANK');
     expect(section).toContain('npm run e2e:preview:ta-flow');
     expect(tcTaFlow).toContain("{ name: 'TC-TA-FLOW-24', fn: runFullFlow }");
+  });
+
+  it('keeps TC-1068 aligned with orphan eliminated-entry ordering coverage', () => {
+    const section = e2eCaseSection('TC-1068');
+
+    expect(section).toContain('issue #1068');
+    expect(section).toContain('`eliminatedIds`');
+    expect(section).toContain('orphan player');
+    expect(section).toContain('fallback round `-1`');
+    expect(section).toContain('smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts');
+    expect(taPhasesRouteTest).toContain('keeps orphaned eliminated entries after round-backed eliminations');
+    expect(taPhasesRouteTest).toContain('player-orphan-eliminated');
+    expect(taPhasesRouteTest).toContain("'player-eliminated-late'");
+    expect(taPhasesRouteTest).toContain("'player-eliminated-early'");
+    expect(taPhasesRouteTest).toContain("'player-orphan-eliminated'");
   });
 
   it('keeps TC-717 aligned with the assignedCups scenario', () => {

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
@@ -111,6 +111,8 @@ function sortPhaseEntriesForDisplay<T extends PhaseEntryForDisplay>(
 
     const aMeta = eliminationMeta.get(a.playerId);
     const bMeta = eliminationMeta.get(b.playerId);
+    // Entries marked eliminated without matching round history are legacy/orphaned data;
+    // keep them behind all round-backed eliminations instead of inventing placement.
     const aRound = aMeta?.roundNumber ?? -1;
     const bRound = bMeta?.roundNumber ?? -1;
     if (aRound !== bRound) return bRound - aRound;


### PR DESCRIPTION
Summary
- Add TC-1068 E2E scenario coverage for TA finals eliminated entries missing from round history.
- Add drift and API route unit coverage proving orphan eliminated entries sort behind round-backed eliminations.
- Document the legacy/orphan fallback intent in the phase display sorter.

Issues: Closes #1068

Validation
- git diff --check
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts' '__tests__/docs/e2e-cases-drift.test.ts'
- npm run lint
- npm test -- --runInBand