### PR TITLE
test: reduce TC-1068 drift wording coupling

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -80,16 +80,26 @@ describe('E2E case drift coverage', () => {
   it('keeps TC-1068 aligned with orphan eliminated-entry ordering coverage', () => {
     const section = e2eCaseSection('TC-1068');
 
+    // Keep the doc assertions intentionally narrow: TC prose can change as long as
+    // it still links the issue to the executable API route coverage.
     expect(section).toContain('issue #1068');
-    expect(section).toContain('`eliminatedIds`');
-    expect(section).toContain('orphan player');
-    expect(section).toContain('fallback round `-1`');
     expect(section).toContain('smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts');
-    expect(taPhasesRouteTest).toContain('keeps orphaned eliminated entries after round-backed eliminations');
-    expect(taPhasesRouteTest).toContain('player-orphan-eliminated');
-    expect(taPhasesRouteTest).toContain("'player-eliminated-late'");
-    expect(taPhasesRouteTest).toContain("'player-eliminated-early'");
-    expect(taPhasesRouteTest).toContain("'player-orphan-eliminated'");
+    const routeCase = sectionBetween(
+      taPhasesRouteTest,
+      "it('keeps orphaned eliminated entries after round-backed eliminations'",
+      "it('should query rounds with correct phase filter'",
+    );
+    expect(routeCase).toContain('player-orphan-eliminated');
+    const orderAssertion = routeCase.slice(routeCase.indexOf('expect(call.data.entries.map'));
+    const expectedOrder = [
+      "'player-active'",
+      "'player-eliminated-late'",
+      "'player-eliminated-early'",
+      "'player-orphan-eliminated'",
+    ];
+    const orderIndexes = expectedOrder.map((playerId) => orderAssertion.indexOf(playerId));
+    expect(orderIndexes.every((index) => index >= 0)).toBe(true);
+    expect(orderIndexes).toEqual([...orderIndexes].sort((a, b) => a - b));
   });
 
   it('keeps TC-717 aligned with the assignedCups scenario', () => {


### PR DESCRIPTION
Summary
- Narrow TC-1068 drift assertions so E2E_TEST_CASES.md prose can be rewritten without breaking the test.
- Keep the executable coverage check focused on the route test case and the asserted player ordering.
- Add a short comment documenting the intended boundary between doc linkage and semantic test coverage.

Issues: Closes #1540

Validation
- git diff --check
- npm test -- --runTestsByPath '__tests__/docs/e2e-cases-drift.test.ts'
- npm run lint -- --quiet