### PR TITLE
test: clarify drift anchor failures

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -90,7 +90,9 @@ describe('E2E case drift coverage', () => {
       "it('should query rounds with correct phase filter'",
     );
     expect(routeCase).toContain('player-orphan-eliminated');
-    const orderAssertion = routeCase.slice(routeCase.indexOf('expect(call.data.entries.map'));
+    const anchorIdx = routeCase.indexOf('expect(call.data.entries.map');
+    expect(anchorIdx).toBeGreaterThanOrEqual(0);
+    const orderAssertion = routeCase.slice(anchorIdx);
     const expectedOrder = [
       "'player-active'",
       "'player-eliminated-late'",


### PR DESCRIPTION
Summary
- Add an explicit TC-1068 drift-test anchor assertion before slicing the route-test body.
- Make anchor text changes fail with a clear expectation instead of falling through to a vague ordering failure.

Issues: Closes #1542

Validation
- git diff --check
- npm test -- --runTestsByPath '__tests__/docs/e2e-cases-drift.test.ts'
- npm run lint -- --quiet