### PR TITLE
test: document TA eliminatedIds ordering

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2507,6 +2507,18 @@
 - **期待結果**: `eliminatedIds` に履歴がない eliminated entry は fallback round `-1` として扱われ、すべての round-backed 脱落者の後ろに表示される
 - **スクリプト**: smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
 
+## TC-1067: TA Finals の同時脱落者は eliminatedIds の順序で並ぶ (issue #1067)
+- **URL**: /api/tournaments/[temp-id]/ta/phases?phase=phase3
+- **authRequired**: true (admin)
+- **背景**: 同一ラウンドで同じ `timeMs` のまま複数プレイヤーが脱落した場合、表示順位は `rounds[].eliminatedIds` の配列順で安定させる。`eliminatedIds` は同ラウンド・同タイムの脱落者を並べるための保存順で、先頭ほど表示順でも先に扱う。
+- **手順**:
+  1. Phase 3 entries に active player と、同一ラウンドで脱落した2名を用意する
+  2. 該当 round の `results` では2名の `timeMs` を同じ値にする
+  3. 該当 round の `eliminatedIds` を `[player-a, player-b]` にする
+  4. `/api/tournaments/[temp-id]/ta/phases?phase=phase3` の表示用 entries 並び順を取得する
+- **期待結果**: active player が先頭になり、同一ラウンド・同一タイムの脱落者は `eliminatedIds` の先頭 `player-a`、次に `player-b` の順に並ぶ
+- **スクリプト**: smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
+
 ## TC-809: TA Phase 1 で未提出ラウンドをキャンセルできる
 - **URL**: /tournaments/[temp-id]/ta/phase1
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
@@ -623,6 +623,65 @@ describe('GET /api/tournaments/[id]/ta/phases', () => {
       ]);
     });
 
+    it('uses eliminatedIds order as the tiebreaker for same-round same-time eliminations', async () => {
+      (prisma.tTEntry.findMany as jest.Mock).mockResolvedValue([
+        {
+          ...mockEntries[0],
+          id: 'entry-eliminated-second',
+          playerId: 'player-eliminated-second',
+          lives: 0,
+          eliminated: true,
+          totalTime: 45000,
+          rank: 1,
+          player: { ...mockEntries[0].player, id: 'player-eliminated-second', nickname: 'second-out' },
+        },
+        {
+          ...mockEntries[0],
+          id: 'entry-eliminated-first',
+          playerId: 'player-eliminated-first',
+          lives: 0,
+          eliminated: true,
+          totalTime: 90000,
+          rank: 4,
+          player: { ...mockEntries[0].player, id: 'player-eliminated-first', nickname: 'first-out' },
+        },
+        {
+          ...mockEntries[0],
+          id: 'entry-active',
+          playerId: 'player-active',
+          lives: 2,
+          eliminated: false,
+          totalTime: 80000,
+          rank: 3,
+          player: { ...mockEntries[0].player, id: 'player-active', nickname: 'active' },
+        },
+      ]);
+      (prisma.tTPhaseRound.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'round-1',
+          phase: 'phase3',
+          roundNumber: 1,
+          course: 'MC1',
+          results: [
+            { playerId: 'player-eliminated-second', timeMs: 88000, isRetry: false },
+            { playerId: 'player-eliminated-first', timeMs: 88000, isRetry: false },
+          ],
+          eliminatedIds: ['player-eliminated-first', 'player-eliminated-second'],
+          livesReset: false,
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+      ]);
+
+      await phasesRoute.GET(createRequest('?phase=phase3'), { params: mockParams });
+
+      const call = NextResponse.json.mock.calls[0][0];
+      expect(call.data.entries.map((entry: { playerId: string }) => entry.playerId)).toEqual([
+        'player-active',
+        'player-eliminated-first',
+        'player-eliminated-second',
+      ]);
+    });
+
     it('keeps orphaned eliminated entries after round-backed eliminations', async () => {
       (prisma.tTEntry.findMany as jest.Mock).mockResolvedValue([
         {

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -104,6 +104,37 @@ describe('E2E case drift coverage', () => {
     expect(orderIndexes).toEqual([...orderIndexes].sort((a, b) => a - b));
   });
 
+  it('keeps TC-1067 aligned with eliminatedIds index tiebreak coverage', () => {
+    const section = e2eCaseSection('TC-1067');
+
+    expect(section).toContain('issue #1067');
+    expect(section).toContain('同一ラウンド');
+    expect(section).toContain('同じ `timeMs`');
+    expect(section).toContain('eliminatedIds');
+    expect(section).toContain('smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts');
+
+    const routeCase = sectionBetween(
+      taPhasesRouteTest,
+      "it('uses eliminatedIds order as the tiebreaker for same-round same-time eliminations'",
+      "it('keeps orphaned eliminated entries after round-backed eliminations'",
+    );
+    expect(routeCase).toContain('player-eliminated-first');
+    expect(routeCase).toContain('player-eliminated-second');
+    expect(routeCase).toContain("eliminatedIds: ['player-eliminated-first', 'player-eliminated-second']");
+    expect(routeCase).toContain('timeMs: 88000');
+    const anchorIdx = routeCase.indexOf('expect(call.data.entries.map');
+    expect(anchorIdx).toBeGreaterThanOrEqual(0);
+    const orderAssertion = routeCase.slice(anchorIdx);
+    const expectedOrder = [
+      "'player-active'",
+      "'player-eliminated-first'",
+      "'player-eliminated-second'",
+    ];
+    const orderIndexes = expectedOrder.map((playerId) => orderAssertion.indexOf(playerId));
+    expect(orderIndexes.every((index) => index >= 0)).toBe(true);
+    expect(orderIndexes).toEqual([...orderIndexes].sort((a, b) => a - b));
+  });
+
   it('keeps TC-717 aligned with the assignedCups scenario', () => {
     const section = e2eCaseSection('TC-717');
 

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
@@ -119,6 +119,7 @@ function sortPhaseEntriesForDisplay<T extends PhaseEntryForDisplay>(
     if ((aMeta?.timeMs ?? Number.POSITIVE_INFINITY) !== (bMeta?.timeMs ?? Number.POSITIVE_INFINITY)) {
       return (aMeta?.timeMs ?? Number.POSITIVE_INFINITY) - (bMeta?.timeMs ?? Number.POSITIVE_INFINITY);
     }
+    // eliminatedIds preserves the authoritative same-round display order when timeMs is tied.
     if ((aMeta?.index ?? Number.POSITIVE_INFINITY) !== (bMeta?.index ?? Number.POSITIVE_INFINITY)) {
       return (aMeta?.index ?? Number.POSITIVE_INFINITY) - (bMeta?.index ?? Number.POSITIVE_INFINITY);
     }


### PR DESCRIPTION
Summary
- Add TC-1067 to document the TA Finals eliminatedIds same-round same-time ordering contract.
- Add drift coverage and API route coverage that pin eliminatedIds index order before qualification fallbacks.
- Clarify the display-order contract directly beside the phase entry sorting tiebreaker.

Issues: Closes #1067

Validation
- npm test -- --runTestsByPath __tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts
- npm run lint
- git diff --check