### PR TITLE
test: clarify TC-1067 fixture intent

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2517,6 +2517,7 @@
   3. 該当 round の `eliminatedIds` を `[player-a, player-b]` にする
   4. `/api/tournaments/[temp-id]/ta/phases?phase=phase3` の表示用 entries 並び順を取得する
 - **期待結果**: active player が先頭になり、同一ラウンド・同一タイムの脱落者は `eliminatedIds` の先頭 `player-a`、次に `player-b` の順に並ぶ
+- **備考**: route test の fixture は `totalTime` / `rank` を意図的に `eliminatedIds` 順と逆向きにし、同一ラウンド・同一タイムでは fallback の qualification fields ではなく `eliminatedIds` index が使われることを固定する
 - **スクリプト**: smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
 
 ## TC-809: TA Phase 1 で未提出ラウンドをキャンセルできる

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
@@ -624,6 +624,8 @@ describe('GET /api/tournaments/[id]/ta/phases', () => {
     });
 
     it('uses eliminatedIds order as the tiebreaker for same-round same-time eliminations', async () => {
+      // Keep totalTime/rank intentionally opposite to eliminatedIds order so this
+      // test proves same-time ordering does not fall through to qualification fields.
       (prisma.tTEntry.findMany as jest.Mock).mockResolvedValue([
         {
           ...mockEntries[0],

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -111,6 +111,9 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('同一ラウンド');
     expect(section).toContain('同じ `timeMs`');
     expect(section).toContain('eliminatedIds');
+    expect(section).toContain('totalTime');
+    expect(section).toContain('rank');
+    expect(section).toContain('fallback の qualification fields ではなく `eliminatedIds` index');
     expect(section).toContain('smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts');
 
     const routeCase = sectionBetween(
@@ -120,6 +123,7 @@ describe('E2E case drift coverage', () => {
     );
     expect(routeCase).toContain('player-eliminated-first');
     expect(routeCase).toContain('player-eliminated-second');
+    expect(routeCase).toContain('Keep totalTime/rank intentionally opposite to eliminatedIds order');
     expect(routeCase).toContain("eliminatedIds: ['player-eliminated-first', 'player-eliminated-second']");
     expect(routeCase).toContain('timeMs: 88000');
     const anchorIdx = routeCase.indexOf('expect(call.data.entries.map');


### PR DESCRIPTION
Summary
- Clarify that TC-1067 intentionally keeps totalTime/rank opposite to eliminatedIds order.
- Extend the TC-1067 scenario and drift test so the fixture intent remains documented.

Issues: Closes #1545

Validation
- npm test -- --runTestsByPath __tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts
- npm run lint
- git diff --check