### PR TITLE
fix: translate qualification playoff broadcast label

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2495,6 +2495,18 @@
   5. 最後に脱落したプレイヤーの `taFinalsPoints` が、最初に脱落したプレイヤーの `taFinalsPoints` より大きいことを確認
 - **期待結果**: 総合ランキングの TA Finals 配点が「最後まで生き残った順」を反映する。早期脱落者が後期脱落者を上回ることはない
 
+## TC-1062: 予選同着プレーオフの配信ラベルは表示言語と一致する (issue #1062)
+- **URL**: /tournaments/[temp-id]/bm, /tournaments/[temp-id]/mr
+- **authRequired**: true (admin)
+- **背景**: BM/MR 予選で同順位プレーオフが必要になったとき、管理画面の同着プレーオフカードと OBS 配信用 `matchLabel` は同じ翻訳キーを使う。過去の実装ではカード表示だけが翻訳され、配信ラベルは英語固定の `Qualification Playoff Rank N` になっていた。
+- **手順**:
+  1. 2名以上が同じ暫定順位になる予選データを用意し、`QualificationPlayoffManager` を表示する
+  2. 同着プレーオフカードのタイトルが `playoffGroupTitle` の翻訳で表示されることを確認する
+  3. 管理者として「配信に反映」を実行する
+  4. `onBroadcast` に渡される `matchInfo.matchLabel` がカードタイトルと同じ `playoffGroupTitle` 翻訳値になることを確認する
+- **期待結果**: OBS 配信用の lower-frame label は UI 表示と同じ言語・同じ順位表記になる
+- **スクリプト**: smkc-score-app/__tests__/components/tournament/qualification-playoff-manager.test.tsx + smkc-score-app/__tests__/static/tc-1062-qualification-playoff-label.test.ts
+
 ## TC-1068: TA Finals の orphan eliminated entry は末尾に並ぶ (issue #1068)
 - **URL**: /api/tournaments/[temp-id]/ta/phases?phase=phase3
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/components/tournament/qualification-playoff-manager.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/qualification-playoff-manager.test.tsx
@@ -41,7 +41,7 @@ describe("QualificationPlayoffManager broadcast", () => {
 
     await waitFor(() => expect(onBroadcast).toHaveBeenCalledTimes(1));
     expect(onBroadcast).toHaveBeenCalledWith("Mario", "Luigi", {
-      matchLabel: "Qualification Playoff Rank 3",
+      matchLabel: "Playoff rank 3",
       player1Wins: null,
       player2Wins: null,
       matchFt: null,

--- a/smkc-score-app/__tests__/static/tc-1062-qualification-playoff-label.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1062-qualification-playoff-label.test.ts
@@ -1,0 +1,30 @@
+import { e2eCaseSection, readRepoFile, sectionBetween } from '../helpers/e2e-cases';
+
+describe('TC-1062 qualification playoff broadcast label guard', () => {
+  it('documents the review follow-up scenario', () => {
+    const section = e2eCaseSection('TC-1062');
+
+    expect(section).toContain('issue #1062');
+    expect(section).toContain('playoffGroupTitle');
+    expect(section).toContain('matchInfo.matchLabel');
+    expect(section).toContain('qualification-playoff-manager.test.tsx');
+  });
+
+  it('keeps the broadcast match label on the translated playoff title', () => {
+    const source = readRepoFile(
+      'smkc-score-app',
+      'src',
+      'components',
+      'tournament',
+      'qualification-playoff-manager.tsx',
+    );
+    const broadcastBlock = sectionBetween(
+      source,
+      'await onBroadcast(group.players[0].nickname, group.players[1].nickname',
+      'setBroadcastingGroupId(null);',
+    );
+
+    expect(broadcastBlock).toContain('matchLabel: tc("playoffGroupTitle", { rank: group.rank })');
+    expect(broadcastBlock).not.toContain('Qualification Playoff Rank');
+  });
+});

--- a/smkc-score-app/src/components/tournament/qualification-playoff-manager.tsx
+++ b/smkc-score-app/src/components/tournament/qualification-playoff-manager.tsx
@@ -110,7 +110,7 @@ export function QualificationPlayoffManager({
                     onClick={async () => {
                       setBroadcastingGroupId(group.id);
                       await onBroadcast(group.players[0].nickname, group.players[1].nickname, {
-                        matchLabel: `Qualification Playoff Rank ${group.rank}`,
+                        matchLabel: tc("playoffGroupTitle", { rank: group.rank }),
                         player1Wins: null,
                         player2Wins: null,
                         matchFt: null,


### PR DESCRIPTION
## Summary
- add TC-1062 E2E scenario coverage for localized qualification playoff broadcast labels
- use the existing `playoffGroupTitle` translation for `QualificationPlayoffManager` broadcast `matchLabel`
- add component/static guards so the broadcast label stays aligned with the displayed playoff title

## Issues
Closes #1062

## Validation
- `npm test -- --runTestsByPath __tests__/components/tournament/qualification-playoff-manager.test.tsx __tests__/static/tc-1062-qualification-playoff-label.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npm run lint` (exit 0; existing warnings only)
- `git diff --check`
