### PR TITLE
test: address overlay toast title followups

### DIFF
--- a/smkc-score-app/__tests__/e2e/overlay-toast-assertions.test.ts
+++ b/smkc-score-app/__tests__/e2e/overlay-toast-assertions.test.ts
@@ -1,37 +1,28 @@
 describe('overlay toast title assertions', () => {
   let hasKnownOverlayToastTitle: (text: string) => boolean;
+  let titleCases: string[];
+  let rejectedTitleCases: string[];
 
   beforeAll(async () => {
     const helper = await import('../../e2e/lib/overlay-toast-assertions.js') as {
+      OVERLAY_TOAST_TITLE_CASES: string[];
+      OVERLAY_TOAST_TITLE_REJECTIONS: string[];
       hasKnownOverlayToastTitle: (text: string) => boolean;
     };
+    titleCases = helper.OVERLAY_TOAST_TITLE_CASES;
+    rejectedTitleCases = helper.OVERLAY_TOAST_TITLE_REJECTIONS;
     hasKnownOverlayToastTitle = helper.hasKnownOverlayToastTitle;
   });
 
   it('accepts concrete overlay event title terms', () => {
-    const cases = [
-      '総合順位を更新しました',
-      '予選確定',
-      '試合終了',
-      'スコア申告',
-      'タイム更新',
-      'Overall Ranking Updated',
-      'Qualification Locked',
-      'Match Completed',
-      'Time Attack Phase 1 Started',
-      'Score Reported',
-      'Qualification summary',
-      'Ranking snapshot',
-      'タイムトライアル予選を完走',
-    ];
-
-    for (const title of cases) {
+    for (const title of titleCases) {
       expect(hasKnownOverlayToastTitle(title)).toBe(true);
     }
   });
 
   it('does not accept the generic Time word by itself', () => {
-    expect(hasKnownOverlayToastTitle('Server Time: 2026-05-01T00:00:00.000Z')).toBe(false);
-    expect(hasKnownOverlayToastTitle('Time')).toBe(false);
+    for (const title of rejectedTitleCases) {
+      expect(hasKnownOverlayToastTitle(title)).toBe(false);
+    }
   });
 });

--- a/smkc-score-app/e2e/lib/overlay-toast-assertions.js
+++ b/smkc-score-app/e2e/lib/overlay-toast-assertions.js
@@ -1,10 +1,33 @@
 const OVERLAY_TOAST_TITLE_PATTERN =
   /(更新|確定|終了|申告|タイム|Updated|Locked|Completed|Started|Reported|Qualification|Ranking|Time\s+Attack)/i;
 
+const OVERLAY_TOAST_TITLE_CASES = [
+  '総合順位を更新しました',
+  '予選確定',
+  '試合終了',
+  'スコア申告',
+  'タイム更新',
+  'Overall Ranking Updated',
+  'Qualification Locked',
+  'Match Completed',
+  'Time Attack Phase 1 Started',
+  'Score Reported',
+  'Qualification summary',
+  'Ranking snapshot',
+  'タイムトライアル予選を完走',
+];
+
+const OVERLAY_TOAST_TITLE_REJECTIONS = [
+  'Server Time: 2026-05-01T00:00:00.000Z',
+  'Time',
+];
+
 function hasKnownOverlayToastTitle(text) {
   return OVERLAY_TOAST_TITLE_PATTERN.test(text || '');
 }
 
 module.exports = {
+  OVERLAY_TOAST_TITLE_CASES,
+  OVERLAY_TOAST_TITLE_REJECTIONS,
   hasKnownOverlayToastTitle,
 };

--- a/smkc-score-app/e2e/tc-overlay.js
+++ b/smkc-score-app/e2e/tc-overlay.js
@@ -75,7 +75,11 @@ const {
   makeTaTimesForRank,
   BASE,
 } = require('./lib/common');
-const { hasKnownOverlayToastTitle } = require('./lib/overlay-toast-assertions');
+const {
+  OVERLAY_TOAST_TITLE_CASES,
+  OVERLAY_TOAST_TITLE_REJECTIONS,
+  hasKnownOverlayToastTitle,
+} = require('./lib/overlay-toast-assertions');
 const { runSuite } = require('./lib/runner');
 
 const POLL_TIMEOUT_MS = 15_000;
@@ -97,26 +101,6 @@ function hasQualificationCompletedTitle(title) {
 function hasQualificationLockedTitle(title) {
   return /予選確定/.test(title || '') || /Qualification\s+Locked/i.test(title || '');
 }
-
-const OVERLAY_TOAST_TITLE_CASES = [
-  '総合順位を更新しました',
-  '予選確定',
-  '試合終了',
-  'スコア申告',
-  'タイム更新',
-  'Overall Ranking Updated',
-  'Qualification Locked',
-  'Match Completed',
-  'Time Attack Phase 1 Started',
-  'Score Reported',
-  'Qualification summary',
-  'Ranking snapshot',
-];
-
-const OVERLAY_TOAST_TITLE_REJECTIONS = [
-  'Server Time: 2026-05-01T00:00:00.000Z',
-  'Time',
-];
 
 /**
  * Unauthenticated GET against the configured overlay endpoint via Node's
@@ -1163,7 +1147,7 @@ async function runTc906(adminPage) {
 }
 
 /* ───────── TC-927: known overlay toast title terms ───────── */
-async function runTc927() {
+function runTc927() {
   try {
     const rejected = OVERLAY_TOAST_TITLE_CASES.filter((title) => !hasKnownOverlayToastTitle(title));
     const falselyAccepted = OVERLAY_TOAST_TITLE_REJECTIONS.filter((title) => hasKnownOverlayToastTitle(title));


### PR DESCRIPTION
## Summary
- Centralized overlay toast title acceptance/rejection fixtures in `overlay-toast-assertions.js` so TC-927 and Jest use one source of truth.
- Made `runTc927` synchronous and included the missing `タイムトライアル予選を完走` title case in the shared fixture list.

## Issues
Closes #1549
Closes #1550
Closes #1551

## Validation
- `npm test -- overlay-toast-assertions.test.ts --runInBand`
- `npm test -- e2e-cases-drift.test.ts --runInBand`
- `node --check e2e/tc-overlay.js && node --check e2e/lib/overlay-toast-assertions.js`
- `node - <<'NODE' ... overlay.runTc927() ... NODE`
- `git diff --check`
- `npx eslint __tests__/e2e/overlay-toast-assertions.test.ts`
