### PR TITLE
test: cover TA finals midpoint positions

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2495,6 +2495,18 @@
   5. 最後に脱落したプレイヤーの `taFinalsPoints` が、最初に脱落したプレイヤーの `taFinalsPoints` より大きいことを確認
 - **期待結果**: 総合ランキングの TA Finals 配点が「最後まで生き残った順」を反映する。早期脱落者が後期脱落者を上回ることはない
 
+## TC-1060: TA Finals Phase 1/2 脱落者の中間順位を全件検証する (issue #1060)
+- **URL**: /api/tournaments/[temp-id]/overall-ranking
+- **authRequired**: true (admin)
+- **背景**: TA Finals の Phase 1/2 脱落者は Phase 2 が17〜20位、Phase 1 が21〜24位に割り当てられる。従来の回帰テストは境界値だけを `arrayContaining` で確認していたため、18・19・22・23位の割り当て誤りを検出できなかった。
+- **手順**:
+  1. Phase 3 の優勝者/脱落者に加え、Phase 2 の4名と Phase 1 の4名の脱落履歴を用意する
+  2. Phase 2 round 1〜4 の `eliminatedIds` が 20→19→18→17 位へ逆順に割り当たることを確認する
+  3. Phase 1 round 1〜4 の `eliminatedIds` が 24→23→22→21 位へ逆順に割り当たることを確認する
+  4. `getTAFinalsPositions` の結果が1位、2位、17〜24位を欠落なく完全一致で返すことを確認する
+- **期待結果**: TA Finals position mapping が境界値だけでなく 18・19・22・23 位を含む全対象順位を検証する
+- **スクリプト**: smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
+
 ## TC-1062: 予選同着プレーオフの配信ラベルは表示言語と一致する (issue #1062)
 - **URL**: /tournaments/[temp-id]/bm, /tournaments/[temp-id]/mr
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -77,6 +77,40 @@ describe('E2E case drift coverage', () => {
     expect(tcTaFlow).toContain("{ name: 'TC-TA-FLOW-24', fn: runFullFlow }");
   });
 
+  it('keeps TC-1060 aligned with complete TA finals position unit coverage', () => {
+    const section = e2eCaseSection('TC-1060');
+    const unitTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'lib',
+      'points',
+      'overall-ranking.test.ts',
+    );
+    const testCase = sectionBetween(
+      unitTest,
+      "it('assigns TA finals bonus positions through 24th from phase eliminations'",
+      '  });\n\n  // =========================================================================',
+    );
+
+    expect(section).toContain('issue #1060');
+    expect(section).toContain('18・19・22・23');
+    expect(section).toContain('smkc-score-app/__tests__/lib/points/overall-ranking.test.ts');
+    expect(testCase).toContain("expect(positions).toEqual([");
+    for (const [playerId, position] of [
+      ['p17', 17],
+      ['p18', 18],
+      ['p19', 19],
+      ['p20', 20],
+      ['p21', 21],
+      ['p22', 22],
+      ['p23', 23],
+      ['p24', 24],
+    ] as const) {
+      expect(testCase).toContain(`{ playerId: '${playerId}', position: ${position} }`);
+    }
+    expect(testCase).not.toContain('expect.arrayContaining');
+  });
+
   it('keeps TC-1068 aligned with orphan eliminated-entry ordering coverage', () => {
     const section = e2eCaseSection('TC-1068');
 

--- a/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
+++ b/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
@@ -480,16 +480,18 @@ describe('Overall Ranking module', () => {
 
       const positions = await getTAFinalsPositions(mockPrisma as any, TOURNAMENT_ID);
 
-      expect(positions).toEqual(
-        expect.arrayContaining([
-          { playerId: 'p1', position: 1 },
-          { playerId: 'p2', position: 2 },
-          { playerId: 'p17', position: 17 },
-          { playerId: 'p20', position: 20 },
-          { playerId: 'p21', position: 21 },
-          { playerId: 'p24', position: 24 },
-        ])
-      );
+      expect(positions).toEqual([
+        { playerId: 'p1', position: 1 },
+        { playerId: 'p2', position: 2 },
+        { playerId: 'p17', position: 17 },
+        { playerId: 'p18', position: 18 },
+        { playerId: 'p19', position: 19 },
+        { playerId: 'p20', position: 20 },
+        { playerId: 'p21', position: 21 },
+        { playerId: 'p22', position: 22 },
+        { playerId: 'p23', position: 23 },
+        { playerId: 'p24', position: 24 },
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add TC-1060 to the E2E scenario catalog for complete TA Finals Phase 1/2 position coverage.
- Add a drift guard that keeps TC-1060 linked to the executable unit coverage.
- Strengthen the TA finals position regression from boundary-only `arrayContaining` to full 1/2/17-24 exact position assertions.

## Issues
Closes #1060

## Validation
- `npm test -- --runTestsByPath __tests__/lib/points/overall-ranking.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand`
- `npx eslint __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/points/overall-ranking.test.ts`
- `git diff --check`
