### PR TITLE
test: cover participant report message branches

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1909,6 +1909,19 @@
   7. クリーンアップ
 - **期待結果**: 不一致時はマッチが未完了のまま管理者レビュー待ちになる
 
+## TC-1015: participant report success message branch coverage
+- **URL**: /tournaments/[temp-id]/bm/participant, /tournaments/[temp-id]/mr/participant, /tournaments/[temp-id]/gp/participant
+- **authRequired**: true (player)
+- **背景**: issue #1015/#1016。参加者側の報告完了メッセージは API の `mismatch`/`corrected`/`autoConfirmed`/`waitingFor` フラグで分岐するため、dual-report の不一致や修正送信時に汎用成功文へ落ちないことを固定する。
+- **手順**:
+  1. BM/MR/GP の既存 dual-report E2E (TC-508, TC-609, TC-708) で `mismatch: true` レスポンスが返ることを確認する
+  2. participant success-message helper の単体テストで score report の `mismatch: true` が mismatch 文言を返すことを確認する
+  3. participant success-message helper の単体テストで score report の `corrected: true` が correction 文言を返すことを確認する
+  4. participant success-message helper の単体テストで match report の `mismatch: true` が mismatch 文言を返すことを確認する
+  5. `ParticipantReportResult` の型が API レスポンス実態に合わせて boolean/string に厳密化されていることを静的ガードで確認する
+- **期待結果**: mismatch/corrected 分岐が UI helper と型定義の両方で保護され、参加者側の完了通知が API 状態に一致する
+- **スクリプト**: `smkc-score-app/__tests__/static/tc-1015-participant-report-message.test.ts`, `smkc-score-app/__tests__/lib/participant-report-message.test.ts`
+
 ## TC-709: GP決勝 — 非管理者のスコア入力拒否
 - **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)
 - **authRequired**: true (player — 管理者ではない)

--- a/smkc-score-app/__tests__/lib/participant-report-message.test.ts
+++ b/smkc-score-app/__tests__/lib/participant-report-message.test.ts
@@ -31,6 +31,18 @@ describe("participant report success messages", () => {
     );
   });
 
+  it("shows mismatch score copy when both score reports disagree", () => {
+    expect(getScoreReportSuccessMessage({ mismatch: true }, scoreMessages)).toBe(
+      "Scores reported, but the two reports do not match. Admin review is needed."
+    );
+  });
+
+  it("shows correction copy before generic score-report success copy", () => {
+    expect(getScoreReportSuccessMessage({ corrected: true }, scoreMessages)).toBe(
+      "Score correction saved."
+    );
+  });
+
   it("shows confirmed match-result copy when dual report is disabled and the API auto-confirms", () => {
     expect(getMatchReportSuccessMessage({ autoConfirmed: true }, matchMessages)).toBe(
       "Match result saved and confirmed."
@@ -40,6 +52,12 @@ describe("participant report success messages", () => {
   it("keeps dual-report waiting copy for MR/GP when the API is waiting for the other player", () => {
     expect(getMatchReportSuccessMessage({ waitingFor: "player1" }, matchMessages)).toContain(
       "Both players must report matching results"
+    );
+  });
+
+  it("shows mismatch match-result copy when both match reports disagree", () => {
+    expect(getMatchReportSuccessMessage({ mismatch: true }, matchMessages)).toBe(
+      "Match result reported, but the two reports do not match. Admin review is needed."
     );
   });
 });

--- a/smkc-score-app/__tests__/static/tc-1015-participant-report-message.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1015-participant-report-message.test.ts
@@ -1,0 +1,44 @@
+import { e2eCaseSection, readRepoFile } from '../helpers/e2e-cases';
+
+describe('TC-1015 participant report message coverage', () => {
+  const helper = readRepoFile('smkc-score-app', 'src', 'lib', 'participant-report-message.ts');
+  const unitTest = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'lib',
+    'participant-report-message.test.ts',
+  );
+
+  it('documents participant success-message mismatch and correction coverage', () => {
+    const section = e2eCaseSection('TC-1015');
+
+    expect(section).toContain('issue #1015/#1016');
+    expect(section).toContain('TC-508');
+    expect(section).toContain('TC-609');
+    expect(section).toContain('TC-708');
+    expect(section).toContain('mismatch: true');
+    expect(section).toContain('corrected: true');
+    expect(section).toContain('ParticipantReportResult');
+    expect(section).toContain('participant-report-message.test.ts');
+  });
+
+  it('keeps ParticipantReportResult typed to the report API response shape', () => {
+    expect(helper).toContain('autoConfirmed?: boolean');
+    expect(helper).toContain('corrected?: boolean');
+    expect(helper).toContain('mismatch?: boolean');
+    expect(helper).toContain('waitingFor?: string');
+    expect(helper).not.toContain('autoConfirmed?: unknown');
+    expect(helper).not.toContain('corrected?: unknown');
+    expect(helper).not.toContain('mismatch?: unknown');
+    expect(helper).not.toContain('waitingFor?: unknown');
+  });
+
+  it('keeps mismatch and correction helper branches under unit coverage', () => {
+    expect(unitTest).toContain('shows mismatch score copy');
+    expect(unitTest).toContain('shows correction copy');
+    expect(unitTest).toContain('shows mismatch match-result copy');
+    expect(unitTest).toContain('getScoreReportSuccessMessage({ mismatch: true }');
+    expect(unitTest).toContain('getScoreReportSuccessMessage({ corrected: true }');
+    expect(unitTest).toContain('getMatchReportSuccessMessage({ mismatch: true }');
+  });
+});

--- a/smkc-score-app/src/lib/participant-report-message.ts
+++ b/smkc-score-app/src/lib/participant-report-message.ts
@@ -1,8 +1,8 @@
 export type ParticipantReportResult = {
-  autoConfirmed?: unknown;
-  corrected?: unknown;
-  mismatch?: unknown;
-  waitingFor?: unknown;
+  autoConfirmed?: boolean;
+  corrected?: boolean;
+  mismatch?: boolean;
+  waitingFor?: string;
 };
 
 export type ScoreReportMessages = {


### PR DESCRIPTION
Summary
- Add TC-1015 E2E scenario coverage tying participant report success-message branches to existing BM/MR/GP dual-report mismatch flows.
- Add unit coverage for score mismatch, score correction, and match-result mismatch success copy.
- Tighten ParticipantReportResult fields from unknown to the report API response shape and keep the static guard on durable call signatures.

Issues: Closes #1015, Closes #1016, Closes #1571

Validation
- npm test -- --runTestsByPath __tests__/lib/participant-report-message.test.ts __tests__/static/tc-1015-participant-report-message.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm test -- --runTestsByPath __tests__/static/tc-1015-participant-report-message.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npx eslint src/lib/participant-report-message.ts __tests__/lib/participant-report-message.test.ts __tests__/static/tc-1015-participant-report-message.test.ts
- npx eslint __tests__/static/tc-1015-participant-report-message.test.ts
- git diff --check
- npx tsc --noEmit (fails on pre-existing project-wide test typing errors outside this diff)
