### PR TITLE
test: harden participant report static guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1912,13 +1912,13 @@
 ## TC-1015: participant report success message branch coverage
 - **URL**: /tournaments/[temp-id]/bm/participant, /tournaments/[temp-id]/mr/participant, /tournaments/[temp-id]/gp/participant
 - **authRequired**: true (player)
-- **背景**: issue #1015/#1016。参加者側の報告完了メッセージは API の `mismatch`/`corrected`/`autoConfirmed`/`waitingFor` フラグで分岐するため、dual-report の不一致や修正送信時に汎用成功文へ落ちないことを固定する。
+- **背景**: issue #1015/#1016/#1571。参加者側の報告完了メッセージは API の `mismatch`/`corrected`/`autoConfirmed`/`waitingFor` フラグで分岐するため、dual-report の不一致や修正送信時に汎用成功文へ落ちないことを固定する。
 - **手順**:
   1. BM/MR/GP の既存 dual-report E2E (TC-508, TC-609, TC-708) で `mismatch: true` レスポンスが返ることを確認する
   2. participant success-message helper の単体テストで score report の `mismatch: true` が mismatch 文言を返すことを確認する
   3. participant success-message helper の単体テストで score report の `corrected: true` が correction 文言を返すことを確認する
   4. participant success-message helper の単体テストで match report の `mismatch: true` が mismatch 文言を返すことを確認する
-  5. `ParticipantReportResult` の型が API レスポンス実態に合わせて boolean/string に厳密化されていることを静的ガードで確認する
+  5. `ParticipantReportResult` の型が API レスポンス実態に合わせて boolean/string に厳密化され、静的ガードが unit test の説明文ではなく関数呼び出しシグネチャを確認することを検証する
 - **期待結果**: mismatch/corrected 分岐が UI helper と型定義の両方で保護され、参加者側の完了通知が API 状態に一致する
 - **スクリプト**: `smkc-score-app/__tests__/static/tc-1015-participant-report-message.test.ts`, `smkc-score-app/__tests__/lib/participant-report-message.test.ts`
 

--- a/smkc-score-app/__tests__/static/tc-1015-participant-report-message.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1015-participant-report-message.test.ts
@@ -34,9 +34,6 @@ describe('TC-1015 participant report message coverage', () => {
   });
 
   it('keeps mismatch and correction helper branches under unit coverage', () => {
-    expect(unitTest).toContain('shows mismatch score copy');
-    expect(unitTest).toContain('shows correction copy');
-    expect(unitTest).toContain('shows mismatch match-result copy');
     expect(unitTest).toContain('getScoreReportSuccessMessage({ mismatch: true }');
     expect(unitTest).toContain('getScoreReportSuccessMessage({ corrected: true }');
     expect(unitTest).toContain('getMatchReportSuccessMessage({ mismatch: true }');


### PR DESCRIPTION
Summary
- Remove fragile static assertions that depended on participant-report-message unit test descriptions.
- Keep the TC-1015 static guard focused on durable helper call signatures.
- Update the E2E scenario note to include the review follow-up coverage.

Issues: Closes #1571

Validation
- npm test -- --runTestsByPath __tests__/static/tc-1015-participant-report-message.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npx eslint __tests__/static/tc-1015-participant-report-message.test.ts
- git diff --check
