### PR TITLE
Fix TA phase elimination placement overflow

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2520,6 +2520,18 @@
 - **期待結果**: TA Finals position mapping が境界値だけでなく 18・19・22・23 位を含む全対象順位を検証する
 - **スクリプト**: smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
 
+## TC-1059: TA Finals Phase 1/2 の想定外脱落数は順位帯を越えない (issue #1059)
+- **URL**: /api/tournaments/[temp-id]/overall-ranking
+- **authRequired**: true (admin)
+- **背景**: Phase 2 の脱落者は17〜20位、Phase 1 の脱落者は21〜24位にだけ割り当てる。想定外データで Phase 2 に5名以上、Phase 1 に5名以上の `eliminatedIds` が残ると、以前の実装では position を単純に減算し続けて Phase 2 が16位以下、Phase 1 が20位以下へ溢れる可能性があった。
+- **手順**:
+  1. Phase 3 の優勝者/脱落者に加え、Phase 2 と Phase 1 に通常より多い脱落履歴を用意する
+  2. `getTAFinalsPositions` を実行し、Phase 2 由来の順位が17〜20位だけに収まることを確認する
+  3. Phase 1 由来の順位が21〜24位だけに収まることを確認する
+  4. 範囲外の余剰脱落者が16位以下や20位以下に割り当てられないことを確認する
+- **期待結果**: TA Finals の Phase 1/2 position mapping はデータ不整合時もフェーズごとの順位帯を越えず、Phase 3 の順位帯と衝突しない
+- **スクリプト**: smkc-score-app/__tests__/lib/points/overall-ranking.test.ts + smkc-score-app/__tests__/e2e/tc-1059-ta-phase-position-floor.test.ts
+
 ## TC-1062: 予選同着プレーオフの配信ラベルは表示言語と一致する (issue #1062)
 - **URL**: /tournaments/[temp-id]/bm, /tournaments/[temp-id]/mr
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -111,6 +111,34 @@ describe('E2E case drift coverage', () => {
     expect(testCase).not.toContain('expect.arrayContaining');
   });
 
+  it('keeps TC-1059 aligned with the TA phase position floor guard', () => {
+    const section = e2eCaseSection('TC-1059');
+    const unitTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'lib',
+      'points',
+      'overall-ranking.test.ts',
+    );
+    const e2eGuard = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'e2e',
+      'tc-1059-ta-phase-position-floor.test.ts',
+    );
+
+    expect(section).toContain('issue #1059');
+    expect(section).toContain('17〜20位');
+    expect(section).toContain('21〜24位');
+    expect(section).toContain('順位帯を越えず');
+    expect(section).toContain('tc-1059-ta-phase-position-floor.test.ts');
+    expect(unitTest).toContain("does not assign excess phase1/2 eliminations outside their position ranges");
+    expect(unitTest).toContain("{ playerId: 'p16-overflow', position: 16 }");
+    expect(unitTest).toContain("{ playerId: 'p20-overflow', position: 20 }");
+    expect(e2eGuard).toContain('TC-1059');
+    expect(e2eGuard).toContain('issue #1059');
+  });
+
   it('keeps TC-1063 aligned with the combined standings memoization guard', () => {
     const section = e2eCaseSection('TC-1063');
     const tc1555 = e2eCaseSection('TC-1555');

--- a/smkc-score-app/__tests__/e2e/tc-1059-ta-phase-position-floor.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-1059-ta-phase-position-floor.test.ts
@@ -1,0 +1,22 @@
+import { e2eCaseSection, readRepoFile } from '../helpers/e2e-cases';
+
+describe('TC-1059 TA phase position floor coverage', () => {
+  it('documents and backs issue #1059 with TA finals position unit coverage', () => {
+    const section = e2eCaseSection('TC-1059');
+    const unitTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'lib',
+      'points',
+      'overall-ranking.test.ts',
+    );
+
+    expect(section).toContain('issue #1059');
+    expect(section).toContain('Phase 2');
+    expect(section).toContain('17〜20位');
+    expect(section).toContain('Phase 1');
+    expect(section).toContain('21〜24位');
+    expect(unitTest).toContain('p16-overflow');
+    expect(unitTest).toContain('p20-overflow');
+  });
+});

--- a/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
+++ b/smkc-score-app/__tests__/lib/points/overall-ranking.test.ts
@@ -493,6 +493,57 @@ describe('Overall Ranking module', () => {
         { playerId: 'p24', position: 24 },
       ]);
     });
+
+    it('does not assign excess phase1/2 eliminations outside their position ranges', async () => {
+      mockPrisma.tTEntry.findMany.mockResolvedValueOnce([
+        { playerId: 'p1', stage: 'phase3', eliminated: false, lives: 1, totalTime: 90000 },
+        { playerId: 'p2', stage: 'phase3', eliminated: true, lives: 0, totalTime: 92000 },
+        ...['p20', 'p19', 'p18', 'p17', 'p16-overflow'].map((playerId, index) => ({
+          playerId,
+          stage: 'phase2',
+          eliminated: true,
+          lives: 0,
+          totalTime: 100000 + index,
+        })),
+        ...['p24', 'p23', 'p22', 'p21', 'p20-overflow'].map((playerId, index) => ({
+          playerId,
+          stage: 'phase1',
+          eliminated: true,
+          lives: 0,
+          totalTime: 110000 + index,
+        })),
+      ]);
+      mockPrisma.tTPhaseRound.findMany.mockResolvedValueOnce([
+        { phase: 'phase1', roundNumber: 1, results: [{ playerId: 'p24', timeMs: 124000 }], eliminatedIds: ['p24'] },
+        { phase: 'phase1', roundNumber: 2, results: [{ playerId: 'p23', timeMs: 123000 }], eliminatedIds: ['p23'] },
+        { phase: 'phase1', roundNumber: 3, results: [{ playerId: 'p22', timeMs: 122000 }], eliminatedIds: ['p22'] },
+        { phase: 'phase1', roundNumber: 4, results: [{ playerId: 'p21', timeMs: 121000 }], eliminatedIds: ['p21'] },
+        { phase: 'phase1', roundNumber: 5, results: [{ playerId: 'p20-overflow', timeMs: 120000 }], eliminatedIds: ['p20-overflow'] },
+        { phase: 'phase2', roundNumber: 1, results: [{ playerId: 'p20', timeMs: 116000 }], eliminatedIds: ['p20'] },
+        { phase: 'phase2', roundNumber: 2, results: [{ playerId: 'p19', timeMs: 115000 }], eliminatedIds: ['p19'] },
+        { phase: 'phase2', roundNumber: 3, results: [{ playerId: 'p18', timeMs: 114000 }], eliminatedIds: ['p18'] },
+        { phase: 'phase2', roundNumber: 4, results: [{ playerId: 'p17', timeMs: 113000 }], eliminatedIds: ['p17'] },
+        { phase: 'phase2', roundNumber: 5, results: [{ playerId: 'p16-overflow', timeMs: 112000 }], eliminatedIds: ['p16-overflow'] },
+        { phase: 'phase3', roundNumber: 1, results: [{ playerId: 'p2', timeMs: 111000 }], eliminatedIds: ['p2'] },
+      ]);
+
+      const positions = await getTAFinalsPositions(mockPrisma as any, TOURNAMENT_ID);
+
+      expect(positions).toEqual([
+        { playerId: 'p1', position: 1 },
+        { playerId: 'p2', position: 2 },
+        { playerId: 'p17', position: 17 },
+        { playerId: 'p18', position: 18 },
+        { playerId: 'p19', position: 19 },
+        { playerId: 'p20', position: 20 },
+        { playerId: 'p21', position: 21 },
+        { playerId: 'p22', position: 22 },
+        { playerId: 'p23', position: 23 },
+        { playerId: 'p24', position: 24 },
+      ]);
+      expect(positions).not.toContainEqual({ playerId: 'p16-overflow', position: 16 });
+      expect(positions).not.toContainEqual({ playerId: 'p20-overflow', position: 20 });
+    });
   });
 
   // =========================================================================

--- a/smkc-score-app/src/lib/points/overall-ranking.ts
+++ b/smkc-score-app/src/lib/points/overall-ranking.ts
@@ -465,7 +465,7 @@ export async function getTAFinalsPositions(
     });
   };
 
-  const assignPhaseEliminations = (phase: string, startingPosition: number) => {
+  const assignPhaseEliminations = (phase: string, startingPosition: number, lowestPosition: number) => {
     let position = startingPosition;
     const eliminations = [...getPhaseEliminations(phase).entries()].sort(([, a], [, b]) => {
       if (a.round !== b.round) return a.round - b.round;
@@ -475,6 +475,16 @@ export async function getTAFinalsPositions(
 
     for (const [playerId] of eliminations) {
       if (assignedPlayerIds.has(playerId)) continue;
+      if (position < lowestPosition) {
+        logger.warn("Skipping excess TA phase elimination outside placement range", {
+          tournamentId,
+          phase,
+          playerId,
+          attemptedPosition: position,
+          lowestPosition,
+        });
+        continue;
+      }
       positions.push({ playerId, position });
       assignedPlayerIds.add(playerId);
       position -= 1;
@@ -496,8 +506,8 @@ export async function getTAFinalsPositions(
 
   // TA finals are staged from the bottom up: Phase 1 eliminations decide
   // 24th through 21st, and Phase 2 eliminations decide 20th through 17th.
-  assignPhaseEliminations("phase2", 20);
-  assignPhaseEliminations("phase1", 24);
+  assignPhaseEliminations("phase2", 20, 17);
+  assignPhaseEliminations("phase1", 24, 21);
 
   return positions.sort((a, b) => a.position - b.position || a.playerId.localeCompare(b.playerId));
 }


### PR DESCRIPTION
Summary
- Add TC-1059 coverage for TA Phase 1/2 overflow placement ranges.
- Guard TA finals phase elimination placement so excess Phase 2 eliminations cannot enter 16th or lower and excess Phase 1 eliminations cannot enter 20th or lower.
- Log skipped overflow phase eliminations for diagnostics.

Issues: Closes #1059

Validation
- npm test -- --runTestsByPath __tests__/lib/points/overall-ranking.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/tc-1059-ta-phase-position-floor.test.ts
- npm run lint
