### PR TITLE
Fix TC-1579 Jest format placeholder

### DIFF
--- a/smkc-score-app/__tests__/static/tc-1579-combined-standings-tooltip-contract.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1579-combined-standings-tooltip-contract.test.ts
@@ -42,7 +42,7 @@ describe('TC-1579 combined standings tooltip label contract', () => {
   it.each([
     ['BM', ['src', 'app', 'tournaments', '[id]', 'bm', 'page-client.tsx']],
     ['MR', ['src', 'app', 'tournaments', '[id]', 'mr', 'page-client.tsx']],
-  ] as const)('passes the localized tooltip label from %0 combined standings', (_mode, path) => {
+  ] as const)('passes the localized tooltip label from %s combined standings', (_mode, path) => {
     const source = readRepoFile('smkc-score-app', ...path);
     const combinedTab = sectionBetween(
       source,


### PR DESCRIPTION
Summary
- Replace the non-standard Jest %0 placeholder in the TC-1579 static test title with %s.

Issues: Closes #1581

Validation
- npm test -- --runTestsByPath __tests__/static/tc-1579-combined-standings-tooltip-contract.test.ts
