### PR TITLE
Clarify tooltip guard self-inspection

### DIFF
--- a/smkc-score-app/__tests__/static/tc-1578-qualification-points-tooltip-source.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1578-qualification-points-tooltip-source.test.ts
@@ -60,6 +60,7 @@ describe('TC-1578 qualification points tooltip source', () => {
     const tc1588 = e2eCaseSection('TC-1588');
     const tc1590 = e2eCaseSection('TC-1590');
     const tc1591 = e2eCaseSection('TC-1591');
+    // Split forbidden strings so this self-inspection guard does not match itself.
     const forbiddenSectionHelper = 'section' + 'Between';
     const chromiumRequire = "const { chromium } = require('play" + "wright');";
 


### PR DESCRIPTION
Summary
- Add a short comment explaining why forbidden self-inspection strings are split in the TC-1578 static guard.

Issues: Closes #1593

Validation
- npm test -- tc-1578-qualification-points-tooltip-source.test.ts --runInBand
