### PR TITLE
Guard Top-24 playoff upper seed mapping

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1348,6 +1348,19 @@
 - **期待結果**: Top-24 playoff と Phase 2 finals のシード表示は、seed 番号ではなく予選グループ順位ラベルを優先する
 - **スクリプト**: tc-bm.js TC-510（API payload の `qualificationRankLabel` を検証） + `smkc-score-app/__tests__/components/tournament/playoff-bracket.test.tsx`（UI 表示を検証）
 
+## TC-1053: BM Top-24 Phase 2 — playoff upper seed 定義欠損を検出する
+- **URL**: /api/tournaments/[id]/bm/finals (POST)
+- **authRequired**: true (admin)
+- **背景**: issue #1053。Top-24 Phase 2 は `generatePlayoffStructure(12)` の `playoff_r2` 4試合にある `advancesToUpperSeed` を使い、playoff 勝者を Upper Bracket の seed 16/12/14/10 に配置する。構造定義の変更やバグで `playoffUpperSeeds` が4件そろわない場合、勝者を欠落させたままブラケットを作ると原因調査が難しい。
+- **手順**:
+  1. 24名以上の予選済みトーナメントで Top-24 playoff を作成する
+  2. `playoff_r2` の4試合を completed にする
+  3. テストでは `generatePlayoffStructure(12)` が `playoff_r2` の `advancesToUpperSeed` を返さない状態を再現する
+  4. `POST /bm/finals { topN: 24 }` で Phase 2 を生成しようとする
+  5. Phase 2 作成が `Expected 4 playoff R2 upper seeds` の guard で停止し、finals stage の `createMany` が呼ばれないことを確認する
+- **期待結果**: Top-24 Phase 2 は `playoffUpperSeeds` が4件そろわない構造を無音で受け入れず、Upper Bracket 勝者シード欠落を防ぐ
+- **スクリプト**: n/a（構造異常のサーバーサイド防御のため `smkc-score-app/__tests__/static/tc-1053-playoff-upper-seeds-guard.test.ts` + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts` で検証）
+
 ---
 
 ## MR (Match Race) フルワークフローテスト

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1355,6 +1355,49 @@ describe('Finals Route Factory', () => {
       ]);
     });
 
+    it('Phase 2 fails fast when the malformed playoff structure is missing R2 upper seeds', async () => {
+      (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(24));
+      mockGeneratePlayoffStructure.mockReturnValue([
+        { matchNumber: 1, round: 'playoff_r1', bracket: 'winners', player1Seed: 8, player2Seed: 9, winnerGoesTo: 5, position: 2 },
+        { matchNumber: 2, round: 'playoff_r1', bracket: 'winners', player1Seed: 5, player2Seed: 12, winnerGoesTo: 6, position: 2 },
+        { matchNumber: 3, round: 'playoff_r1', bracket: 'winners', player1Seed: 6, player2Seed: 11, winnerGoesTo: 7, position: 2 },
+        { matchNumber: 4, round: 'playoff_r1', bracket: 'winners', player1Seed: 7, player2Seed: 10, winnerGoesTo: 8, position: 2 },
+        { matchNumber: 5, round: 'playoff_r2', bracket: 'winners', player1Seed: 1 },
+        { matchNumber: 6, round: 'playoff_r2', bracket: 'winners', player1Seed: 4 },
+        { matchNumber: 7, round: 'playoff_r2', bracket: 'winners', player1Seed: 3 },
+        { matchNumber: 8, round: 'playoff_r2', bracket: 'winners', player1Seed: 2 },
+      ]);
+      const playoffRows = [
+        { id: 'p-r2-5', matchNumber: 5, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-19', player2Id: 'player-8', player1: { id: 'player-19' }, player2: { id: 'player-8' } },
+        { id: 'p-r2-6', matchNumber: 6, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-6', player2Id: 'player-21', player1: { id: 'player-6' }, player2: { id: 'player-21' } },
+        { id: 'p-r2-7', matchNumber: 7, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-7', player2Id: 'player-20', player1: { id: 'player-7' }, player2: { id: 'player-20' } },
+        { id: 'p-r2-8', matchNumber: 8, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-18', player2Id: 'player-9', player1: { id: 'player-18' }, player2: { id: 'player-9' } },
+      ];
+      (prisma.bMMatch as any).findMany.mockImplementation((args: any) => {
+        if (args?.where?.stage === 'finals') return Promise.resolve([]);
+        return Promise.resolve(playoffRows);
+      });
+
+      const config = createMockConfig();
+      const { POST } = createFinalsHandlers(config);
+
+      const response = await POST(new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 24 }),
+      }), {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(500);
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to create Top-24 finals', {
+        error: expect.objectContaining({
+          message: 'Expected 4 playoff R2 upper seeds, got 0',
+        }),
+        tournamentId: 'tournament-123',
+      });
+      expect((prisma.bMMatch as any).createMany).not.toHaveBeenCalled();
+    });
+
     it('Phase 2: derives playoff winners from configured score fields for GP-style routes', async () => {
       (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(24));
       const playoffRows = [

--- a/smkc-score-app/__tests__/static/tc-1053-playoff-upper-seeds-guard.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1053-playoff-upper-seeds-guard.test.ts
@@ -1,0 +1,34 @@
+import { e2eCaseSection, readRepoFile } from '../helpers/e2e-cases';
+
+describe('TC-1053 Top-24 playoff upper seed guard', () => {
+  const finalsRoute = readRepoFile(
+    'smkc-score-app',
+    'src',
+    'lib',
+    'api-factories',
+    'finals-route.ts',
+  );
+  const unitTest = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'lib',
+    'api-factories',
+    'finals-route.test.ts',
+  );
+
+  it('documents the malformed playoff structure regression scenario', () => {
+    const section = e2eCaseSection('TC-1053');
+
+    expect(section).toContain('issue #1053');
+    expect(section).toContain('playoffUpperSeeds');
+    expect(section).toContain('advancesToUpperSeed');
+    expect(section).toContain('Expected 4 playoff R2 upper seeds');
+    expect(section).toContain('finals-route.test.ts');
+  });
+
+  it('keeps Phase 2 from silently omitting playoff winners', () => {
+    expect(finalsRoute).toContain('playoffUpperSeeds.length !== 4');
+    expect(finalsRoute).toContain('Expected 4 playoff R2 upper seeds');
+    expect(unitTest).toContain('malformed playoff structure is missing R2 upper seeds');
+  });
+});

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -1677,6 +1677,9 @@ export function createFinalsHandlers(config: FinalsConfig) {
       const playoffUpperSeeds = playoffStructure
         .filter((m) => m.round === 'playoff_r2' && m.advancesToUpperSeed)
         .map((m) => m.advancesToUpperSeed as number);
+      if (playoffUpperSeeds.length !== 4) {
+        throw new Error(`Expected 4 playoff R2 upper seeds, got ${playoffUpperSeeds.length}`);
+      }
       const playoffWinnerSeeds = playoffUpperSeeds.map((upperSeed) => {
         const winner = upperSeedToPlayer.get(upperSeed);
         if (!winner) {


### PR DESCRIPTION
Summary
- Add TC-1053 scenario and static guard coverage for malformed Top-24 playoff R2 seed definitions.
- Add a Phase 2 regression test that simulates missing advancesToUpperSeed values and verifies finals creation stops.
- Guard Top-24 Phase 2 so playoffUpperSeeds must contain exactly four Upper Bracket seeds before winners are mapped.

Issues: Closes #1053

Validation
- npm test -- --runTestsByPath __tests__/static/tc-1053-playoff-upper-seeds-guard.test.ts __tests__/lib/api-factories/finals-route.test.ts --runInBand
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint
- git diff --check
