### PR TITLE
Clean up TC-1053 guard follow-ups

### DIFF
--- a/smkc-score-app/__tests__/static/tc-1053-playoff-upper-seeds-guard.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1053-playoff-upper-seeds-guard.test.ts
@@ -1,21 +1,6 @@
-import { e2eCaseSection, readRepoFile } from '../helpers/e2e-cases';
+import { e2eCaseSection } from '../helpers/e2e-cases';
 
 describe('TC-1053 Top-24 playoff upper seed guard', () => {
-  const finalsRoute = readRepoFile(
-    'smkc-score-app',
-    'src',
-    'lib',
-    'api-factories',
-    'finals-route.ts',
-  );
-  const unitTest = readRepoFile(
-    'smkc-score-app',
-    '__tests__',
-    'lib',
-    'api-factories',
-    'finals-route.test.ts',
-  );
-
   it('documents the malformed playoff structure regression scenario', () => {
     const section = e2eCaseSection('TC-1053');
 
@@ -24,11 +9,5 @@ describe('TC-1053 Top-24 playoff upper seed guard', () => {
     expect(section).toContain('advancesToUpperSeed');
     expect(section).toContain('Expected 4 playoff R2 upper seeds');
     expect(section).toContain('finals-route.test.ts');
-  });
-
-  it('keeps Phase 2 from silently omitting playoff winners', () => {
-    expect(finalsRoute).toContain('playoffUpperSeeds.length !== 4');
-    expect(finalsRoute).toContain('Expected 4 playoff R2 upper seeds');
-    expect(unitTest).toContain('malformed playoff structure is missing R2 upper seeds');
   });
 });

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -47,6 +47,7 @@ const BRACKET_SIZE_THRESHOLD = 20;
  * positions 13-24 competing for the 4 Upper-Bracket barrage seats.
  */
 const PLAYOFF_ENTRANT_COUNT = 12;
+const PLAYOFF_R2_UPPER_SEED_COUNT = 4;
 
 type QualificationConfirmedField =
   | 'bmQualificationConfirmed'
@@ -1677,8 +1678,8 @@ export function createFinalsHandlers(config: FinalsConfig) {
       const playoffUpperSeeds = playoffStructure
         .filter((m) => m.round === 'playoff_r2' && m.advancesToUpperSeed)
         .map((m) => m.advancesToUpperSeed as number);
-      if (playoffUpperSeeds.length !== 4) {
-        throw new Error(`Expected 4 playoff R2 upper seeds, got ${playoffUpperSeeds.length}`);
+      if (playoffUpperSeeds.length !== PLAYOFF_R2_UPPER_SEED_COUNT) {
+        throw new Error(`Expected ${PLAYOFF_R2_UPPER_SEED_COUNT} playoff R2 upper seeds, got ${playoffUpperSeeds.length}`);
       }
       const playoffWinnerSeeds = playoffUpperSeeds.map((upperSeed) => {
         const winner = upperSeedToPlayer.get(upperSeed);


### PR DESCRIPTION
Summary
- Replace the Top-24 playoff R2 upper-seed guard magic number with a named constant.
- Trim TC-1053 static coverage so it only verifies the scenario documentation; behavior remains covered by finals-route.test.ts.

Issues: Closes #1596, Closes #1597

Validation
- npm test -- --runTestsByPath __tests__/static/tc-1053-playoff-upper-seeds-guard.test.ts __tests__/lib/api-factories/finals-route.test.ts --runInBand
- npm run lint
- git diff --check
