### PR TITLE
Guard Top-24 three-group seeding

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1361,6 +1361,18 @@
 - **期待結果**: Top-24 Phase 2 は `playoffUpperSeeds` が4件そろわない構造を無音で受け入れず、Upper Bracket 勝者シード欠落を防ぐ
 - **スクリプト**: n/a（構造異常のサーバーサイド防御のため `smkc-score-app/__tests__/static/tc-1053-playoff-upper-seeds-guard.test.ts` + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts` で検証）
 
+## TC-1052: BM Top-24 — 3グループ時は未定義のシード衝突を拒否する
+- **URL**: /api/tournaments/[id]/bm/finals (POST)
+- **authRequired**: true (admin)
+- **背景**: issue #1052。現行の Top-24 紙配置は2グループ専用で、playoff_r2 勝者が Upper Bracket の seed 16/12/14/10 に入る。3グループの暫定 interleave をそのまま使うと direct seed 10/12 とバラッジ勝者 seed 10/12 が衝突するため、3+グループ用の正式配置が決まるまでは明示的に拒否する。
+- **手順**:
+  1. 管理者セッションで3グループの BM 予選を27名分作成し、全予選マッチを completed にする
+  2. `POST /api/tournaments/[id]/bm/finals` `{ topN: 24 }` を実行する
+  3. レスポンスが 400 `VALIDATION_ERROR` で、`qualifications` フィールドのエラーとして「Top-24 は2グループのみ対応」と分かることを確認する
+  4. playoff/finals stage のマッチが作成されていないことを確認する
+- **期待結果**: 3+グループの Top-24 はサイレントに壊れたブラケットを作らず、正式な3+グループ配置実装まで安全に停止する
+- **スクリプト**: tc-bm.js TC-1052 + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts`
+
 ---
 
 ## MR (Match Race) フルワークフローテスト

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1218,6 +1218,31 @@ describe('Finals Route Factory', () => {
       expect((prisma.bMMatch as any).create).not.toHaveBeenCalled();
     });
 
+    it('returns 400 for 3-group Top-24 because direct seeds would overlap playoff winner slots', async () => {
+      /* Issue #1052: the only specified Top-24 paper layout is the 2-group
+       * layout. Letting the old 3-group interleave through would assign direct
+       * advancers to seeds 10 and 12 while playoff winners also target reserved
+       * seeds 10/12/14/16, corrupting the final 16-player bracket. */
+      (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(27, 3));
+
+      const config = createMockConfig();
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 24 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.error).toBe('Top-24 playoff currently supports exactly 2 qualification groups; found 3');
+      expect(json.details).toEqual({ field: 'qualifications' });
+      expect((prisma.bMMatch as any).createMany).not.toHaveBeenCalled();
+    });
+
     it('Phase 2 blocked: returns 409 when playoff R2 matches are still incomplete', async () => {
       /* Second POST after Phase 1 must wait until all 4 playoff_r2 matches
        * are completed. If the admin tries to jump ahead, we return

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -26,6 +26,7 @@
  *   TC-532  BM qualification standings show 0-1000 qualification points
  *   TC-533  BM combined standings tab shows rows with ascending ranks
  *   TC-535  BM Top-24 playoff seed labels use group-rank labels
+ *   TC-1052 BM Top-24 rejects unsupported 3-group seeding
  *
  * Setup:
  *   - Uses Playwright persistent profile at /tmp/playwright-smkc-preview-profile by default.
@@ -45,6 +46,7 @@ const {
   matchUpdateUsesLeanPayload,
   apiFetchBm, apiPutBmQualScore,
   apiSetBmFinalsScore, apiGenerateBmFinals, apiFetchBmFinalsMatches, apiFetchBmFinalsState,
+  apiPutAllBmQualScores,
   apiUpdateTournament,
   loginPlayerBrowser,
   setupBmQualViaUi,
@@ -988,6 +990,56 @@ async function runTc510(adminPage) {
   } catch (err) {
     log('TC-510', 'FAIL', err instanceof Error ? err.message : 'BM 510 failed');
   } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-1052: BM Top-24 rejects unsupported 3-group seeding ─────────
+ * The shipped Top-24 paper layout is intentionally 2-group only. A 3-group
+ * direct-seed interleave would collide with the playoff-winner slots reserved
+ * in the 16-player Upper Bracket, so the API must fail before creating rows. */
+async function runTc1052(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedBmFinalsSetup(adminPage);
+    const { tournamentId } = setup;
+    const players = sharedBmPlayers(27);
+
+    await apiUpdateTournament(adminPage, tournamentId, { bmQualificationConfirmed: false });
+    const resetRes = await adminPage.evaluate(async (tid) => {
+      const r = await fetch(`/api/tournaments/${tid}/bm/finals`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reset: true }),
+      });
+      return { s: r.status };
+    }, tournamentId);
+    if (resetRes.s !== 200 && resetRes.s !== 201) {
+      throw new Error(`Bracket reset failed before TC-1052 (${resetRes.s})`);
+    }
+
+    await setupModePlayersViaUi(adminPage, 'bm', tournamentId, players, { groupCount: 3 });
+    await apiPutAllBmQualScores(adminPage, tournamentId, { score1: 3, score2: 1, randomize: false });
+
+    const rejected = await apiGenerateBmFinals(adminPage, tournamentId, 24);
+    const state = await apiFetchBmFinalsState(adminPage, tournamentId);
+    const ok =
+      rejected.s === 400 &&
+      rejected.b?.code === 'VALIDATION_ERROR' &&
+      /exactly 2 qualification groups/.test(rejected.b?.error || '') &&
+      state.matches.length === 0 &&
+      state.playoffMatches.length === 0;
+
+    log('TC-1052', ok ? 'PASS' : 'FAIL',
+      rejected.s !== 400 ? `expected 400, got ${rejected.s}`
+      : rejected.b?.code !== 'VALIDATION_ERROR' ? `expected VALIDATION_ERROR, got ${rejected.b?.code}`
+      : !/exactly 2 qualification groups/.test(rejected.b?.error || '') ? `unexpected error=${rejected.b?.error}`
+      : state.matches.length !== 0 || state.playoffMatches.length !== 0 ? `created matches finals=${state.matches.length} playoff=${state.playoffMatches.length}`
+      : '');
+  } catch (err) {
+    log('TC-1052', 'FAIL', err instanceof Error ? err.message : 'TC-1052 failed');
+  } finally {
+    sharedBmFinalsReady = false;
     if (setup) await setup.cleanup();
   }
 }
@@ -2181,6 +2233,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-533', fn: runTc533 },
       { name: 'TC-504', fn: runTc504 },
       { name: 'TC-510', fn: runTc510 },
+      { name: 'TC-1052', fn: runTc1052 },
       { name: 'TC-515', fn: runTc515 },
       { name: 'TC-516', fn: runTc516 },
       { name: 'TC-517', fn: runTc517 },
@@ -2204,7 +2257,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 
 module.exports = {
   runTc501, runTc502, runTc322, runTc503, runTc504, runTc505, runTc506, runTc511, runTc512, runTc513,
-  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522, runTc523, runTc524, runTc525, runTc526, runTc528, runTc529, runTc530, runTc531, runTc533,
+  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522, runTc523, runTc524, runTc525, runTc526, runTc528, runTc529, runTc530, runTc531, runTc533, runTc1052,
   getSuite,
   results,
   setSharedBmFinalsReady: (v) => { sharedBmFinalsReady = v; },

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -48,6 +48,7 @@ const BRACKET_SIZE_THRESHOLD = 20;
  */
 const PLAYOFF_ENTRANT_COUNT = 12;
 const PLAYOFF_R2_UPPER_SEED_COUNT = 4;
+const TOP24_SUPPORTED_GROUP_COUNT = 2;
 
 type QualificationConfirmedField =
   | 'bmQualificationConfirmed'
@@ -1514,6 +1515,17 @@ export function createFinalsHandlers(config: FinalsConfig) {
       } catch (err) {
         return handleValidationError(
           err instanceof Error ? err.message : 'Invalid group distribution',
+          'qualifications',
+        );
+      }
+      if (selection.groupCount !== TOP24_SUPPORTED_GROUP_COUNT) {
+        /* The current Top-24 paper layout reserves Upper Bracket seeds 10/12/14/16
+         * for playoff_r2 winners. The legacy 3+ group interleave assigns direct
+         * advancers to seeds 1..12, which overlaps those reserved barrage slots.
+         * Rejecting the unsupported shape at the API boundary keeps bracket
+         * seeding one-to-one until a real 3+ group Top-24 layout is specified. */
+        return handleValidationError(
+          `Top-24 playoff currently supports exactly ${TOP24_SUPPORTED_GROUP_COUNT} qualification groups; found ${selection.groupCount}`,
           'qualifications',
         );
       }


### PR DESCRIPTION
Summary
- Reject BM Top-24 finals generation when qualification has 3+ groups, because the only implemented Top-24 paper layout reserves Upper Bracket seeds 10/12/14/16 for playoff winners.
- Add TC-1052 scenario documentation, E2E runner coverage, and API unit coverage for the explicit validation error and no-match-creation guard.

Issues: Closes #1052

Validation
- npm test -- --runInBand __tests__/lib/api-factories/finals-route.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/tc-all-registration.test.ts
- node --check e2e/tc-bm.js
- npm run lint
- git diff --check
