### PR TITLE
Clean up TC-1052 follow-ups

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1368,7 +1368,7 @@
 - **手順**:
   1. 管理者セッションで3グループの BM 予選を27名分作成し、全予選マッチを completed にする
   2. `POST /api/tournaments/[id]/bm/finals` `{ topN: 24 }` を実行する
-  3. レスポンスが 400 `VALIDATION_ERROR` で、`qualifications` フィールドのエラーとして「Top-24 は2グループのみ対応」と分かることを確認する
+  3. レスポンスが 400 `VALIDATION_ERROR` で、`qualifications` フィールドのエラーとして「Top-24 は最大2グループまで対応」と分かることを確認する
   4. playoff/finals stage のマッチが作成されていないことを確認する
 - **期待結果**: 3+グループの Top-24 はサイレントに壊れたブラケットを作らず、正式な3+グループ配置実装まで安全に停止する
 - **スクリプト**: tc-bm.js TC-1052 + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts`

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1238,7 +1238,7 @@ describe('Finals Route Factory', () => {
 
       expect(response.status).toBe(400);
       const json = await response.json();
-      expect(json.error).toBe('Top-24 playoff currently supports exactly 2 qualification groups; found 3');
+      expect(json.error).toBe('Top-24 playoff currently supports at most 2 qualification groups; found 3');
       expect(json.details).toEqual({ field: 'qualifications' });
       expect((prisma.bMMatch as any).createMany).not.toHaveBeenCalled();
     });

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -999,25 +999,12 @@ async function runTc510(adminPage) {
  * direct-seed interleave would collide with the playoff-winner slots reserved
  * in the 16-player Upper Bracket, so the API must fail before creating rows. */
 async function runTc1052(adminPage) {
-  let setup = null;
+  let tournamentId = null;
   try {
-    setup = await prepareSharedBmFinalsSetup(adminPage);
-    const { tournamentId } = setup;
     const players = sharedBmPlayers(27);
 
-    await apiUpdateTournament(adminPage, tournamentId, { bmQualificationConfirmed: false });
-    const resetRes = await adminPage.evaluate(async (tid) => {
-      const r = await fetch(`/api/tournaments/${tid}/bm/finals`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ reset: true }),
-      });
-      return { s: r.status };
-    }, tournamentId);
-    if (resetRes.s !== 200 && resetRes.s !== 201) {
-      throw new Error(`Bracket reset failed before TC-1052 (${resetRes.s})`);
-    }
-
+    tournamentId = await uiCreateTournament(adminPage, `E2E BM TC-1052 ${Date.now()}`);
+    await uiActivateTournament(adminPage, tournamentId);
     await setupModePlayersViaUi(adminPage, 'bm', tournamentId, players, { groupCount: 3 });
     await apiPutAllBmQualScores(adminPage, tournamentId, { score1: 3, score2: 1, randomize: false });
 
@@ -1026,21 +1013,20 @@ async function runTc1052(adminPage) {
     const ok =
       rejected.s === 400 &&
       rejected.b?.code === 'VALIDATION_ERROR' &&
-      /exactly 2 qualification groups/.test(rejected.b?.error || '') &&
+      /at most 2 qualification groups/.test(rejected.b?.error || '') &&
       state.matches.length === 0 &&
       state.playoffMatches.length === 0;
 
     log('TC-1052', ok ? 'PASS' : 'FAIL',
       rejected.s !== 400 ? `expected 400, got ${rejected.s}`
       : rejected.b?.code !== 'VALIDATION_ERROR' ? `expected VALIDATION_ERROR, got ${rejected.b?.code}`
-      : !/exactly 2 qualification groups/.test(rejected.b?.error || '') ? `unexpected error=${rejected.b?.error}`
+      : !/at most 2 qualification groups/.test(rejected.b?.error || '') ? `unexpected error=${rejected.b?.error}`
       : state.matches.length !== 0 || state.playoffMatches.length !== 0 ? `created matches finals=${state.matches.length} playoff=${state.playoffMatches.length}`
       : '');
   } catch (err) {
     log('TC-1052', 'FAIL', err instanceof Error ? err.message : 'TC-1052 failed');
   } finally {
-    sharedBmFinalsReady = false;
-    if (setup) await setup.cleanup();
+    if (tournamentId) await apiDeleteTournament(adminPage, tournamentId);
   }
 }
 

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -1518,14 +1518,14 @@ export function createFinalsHandlers(config: FinalsConfig) {
           'qualifications',
         );
       }
-      if (selection.groupCount !== TOP24_SUPPORTED_GROUP_COUNT) {
+      if (selection.groupCount > TOP24_SUPPORTED_GROUP_COUNT) {
         /* The current Top-24 paper layout reserves Upper Bracket seeds 10/12/14/16
          * for playoff_r2 winners. The legacy 3+ group interleave assigns direct
          * advancers to seeds 1..12, which overlaps those reserved barrage slots.
          * Rejecting the unsupported shape at the API boundary keeps bracket
          * seeding one-to-one until a real 3+ group Top-24 layout is specified. */
         return handleValidationError(
-          `Top-24 playoff currently supports exactly ${TOP24_SUPPORTED_GROUP_COUNT} qualification groups; found ${selection.groupCount}`,
+          `Top-24 playoff currently supports at most ${TOP24_SUPPORTED_GROUP_COUNT} qualification groups; found ${selection.groupCount}`,
           'qualifications',
         );
       }


### PR DESCRIPTION
Summary
- Align the BM Top-24 guard with the documented unsupported case by rejecting only 3+ qualification groups.
- Make TC-1052 create and delete a dedicated lightweight tournament instead of mutating the shared BM finals fixture.

Issues: Closes #1600, Closes #1601

Validation
- npm test -- --runInBand __tests__/lib/api-factories/finals-route.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/tc-all-registration.test.ts
- node --check e2e/tc-bm.js
- git diff --check
- npm run lint
