### PR TITLE
Cover Top-24 one-group validation

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1373,6 +1373,18 @@
 - **期待結果**: 3+グループの Top-24 はサイレントに壊れたブラケットを作らず、正式な3+グループ配置実装まで安全に停止する
 - **スクリプト**: tc-bm.js TC-1052 + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts`
 
+## TC-1603: BM Top-24 — 1グループ時も予選グループ数エラーで停止する
+- **URL**: /api/tournaments/[id]/bm/finals (POST)
+- **authRequired**: true (admin)
+- **背景**: issue #1603。3+グループ拒否 guard は `groupCount > 2` を見るため、1グループ入力は `selectFinalsEntrantsByGroup` 側の「2〜4グループのみ対応」バリデーションで止まる。この経路が書き込み前に 400 になることを明示する。
+- **手順**:
+  1. 1グループ24名分の BM 予選済みデータを用意する
+  2. `POST /api/tournaments/[id]/bm/finals` `{ topN: 24 }` を実行する
+  3. レスポンスが 400 `VALIDATION_ERROR` で、`Unsupported group count 1` が返ることを確認する
+  4. playoff/finals stage のマッチが作成されていないことを確認する
+- **期待結果**: 1グループの Top-24 も未定義ブラケットを作らず、予選グループ数バリデーションで安全に停止する
+- **スクリプト**: n/a（server-side guard のため `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts` で検証）
+
 ---
 
 ## MR (Match Race) フルワークフローテスト

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -102,6 +102,13 @@ describe('Finals Route Factory', () => {
     ...overrides,
   });
 
+  const expectNoBmMatchWrites = () => {
+    const matchModel = prisma.bMMatch as any;
+    for (const method of ['create', 'createMany', 'deleteMany', 'update', 'updateMany']) {
+      expect(matchModel[method]).not.toHaveBeenCalled();
+    }
+  };
+
   describe('buildQualificationRankLabelMap', () => {
     it('assigns group labels from rank order even when input rows are shuffled', () => {
       const labels = buildQualificationRankLabelMap([
@@ -1241,6 +1248,30 @@ describe('Finals Route Factory', () => {
       expect(json.error).toBe('Top-24 playoff currently supports at most 2 qualification groups; found 3');
       expect(json.details).toEqual({ field: 'qualifications' });
       expect((prisma.bMMatch as any).createMany).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for 1-group Top-24 before creating playoff rows', async () => {
+      /* Issue #1603: the explicit 3+ group guard should not hide the separate
+       * selection-layer contract. Top-24 still needs at least two qualification
+       * groups, and the API must surface that validation failure without writes. */
+      (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(24, 1));
+
+      const config = createMockConfig();
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 24 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.error).toBe('selectFinalsEntrantsByGroup: Unsupported group count 1 (must be 2, 3, or 4)');
+      expect(json.details).toEqual({ field: 'qualifications' });
+      expectNoBmMatchWrites();
     });
 
     it('Phase 2 blocked: returns 409 when playoff R2 matches are still incomplete', async () => {


### PR DESCRIPTION
Summary
- Document TC-1603 for BM Top-24 one-group validation.
- Add finals-route unit coverage proving 1-group Top-24 returns validation error before creating playoff rows.

Issues: Closes #1603

Validation
- npm test -- --runInBand __tests__/lib/api-factories/finals-route.test.ts __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
- npm run lint
