### PR TITLE
Strengthen Top-24 no-write assertion

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1247,7 +1247,7 @@ describe('Finals Route Factory', () => {
       const json = await response.json();
       expect(json.error).toBe('Top-24 playoff currently supports at most 2 qualification groups; found 3');
       expect(json.details).toEqual({ field: 'qualifications' });
-      expect((prisma.bMMatch as any).createMany).not.toHaveBeenCalled();
+      expectNoBmMatchWrites();
     });
 
     it('returns 400 for 1-group Top-24 before creating playoff rows', async () => {


### PR DESCRIPTION
Summary
- Reuse expectNoBmMatchWrites() in the 3+ group Top-24 rejection test so all match write methods are covered consistently.

Issues: Closes #1605

Validation
- npm test -- --runInBand __tests__/lib/api-factories/finals-route.test.ts
- git diff --check
