### PR TITLE
Remove redundant finals direct selection

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1361,6 +1361,18 @@
 - **期待結果**: Top-24 Phase 2 は `playoffUpperSeeds` が4件そろわない構造を無音で受け入れず、Upper Bracket 勝者シード欠落を防ぐ
 - **スクリプト**: n/a（構造異常のサーバーサイド防御のため `smkc-score-app/__tests__/static/tc-1053-playoff-upper-seeds-guard.test.ts` + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts` で検証）
 
+## TC-1051: BM Top-24 — directSeeds を唯一の direct advancer 公開契約にする
+- **URL**: /api/tournaments/[id]/bm/finals (POST)
+- **authRequired**: true (admin)
+- **背景**: issue #1051。2グループ Top-24 の direct advancer は Upper Bracket seed 1/2/3/4/5/6/7/8/9/11/13/15 に配置されるため、呼び出し側に必要なのは seed 付きの `directSeeds` である。旧 `direct[]` は `directSeeds[].qualification` から派生できる冗長な配列で、2グループでは source of truth を増やすだけになる。
+- **手順**:
+  1. 28名 BM 予選を2グループで完了し、Top-24 playoff を作成する
+  2. playoff 完了後に Phase 2 finals を生成する
+  3. Phase 1/2 の API payload が legacy `direct[]` を公開せず、Phase 2 の `seededPlayers` が `directSeeds` 由来の Upper Bracket seed へ配置されることを確認する
+  4. ユニットテストで `selectFinalsEntrantsByGroup` の戻り値も `direct[]` を持たず、3/4グループの内部 direct order は `directSeeds` として保持されることを確認する
+- **期待結果**: BM Top-24 の公開契約は `directSeeds` と `barrage` に集約され、2グループ専用の冗長 `direct[]` が再導入されない
+- **スクリプト**: tc-bm.js TC-510 内の TC-1051 assertion + `smkc-score-app/__tests__/lib/finals-group-selection.test.ts`
+
 ## TC-1052: BM Top-24 — 3グループ時は未定義のシード衝突を拒否する
 - **URL**: /api/tournaments/[id]/bm/finals (POST)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -553,6 +553,25 @@ describe('E2E case drift coverage', () => {
     expect(tcBm).toContain('directSeedLabelsOk');
   });
 
+  it('documents TC-1051 as the Top-24 directSeeds-only contract', () => {
+    const section = e2eCaseSection('TC-1051');
+    const unitTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'lib',
+      'finals-group-selection.test.ts',
+    );
+
+    expect(section).toContain('issue #1051');
+    expect(section).toContain('legacy `direct[]`');
+    expect(section).toContain('`directSeeds`');
+    expect(section).toContain('tc-bm.js TC-510');
+    expect(tcBm).toContain("log('TC-1051'");
+    expect(tcBm).toContain('legacyDirectPayloadAbsent');
+    expect(unitTest).toContain("does not expose the redundant direct[] projection for 2 groups");
+    expect(unitTest).toContain("expect('direct' in result).toBe(false)");
+  });
+
   it('does not leave retired TC identifiers in runnable E2E scripts as false drift signals', () => {
     expect(tcAll).not.toContain('TC-403');
   });

--- a/smkc-score-app/__tests__/lib/finals-group-selection.test.ts
+++ b/smkc-score-app/__tests__/lib/finals-group-selection.test.ts
@@ -62,12 +62,8 @@ describe('selectFinalsEntrantsByGroup', () => {
       ]);
     });
 
-    it('direct[] follows the same deterministic order as directSeeds[]', () => {
-      expect(result.direct.map(q => q.playerId)).toEqual([
-        'A1', 'B3', 'B1', 'A3',
-        'B2', 'A4', 'A2', 'B4',
-        'A5', 'B5', 'B6', 'A6',
-      ]);
+    it('does not expose the redundant direct[] projection for 2 groups', () => {
+      expect('direct' in result).toBe(false);
     });
 
     it('directSeeds[] renders top-to-bottom as the handwritten 2-group Upper R1 bracket', () => {
@@ -117,8 +113,18 @@ describe('selectFinalsEntrantsByGroup', () => {
       expect(result.groupCount).toBe(3);
     });
 
-    it('direct[] is Top1-4 from each group, interleaved', () => {
-      expect(result.direct.map(q => q.playerId)).toEqual([
+    it('directSeeds[] is Top1-4 from each group, interleaved', () => {
+      expect(result.directSeeds.map(({ seed, qualification }) => [seed, qualification.playerId])).toEqual([
+        [1, 'A1'], [2, 'B1'], [3, 'C1'],
+        [4, 'A2'], [5, 'B2'], [6, 'C2'],
+        [7, 'A3'], [8, 'B3'], [9, 'C3'],
+        [10, 'A4'], [11, 'B4'], [12, 'C4'],
+      ]);
+    });
+
+    it('does not expose legacy direct[] because callers should use directSeeds[]', () => {
+      expect('direct' in result).toBe(false);
+      expect(result.directSeeds.map(({ qualification }) => qualification.playerId)).toEqual([
         'A1', 'B1', 'C1',
         'A2', 'B2', 'C2',
         'A3', 'B3', 'C3',
@@ -144,8 +150,17 @@ describe('selectFinalsEntrantsByGroup', () => {
       expect(result.groupCount).toBe(4);
     });
 
-    it('direct[] is Top1-3 from each group, interleaved', () => {
-      expect(result.direct.map(q => q.playerId)).toEqual([
+    it('directSeeds[] is Top1-3 from each group, interleaved', () => {
+      expect(result.directSeeds.map(({ seed, qualification }) => [seed, qualification.playerId])).toEqual([
+        [1, 'A1'], [2, 'B1'], [3, 'C1'], [4, 'D1'],
+        [5, 'A2'], [6, 'B2'], [7, 'C2'], [8, 'D2'],
+        [9, 'A3'], [10, 'B3'], [11, 'C3'], [12, 'D3'],
+      ]);
+    });
+
+    it('does not expose legacy direct[] because callers should use directSeeds[]', () => {
+      expect('direct' in result).toBe(false);
+      expect(result.directSeeds.map(({ qualification }) => qualification.playerId)).toEqual([
         'A1', 'B1', 'C1', 'D1',
         'A2', 'B2', 'C2', 'D2',
         'A3', 'B3', 'C3', 'D3',
@@ -227,11 +242,12 @@ describe('selectFinalsEntrantsByGroup', () => {
         quals.push(mk('A', r), mk('B', r));
       }
       const result = selectFinalsEntrantsByGroup(quals);
-      expect(result.direct.map(q => q.playerId)).toEqual([
+      expect(result.directSeeds.map(({ qualification }) => qualification.playerId)).toEqual([
         'A1', 'B3', 'B1', 'A3',
         'B2', 'A4', 'A2', 'B4',
         'A5', 'B5', 'B6', 'A6',
       ]);
+      expect('direct' in result).toBe(false);
     });
   });
 });

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -26,6 +26,7 @@
  *   TC-532  BM qualification standings show 0-1000 qualification points
  *   TC-533  BM combined standings tab shows rows with ascending ranks
  *   TC-535  BM Top-24 playoff seed labels use group-rank labels
+ *   TC-1051 BM Top-24 direct-seed API no longer depends on legacy direct[]
  *   TC-1052 BM Top-24 rejects unsupported 3-group seeding
  *
  * Setup:
@@ -205,7 +206,6 @@ function expectedTwoGroupPaperSeedIds(qualifications) {
   ];
 
   return {
-    direct: directTokensByUpperSeed.map(([, token]) => playerIdForToken(token)),
     directSeeds: directTokensByUpperSeed.map(([seed, token]) => ({
       seed,
       playerId: playerIdForToken(token),
@@ -955,6 +955,9 @@ async function runTc510(adminPage) {
     const phase2Data = phase2.b?.data || {};
     state = await apiFetchBmFinalsState(adminPage, tournamentId);
     const seededPlayers = phase2Data.seededPlayers || [];
+    const legacyDirectPayloadAbsent =
+      !Object.prototype.hasOwnProperty.call(phase1Data, 'direct') &&
+      !Object.prototype.hasOwnProperty.call(phase2Data, 'direct');
     const directSeedOrderOk = expectedSeedIds.directSeeds.every(({ seed, playerId }) => {
       const seeded = seededPlayers.find((p) => p.seed === seed);
       return seeded?.playerId === playerId;
@@ -975,6 +978,11 @@ async function runTc510(adminPage) {
       directSeedOrderOk &&
       directSeedLabelsOk &&
       playoffWinnersSeeded;
+
+    log('TC-1051', legacyDirectPayloadAbsent && directSeedOrderOk ? 'PASS' : 'FAIL',
+      !legacyDirectPayloadAbsent ? 'Top-24 response exposed legacy direct[] payload'
+      : !directSeedOrderOk ? `direct seed order mismatch expected=${JSON.stringify(expectedSeedIds.directSeeds)} actual=${JSON.stringify(seededPlayers)}`
+      : '');
 
     const ok = playoffCreated && playoffSeedOrderOk && playoffSeedLabelsOk && playoffBlocksOk && phase2Blocked && r1Routed && playoffCompleteSignal && finalsCreated;
     log('TC-510', ok ? 'PASS' : 'FAIL',

--- a/smkc-score-app/src/lib/finals-group-selection.ts
+++ b/smkc-score-app/src/lib/finals-group-selection.ts
@@ -38,8 +38,6 @@ export interface FinalsQualInput {
 }
 
 interface FinalsGroupSelection {
-  /** 12 direct advancers, in deterministic display/spec order. */
-  direct: FinalsQualInput[];
   /** Direct advancers with their actual Upper Bracket seed numbers. */
   directSeeds: Array<{ seed: number; qualification: FinalsQualInput }>;
   /** 12 barrage entrants, ordered for Playoff seeds 1-12. */
@@ -144,7 +142,6 @@ export function selectFinalsEntrantsByGroup(
     }));
 
     return {
-      direct: directSeeds.map(({ qualification }) => qualification),
       directSeeds,
       barrage: TWO_GROUP_BARRAGE_SEED_TOKENS.map(playerForToken),
       groupCount: 2,
@@ -164,7 +161,10 @@ export function selectFinalsEntrantsByGroup(
   }
 
   return {
-    direct,
+    /* `directSeeds` is the sole public direct-advancer contract. Keeping a
+     * parallel unseeded `direct[]` array would duplicate the same qualifiers
+     * without the Upper Bracket seed metadata that every current caller needs,
+     * and risks future drift between two representations of one bracket slot. */
     directSeeds: direct.map((qualification, index) => ({
       seed: index + 1,
       qualification,


### PR DESCRIPTION
Summary
- Remove the redundant unseeded `direct[]` return from finals group selection so `directSeeds` is the single direct-advancer contract.
- Add TC-1051 scenario coverage, BM E2E assertion, docs drift guard, and unit coverage across 2/3/4-group selection shapes.

Issues: Closes #1051

Validation
- npm test -- finals-group-selection.test.ts --runInBand
- npm test -- e2e-cases-drift.test.ts --runInBand
- node --check e2e/tc-bm.js
- git diff --check
- npm run lint (exit 0; existing warnings only)
- reviewer pass: no blocking findings
