### PR TITLE
Address TC-1051 review follow-ups

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -561,6 +561,11 @@ describe('E2E case drift coverage', () => {
       'lib',
       'finals-group-selection.test.ts',
     );
+    const runTc510OkBlock = sectionBetween(
+      tcBm,
+      'const ok = playoffCreated',
+      "log('TC-510'",
+    );
 
     expect(section).toContain('issue #1051');
     expect(section).toContain('legacy `direct[]`');
@@ -568,6 +573,7 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('tc-bm.js TC-510');
     expect(tcBm).toContain("log('TC-1051'");
     expect(tcBm).toContain('legacyDirectPayloadAbsent');
+    expect(runTc510OkBlock).toContain('legacyDirectPayloadAbsent');
     expect(unitTest).toContain("does not expose the redundant direct[] projection for 2 groups");
     expect(unitTest).toContain("expect('direct' in result).toBe(false)");
   });

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -984,7 +984,7 @@ async function runTc510(adminPage) {
       : !directSeedOrderOk ? `direct seed order mismatch expected=${JSON.stringify(expectedSeedIds.directSeeds)} actual=${JSON.stringify(seededPlayers)}`
       : '');
 
-    const ok = playoffCreated && playoffSeedOrderOk && playoffSeedLabelsOk && playoffBlocksOk && phase2Blocked && r1Routed && playoffCompleteSignal && finalsCreated;
+    const ok = playoffCreated && playoffSeedOrderOk && playoffSeedLabelsOk && playoffBlocksOk && phase2Blocked && r1Routed && playoffCompleteSignal && legacyDirectPayloadAbsent && finalsCreated;
     log('TC-510', ok ? 'PASS' : 'FAIL',
       !playoffCreated ? `playoff=${state.playoffMatches.length} finals=${state.matches.length} r1=${r1.length} r2=${r2.length}`
       : !playoffSeedOrderOk ? `playoff seed order mismatch expected=${expectedSeedIds.barrage.join(',')} actual=${playoffSeedIds.join(',')}`
@@ -993,6 +993,7 @@ async function runTc510(adminPage) {
       : !phase2Blocked ? `Phase 2 was not blocked before completion (${blocked.s}, ${blocked.b?.code || blocked.b?.error})`
       : !r1Routed ? 'R1 winner did not route into R2 player2'
       : !playoffCompleteSignal ? 'Last R2 PUT did not signal playoffComplete=true'
+      : !legacyDirectPayloadAbsent ? 'Top-24 response exposed legacy direct[] payload'
       : !finalsCreated ? `finals=${state.matches.length} bracketSize=${state.bracketSize} directSeedOrder=${directSeedOrderOk} directSeedLabels=${directSeedLabelsOk} winnersSeeded=${playoffWinnersSeeded}`
       : '');
   } catch (err) {

--- a/smkc-score-app/src/lib/finals-group-selection.ts
+++ b/smkc-score-app/src/lib/finals-group-selection.ts
@@ -161,10 +161,7 @@ export function selectFinalsEntrantsByGroup(
   }
 
   return {
-    /* `directSeeds` is the sole public direct-advancer contract. Keeping a
-     * parallel unseeded `direct[]` array would duplicate the same qualifiers
-     * without the Upper Bracket seed metadata that every current caller needs,
-     * and risks future drift between two representations of one bracket slot. */
+    // directSeeds is the sole direct-advancer contract; a parallel direct[] would risk drift between two slot representations.
     directSeeds: direct.map((qualification, index) => ({
       seed: index + 1,
       qualification,


### PR DESCRIPTION
Summary
- Include the TC-1051 legacy direct[] guard in the TC-510 aggregate PASS/FAIL path.
- Compress the finals-group-selection design comment to a single-line note.
- Keep drift coverage focused on the TC-510 ok block without pinning the entire expression shape.

Issues: Closes #1608, Closes #1609

Validation
- npm test -- e2e-cases-drift.test.ts --runInBand
- npm test -- finals-group-selection.test.ts --runInBand
- node --check e2e/tc-bm.js
- git diff --check
- npm run lint (exit 0; existing warnings only)
- reviewer pass after one drift-test robustness fix
