### PR TITLE
Share Top-24 playoff complete action card

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1062,6 +1062,19 @@
   9. クリーンアップ
 - **期待結果**: BM Top-24 バラッジの UI フローが全段階で正常動作する
 
+## TC-1048: BM/MR/GP Top-24 Phase 2 アクションカード共通化
+- **URL**: /tournaments/[temp-id]/bm/finals, /mr/finals, /gp/finals
+- **authRequired**: true (admin)
+- **背景**: issue #1048。バラージ完了後に表示する「上位ブラケット作成」カードは BM/MR/GP で同じ Phase 2 遷移アクションなので、表示・文言・クリック処理を共通コンポーネントから提供する。
+- **手順**:
+  1. TC-515 / TC-615 / TC-715 と同じ Top-24 バラージを作成する
+  2. 各モードで playoff_r1 と playoff_r2 を全て完了し、`playoffComplete=true` にする
+  3. Phase 2 API を呼ぶ前に finals ページを開く
+  4. 「Create Upper Bracket / 上位ブラケット作成」ボタンが表示されることを確認する
+  5. Phase 2 を生成し、Upper Bracket 表示へ遷移できることを確認する
+- **期待結果**: BM/MR/GP の Top-24 バラージ完了状態で同じ Phase 2 アクションが表示され、共通コンポーネントの unit test と既存 Top-24 E2E フローで退行を検出できる
+- **スクリプト**: tc-bm.js TC-515 + tc-mr.js TC-615 + tc-gp.js TC-715 + `smkc-score-app/__tests__/components/tournament/playoff-complete-card.test.tsx`
+
 ## TC-516: BM 予選ページの決勝ブラケット存在状態 + リセット
 - **URL**: /tournaments/[temp-id]/bm
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/components/tournament/playoff-complete-card.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/playoff-complete-card.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { PlayoffCompleteCard } from "@/components/tournament/playoff-complete-card";
+
+describe("PlayoffCompleteCard", () => {
+  it("renders the shared Phase-2 message and invokes the upper-bracket action", () => {
+    const onCreateUpperBracket = jest.fn();
+
+    render(
+      <PlayoffCompleteCard
+        description="All playoff matches complete! Create the upper bracket to continue."
+        actionLabel="Create Upper Bracket"
+        onCreateUpperBracket={onCreateUpperBracket}
+      />,
+    );
+
+    expect(screen.getByText("All playoff matches complete! Create the upper bracket to continue.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Upper Bracket" }));
+
+    expect(onCreateUpperBracket).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the tab-panel spacing class when rendered below a playoff bracket", () => {
+    render(
+      <PlayoffCompleteCard
+        className="mt-4 border-green-500/50 bg-green-500/10"
+        description="全プレーオフ試合が完了しました！上位ブラケットを作成してください。"
+        actionLabel="上位ブラケット作成"
+        onCreateUpperBracket={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("全プレーオフ試合が完了しました！上位ブラケットを作成してください。").closest(".mt-4")).toBeInTheDocument();
+  });
+});

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -578,6 +578,35 @@ describe('E2E case drift coverage', () => {
     expect(unitTest).toContain("expect('direct' in result).toBe(false)");
   });
 
+  it('keeps TC-1048 aligned with the shared Top-24 Phase-2 action card', () => {
+    const section = e2eCaseSection('TC-1048');
+    const component = readRepoFile(
+      'smkc-score-app',
+      'src',
+      'components',
+      'tournament',
+      'playoff-complete-card.tsx',
+    );
+    const componentTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'components',
+      'tournament',
+      'playoff-complete-card.test.tsx',
+    );
+
+    expect(section).toContain('issue #1048');
+    expect(section).toContain('tc-bm.js TC-515');
+    expect(section).toContain('tc-mr.js TC-615');
+    expect(section).toContain('tc-gp.js TC-715');
+    expect(component).toContain('export function PlayoffCompleteCard');
+    expect(componentTest).toContain('Create Upper Bracket');
+    for (const script of [tcBm, tcMr, tcGp]) {
+      expect(script).toContain('phase2ActionVisible');
+      expect(script).toContain('Create Upper Bracket action missing after playoff completion');
+    }
+  });
+
   it('does not leave retired TC identifiers in runnable E2E scripts as false drift signals', () => {
     expect(tcAll).not.toContain('TC-403');
   });

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -775,6 +775,12 @@ async function runTc515(adminPage) {
     const finalState = await apiFetchBmFinalsState(adminPage, tournamentId);
     const playoffComplete = finalState.playoffComplete === true;
 
+    await nav(adminPage, `/tournaments/${tournamentId}/bm/finals`);
+    const phase2ActionVisible = await adminPage
+      .getByRole('button', { name: /Create Upper Bracket|上位ブラケット作成/ })
+      .isVisible()
+      .catch(() => false);
+
     const phase2 = await apiGenerateBmFinals(adminPage, tournamentId, 24);
     const phase2Ok = phase2.s === 201 && phase2.b?.data?.phase === 'finals';
 
@@ -782,11 +788,12 @@ async function runTc515(adminPage) {
     const postPhase2Text = await adminPage.locator('body').innerText();
     const hasFinalsPhase = postPhase2Text.includes('Upper Bracket') || postPhase2Text.includes('アッパーブラケット');
 
-    const ok = hasPlayoffLabel && hasM1 && playoffComplete && phase2Ok && hasFinalsPhase;
+    const ok = hasPlayoffLabel && hasM1 && playoffComplete && phase2ActionVisible && phase2Ok && hasFinalsPhase;
     log('TC-515', ok ? 'PASS' : 'FAIL',
       !hasPlayoffLabel ? 'Playoff label missing on finals page'
       : !hasM1 ? 'M1 missing on playoff bracket'
       : !playoffComplete ? 'playoffComplete not true'
+      : !phase2ActionVisible ? 'Create Upper Bracket action missing after playoff completion'
       : !phase2Ok ? `Phase 2 failed (${phase2.s})`
       : !hasFinalsPhase ? 'Finals phase not shown after Upper Bracket creation'
       : '');

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -1046,6 +1046,12 @@ async function runTc715(adminPage) {
     const finalState = await apiFetchGpFinalsState(adminPage, tournamentId);
     const playoffComplete = finalState.playoffComplete === true;
 
+    await nav(adminPage, `/tournaments/${tournamentId}/gp/finals`);
+    const phase2ActionVisible = await adminPage
+      .getByRole('button', { name: /Create Upper Bracket|上位ブラケット作成/ })
+      .isVisible()
+      .catch(() => false);
+
     const phase2 = await apiGenerateGpFinals(adminPage, tournamentId, 24);
     const phase2Ok = phase2.s === 201 && phase2.b?.data?.phase === 'finals';
 
@@ -1053,13 +1059,14 @@ async function runTc715(adminPage) {
     const postPhase2Text = await adminPage.locator('body').innerText();
     const hasFinalsPhase = postPhase2Text.includes('Upper Bracket') || postPhase2Text.includes('アッパーブラケット');
 
-    const ok = hasStartPlayoff && playoffCreated && hasPlayoffLabel && hasM1 && playoffComplete && phase2Ok && hasFinalsPhase;
+    const ok = hasStartPlayoff && playoffCreated && hasPlayoffLabel && hasM1 && playoffComplete && phase2ActionVisible && phase2Ok && hasFinalsPhase;
     log('TC-715', ok ? 'PASS' : 'FAIL',
       !hasStartPlayoff ? 'Start Playoff button missing'
       : !playoffCreated ? `Playoff not created server-side (matches=${playoffState.playoffMatches?.length ?? 0}, phase=${playoffState.phase})`
       : !hasPlayoffLabel ? 'Playoff label missing on finals page'
       : !hasM1 ? 'M1 missing on playoff bracket'
       : !playoffComplete ? 'playoffComplete not true'
+      : !phase2ActionVisible ? 'Create Upper Bracket action missing after playoff completion'
       : !phase2Ok ? `Phase 2 failed (${phase2.s})`
       : !hasFinalsPhase ? 'Finals phase not shown after Upper Bracket creation'
       : '');

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -1353,6 +1353,12 @@ async function runTc615(adminPage) {
     const finalState = await apiFetchMrFinalsState(adminPage, tournamentId);
     const playoffComplete = finalState.playoffComplete === true;
 
+    await nav(adminPage, `/tournaments/${tournamentId}/mr/finals`);
+    const phase2ActionVisible = await adminPage
+      .getByRole('button', { name: /Create Upper Bracket|上位ブラケット作成/ })
+      .isVisible()
+      .catch(() => false);
+
     // Trigger Phase 2 (Upper Bracket creation) via API
     const phase2 = await generateMrFinalsBracket(adminPage, tournamentId, 24);
     const phase2Ok = phase2.s === 201 && phase2.b?.data?.phase === 'finals';
@@ -1362,13 +1368,14 @@ async function runTc615(adminPage) {
     const postPhase2Text = await adminPage.locator('body').innerText();
     const hasFinalsPhase = postPhase2Text.includes('Upper Bracket') || postPhase2Text.includes('アッパーブラケット');
 
-    const ok = hasStartPlayoff && playoffCreated && hasPlayoffLabel && hasM1 && playoffComplete && phase2Ok && hasFinalsPhase;
+    const ok = hasStartPlayoff && playoffCreated && hasPlayoffLabel && hasM1 && playoffComplete && phase2ActionVisible && phase2Ok && hasFinalsPhase;
     log('TC-615', ok ? 'PASS' : 'FAIL',
       !hasStartPlayoff ? 'Start Playoff button missing'
       : !playoffCreated ? `Playoff not created server-side (matches=${playoffState.playoffMatches?.length ?? 0}, phase=${playoffState.phase})`
       : !hasPlayoffLabel ? 'Playoff label missing on finals page'
       : !hasM1 ? 'M1 missing on playoff bracket'
       : !playoffComplete ? 'playoffComplete not true'
+      : !phase2ActionVisible ? 'Create Upper Bracket action missing after playoff completion'
       : !phase2Ok ? `Phase 2 failed (${phase2.s})`
       : !hasFinalsPhase ? 'Finals phase not shown after Upper Bracket creation'
       : '');

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -62,6 +62,7 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
 import { PlayoffBracket } from "@/components/tournament/playoff-bracket";
+import { PlayoffCompleteCard } from "@/components/tournament/playoff-complete-card";
 import { POLLING_INTERVAL, TV_NUMBER_OPTIONS } from "@/lib/constants";
 import { getBmFinalsTargetWins } from "@/lib/finals-target-wins";
 import { usePolling } from "@/lib/hooks/usePolling";
@@ -773,16 +774,12 @@ export default function BattleModeFinals({
               getTargetWins={(match, bracketMatch) => getBmFinalsTargetWins({ stage: match?.stage ?? 'playoff', round: match?.round ?? bracketMatch.round })}
             />
             {matches.length === 0 && playoffComplete && isAdmin && (
-              <Card className="mt-4 border-green-500/50 bg-green-500/10">
-                <CardContent className="py-4 text-center">
-                  <p className="text-sm text-muted-foreground mb-3">
-                    {tFinals('allPlayoffMatchesComplete')}
-                  </p>
-                  <Button onClick={handleCreateUpperBracket}>
-                    {tFinals('createUpperBracket')}
-                  </Button>
-                </CardContent>
-              </Card>
+              <PlayoffCompleteCard
+                className="mt-4 border-green-500/50 bg-green-500/10"
+                description={tFinals('allPlayoffMatchesComplete')}
+                actionLabel={tFinals('createUpperBracket')}
+                onCreateUpperBracket={handleCreateUpperBracket}
+              />
             )}
           </TabsContent>
         </Tabs>
@@ -799,16 +796,11 @@ export default function BattleModeFinals({
             getTargetWins={(match, bracketMatch) => getBmFinalsTargetWins({ stage: match?.stage ?? 'playoff', round: match?.round ?? bracketMatch.round })}
           />
           {playoffComplete && isAdmin && (
-            <Card className="border-green-500/50 bg-green-500/10">
-              <CardContent className="py-4 text-center">
-                <p className="text-sm text-muted-foreground mb-3">
-                  {tFinals('allPlayoffMatchesComplete')}
-                </p>
-                <Button onClick={handleCreateUpperBracket}>
-                  {tFinals('createUpperBracket')}
-                </Button>
-              </CardContent>
-            </Card>
+            <PlayoffCompleteCard
+              description={tFinals('allPlayoffMatchesComplete')}
+              actionLabel={tFinals('createUpperBracket')}
+              onCreateUpperBracket={handleCreateUpperBracket}
+            />
           )}
         </>
       ) : (

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -72,6 +72,7 @@ import {
 } from "@/components/ui/select";
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
 import { PlayoffBracket } from "@/components/tournament/playoff-bracket";
+import { PlayoffCompleteCard } from "@/components/tournament/playoff-complete-card";
 import { COURSE_INFO, CUPS, CUP_SUBSTITUTIONS, GP_POSITION_OPTIONS, POLLING_INTERVAL, TOTAL_GP_RACES, TV_NUMBER_OPTIONS, getDriverPoints, type CourseAbbr } from "@/lib/constants";
 import { formatGpPosition } from "@/lib/gp-utils";
 import { usePolling } from "@/lib/hooks/usePolling";
@@ -857,12 +858,12 @@ export default function GrandPrixFinals({
               onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
             />
             {matches.length === 0 && playoffComplete && isAdmin && (
-              <Card className="mt-4 border-green-500/50 bg-green-500/10">
-                <CardContent className="py-4 text-center">
-                  <p className="text-sm text-muted-foreground mb-3">{tFinals('allPlayoffMatchesComplete')}</p>
-                  <Button onClick={handleCreateUpperBracket}>{tFinals('createUpperBracket')}</Button>
-                </CardContent>
-              </Card>
+              <PlayoffCompleteCard
+                className="mt-4 border-green-500/50 bg-green-500/10"
+                description={tFinals('allPlayoffMatchesComplete')}
+                actionLabel={tFinals('createUpperBracket')}
+                onCreateUpperBracket={handleCreateUpperBracket}
+              />
             )}
           </TabsContent>
         </Tabs>
@@ -878,12 +879,11 @@ export default function GrandPrixFinals({
             onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
           />
           {playoffComplete && isAdmin && (
-            <Card className="border-green-500/50 bg-green-500/10">
-              <CardContent className="py-4 text-center">
-                <p className="text-sm text-muted-foreground mb-3">{tFinals('allPlayoffMatchesComplete')}</p>
-                <Button onClick={handleCreateUpperBracket}>{tFinals('createUpperBracket')}</Button>
-              </CardContent>
-            </Card>
+            <PlayoffCompleteCard
+              description={tFinals('allPlayoffMatchesComplete')}
+              actionLabel={tFinals('createUpperBracket')}
+              onCreateUpperBracket={handleCreateUpperBracket}
+            />
           )}
         </>
       ) : (

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -72,6 +72,7 @@ import {
 } from "@/components/ui/select";
 import { DoubleEliminationBracket } from "@/components/tournament/double-elimination-bracket";
 import { PlayoffBracket } from "@/components/tournament/playoff-bracket";
+import { PlayoffCompleteCard } from "@/components/tournament/playoff-complete-card";
 import { COURSE_INFO, POLLING_INTERVAL, TV_NUMBER_OPTIONS, type CourseAbbr } from "@/lib/constants";
 import { getMrFinalsMaxRounds, getMrFinalsTargetWins } from "@/lib/finals-target-wins";
 import { usePolling } from "@/lib/hooks/usePolling";
@@ -742,12 +743,12 @@ export default function MatchRaceFinals({
               onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
             />
             {matches.length === 0 && playoffComplete && isAdmin && (
-              <Card className="mt-4 border-green-500/50 bg-green-500/10">
-                <CardContent className="py-4 text-center">
-                  <p className="text-sm text-muted-foreground mb-3">{tFinals('allPlayoffMatchesComplete')}</p>
-                  <Button onClick={handleCreateUpperBracket}>{tFinals('createUpperBracket')}</Button>
-                </CardContent>
-              </Card>
+              <PlayoffCompleteCard
+                className="mt-4 border-green-500/50 bg-green-500/10"
+                description={tFinals('allPlayoffMatchesComplete')}
+                actionLabel={tFinals('createUpperBracket')}
+                onCreateUpperBracket={handleCreateUpperBracket}
+              />
             )}
           </TabsContent>
         </Tabs>
@@ -762,12 +763,11 @@ export default function MatchRaceFinals({
             onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
           />
           {playoffComplete && isAdmin && (
-            <Card className="border-green-500/50 bg-green-500/10">
-              <CardContent className="py-4 text-center">
-                <p className="text-sm text-muted-foreground mb-3">{tFinals('allPlayoffMatchesComplete')}</p>
-                <Button onClick={handleCreateUpperBracket}>{tFinals('createUpperBracket')}</Button>
-              </CardContent>
-            </Card>
+            <PlayoffCompleteCard
+              description={tFinals('allPlayoffMatchesComplete')}
+              actionLabel={tFinals('createUpperBracket')}
+              onCreateUpperBracket={handleCreateUpperBracket}
+            />
           )}
         </>
       ) : (

--- a/smkc-score-app/src/components/tournament/playoff-complete-card.tsx
+++ b/smkc-score-app/src/components/tournament/playoff-complete-card.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+type PlayoffCompleteCardProps = {
+  description: string;
+  actionLabel: string;
+  onCreateUpperBracket: () => void;
+  className?: string;
+};
+
+/**
+ * Shared Phase-2 action shown after a Top-24 playoff finishes.
+ * BM, MR, and GP use different scoring forms, but this transition card has
+ * the same visibility rule and action. Keeping it in one component prevents
+ * copy/style drift while leaving mode-specific bracket logic in each page.
+ */
+export function PlayoffCompleteCard({
+  description,
+  actionLabel,
+  onCreateUpperBracket,
+  className,
+}: PlayoffCompleteCardProps) {
+  return (
+    <Card className={className ?? "border-green-500/50 bg-green-500/10"}>
+      <CardContent className="py-4 text-center">
+        <p className="text-sm text-muted-foreground mb-3">{description}</p>
+        <Button onClick={onCreateUpperBracket}>{actionLabel}</Button>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Summary
- Extract the duplicated BM/MR/GP Top-24 playoff-complete action into a shared PlayoffCompleteCard component.
- Add TC-1048 scenario documentation, docs drift coverage, component unit coverage, and extend BM/MR/GP Top-24 E2E flows to verify the Phase 2 action appears before upper bracket generation.

Issues: Closes #1048

Validation
- npm test -- playoff-complete-card.test.tsx --runInBand
- npm test -- e2e-cases-drift.test.ts --runInBand
- node --check e2e/tc-bm.js && node --check e2e/tc-mr.js && node --check e2e/tc-gp.js
- npm run lint (exit 0; warnings only, pre-existing/unrelated)
- git diff --check
