### PR TITLE
Fix PlayoffCompleteCard className merging

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1075,6 +1075,18 @@
 - **期待結果**: BM/MR/GP の Top-24 バラージ完了状態で同じ Phase 2 アクションが表示され、共通コンポーネントの unit test と既存 Top-24 E2E フローで退行を検出できる
 - **スクリプト**: tc-bm.js TC-515 + tc-mr.js TC-615 + tc-gp.js TC-715 + `smkc-score-app/__tests__/components/tournament/playoff-complete-card.test.tsx`
 
+## TC-1612: Top-24 Phase 2 アクションカードの追加 className マージ
+- **URL**: /tournaments/[temp-id]/bm/finals, /mr/finals, /gp/finals
+- **authRequired**: true (admin)
+- **背景**: issue #1612。Top-24 バラージ完了後の共通アクションカードは、呼び出し側が `mt-4` などの配置用 className だけを渡しても完了状態を示す緑の枠線・背景を失ってはいけない。
+- **手順**:
+  1. TC-1048 と同じ Top-24 バラージ完了状態を作る
+  2. finals ページで Phase 2 アクションカードが表示されることを確認する
+  3. 共通コンポーネントに追加 className だけを渡すケースでも、カードが `border-green-500/50` と `bg-green-500/10` を保持することを確認する
+  4. 空文字の className を渡す退行ケースでも同じデフォルトスタイルが残ることを確認する
+- **期待結果**: 呼び出し側が配置・余白だけを追加しても、Top-24 完了カードの意味を示すデフォルトスタイルが保持される
+- **スクリプト**: `smkc-score-app/__tests__/components/tournament/playoff-complete-card.test.tsx` + `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-516: BM 予選ページの決勝ブラケット存在状態 + リセット
 - **URL**: /tournaments/[temp-id]/bm
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/components/tournament/playoff-complete-card.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/playoff-complete-card.test.tsx
@@ -36,4 +36,35 @@ describe("PlayoffCompleteCard", () => {
 
     expect(screen.getByText("全プレーオフ試合が完了しました！上位ブラケットを作成してください。").closest(".mt-4")).toBeInTheDocument();
   });
+
+  it("keeps the default complete-state styling when callers provide only additional layout classes", () => {
+    render(
+      <PlayoffCompleteCard
+        className="mt-4"
+        description="The playoff is complete."
+        actionLabel="Create Upper Bracket"
+        onCreateUpperBracket={jest.fn()}
+      />,
+    );
+
+    const card = screen.getByText("The playoff is complete.").closest(".mt-4");
+
+    expect(card).toHaveClass("border-green-500/50");
+    expect(card).toHaveClass("bg-green-500/10");
+  });
+
+  it("does not drop the default complete-state styling when className is empty", () => {
+    render(
+      <PlayoffCompleteCard
+        className=""
+        description="The playoff is complete with empty classes."
+        actionLabel="Create Upper Bracket"
+        onCreateUpperBracket={jest.fn()}
+      />,
+    );
+
+    const card = screen.getByText("The playoff is complete with empty classes.").closest(".border-green-500\\/50");
+
+    expect(card).toHaveClass("bg-green-500/10");
+  });
 });

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -607,6 +607,34 @@ describe('E2E case drift coverage', () => {
     }
   });
 
+  it('keeps TC-1612 aligned with the PlayoffCompleteCard className merge contract', () => {
+    const section = e2eCaseSection('TC-1612');
+    const component = readRepoFile(
+      'smkc-score-app',
+      'src',
+      'components',
+      'tournament',
+      'playoff-complete-card.tsx',
+    );
+    const componentTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'components',
+      'tournament',
+      'playoff-complete-card.test.tsx',
+    );
+
+    expect(section).toContain('issue #1612');
+    expect(section).toContain('border-green-500/50');
+    expect(section).toContain('bg-green-500/10');
+    expect(component).toContain('import { cn } from "@/lib/utils"');
+    expect(component).toContain('className={cn(');
+    expect(component).toContain('"border-green-500/50 bg-green-500/10"');
+    expect(component).toContain('className,');
+    expect(componentTest).toContain('callers provide only additional layout classes');
+    expect(componentTest).toContain('className is empty');
+  });
+
   it('does not leave retired TC identifiers in runnable E2E scripts as false drift signals', () => {
     expect(tcAll).not.toContain('TC-403');
   });

--- a/smkc-score-app/src/components/tournament/playoff-complete-card.tsx
+++ b/smkc-score-app/src/components/tournament/playoff-complete-card.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 
 type PlayoffCompleteCardProps = {
   description: string;
@@ -23,7 +24,15 @@ export function PlayoffCompleteCard({
   className,
 }: PlayoffCompleteCardProps) {
   return (
-    <Card className={className ?? "border-green-500/50 bg-green-500/10"}>
+    <Card
+      className={cn(
+        // The green complete-state styling is semantic, not optional decoration:
+        // callers may add spacing/layout classes, but they should not have to
+        // repeat the state classes to keep the Phase-2 action visually clear.
+        "border-green-500/50 bg-green-500/10",
+        className,
+      )}
+    >
       <CardContent className="py-4 text-center">
         <p className="text-sm text-muted-foreground mb-3">{description}</p>
         <Button onClick={onCreateUpperBracket}>{actionLabel}</Button>


### PR DESCRIPTION
## Summary
- Merge PlayoffCompleteCard default complete-state styles with caller-provided className via cn()
- Add TC-1612 E2E scenario coverage for the className merge contract
- Add component and docs drift tests for additional-only and empty className regressions

## Issues
Closes #1612

## Validation
- npm test -- --runTestsByPath __tests__/components/tournament/playoff-complete-card.test.tsx __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint -- src/components/tournament/playoff-complete-card.tsx __tests__/components/tournament/playoff-complete-card.test.tsx __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
