### PR TITLE
Relax TC-1612 drift guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1087,6 +1087,17 @@
 - **期待結果**: 呼び出し側が配置・余白だけを追加しても、Top-24 完了カードの意味を示すデフォルトスタイルが保持される
 - **スクリプト**: `smkc-score-app/__tests__/components/tournament/playoff-complete-card.test.tsx` + `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-1614: TC-1612 drift テストの実装詳細固定を避ける
+- **URL**: N/A (static coverage)
+- **authRequired**: false
+- **背景**: issue #1614。TC-1612 の drift テストは E2E シナリオと振る舞いテストの関連を守るためのもので、`PlayoffCompleteCard` の import 文・`cn()` 呼び出し構文・クラス文字列の並びを固定してはいけない。
+- **手順**:
+  1. `E2E_TEST_CASES.md` に TC-1612 の背景・期待結果・対応スクリプトが記載されていることを確認する
+  2. `playoff-complete-card.test.tsx` に追加 className と空文字 className の振る舞いテストがあることを確認する
+  3. `e2e-cases-drift.test.ts` の TC-1612 drift テストが、コンポーネントソースファイルの文字列詳細を検査していないことを確認する
+- **期待結果**: TC-1612 の E2E ドキュメント連携は維持しつつ、振る舞いを変えない JSX 整形・import 整理・クラス順変更で drift テストが壊れない
+- **スクリプト**: `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-516: BM 予選ページの決勝ブラケット存在状態 + リセット
 - **URL**: /tournaments/[temp-id]/bm
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -609,13 +609,6 @@ describe('E2E case drift coverage', () => {
 
   it('keeps TC-1612 aligned with the PlayoffCompleteCard className merge contract', () => {
     const section = e2eCaseSection('TC-1612');
-    const component = readRepoFile(
-      'smkc-score-app',
-      'src',
-      'components',
-      'tournament',
-      'playoff-complete-card.tsx',
-    );
     const componentTest = readRepoFile(
       'smkc-score-app',
       '__tests__',
@@ -627,12 +620,30 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #1612');
     expect(section).toContain('border-green-500/50');
     expect(section).toContain('bg-green-500/10');
-    expect(component).toContain('import { cn } from "@/lib/utils"');
-    expect(component).toContain('className={cn(');
-    expect(component).toContain('"border-green-500/50 bg-green-500/10"');
-    expect(component).toContain('className,');
     expect(componentTest).toContain('callers provide only additional layout classes');
     expect(componentTest).toContain('className is empty');
+  });
+
+  it('keeps TC-1614 aligned with implementation-detail-free TC-1612 drift coverage', () => {
+    const section = e2eCaseSection('TC-1614');
+    const driftTestSource = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'docs',
+      'e2e-cases-drift.test.ts',
+    );
+    const tc1612DriftTest = sectionBetween(
+      driftTestSource,
+      "it('keeps TC-1612 aligned with the PlayoffCompleteCard className merge contract'",
+      "  it('keeps TC-1614 aligned",
+    );
+
+    expect(section).toContain('issue #1614');
+    expect(section).toContain('コンポーネントソースファイルの文字列詳細を検査していない');
+    expect(tc1612DriftTest).not.toContain("'src'");
+    expect(tc1612DriftTest).not.toContain("'playoff-complete-card.tsx'");
+    expect(tc1612DriftTest).not.toContain('import { cn }');
+    expect(tc1612DriftTest).not.toContain('className={cn(');
   });
 
   it('does not leave retired TC identifiers in runnable E2E scripts as false drift signals', () => {


### PR DESCRIPTION
## Summary
- Add TC-1614 for keeping TC-1612 drift coverage free of component source implementation details
- Relax the TC-1612 drift guard to verify E2E scenario and behavior-test linkage instead of import/cn/class syntax
- Add a static guard that prevents the TC-1612 drift test from reintroducing component-source string checks

## Issues
Closes #1614

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/components/tournament/playoff-complete-card.test.tsx --runInBand
- npm run lint -- __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
