### PR TITLE
Harden TC-1614 drift guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1098,6 +1098,17 @@
 - **期待結果**: TC-1612 の E2E ドキュメント連携は維持しつつ、振る舞いを変えない JSX 整形・import 整理・クラス順変更で drift テストが壊れない
 - **スクリプト**: `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-1616: TC-1614 drift テストの抽出空振りを防ぐ
+- **URL**: N/A (static coverage)
+- **authRequired**: false
+- **背景**: issue #1616。TC-1614 の drift テストは `sectionBetween()` で TC-1612 テスト本文を抽出して禁止文字列がないことを確認するため、境界文字列の変更で抽出に失敗しても `not.toContain()` だけが空文字列に対して通ってはいけない。
+- **手順**:
+  1. TC-1614 drift テストが `sectionBetween()` で TC-1612 テスト本文を抽出していることを確認する
+  2. 抽出結果に対して、十分な長さや既知の正規アンカーを含むことを確認する陽性アサーションがあることを確認する
+  3. その後に禁止文字列の `not.toContain()` を実行していることを確認する
+- **期待結果**: TC-1612 テスト本文の抽出に失敗した場合、禁止文字列チェックが空振りで成功せず、drift テスト自体が失敗する
+- **スクリプト**: `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-516: BM 予選ページの決勝ブラケット存在状態 + リセット
 - **URL**: /tournaments/[temp-id]/bm
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -640,10 +640,37 @@ describe('E2E case drift coverage', () => {
 
     expect(section).toContain('issue #1614');
     expect(section).toContain('コンポーネントソースファイルの文字列詳細を検査していない');
+    // Positive anchors keep the negative string checks from passing against an
+    // empty extraction if the surrounding test names are refactored later.
+    expect(tc1612DriftTest.length).toBeGreaterThan(300);
+    expect(tc1612DriftTest).toContain("const section = e2eCaseSection('TC-1612');");
     expect(tc1612DriftTest).not.toContain("'src'");
     expect(tc1612DriftTest).not.toContain("'playoff-complete-card.tsx'");
     expect(tc1612DriftTest).not.toContain('import { cn }');
     expect(tc1612DriftTest).not.toContain('className={cn(');
+  });
+
+  it('keeps TC-1616 aligned with positive extraction assertions for the TC-1614 guard', () => {
+    const section = e2eCaseSection('TC-1616');
+    const driftTestSource = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'docs',
+      'e2e-cases-drift.test.ts',
+    );
+    const tc1614DriftTest = sectionBetween(
+      driftTestSource,
+      "it('keeps TC-1614 aligned with implementation-detail-free TC-1612 drift coverage'",
+      "  it('keeps TC-1616 aligned",
+    );
+
+    expect(section).toContain('issue #1616');
+    expect(section).toContain('陽性アサーション');
+    expect(tc1614DriftTest).toContain('toBeGreaterThan');
+    expect(tc1614DriftTest).toContain('e2eCaseSection');
+    expect(tc1614DriftTest.indexOf('toBeGreaterThan')).toBeLessThan(
+      tc1614DriftTest.indexOf("not.toContain(\"'src'\")"),
+    );
   });
 
   it('does not leave retired TC identifiers in runnable E2E scripts as false drift signals', () => {


### PR DESCRIPTION
## Summary
- Add TC-1616 to cover the TC-1614 drift guard extraction failure mode
- Add positive anchors before TC-1614 negative string checks so empty extraction cannot pass trivially
- Add a docs drift guard that keeps those positive assertions in place

## Issues
Closes #1616

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint -- __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
