### PR TITLE
Stabilize TC-1614 drift guard anchors

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1109,6 +1109,28 @@
 - **期待結果**: TC-1612 テスト本文の抽出に失敗した場合、禁止文字列チェックが空振りで成功せず、drift テスト自体が失敗する
 - **スクリプト**: `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-1618: drift guard の境界文字列をインデント非依存にする
+- **URL**: N/A (static coverage)
+- **authRequired**: false
+- **背景**: issue #1618。`sectionBetween()` の終了境界に `"  it(...` のような先頭スペースを含めると、フォーマット変更だけで抽出に失敗する。
+- **手順**:
+  1. TC-1614 / TC-1616 の drift guard が `sectionBetween()` を使っていることを確認する
+  2. 終了境界文字列が先頭スペースに依存していないことを確認する
+  3. 抽出成功を確認する陽性アサーションが維持されていることを確認する
+- **期待結果**: インデント変更だけでは drift guard の抽出境界が壊れない
+- **スクリプト**: `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
+
+## TC-1619: drift guard の抽出長しきい値に根拠コメントを付ける
+- **URL**: N/A (static coverage)
+- **authRequired**: false
+- **背景**: issue #1619。TC-1614 guard の `length` しきい値は、なぜその値で空抽出や短すぎる抽出を検出できるのかをコード上で説明する必要がある。
+- **手順**:
+  1. TC-1614 drift guard に抽出長の陽性アサーションがあることを確認する
+  2. しきい値が名前付き定数になっていることを確認する
+  3. 現在の抽出本文サイズに対する安全側の閾値であることをコメントで説明していることを確認する
+- **期待結果**: 抽出長の閾値がマジックナンバーではなく、将来の調整根拠を読める
+- **スクリプト**: `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-516: BM 予選ページの決勝ブラケット存在状態 + リセット
 - **URL**: /tournaments/[temp-id]/bm
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -635,14 +635,18 @@ describe('E2E case drift coverage', () => {
     const tc1612DriftTest = sectionBetween(
       driftTestSource,
       "it('keeps TC-1612 aligned with the PlayoffCompleteCard className merge contract'",
-      "  it('keeps TC-1614 aligned",
+      "it('keeps TC-1614 aligned",
     );
+    // Current TC-1612 guard body is substantially longer than this threshold;
+    // the named lower bound catches empty/truncated extraction while allowing
+    // harmless wording edits in the test body.
+    const TC1612_DRIFT_MIN_BODY_LENGTH = 300;
 
     expect(section).toContain('issue #1614');
     expect(section).toContain('コンポーネントソースファイルの文字列詳細を検査していない');
     // Positive anchors keep the negative string checks from passing against an
     // empty extraction if the surrounding test names are refactored later.
-    expect(tc1612DriftTest.length).toBeGreaterThan(300);
+    expect(tc1612DriftTest.length).toBeGreaterThan(TC1612_DRIFT_MIN_BODY_LENGTH);
     expect(tc1612DriftTest).toContain("const section = e2eCaseSection('TC-1612');");
     expect(tc1612DriftTest).not.toContain("'src'");
     expect(tc1612DriftTest).not.toContain("'playoff-complete-card.tsx'");
@@ -661,7 +665,7 @@ describe('E2E case drift coverage', () => {
     const tc1614DriftTest = sectionBetween(
       driftTestSource,
       "it('keeps TC-1614 aligned with implementation-detail-free TC-1612 drift coverage'",
-      "  it('keeps TC-1616 aligned",
+      "it('keeps TC-1616 aligned",
     );
 
     expect(section).toContain('issue #1616');
@@ -671,6 +675,30 @@ describe('E2E case drift coverage', () => {
     expect(tc1614DriftTest.indexOf('toBeGreaterThan')).toBeLessThan(
       tc1614DriftTest.indexOf("not.toContain(\"'src'\")"),
     );
+  });
+
+  it('keeps TC-1618 and TC-1619 aligned with stable TC-1614 extraction anchors', () => {
+    const tc1618 = e2eCaseSection('TC-1618');
+    const tc1619 = e2eCaseSection('TC-1619');
+    const driftTestSource = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'docs',
+      'e2e-cases-drift.test.ts',
+    );
+    const tc1614DriftTest = sectionBetween(
+      driftTestSource,
+      "it('keeps TC-1614 aligned with implementation-detail-free TC-1612 drift coverage'",
+      "it('keeps TC-1616 aligned",
+    );
+
+    expect(tc1618).toContain('issue #1618');
+    expect(tc1618).toContain('先頭スペースに依存していない');
+    expect(tc1619).toContain('issue #1619');
+    expect(tc1619).toContain('名前付き定数');
+    expect(tc1614DriftTest).not.toContain('"  it(');
+    expect(tc1614DriftTest).toContain('TC1612_DRIFT_MIN_BODY_LENGTH');
+    expect(tc1614DriftTest).toContain('Current TC-1612 guard body is substantially longer');
   });
 
   it('does not leave retired TC identifiers in runnable E2E scripts as false drift signals', () => {


### PR DESCRIPTION
## Summary
- Add TC-1618 and TC-1619 static scenarios for the TC-1614 drift guard follow-ups
- Remove leading-space dependence from drift-test sectionBetween end markers
- Replace the extraction-length magic number with a named lower bound and rationale comment

## Issues
Closes #1618
Closes #1619

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint -- __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
