### PR TITLE
Clarify Top-24 qualifier count guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1075,6 +1075,18 @@
 - **期待結果**: BM/MR/GP の Top-24 バラージ完了状態で同じ Phase 2 アクションが表示され、共通コンポーネントの unit test と既存 Top-24 E2E フローで退行を検出できる
 - **スクリプト**: tc-bm.js TC-515 + tc-mr.js TC-615 + tc-gp.js TC-715 + `smkc-score-app/__tests__/components/tournament/playoff-complete-card.test.tsx`
 
+## TC-1046: BM Top-24 preview は 24名要件を専用定数で判定する
+- **URL**: /api/tournaments/[id]/bm/finals (GET)
+- **authRequired**: true (admin)
+- **背景**: issue #1046。Top-24 Phase 2 preview の資格者数 guard が裸の `24` だと、12名のバラージ参加者数 (`PLAYOFF_ENTRANT_COUNT`) と誤って同一視されやすい。Top-24 全体の必要資格者数とバラージ参加者数は別概念として固定する。
+- **手順**:
+  1. 管理者セッションで BM Top-24 の playoff stage が存在する状態を用意する
+  2. 資格者数が24名未満の状態で finals GET preview を呼ぶ
+  3. preview 用の `seededPlayers` / Top-16 `bracketStructure` が作られず、既存 playoff 情報だけが返ることを確認する
+  4. 静的テストで `TOP24_QUALIFIER_COUNT` が `PLAYOFF_ENTRANT_COUNT` と別に定義され、`buildTop24FinalsPreview` と POST guard の両方で使われることを確認する
+- **期待結果**: Top-24 preview は「24名必要」という仕様を専用定数で表し、12名のバラージ参加者数に誤置換されない
+- **スクリプト**: tc-bm.js TC-1046 + `smkc-score-app/__tests__/static/tc-1046-top24-qualifier-count.test.ts` + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts`
+
 ## TC-1612: Top-24 Phase 2 アクションカードの追加 className マージ
 - **URL**: /tournaments/[temp-id]/bm/finals, /mr/finals, /gp/finals
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -607,6 +607,32 @@ describe('E2E case drift coverage', () => {
     }
   });
 
+  it('keeps TC-1046 aligned with the Top-24 qualifier-count guard', () => {
+    const section = e2eCaseSection('TC-1046');
+    const routeFactory = readRepoFile(
+      'smkc-score-app',
+      'src',
+      'lib',
+      'api-factories',
+      'finals-route.ts',
+    );
+    const unitTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'lib',
+      'api-factories',
+      'finals-route.test.ts',
+    );
+
+    expect(section).toContain('issue #1046');
+    expect(section).toContain('TOP24_QUALIFIER_COUNT');
+    expect(section).toContain('PLAYOFF_ENTRANT_COUNT');
+    expect(section).toContain('tc-bm.js TC-1046');
+    expect(tcBm).toContain("log('TC-1046'");
+    expect(routeFactory).toContain('const TOP24_QUALIFIER_COUNT = 24');
+    expect(unitTest).toContain('does not build a Top-16 preview when a Top-24 playoff has fewer than 24 qualifiers');
+  });
+
   it('keeps TC-1612 aligned with the PlayoffCompleteCard className merge contract', () => {
     const section = e2eCaseSection('TC-1612');
     const componentTest = readRepoFile(

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1536,6 +1536,33 @@ describe('Finals Route Factory', () => {
       });
     });
 
+    it('does not build a Top-16 preview when a Top-24 playoff has fewer than 24 qualifiers', async () => {
+      (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(23));
+      const playoffRows = [
+        { id: 'p-r2-5', matchNumber: 5, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-19', player2Id: 'player-8', player1: { id: 'player-19' }, player2: { id: 'player-8' } },
+      ];
+      (prisma.bMMatch as any).findMany.mockImplementation((args: any) => {
+        if (args?.where?.stage === 'playoff') return Promise.resolve(playoffRows);
+        return Promise.resolve([]);
+      });
+      (prisma.bMMatch as any).count.mockResolvedValue(0);
+
+      const config = createMockConfig({ getStyle: 'grouped' });
+      const { GET } = createFinalsHandlers(config);
+
+      const response = await GET(new NextRequest('http://localhost:3000'), {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(200);
+      const json = await response.json();
+      expect(json.data.phase).toBe('playoff');
+      expect(json.data.playoffMatches).toHaveLength(1);
+      expect(json.data.seededPlayers).toBeUndefined();
+      expect(json.data.bracketSize).toBe(8);
+      expect(json.data.bracketStructure).toEqual([]);
+    });
+
     it('GET Top-24 preview warns and skips a direct seed with an invalid player payload', async () => {
       const qualifications = createMockQualifications(24);
       qualifications[0].player = null;

--- a/smkc-score-app/__tests__/static/tc-1046-top24-qualifier-count.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1046-top24-qualifier-count.test.ts
@@ -1,0 +1,23 @@
+import { readRepoFile } from '../helpers/e2e-cases';
+
+describe('TC-1046 Top-24 qualifier-count guard', () => {
+  it('keeps Top-24 qualifier count separate from playoff entrant count', () => {
+    const source = readRepoFile(
+      'smkc-score-app',
+      'src',
+      'lib',
+      'api-factories',
+      'finals-route.ts',
+    );
+
+    expect(source).toContain('const TOP24_QUALIFIER_COUNT = 24');
+    expect(source).toContain('const PLAYOFF_ENTRANT_COUNT = 12');
+
+    const previewGuard = source.match(/if \(qualifications\.length < TOP24_QUALIFIER_COUNT\) return null;/g) ?? [];
+    const postGuard = source.match(/if \(qualifications\.length < TOP24_QUALIFIER_COUNT\) \{/g) ?? [];
+
+    expect(previewGuard).toHaveLength(1);
+    expect(postGuard).toHaveLength(1);
+    expect(source).toContain('`Not enough players qualified. Need ${TOP24_QUALIFIER_COUNT}, found ${qualifications.length}`');
+  });
+});

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -26,6 +26,7 @@
  *   TC-532  BM qualification standings show 0-1000 qualification points
  *   TC-533  BM combined standings tab shows rows with ascending ranks
  *   TC-535  BM Top-24 playoff seed labels use group-rank labels
+ *   TC-1046 BM Top-24 preview uses a qualifier-count constant, not barrage count
  *   TC-1051 BM Top-24 direct-seed API no longer depends on legacy direct[]
  *   TC-1052 BM Top-24 rejects unsupported 3-group seeding
  *
@@ -1007,6 +1008,47 @@ async function runTc510(adminPage) {
     log('TC-510', 'FAIL', err instanceof Error ? err.message : 'BM 510 failed');
   } finally {
     if (setup) await setup.cleanup();
+  }
+}
+
+/* ───────── TC-1046: BM Top-24 preview keeps the 24-player guard ─────────
+ * Builds a valid Top-24 playoff first, then replaces qualification with only
+ * 23 players while leaving the playoff rows in place. GET /bm/finals must not
+ * synthesize a 16-player Upper Bracket preview from incomplete qualification
+ * data; the 24-player requirement is distinct from the 12-player barrage pool. */
+async function runTc1046(adminPage) {
+  let tournamentId = null;
+  try {
+    const players = sharedBmPlayers(28);
+    tournamentId = await uiCreateTournament(adminPage, `E2E BM TC-1046 ${Date.now()}`);
+    await setupBmQualViaUi(adminPage, tournamentId, players);
+
+    const phase1 = await apiGenerateBmFinals(adminPage, tournamentId, 24);
+    if (phase1.s !== 201 || phase1.b?.data?.phase !== 'playoff') {
+      throw new Error(`Top-24 playoff setup failed (${phase1.s})`);
+    }
+
+    await setupBmQualViaUi(adminPage, tournamentId, players.slice(0, 23));
+    const state = await apiFetchBmFinalsState(adminPage, tournamentId);
+    const seededPlayersAbsent = !Object.prototype.hasOwnProperty.call(state.raw?.data || {}, 'seededPlayers');
+    const ok =
+      state.phase === 'playoff' &&
+      state.playoffMatches.length === 8 &&
+      seededPlayersAbsent &&
+      state.bracketSize === 8 &&
+      state.matches.length === 0;
+
+    log('TC-1046', ok ? 'PASS' : 'FAIL',
+      state.phase !== 'playoff' ? `phase=${state.phase}`
+      : state.playoffMatches.length !== 8 ? `playoffMatches=${state.playoffMatches.length}`
+      : !seededPlayersAbsent ? 'seededPlayers preview was present with fewer than 24 qualifiers'
+      : state.bracketSize !== 8 ? `bracketSize=${state.bracketSize}`
+      : state.matches.length !== 0 ? `finals matches=${state.matches.length}`
+      : '');
+  } catch (err) {
+    log('TC-1046', 'FAIL', err instanceof Error ? err.message : 'TC-1046 failed');
+  } finally {
+    if (tournamentId) await apiDeleteTournament(adminPage, tournamentId);
   }
 }
 
@@ -2235,6 +2277,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-533', fn: runTc533 },
       { name: 'TC-504', fn: runTc504 },
       { name: 'TC-510', fn: runTc510 },
+      { name: 'TC-1046', fn: runTc1046 },
       { name: 'TC-1052', fn: runTc1052 },
       { name: 'TC-515', fn: runTc515 },
       { name: 'TC-516', fn: runTc516 },
@@ -2259,7 +2302,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 
 module.exports = {
   runTc501, runTc502, runTc322, runTc503, runTc504, runTc505, runTc506, runTc511, runTc512, runTc513,
-  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522, runTc523, runTc524, runTc525, runTc526, runTc528, runTc529, runTc530, runTc531, runTc533, runTc1052,
+  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522, runTc523, runTc524, runTc525, runTc526, runTc528, runTc529, runTc530, runTc531, runTc533, runTc1046, runTc1052,
   getSuite,
   results,
   setSharedBmFinalsReady: (v) => { sharedBmFinalsReady = v; },

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -46,6 +46,7 @@ const BRACKET_SIZE_THRESHOLD = 20;
  * Top 24 qualifiers → Top 16 Upper Bracket, with 12 entrants from qualification
  * positions 13-24 competing for the 4 Upper-Bracket barrage seats.
  */
+const TOP24_QUALIFIER_COUNT = 24;
 const PLAYOFF_ENTRANT_COUNT = 12;
 const PLAYOFF_R2_UPPER_SEED_COUNT = 4;
 const TOP24_SUPPORTED_GROUP_COUNT = 2;
@@ -806,7 +807,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
         orderBy: config.qualificationOrderBy,
       });
 
-      if (qualifications.length < 24) return null;
+      /* This guard is deliberately tied to the full Top-24 qualifier count,
+       * not PLAYOFF_ENTRANT_COUNT. The preview seeds direct qualifiers plus
+       * playoff winners into a 16-player Upper Bracket, so using the 12-player
+       * barrage pool here would let incomplete qualification data produce a
+       * misleading Phase-2 preview. */
+      if (qualifications.length < TOP24_QUALIFIER_COUNT) return null;
 
       const rankedQualifications = await applyFinalsQualificationRanks(
         model,
@@ -1485,9 +1491,9 @@ export function createFinalsHandlers(config: FinalsConfig) {
         orderBy: finalsConfig.qualificationOrderBy,
       });
 
-      if (qualifications.length < 24) {
+      if (qualifications.length < TOP24_QUALIFIER_COUNT) {
         return handleValidationError(
-          `Not enough players qualified. Need 24, found ${qualifications.length}`,
+          `Not enough players qualified. Need ${TOP24_QUALIFIER_COUNT}, found ${qualifications.length}`,
           'qualifications',
         );
       }


### PR DESCRIPTION
Summary
- Add TC-1046 coverage for the BM Top-24 preview guard.
- Introduce TOP24_QUALIFIER_COUNT so the 24-player requirement is not confused with the 12-player playoff entrant count.
- Cover the behavior with E2E catalog/runner registration, a route unit test, docs drift coverage, and a static guard.

Issues: Closes #1046

Validation
- npm test -- --runTestsByPath __tests__/static/tc-1046-top24-qualifier-count.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/api-factories/finals-route.test.ts --runInBand
- node --check e2e/tc-bm.js
- npm run lint -- src/lib/api-factories/finals-route.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/static/tc-1046-top24-qualifier-count.test.ts __tests__/lib/api-factories/finals-route.test.ts
- git diff --check
