### PR TITLE
Guard BM Top-24 reseed count

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1087,6 +1087,18 @@
 - **期待結果**: Top-24 preview は「24名必要」という仕様を専用定数で表し、12名のバラージ参加者数に誤置換されない
 - **スクリプト**: tc-bm.js TC-1046 + `smkc-score-app/__tests__/static/tc-1046-top24-qualifier-count.test.ts` + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts`
 
+## TC-1622: BM Top-24 preview 前の23名再セットアップは資格者を置換する
+- **URL**: /api/tournaments/[id]/bm, /api/tournaments/[id]/bm/finals (GET)
+- **authRequired**: true (admin)
+- **背景**: issue #1622。TC-1046 は 28名で Top-24 playoff を作った後、同じ大会を23名で再セットアップして preview guard を確認する。`setupBmQualViaUi` が既存資格者を差し替えず追記した場合、DBに28名残ってテスト前提が崩れるため、再セットアップ後の資格者数を明示的に検証する。
+- **手順**:
+  1. 管理者セッションで 28名 BM 予選を完了し、Top-24 playoff を生成する
+  2. 同じ大会に対して `setupBmQualViaUi(..., players.slice(0, 23))` を再実行する
+  3. BM qualification API の資格者数が23名に置換されていることを確認する
+  4. その状態で finals GET preview を呼び、TC-1046 と同じく Top-16 preview が作られないことを確認する
+- **期待結果**: TC-1046 の「24名未満」前提は UI セットアップの置換動作で保証され、古い28名 qualification が残って偽陽性にならない
+- **スクリプト**: tc-bm.js TC-1046 + `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts` + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts`
+
 ## TC-1612: Top-24 Phase 2 アクションカードの追加 className マージ
 - **URL**: /tournaments/[temp-id]/bm/finals, /mr/finals, /gp/finals
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -633,6 +633,17 @@ describe('E2E case drift coverage', () => {
     expect(unitTest).toContain('does not build a Top-16 preview when a Top-24 playoff has fewer than 24 qualifiers');
   });
 
+  it('keeps TC-1622 aligned with the BM 28-to-23 reseed guard', () => {
+    const section = e2eCaseSection('TC-1622');
+
+    expect(section).toContain('issue #1622');
+    expect(section).toContain('23名に置換');
+    expect(section).toContain('tc-bm.js TC-1046');
+    expect(section).toContain('finals-route.test.ts');
+    expect(tcBm).toContain('TC-1622');
+    expect(tcBm).toContain('qualificationCountAfterReseed === 23');
+  });
+
   it('keeps TC-1612 aligned with the PlayoffCompleteCard className merge contract', () => {
     const section = e2eCaseSection('TC-1612');
     const componentTest = readRepoFile(

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -2353,7 +2353,10 @@ async function assertCombinedStandingsTab(page, mode, tournamentId) {
 
 /** UI-driven BM qualification: group assignment + all match scores.
  *  `players` must be `{ id, name, nickname }[]`. Idempotent — safe to re-run
- *  because setupModePlayersViaUi clears selected players before re-adding. */
+ *  because setupModePlayersViaUi clears the existing selection before
+ *  re-adding. That replacement contract matters for Top-24 guard tests:
+ *  re-running with fewer players replaces the qualification set instead of
+ *  leaving stale higher-count rows behind. */
 async function setupBmQualViaUi(adminPage, tournamentId, players, { score1 = 3, score2 = 1, randomize = true, resolveTies = true } = {}) {
   /* Freshly created tournaments start in draft status. The setup dialog
    * opens on draft pages but score PUTs require status='active' — without

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -27,6 +27,7 @@
  *   TC-533  BM combined standings tab shows rows with ascending ranks
  *   TC-535  BM Top-24 playoff seed labels use group-rank labels
  *   TC-1046 BM Top-24 preview uses a qualifier-count constant, not barrage count
+ *   TC-1622 BM Top-24 28-to-23 reseed replaces qualification entries
  *   TC-1051 BM Top-24 direct-seed API no longer depends on legacy direct[]
  *   TC-1052 BM Top-24 rejects unsupported 3-group seeding
  *
@@ -1011,11 +1012,14 @@ async function runTc510(adminPage) {
   }
 }
 
-/* ───────── TC-1046: BM Top-24 preview keeps the 24-player guard ─────────
+/* ───────── TC-1046 / TC-1622: BM Top-24 preview keeps the 24-player guard ─────────
  * Builds a valid Top-24 playoff first, then replaces qualification with only
  * 23 players while leaving the playoff rows in place. GET /bm/finals must not
  * synthesize a 16-player Upper Bracket preview from incomplete qualification
- * data; the 24-player requirement is distinct from the 12-player barrage pool. */
+ * data; the 24-player requirement is distinct from the 12-player barrage pool.
+ * TC-1622 explicitly verifies the reseed step replaced the 28-player
+ * qualification set with 23 rows, otherwise TC-1046 could accidentally pass
+ * against stale qualification data rather than the intended under-24 state. */
 async function runTc1046(adminPage) {
   let tournamentId = null;
   try {
@@ -1029,9 +1033,13 @@ async function runTc1046(adminPage) {
     }
 
     await setupBmQualViaUi(adminPage, tournamentId, players.slice(0, 23));
+    const bmAfterReseed = await apiFetchBm(adminPage, tournamentId);
+    const qualificationCountAfterReseed =
+      (bmAfterReseed.qualifications || bmAfterReseed.data?.qualifications || []).length;
     const state = await apiFetchBmFinalsState(adminPage, tournamentId);
     const seededPlayersAbsent = !Object.prototype.hasOwnProperty.call(state.raw?.data || {}, 'seededPlayers');
     const ok =
+      qualificationCountAfterReseed === 23 &&
       state.phase === 'playoff' &&
       state.playoffMatches.length === 8 &&
       seededPlayersAbsent &&
@@ -1039,7 +1047,8 @@ async function runTc1046(adminPage) {
       state.matches.length === 0;
 
     log('TC-1046', ok ? 'PASS' : 'FAIL',
-      state.phase !== 'playoff' ? `phase=${state.phase}`
+      qualificationCountAfterReseed !== 23 ? `TC-1622 qualification count after 23-player reseed=${qualificationCountAfterReseed}`
+      : state.phase !== 'playoff' ? `phase=${state.phase}`
       : state.playoffMatches.length !== 8 ? `playoffMatches=${state.playoffMatches.length}`
       : !seededPlayersAbsent ? 'seededPlayers preview was present with fewer than 24 qualifiers'
       : state.bracketSize !== 8 ? `bracketSize=${state.bracketSize}`


### PR DESCRIPTION
Summary
- Add TC-1622 documentation for the BM Top-24 28-to-23 reseed assumption.
- Extend TC-1046 to assert the BM qualification count is exactly 23 after reseeding before checking the Top-24 preview guard.
- Document the setupBmQualViaUi replacement contract and add drift coverage tying TC-1622 to the runnable BM E2E.

Issues: Closes #1622

Validation
- npm test -- e2e-cases-drift.test.ts --runInBand
- npm test -- finals-route.test.ts --runInBand
- node --check e2e/tc-bm.js
- git diff --check
- npm run lint (exit 0; existing warnings only)
- E2E_TEST=TC-1046 npm run e2e:bm attempted, blocked by Chromium crashpad permission error: bootstrap_check_in ... Permission denied (1100), settings.dat Operation not permitted
