### PR TITLE
Clean up TC-1622 follow-up guards

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -641,7 +641,7 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('tc-bm.js TC-1046');
     expect(section).toContain('finals-route.test.ts');
     expect(tcBm).toContain('TC-1622');
-    expect(tcBm).toContain('qualificationCountAfterReseed === 23');
+    expect(tcBm).toContain('TC-1622 qualification count after 23-player reseed');
   });
 
   it('keeps TC-1612 aligned with the PlayoffCompleteCard className merge contract', () => {

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -1045,15 +1045,16 @@ async function runTc1046(adminPage) {
       seededPlayersAbsent &&
       state.bracketSize === 8 &&
       state.matches.length === 0;
-
-    log('TC-1046', ok ? 'PASS' : 'FAIL',
+    const reason =
       qualificationCountAfterReseed !== 23 ? `TC-1622 qualification count after 23-player reseed=${qualificationCountAfterReseed}`
       : state.phase !== 'playoff' ? `phase=${state.phase}`
       : state.playoffMatches.length !== 8 ? `playoffMatches=${state.playoffMatches.length}`
       : !seededPlayersAbsent ? 'seededPlayers preview was present with fewer than 24 qualifiers'
       : state.bracketSize !== 8 ? `bracketSize=${state.bracketSize}`
       : state.matches.length !== 0 ? `finals matches=${state.matches.length}`
-      : '');
+      : '';
+
+    log('TC-1046', ok ? 'PASS' : 'FAIL', reason);
   } catch (err) {
     log('TC-1046', 'FAIL', err instanceof Error ? err.message : 'TC-1046 failed');
   } finally {


### PR DESCRIPTION
Summary
- Make the TC-1622 drift assertion use the stable reseed failure message instead of the local variable/comparison spelling.
- Move the TC-1046 failure detail calculation into a named reason before calling log().

Issues: Closes #1624, Closes #1625

Validation
- npm test -- e2e-cases-drift.test.ts --runInBand
- node --check e2e/tc-bm.js
- git diff --check
- internal re-review: no findings
