### PR TITLE
Harden TA flow rank assertions

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2659,9 +2659,11 @@
   1. 24名の TA Phase 3 を実行し、ランク順 (`60_000 + rank*200ms`) で全ラウンドを進行（rank=1 が常勝、rank=24 が最初に脱落）
   2. `/api/tournaments/[temp-id]/ta/phases?phase=phase3` でラウンド一覧を取得し、`eliminatedIds` を時系列で連結して脱落順序を抽出
   3. POST `/api/tournaments/[temp-id]/overall-ranking` でランキングを再計算
-  4. champion (rank=1) の `taFinalsPoints` が 2000 (1位の点数) であることを確認
-  5. 最後に脱落したプレイヤーの `taFinalsPoints` が、最初に脱落したプレイヤーの `taFinalsPoints` より大きいことを確認
-- **期待結果**: 総合ランキングの TA Finals 配点が「最後まで生き残った順」を反映する。早期脱落者が後期脱落者を上回ることはない
+  4. champion (rank=1) の `taFinalsPoints` が正の値で、取得したランキング内の最大 TA Finals 点であることを確認する（点数テーブルの固定値には依存しない）
+  5. `eliminatedIds` が2件未満の場合は比較不能として TC-TA-FLOW-24-RANK のみ SKIP し、誤解を招く 0 点同士の FAIL を出さないことを確認する
+  6. 最後に脱落したプレイヤーの `taFinalsPoints` が、最初に脱落したプレイヤーの `taFinalsPoints` より大きいことを確認する
+  7. Phase 3 ラウンド取得または POST `/overall-ranking` が 2xx 以外の場合、TC-TA-FLOW-24-RANK を FAIL として記録し、runFullFlow 全体から早期 return しないことを確認する
+- **期待結果**: 総合ランキングの TA Finals 配点が「最後まで生き残った順」を反映する。早期脱落者が後期脱落者を上回ることはなく、比較不能な途中状態や再計算失敗もケース単位の明確な結果になる
 
 ## TC-1060: TA Finals Phase 1/2 脱落者の中間順位を全件検証する (issue #1060)
 - **URL**: /api/tournaments/[temp-id]/overall-ranking

--- a/smkc-score-app/__tests__/e2e/ta-flow-rank-assertions.test.ts
+++ b/smkc-score-app/__tests__/e2e/ta-flow-rank-assertions.test.ts
@@ -1,0 +1,119 @@
+import { evaluateTaFlowRankAssertion } from '../../e2e/lib/ta-flow-rank-assertions';
+
+const entries = [
+  { playerId: 'champion', rank: 1 },
+  { playerId: 'early', rank: 24 },
+  { playerId: 'late', rank: 2 },
+];
+
+describe('TC-TA-FLOW-24-RANK assertion helper', () => {
+  it('passes when the champion has the highest TA finals points and late eliminations outrank early eliminations', () => {
+    expect(evaluateTaFlowRankAssertion({
+      entries,
+      phase3Rounds: [
+        { eliminatedIds: ['early'] },
+        { eliminatedIds: ['late'] },
+      ],
+      recalcStatus: 200,
+      recalcBody: {
+        data: {
+          scores: [
+            { playerId: 'champion', taFinalsPoints: 2100 },
+            { playerId: 'late', taFinalsPoints: 1600 },
+            { playerId: 'early', taFinalsPoints: 1000 },
+          ],
+        },
+      },
+    })).toEqual({ status: 'PASS', detail: '' });
+  });
+
+  it('does not hard-code the champion point value', () => {
+    expect(evaluateTaFlowRankAssertion({
+      entries,
+      phase3Rounds: [
+        { eliminatedIds: ['early'] },
+        { eliminatedIds: ['late'] },
+      ],
+      recalcStatus: 200,
+      recalcBody: {
+        data: {
+          scores: [
+            { playerId: 'champion', taFinalsPoints: 2400 },
+            { playerId: 'late', taFinalsPoints: 1600 },
+            { playerId: 'early', taFinalsPoints: 1000 },
+          ],
+        },
+      },
+    })).toEqual({ status: 'PASS', detail: '' });
+  });
+
+  it('skips the elimination-order assertion when phase3 produced too little elimination data', () => {
+    expect(evaluateTaFlowRankAssertion({
+      entries,
+      phase3Rounds: [{ eliminatedIds: [] }],
+      recalcStatus: 200,
+      recalcBody: {
+        data: {
+          scores: [
+            { playerId: 'champion', taFinalsPoints: 2000 },
+            { playerId: 'early', taFinalsPoints: 0 },
+            { playerId: 'late', taFinalsPoints: 0 },
+          ],
+        },
+      },
+    })).toEqual({
+      status: 'SKIP',
+      detail: 'not enough phase3 elimination data to compare TA finals order',
+    });
+  });
+
+  it('skips incomplete phase3 data before checking champion points', () => {
+    expect(evaluateTaFlowRankAssertion({
+      entries,
+      phase3Rounds: [],
+      recalcStatus: 200,
+      recalcBody: {
+        data: {
+          scores: [
+            { playerId: 'champion', taFinalsPoints: 0 },
+            { playerId: 'early', taFinalsPoints: 0 },
+            { playerId: 'late', taFinalsPoints: 0 },
+          ],
+        },
+      },
+    })).toEqual({
+      status: 'SKIP',
+      detail: 'not enough phase3 elimination data to compare TA finals order',
+    });
+  });
+
+  it('reports recalculate failures as a local FAIL result', () => {
+    expect(evaluateTaFlowRankAssertion({
+      entries,
+      phase3Rounds: [
+        { eliminatedIds: ['early'] },
+        { eliminatedIds: ['late'] },
+      ],
+      recalcStatus: 500,
+      recalcBody: {},
+    })).toEqual({ status: 'FAIL', detail: 'recalculate failed: 500' });
+  });
+
+  it('reports phase3 round fetch failures instead of treating missing rounds as a skip', () => {
+    expect(evaluateTaFlowRankAssertion({
+      entries,
+      phase3Status: 503,
+      phase3Rounds: [],
+      recalcStatus: 200,
+      recalcBody: {
+        data: {
+          scores: [
+            { playerId: 'champion', taFinalsPoints: 2000 },
+            { playerId: 'early', taFinalsPoints: 0 },
+            { playerId: 'late', taFinalsPoints: 0 },
+          ],
+        },
+      },
+    })).toEqual({ status: 'FAIL', detail: 'phase3 rounds fetch failed: 503' });
+  });
+});

--- a/smkc-score-app/e2e/lib/ta-flow-rank-assertions.js
+++ b/smkc-score-app/e2e/lib/ta-flow-rank-assertions.js
@@ -1,0 +1,79 @@
+function collectEliminationOrder(rounds) {
+  const order = [];
+  for (const round of rounds ?? []) {
+    for (const playerId of round?.eliminatedIds ?? []) {
+      if (typeof playerId === 'string' && playerId.length > 0) {
+        order.push(playerId);
+      }
+    }
+  }
+  return order;
+}
+
+function getRankedScores(recalcBody) {
+  return recalcBody?.data?.scores ?? recalcBody?.scores ?? [];
+}
+
+function getTaFinalsPoints(scores, playerId) {
+  return scores.find((score) => score.playerId === playerId)?.taFinalsPoints ?? 0;
+}
+
+function evaluateTaFlowRankAssertion({ entries, phase3Status = 200, phase3Rounds, recalcStatus, recalcBody }) {
+  if (phase3Status < 200 || phase3Status >= 300) {
+    return { status: 'FAIL', detail: `phase3 rounds fetch failed: ${phase3Status}` };
+  }
+
+  if (recalcStatus < 200 || recalcStatus >= 300) {
+    return { status: 'FAIL', detail: `recalculate failed: ${recalcStatus}` };
+  }
+
+  const eliminationOrder = collectEliminationOrder(phase3Rounds);
+  if (eliminationOrder.length < 2) {
+    return {
+      status: 'SKIP',
+      detail: 'not enough phase3 elimination data to compare TA finals order',
+    };
+  }
+
+  const ranked = getRankedScores(recalcBody);
+  const champion = entries.find((entry) => entry.rank === 1);
+  const championPoints = getTaFinalsPoints(ranked, champion?.playerId);
+  const maxTaFinalsPoints = Math.max(0, ...ranked.map((score) => score.taFinalsPoints ?? 0));
+
+  /* Keep the assertion coupled to the observable ranking contract, not the
+   * current point table value.  The table has historically changed during
+   * tournament-format work; requiring "positive and highest" still proves
+   * the rank=1 survivor receives the winner slot without making this E2E
+   * fail for an intentional scoring-scale update. */
+  if (championPoints <= 0) {
+    return {
+      status: 'FAIL',
+      detail: `champion (rank 1) expected positive TA finals points, got ${championPoints}`,
+    };
+  }
+  if (championPoints !== maxTaFinalsPoints) {
+    return {
+      status: 'FAIL',
+      detail: `champion (rank 1) expected highest TA finals points (${maxTaFinalsPoints}), got ${championPoints}`,
+    };
+  }
+
+  const lastEliminatedId = eliminationOrder[eliminationOrder.length - 1];
+  const earliestEliminatedId = eliminationOrder[0];
+  const lastEliminatedPoints = getTaFinalsPoints(ranked, lastEliminatedId);
+  const earliestEliminatedPoints = getTaFinalsPoints(ranked, earliestEliminatedId);
+
+  if (lastEliminatedPoints <= earliestEliminatedPoints) {
+    return {
+      status: 'FAIL',
+      detail: `late-eliminated player (${lastEliminatedPoints} pts) should outrank earliest eliminated (${earliestEliminatedPoints} pts)`,
+    };
+  }
+
+  return { status: 'PASS', detail: '' };
+}
+
+module.exports = {
+  collectEliminationOrder,
+  evaluateTaFlowRankAssertion,
+};

--- a/smkc-score-app/e2e/tc-ta-flow.js
+++ b/smkc-score-app/e2e/tc-ta-flow.js
@@ -35,6 +35,7 @@ const {
 } = require('./lib/common');
 const { createSharedE2eFixture } = require('./lib/fixtures');
 const { runSuite } = require('./lib/runner');
+const { evaluateTaFlowRankAssertion } = require('./lib/ta-flow-rank-assertions');
 
 const PLAYER_COUNT = 24;
 const PHASE1_ROUNDS = 4;
@@ -161,53 +162,24 @@ async function runFullFlow(adminPage) {
      * appear at TA finals position 1, and the top finals positions must
      * not be dominated by players who were eliminated earliest.
      */
-    const eliminationOrder = [];
     const phase3RoundsResp = await adminPage.evaluate(async (u) => {
       const r = await fetch(u);
       return { s: r.status, b: await r.json().catch(() => ({})) };
     }, `/api/tournaments/${tournamentId}/ta/phases?phase=phase3`);
     const phase3Rounds = phase3RoundsResp.b?.data?.rounds ?? [];
-    for (const round of phase3Rounds) {
-      for (const pid of (round.eliminatedIds ?? [])) {
-        eliminationOrder.push(pid);
-      }
-    }
 
     const recRes = await adminPage.evaluate(async (u) => {
       const r = await fetch(u, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}' });
       return { s: r.status, b: await r.json().catch(() => ({})) };
     }, `/api/tournaments/${tournamentId}/overall-ranking`);
-    if (recRes.s < 200 || recRes.s >= 300) {
-      log('TC-TA-FLOW-24-RANK', 'FAIL', `recalculate failed: ${recRes.s}`);
-      return;
-    }
-    const ranked = (recRes.b?.data?.scores ?? recRes.b?.scores ?? []);
-
-    /* The player with qualification rank 1 (fastest under our formula)
-     * survives every round and must take TA finals points for 1st place. */
-    const champion = entries.find((e) => e.rank === 1);
-    const championScore = ranked.find((s) => s.playerId === champion?.playerId);
-    const championPoints = championScore?.taFinalsPoints ?? 0;
-
-    /* Identify the latest-eliminated player (the one in the last round to
-     * have a non-empty eliminatedIds list).  They must outrank earlier
-     * eliminations in TA finals points — which would not hold under the
-     * old `totalTime ASC` logic when an early-out player happened to have
-     * a low cumulative time from playing few rounds. */
-    const lastEliminatedId = eliminationOrder[eliminationOrder.length - 1];
-    const earliestEliminatedId = eliminationOrder[0];
-    const lastEliminatedPoints = ranked.find((s) => s.playerId === lastEliminatedId)?.taFinalsPoints ?? 0;
-    const earliestEliminatedPoints = ranked.find((s) => s.playerId === earliestEliminatedId)?.taFinalsPoints ?? 0;
-
-    if (championPoints !== 2000) {
-      log('TC-TA-FLOW-24-RANK', 'FAIL',
-        `champion (rank 1) expected 2000 TA finals points, got ${championPoints}`);
-    } else if (lastEliminatedPoints <= earliestEliminatedPoints) {
-      log('TC-TA-FLOW-24-RANK', 'FAIL',
-        `late-eliminated player (${lastEliminatedPoints} pts) should outrank earliest eliminated (${earliestEliminatedPoints} pts)`);
-    } else {
-      log('TC-TA-FLOW-24-RANK', 'PASS', '');
-    }
+    const rankResult = evaluateTaFlowRankAssertion({
+      entries,
+      phase3Status: phase3RoundsResp.s,
+      phase3Rounds,
+      recalcStatus: recRes.s,
+      recalcBody: recRes.b,
+    });
+    log('TC-TA-FLOW-24-RANK', rankResult.status, rankResult.detail);
   } catch (err) {
     log('TC-TA-FLOW-24', 'FAIL', err instanceof Error ? err.message : 'TA flow failed');
   }


### PR DESCRIPTION
Summary
- Add documented TC-TA-FLOW-24-RANK coverage for incomplete elimination data and failed ranking recalculation.
- Move TA flow rank checks into a focused helper so recalculate failures log a local FAIL instead of returning from the full flow.
- Avoid hard-coding the champion's TA finals point value; assert the rank=1 survivor receives a positive highest score instead.

Issues: Closes #1041, Closes #1042, Closes #1043

Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/ta-flow-rank-assertions.test.ts
- npm run lint (exits 0; existing warnings remain)
- git diff --check
- Review pass by subagent after fix: no actionable findings
