### PR TITLE
Add TA flow rank helper type coverage

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2663,6 +2663,8 @@
   5. `eliminatedIds` が2件未満の場合は比較不能として TC-TA-FLOW-24-RANK のみ SKIP し、誤解を招く 0 点同士の FAIL を出さないことを確認する
   6. 最後に脱落したプレイヤーの `taFinalsPoints` が、最初に脱落したプレイヤーの `taFinalsPoints` より大きいことを確認する
   7. Phase 3 ラウンド取得または POST `/overall-ranking` が 2xx 以外の場合、TC-TA-FLOW-24-RANK を FAIL として記録し、runFullFlow 全体から早期 return しないことを確認する
+  8. `collectEliminationOrder` は Phase 3 レスポンスの `rounds` / `eliminatedIds` が欠損しても runner を落とさず、空文字や非文字列の playerId を脱落順序に混ぜないことを単体テストで固定する
+  9. TypeScript テストから CommonJS helper を安全に import できるよう、`ta-flow-rank-assertions.d.ts` で公開 API の型を明示する
 - **期待結果**: 総合ランキングの TA Finals 配点が「最後まで生き残った順」を反映する。早期脱落者が後期脱落者を上回ることはなく、比較不能な途中状態や再計算失敗もケース単位の明確な結果になる
 
 ## TC-1060: TA Finals Phase 1/2 脱落者の中間順位を全件検証する (issue #1060)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -18,6 +18,7 @@ describe('E2E case drift coverage', () => {
   const tcDebugFill = readE2eScript('tc-debug-fill.js');
   const tcTa = readE2eScript('tc-ta.js');
   const tcTaFlow = readE2eScript('tc-ta-flow.js');
+  const taFlowRankAssertionsTypes = readE2eLib('ta-flow-rank-assertions.d.ts');
   const gpFinalsValidators = readE2eLib('gp-finals-validators.js');
   const tc1073Lr2Slots = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'tc-1073-16p-lr2-slots.test.ts');
   const taPhasesRouteTest = readRepoFile(
@@ -75,6 +76,18 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('TC-TA-FLOW-24-RANK');
     expect(section).toContain('npm run e2e:preview:ta-flow');
     expect(tcTaFlow).toContain("{ name: 'TC-TA-FLOW-24', fn: runFullFlow }");
+  });
+
+  it('keeps TC-TA-FLOW-24-RANK aligned with direct helper and TypeScript contract coverage', () => {
+    const section = e2eCaseSection('TC-TA-FLOW-24-RANK');
+    const unitTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'ta-flow-rank-assertions.test.ts');
+
+    expect(section).toContain('collectEliminationOrder');
+    expect(section).toContain('ta-flow-rank-assertions.d.ts');
+    expect(unitTest).toContain('collects no eliminations from missing phase3 rounds');
+    expect(unitTest).toContain('ignores missing eliminatedIds and invalid player ids');
+    expect(taFlowRankAssertionsTypes).toContain('export function collectEliminationOrder');
+    expect(taFlowRankAssertionsTypes).toContain('export function evaluateTaFlowRankAssertion');
   });
 
   it('keeps TC-1060 aligned with complete TA finals position unit coverage', () => {

--- a/smkc-score-app/__tests__/e2e/ta-flow-rank-assertions.test.ts
+++ b/smkc-score-app/__tests__/e2e/ta-flow-rank-assertions.test.ts
@@ -1,4 +1,4 @@
-import { evaluateTaFlowRankAssertion } from '../../e2e/lib/ta-flow-rank-assertions';
+import { collectEliminationOrder, evaluateTaFlowRankAssertion } from '../../e2e/lib/ta-flow-rank-assertions';
 
 const entries = [
   { playerId: 'champion', rank: 1 },
@@ -7,6 +7,28 @@ const entries = [
 ];
 
 describe('TC-TA-FLOW-24-RANK assertion helper', () => {
+  it('collects phase3 eliminations in chronological order', () => {
+    expect(collectEliminationOrder([
+      { eliminatedIds: ['p24', 'p23'] },
+      { eliminatedIds: ['p22'] },
+      { eliminatedIds: ['p21', 'p20'] },
+    ])).toEqual(['p24', 'p23', 'p22', 'p21', 'p20']);
+  });
+
+  it('collects no eliminations from missing phase3 rounds', () => {
+    expect(collectEliminationOrder(null)).toEqual([]);
+    expect(collectEliminationOrder(undefined)).toEqual([]);
+  });
+
+  it('ignores missing eliminatedIds and invalid player ids', () => {
+    expect(collectEliminationOrder([
+      null,
+      {},
+      { eliminatedIds: null },
+      { eliminatedIds: ['', 42, 'p19', false, 'p18'] },
+    ])).toEqual(['p19', 'p18']);
+  });
+
   it('passes when the champion has the highest TA finals points and late eliminations outrank early eliminations', () => {
     expect(evaluateTaFlowRankAssertion({
       entries,

--- a/smkc-score-app/e2e/lib/ta-flow-rank-assertions.d.ts
+++ b/smkc-score-app/e2e/lib/ta-flow-rank-assertions.d.ts
@@ -1,0 +1,45 @@
+export interface TaFlowRoundData {
+  eliminatedIds?: readonly unknown[] | null;
+}
+
+export type TaFlowRound = TaFlowRoundData | null | undefined;
+
+export interface TaFlowEntry {
+  playerId?: string;
+  rank?: number;
+}
+
+export interface TaFlowRankScore {
+  playerId?: string;
+  taFinalsPoints?: number | null;
+}
+
+export interface TaFlowRankResponseBody {
+  data?: {
+    scores?: TaFlowRankScore[];
+  };
+  scores?: TaFlowRankScore[];
+}
+
+export interface TaFlowRankAssertionInput {
+  entries: readonly TaFlowEntry[];
+  phase3Status?: number;
+  phase3Rounds?: readonly TaFlowRound[] | null;
+  recalcStatus: number;
+  recalcBody?: TaFlowRankResponseBody | null;
+}
+
+export interface TaFlowRankAssertionResult {
+  status: 'PASS' | 'FAIL' | 'SKIP';
+  detail: string;
+}
+
+/*
+ * These declarations intentionally mirror the CommonJS helper instead of
+ * rewriting the runner to TypeScript.  The E2E scripts still execute directly
+ * with Node, while TypeScript unit tests get a stable contract for the helper
+ * boundary that consumes partially trusted API JSON.
+ */
+export function collectEliminationOrder(rounds?: readonly TaFlowRound[] | null): string[];
+
+export function evaluateTaFlowRankAssertion(input: TaFlowRankAssertionInput): TaFlowRankAssertionResult;


### PR DESCRIPTION
Summary
- Document TC-TA-FLOW-24-RANK helper edge cases in the E2E scenario.
- Add direct collectEliminationOrder unit coverage for missing rounds, missing eliminatedIds, and invalid player ids.
- Add a TypeScript declaration contract for the CommonJS ta-flow-rank-assertions helper.

Issues: Closes #1633, Closes #1634

Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/ta-flow-rank-assertions.test.ts
- git diff --check
- npm run lint (exit 0; existing warnings remain)
