### PR TITLE
Address TC-1033 review follow-ups

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-1033-deterministic-entry-order.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-1033-deterministic-entry-order.test.ts
@@ -1,12 +1,32 @@
+import { orderTaEntriesForDeterministicResultSlots } from '../../e2e/lib/deterministic-order';
+
 describe('TC-1033 deterministic TA entry ordering', () => {
+  it('sorts entries by playerId with numeric locale options before assigning result slots', () => {
+    const entries = [
+      { playerId: 'player-10', entryId: 'entry-10' },
+      { playerId: 'player-2', entryId: 'entry-2' },
+      { playerId: 'player-1', entryId: 'entry-1' },
+    ];
+
+    const ordered = orderTaEntriesForDeterministicResultSlots(entries);
+
+    expect(ordered.map((entry) => entry.playerId)).toEqual(['player-1', 'player-2', 'player-10']);
+    expect(entries.map((entry) => entry.playerId)).toEqual(['player-10', 'player-2', 'player-1']);
+  });
+
   it('keeps TC-1033 grouped after boundary sudden-death coverage in the TA suite', async () => {
     const taSuite = await import('../../e2e/tc-ta.js') as {
       getSuite: () => { tests: Array<{ name: string }> };
     };
 
     const names = taSuite.getSuite().tests.map((test) => test.name);
+    const tc815Index = names.indexOf('TC-815');
+    const tc1033Index = names.indexOf('TC-1033');
+    const tc817Index = names.indexOf('TC-817');
 
-    expect(names.indexOf('TC-1033')).toBeGreaterThan(names.indexOf('TC-815'));
-    expect(names.indexOf('TC-1033')).toBeLessThan(names.indexOf('TC-817'));
+    expect(tc815Index).toBeGreaterThanOrEqual(0);
+    expect(tc1033Index).toBeGreaterThan(tc815Index);
+    expect(tc817Index).toBeGreaterThanOrEqual(0);
+    expect(tc1033Index).toBeLessThan(tc817Index);
   });
 });

--- a/smkc-score-app/__tests__/static/tc-1637-1638-ta-tc1033-stability.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1637-1638-ta-tc1033-stability.test.ts
@@ -11,18 +11,13 @@ describe('TC-1033 review follow-up coverage', () => {
     expect(section).toContain('`playerId` 順に並べた最後の2名');
   });
 
-  it('keeps the runner deterministic and grouped after TC-815', () => {
-    expect(tcTa).toContain('function orderTaEntriesForDeterministicResultSlots(entries)');
-    expect(tcTa).toContain('localeCompare');
-    expect(tcTa).toContain('const entries = orderTaEntriesForDeterministicResultSlots');
-    expect(tcTa).toContain('const expectedTargetIds = entries.slice(6).map');
-    expect(tcTa).toContain('targetIdsMatch');
-
+  it('keeps TC-1033 grouped after TC-815 in the runnable TA suite', () => {
     const tc815Index = tcTa.indexOf("{ name: 'TC-815', fn: runTc815 }");
     const tc1033Index = tcTa.indexOf("{ name: 'TC-1033', fn: runTc1033 }");
     const tc817Index = tcTa.indexOf("{ name: 'TC-817', fn: runTc817 }");
     expect(tc815Index).toBeGreaterThanOrEqual(0);
     expect(tc1033Index).toBeGreaterThan(tc815Index);
+    expect(tc817Index).toBeGreaterThanOrEqual(0);
     expect(tc1033Index).toBeLessThan(tc817Index);
   });
 });

--- a/smkc-score-app/e2e/lib/deterministic-order.js
+++ b/smkc-score-app/e2e/lib/deterministic-order.js
@@ -1,0 +1,14 @@
+function orderTaEntriesForDeterministicResultSlots(entries) {
+  /* TC-1033 assigns result slots by index. API/database ordering is not a stable
+   * contract, so use an explicit locale/options pair for deterministic,
+   * human-natural playerId ordering across local Node and GitHub Actions. */
+  return [...entries].sort((a, b) => String(a.playerId).localeCompare(
+    String(b.playerId),
+    'en',
+    { numeric: true, sensitivity: 'base' },
+  ));
+}
+
+module.exports = {
+  orderTaEntriesForDeterministicResultSlots,
+};

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -63,6 +63,7 @@ const {
 const { createSharedE2eFixture, setupTaEntriesFromShared, ensurePlayerPassword } = require('./lib/fixtures');
 const { assertStackedCardBoxes } = require('./lib/layout-assertions');
 const { runSuite } = require('./lib/runner');
+const { orderTaEntriesForDeterministicResultSlots } = require('./lib/deterministic-order');
 
 const results = makeResults();
 const log = makeLog(results);
@@ -145,13 +146,6 @@ function formatTc813Time(ms) {
   const seconds = Math.floor((ms % 60000) / 1000);
   const hundredths = Math.floor((ms % 1000) / 10);
   return `${minutes}:${seconds.toString().padStart(2, '0')}.${hundredths.toString().padStart(2, '0')}`;
-}
-
-function orderTaEntriesForDeterministicResultSlots(entries) {
-  /* API/database ordering is not part of the TC-1033 contract. Sort by the stable
-   * playerId before assigning result slots so the two tied players are selected
-   * deterministically even if D1 changes the raw entries order. */
-  return [...entries].sort((a, b) => String(a.playerId).localeCompare(String(b.playerId)));
 }
 
 function makeTc813QualificationTimes(pattern) {


### PR DESCRIPTION
Summary
- Move TC-1033 deterministic entry ordering into a small E2E helper and sort with explicit locale/numeric options.
- Replace brittle runner implementation-string assertions with direct helper behavior coverage.
- Make TC-817 existence checks explicit in both TC-1033 order tests.

Issues: Closes #1640, Closes #1641, Closes #1642

Validation
- npm test -- --runTestsByPath __tests__/e2e/tc-1033-deterministic-entry-order.test.ts __tests__/static/tc-1637-1638-ta-tc1033-stability.test.ts __tests__/e2e/ta-phase-submit-helper.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint -- --quiet --no-warn-ignored __tests__/e2e/tc-1033-deterministic-entry-order.test.ts __tests__/static/tc-1637-1638-ta-tc1033-stability.test.ts
- node --check e2e/tc-ta.js
- node --check e2e/lib/deterministic-order.js
- git diff --check
