### PR TITLE
Address TC-1032 review follow-ups

### DIFF
--- a/smkc-score-app/__tests__/static/tc-1032-phase3-revival-comment.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1032-phase3-revival-comment.test.ts
@@ -27,5 +27,12 @@ describe('TC-1032 phase3 revival comment coverage', () => {
     expect(section).toContain('ゼロライフ候補3名すべて');
     expect(tcTa).toContain("{ name: 'TC-1032', fn: runTc1032 }");
     expect(tcTa).toContain('apiUpdateTaLives');
+    const tc1032Runner = sectionBetween(
+      tcTa,
+      'async function runTc1032(adminPage) {',
+      '/* ───────── TC-815:',
+    );
+    expect(tc1032Runner).toContain('Phase3 entries start with 3 lives');
+    expect(tc1032Runner).toContain('to 1 life so one more bottom-half loss makes each of them a zero-life');
   });
 });

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -1594,14 +1594,19 @@ async function runTc1032(adminPage) {
     if (entries.length !== 9) throw new Error(`phase3 entries=${entries.length}, expected 9`);
 
     const candidates = entries.slice(6);
+    const phase3InitialLives = 3;
+    const oneLifeRemainingDelta = -(phase3InitialLives - 1);
     for (const entry of candidates) {
-      const lifeUpdate = await apiUpdateTaLives(adminPage, tournamentId, entry.id, -2);
+      /* Phase3 entries start with 3 lives. Reduce the reset-overflow candidates
+       * to 1 life so one more bottom-half loss makes each of them a zero-life
+       * candidate for the 9 -> 8 reset threshold check. */
+      const lifeUpdate = await apiUpdateTaLives(adminPage, tournamentId, entry.id, oneLifeRemainingDelta);
       if (lifeUpdate.s !== 200) throw new Error(`update_lives failed (${lifeUpdate.s}) for ${entry.playerId}`);
     }
 
     const start = await apiPostTaPhase(adminPage, tournamentId, { action: 'start_round', phase });
     if (start.s !== 200) throw new Error(`start_round phase3 failed (${start.s})`);
-    const tied = await apiPostTaPhase(adminPage, tournamentId, {
+    const submitResult = await apiPostTaPhase(adminPage, tournamentId, {
       action: 'submit_results',
       phase,
       roundNumber: start.b?.data?.roundNumber,
@@ -1610,13 +1615,13 @@ async function runTc1032(adminPage) {
         timeMs: 80000 + index * 1000,
       })),
     });
-    const targetIds = [...(tied.b?.data?.suddenDeathRound?.targetPlayerIds ?? [])].sort();
+    const targetIds = [...(submitResult.b?.data?.suddenDeathRound?.targetPlayerIds ?? [])].sort();
     const expectedTargetIds = candidates.map((entry) => entry.playerId).sort();
-    const ok = tied.s === 200 &&
-      tied.b?.data?.tieBreakRequired === true &&
+    const ok = submitResult.s === 200 &&
+      submitResult.b?.data?.tieBreakRequired === true &&
       JSON.stringify(targetIds) === JSON.stringify(expectedTargetIds);
     log('TC-1032', ok ? 'PASS' : 'FAIL',
-      ok ? '' : `targetPlayerIds=${targetIds.join(',')} expected=${expectedTargetIds.join(',')} body=${JSON.stringify(tied.b).slice(0, 220)}`);
+      ok ? '' : `targetPlayerIds=${targetIds.join(',')} expected=${expectedTargetIds.join(',')} body=${JSON.stringify(submitResult.b).slice(0, 220)}`);
   } catch (err) {
     log('TC-1032', 'FAIL', err instanceof Error ? err.message : 'TA phase3 revival target coverage failed');
   } finally {


### PR DESCRIPTION
Summary
- Rename the TC-1032 submit response variable so the reset-threshold overflow scenario is not described as a tie.
- Replace the raw `-2` lives delta with a named one-life setup value and a source comment explaining the Phase 3 3-lives-to-1-life setup.
- Keep the static follow-up guard scoped to durable TC-1032 documentation rather than brittle local names.

Issues: Closes #1645, Closes #1646

Validation
- npm test -- --runTestsByPath __tests__/static/tc-1032-phase3-revival-comment.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npx eslint __tests__/static/tc-1032-phase3-revival-comment.test.ts __tests__/docs/e2e-cases-drift.test.ts
- node --check e2e/tc-ta.js
- git diff --check
