### PR TITLE
Stabilize TC-349 cleanup guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -709,7 +709,7 @@
 
 ## TC-349: レスポンシブ — BM/MR/GP 予選ページが 375px 幅で JS エラーなしに表示される
 - **authRequired**: true (admin)
-- **背景**: スマートフォン幅でも JS エラーなしにレンダリングできること。issue #1028 の回帰として、途中で例外が発生しても TC-349 が登録した `pageerror` / `response` listener を残留させず、後続 TC に 5xx 検知や JS エラー検知を漏らさないことも確認する。
+- **背景**: スマートフォン幅でも JS エラーなしにレンダリングできること。issue #1028 の回帰として、途中で例外が発生しても TC-349 が登録した `pageerror` / `response` listener を残留させず、後続 TC に 5xx 検知や JS エラー検知を漏らさないことも確認する。issue #1649 の回帰として、cleanup 検証は外側の `else` 構造ではなく TC-349 cleanup 専用マーカーで範囲を特定する。
 - **手順**:
   1. ビューポートを 375×812 に設定
   2. /bm, /mr, /gp を順に nav → pageerror がゼロ、body に内容あり

--- a/smkc-score-app/__tests__/e2e/tc-349-listener-cleanup.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-349-listener-cleanup.test.ts
@@ -7,9 +7,11 @@ describe('TC-349 listener cleanup', () => {
     const section = e2eCaseSection('TC-349');
 
     expect(section).toContain('issue #1028');
+    expect(section).toContain('issue #1649');
     expect(section).toContain("page.off('pageerror', onErr)");
     expect(section).toContain("page.off('response', onResponse)");
     expect(section).toContain('失敗時にも解除');
+    expect(section).toContain('TC-349 cleanup 専用マーカー');
   });
 
   it('removes the TC-349 listeners through a finally block', () => {
@@ -23,10 +25,11 @@ describe('TC-349 listener cleanup', () => {
 
     const cleanup = sectionBetween(
       tc349Runner,
-      'finally {',
-      '} else {',
+      '// TC-349 cleanup start',
+      '// TC-349 cleanup end',
     );
 
+    expect(cleanup).not.toContain('} else {');
     expect(cleanup).toContain("page.off('pageerror', onErr)");
     expect(cleanup).toContain("page.off('response', onResponse)");
     expect(cleanup).toContain('page.setViewportSize({ width: 1280, height: 720 })');

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3436,6 +3436,7 @@ async function main() {
       } catch (err) {
         log('TC-349', 'FAIL', err instanceof Error ? err.message : 'Responsive test failed');
       } finally {
+        // TC-349 cleanup start
         if (listenersRegistered) {
           // TC-349 installs broad page-level listeners; using finally keeps those
           // listeners scoped to this responsive probe even when navigation or
@@ -3444,6 +3445,7 @@ async function main() {
           page.off('response', onResponse);
         }
         await page.setViewportSize({ width: 1280, height: 720 });
+        // TC-349 cleanup end
       }
     } else {
       log('TC-349', 'SKIP', 'No tournament ID available');


### PR DESCRIPTION
Summary
- Add TC-349 cleanup start/end markers so the regression test does not slice through the outer fallback branch
- Update TC-349 docs and Jest guard coverage for issue #1649
- Keep the listener cleanup assertions focused on the finally cleanup block

Issues: Closes #1649

Validation
- npm test -- --runTestsByPath __tests__/e2e/tc-349-listener-cleanup.test.ts
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/tc-all-registration.test.ts __tests__/e2e/tc-349-listener-cleanup.test.ts
- npm run lint (exit 0; existing warnings only)
- git diff --check
