### PR TITLE
Decouple MR course deck repeat count

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2241,6 +2241,17 @@
 - **期待結果**: 8人 MR 予選で各ラウンドが4試合になる理由が単体テスト上で読み取れ、将来の fixture 変更時に前提の更新漏れを検知できる
 - **スクリプト**: smkc-score-app/__tests__/static/tc-1080-qualification-route-comment.test.ts
 
+## TC-1017: MR 予選コースデッキ回数を試合レース数から分離する
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #1017。MR 予選では「4コースで1試合を構成する」ことと「フルコースデッキを4回シャッフルして予選全体の割当順を作る」ことが別仕様であるため、`TOTAL_MR_RACES` をデッキ繰り返し回数として流用しないことを固定する。
+- **手順**:
+  1. `qualification-route.ts` が `MR_QUALIFICATION_COURSE_DECK_REPEATS` を宣言していることを確認する
+  2. `generateShuffledCourseList()` が `TOTAL_MR_RACES` ではなく `MR_QUALIFICATION_COURSE_DECK_REPEATS` でフルコースデッキを生成することを確認する
+  3. 単体テストで MR コースリスト長が `COURSES.length * MR_QUALIFICATION_COURSE_DECK_REPEATS` になることを確認する
+- **期待結果**: MR の1試合あたりレース数を変更しても、予選全体の4デッキ割当仕様が暗黙に変わらない
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts / smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+
 ## TC-717: GP決勝 — ラウンドごとのカップ組み合わせがFT3の5カップ目以外で重複しない
 - **URL**: /api/tournaments/[temp-id]/gp/finals (GET)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts
@@ -1,0 +1,32 @@
+import { e2eCaseSection, readRepoFile, sectionBetween } from '../helpers/e2e-cases';
+
+describe('TC-1017 MR course deck repeat guard', () => {
+  const qualificationRoute = readRepoFile(
+    'smkc-score-app',
+    'src',
+    'lib',
+    'api-factories',
+    'qualification-route.ts',
+  );
+
+  it('documents the MR qualification deck-repeat scenario', () => {
+    const section = e2eCaseSection('TC-1017');
+
+    expect(section).toContain('issue #1017');
+    expect(section).toContain('MR_QUALIFICATION_COURSE_DECK_REPEATS');
+    expect(section).toContain('TOTAL_MR_RACES');
+    expect(section).toContain('tc-1017-mr-course-deck-repeats.test.ts');
+  });
+
+  it('keeps MR course-deck repeats independent from the per-match race count', () => {
+    const deckBuilder = sectionBetween(
+      qualificationRoute,
+      'export function generateShuffledCourseList()',
+      '/**\n * Generate the qualification cup deck for GP match assignment',
+    );
+
+    expect(qualificationRoute).toContain('export const MR_QUALIFICATION_COURSE_DECK_REPEATS = 4;');
+    expect(deckBuilder).toContain('MR_QUALIFICATION_COURSE_DECK_REPEATS');
+    expect(deckBuilder).not.toContain('TOTAL_MR_RACES');
+  });
+});

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -34,8 +34,10 @@
 
 import {
   createQualificationHandlers,
+  generateShuffledCourseList,
   getAssignedCoursesForRound,
   getAssignedCupForRound,
+  MR_QUALIFICATION_COURSE_DECK_REPEATS,
 } from '@/lib/api-factories/qualification-route';
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { NextRequest } from 'next/server';
@@ -908,6 +910,25 @@ describe('Qualification Route Factory', () => {
         expect([...firstDeck].sort()).toEqual([...COURSES].sort());
         expect([...secondDeck].sort()).toEqual([...COURSES].sort());
         expect(secondDeck).not.toEqual(firstDeck);
+      } finally {
+        randomSpy.mockRestore();
+      }
+    });
+
+    it('should size MR qualification course decks from the deck repeat policy, not per-match race count', () => {
+      const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
+      try {
+        const shuffledCourses = generateShuffledCourseList();
+
+        /*
+         * Regression for issue #1017 / TC-1017: MR uses 4 races per match
+         * today, but the qualification deck policy is independently "four
+         * full course decks". Assert the exported policy constant directly so
+         * a future TOTAL_MR_RACES format change cannot hide an unintended
+         * schedule-length change inside this test.
+         */
+        expect(MR_QUALIFICATION_COURSE_DECK_REPEATS).toBe(4);
+        expect(shuffledCourses).toHaveLength(COURSES.length * MR_QUALIFICATION_COURSE_DECK_REPEATS);
       } finally {
         randomSpy.mockRestore();
       }

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -35,6 +35,7 @@ import {
 } from '@/lib/round-robin';
 import { COURSES, MAX_TV_NUMBER, TOTAL_MR_RACES } from '@/lib/constants';
 
+export const MR_QUALIFICATION_COURSE_DECK_REPEATS = 4;
 const GP_QUALIFICATION_CUP_DECK_REPEATS = 5;
 
 /**
@@ -60,13 +61,16 @@ function fisherYatesShuffle<T>(arr: readonly T[]): T[] {
  *
  * The VSMR qualification rule is: shuffle the full MC1-RR course list four
  * separate times, concatenate those four orders, then assign each round from
- * the resulting sequence. Every match in the same round consumes the same 4
- * consecutive courses in the same order.
+ * the resulting sequence. Keep the deck-repeat count separate from
+ * TOTAL_MR_RACES: the former is how many full-course decks the qualification
+ * schedule owns, while the latter is how many courses a single MR match uses.
+ * They are both 4 today, but coupling them would silently change schedule
+ * length if match format and qualification deck policy ever diverge.
  *
  * @returns Array of 80 course abbreviations (4 shuffled full-course decks)
  */
-function generateShuffledCourseList(): string[] {
-  return Array.from({ length: TOTAL_MR_RACES }, () => fisherYatesShuffle(COURSES)).flat();
+export function generateShuffledCourseList(): string[] {
+  return Array.from({ length: MR_QUALIFICATION_COURSE_DECK_REPEATS }, () => fisherYatesShuffle(COURSES)).flat();
 }
 
 /**


### PR DESCRIPTION
Summary
- Add TC-1017 E2E scenario/static coverage for MR course deck repeat policy.
- Introduce MR_QUALIFICATION_COURSE_DECK_REPEATS and use it in MR shuffled course deck generation instead of TOTAL_MR_RACES.
- Add unit coverage that locks MR course deck length to the dedicated policy constant.

Issues: Closes #1017

Validation
- npm run test -- --runTestsByPath __tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts __tests__/lib/api-factories/qualification-route.test.ts --runInBand
- npm run test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run test -- --runInBand
- npm run lint (exit 0; existing warnings remain)
- git diff --check
