### PR TITLE
Remove unused TC-1017 random mock

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2252,6 +2252,17 @@
 - **期待結果**: MR の1試合あたりレース数を変更しても、予選全体の4デッキ割当仕様が暗黙に変わらない
 - **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts / smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
 
+## TC-1662: TC-1017 の配列長テストから未使用 Math.random mock を除去する
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #1662。TC-1017 の単体テストは MR コースデッキの配列長だけを検証するため、シャッフル順に影響する `Math.random` mock は不要である。未使用 mock を残すと、テストの意図が「順序固定も必要」に見えてしまう。
+- **手順**:
+  1. `qualification-route.test.ts` の TC-1017 単体テストを確認する
+  2. 同テストが `generateShuffledCourseList()` の戻り値長だけを検証し、`Math.random` / `mockReturnValue` / `mockRestore` を使っていないことを確認する
+  3. TC-1017 の static guard が引き続き MR デッキ回数の独立性を検査していることを確認する
+- **期待結果**: TC-1017 の単体テストは配列長ポリシーだけを最小限に検証し、不要なランダム mock を持たない
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts / smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+
 ## TC-717: GP決勝 — ラウンドごとのカップ組み合わせがFT3の5カップ目以外で重複しない
 - **URL**: /api/tournaments/[temp-id]/gp/finals (GET)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts
@@ -18,6 +18,14 @@ describe('TC-1017 MR course deck repeat guard', () => {
     expect(section).toContain('tc-1017-mr-course-deck-repeats.test.ts');
   });
 
+  it('documents that the TC-1017 length test does not need a random mock', () => {
+    const section = e2eCaseSection('TC-1662');
+
+    expect(section).toContain('issue #1662');
+    expect(section).toContain('Math.random');
+    expect(section).toContain('配列長');
+  });
+
   it('keeps MR course-deck repeats independent from the per-match race count', () => {
     const deckBuilder = sectionBetween(
       qualificationRoute,
@@ -28,5 +36,25 @@ describe('TC-1017 MR course deck repeat guard', () => {
     expect(qualificationRoute).toContain('export const MR_QUALIFICATION_COURSE_DECK_REPEATS = 4;');
     expect(deckBuilder).toContain('MR_QUALIFICATION_COURSE_DECK_REPEATS');
     expect(deckBuilder).not.toContain('TOTAL_MR_RACES');
+  });
+
+  it('keeps the TC-1017 unit assertion free of unused Math.random mocking', () => {
+    const unitTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'lib',
+      'api-factories',
+      'qualification-route.test.ts',
+    );
+    const testBlock = sectionBetween(
+      unitTest,
+      "it('should size MR qualification course decks from the deck repeat policy, not per-match race count'",
+      "it('should reject non-positive, fractional, and non-finite MR qualification round numbers before assigning courses'",
+    );
+
+    expect(testBlock).toContain('generateShuffledCourseList()');
+    expect(testBlock).not.toContain('Math.random');
+    expect(testBlock).not.toContain('mockReturnValue');
+    expect(testBlock).not.toContain('mockRestore');
   });
 });

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -916,22 +916,17 @@ describe('Qualification Route Factory', () => {
     });
 
     it('should size MR qualification course decks from the deck repeat policy, not per-match race count', () => {
-      const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
-      try {
-        const shuffledCourses = generateShuffledCourseList();
+      const shuffledCourses = generateShuffledCourseList();
 
-        /*
-         * Regression for issue #1017 / TC-1017: MR uses 4 races per match
-         * today, but the qualification deck policy is independently "four
-         * full course decks". Assert the exported policy constant directly so
-         * a future TOTAL_MR_RACES format change cannot hide an unintended
-         * schedule-length change inside this test.
-         */
-        expect(MR_QUALIFICATION_COURSE_DECK_REPEATS).toBe(4);
-        expect(shuffledCourses).toHaveLength(COURSES.length * MR_QUALIFICATION_COURSE_DECK_REPEATS);
-      } finally {
-        randomSpy.mockRestore();
-      }
+      /*
+       * Regression for issue #1017 / TC-1017: MR uses 4 races per match
+       * today, but the qualification deck policy is independently "four
+       * full course decks". Assert the exported policy constant directly so
+       * a future TOTAL_MR_RACES format change cannot hide an unintended
+       * schedule-length change inside this test.
+       */
+      expect(MR_QUALIFICATION_COURSE_DECK_REPEATS).toBe(4);
+      expect(shuffledCourses).toHaveLength(COURSES.length * MR_QUALIFICATION_COURSE_DECK_REPEATS);
     });
 
     it('should reject non-positive, fractional, and non-finite MR qualification round numbers before assigning courses', () => {


### PR DESCRIPTION
Summary
- Remove the unused Math.random mock from the TC-1017 MR course deck length test.
- Add TC-1662 documentation/static coverage so the test stays focused on array length policy.

Issues: Closes #1662

Validation
- npm run test -- --runTestsByPath __tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts __tests__/lib/api-factories/qualification-route.test.ts --runInBand
- npm run test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint (exit 0; existing warnings remain)
- git diff --check
