### PR TITLE
Relax TC-1664 doc guard wording

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2275,6 +2275,17 @@
 - **期待結果**: static guard は TC-1017 の配列長テスト本体を検査していることを先に固定し、境界変更で無関係な範囲を検査してしまう退行を検出できる
 - **スクリプト**: n/a (static coverage) — smkc-score-app/__tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts
 
+## TC-1666: TC-1664 文書 guard から issue 番号リテラル依存を外す
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #1666。TC-1664 の文書 guard が `issue #1664` の文字列そのものに依存すると、E2E シナリオ文書の整理で issue 番号表記を変えただけでもテストが壊れる。guard はシナリオ固有の仕様語に絞る。
+- **手順**:
+  1. `tc-1017-mr-course-deck-repeats.test.ts` の TC-1664 文書 guard を確認する
+  2. 同 guard が `sectionBetween`、`MR_QUALIFICATION_COURSE_DECK_REPEATS`、`toHaveLength(COURSES.length * MR_QUALIFICATION_COURSE_DECK_REPEATS)` を確認していることを確認する
+  3. 同 guard が `issue #1664` の文字列リテラルを要求していないことを確認する
+- **期待結果**: TC-1664 の文書 guard は仕様内容に依存し、issue 番号表記の変更では壊れない
+- **スクリプト**: n/a (static coverage) — smkc-score-app/__tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts
+
 ## TC-717: GP決勝 — ラウンドごとのカップ組み合わせがFT3の5カップ目以外で重複しない
 - **URL**: /api/tournaments/[temp-id]/gp/finals (GET)
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts
@@ -29,9 +29,9 @@ describe('TC-1017 MR course deck repeat guard', () => {
   it('documents that the TC-1017 static guard validates the extracted block', () => {
     const section = e2eCaseSection('TC-1664');
 
-    expect(section).toContain('issue #1664');
     expect(section).toContain('sectionBetween');
     expect(section).toContain('MR_QUALIFICATION_COURSE_DECK_REPEATS');
+    expect(section).toContain('toHaveLength(COURSES.length * MR_QUALIFICATION_COURSE_DECK_REPEATS)');
   });
 
   it('keeps MR course-deck repeats independent from the per-match race count', () => {


### PR DESCRIPTION
Summary
- Remove the TC-1664 documentation guard's dependency on the literal issue number wording.
- Add TC-1666 documentation for keeping that guard tied to behavior-specific terms instead.

Issues: Closes #1666

Validation
- npm run test -- --runTestsByPath __tests__/e2e/tc-1017-mr-course-deck-repeats.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint (exit 0; existing warnings remain)
- git diff --check
