### PR TITLE
Document overall ranking bracket thresholds

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2230,6 +2230,17 @@
 - **期待結果**: 4人 GP 予選で3ラウンドになる理由が単体テスト上で読み取れ、将来の fixture 変更時に前提の更新漏れを検知できる
 - **スクリプト**: smkc-score-app/__tests__/static/tc-1088-qualification-route-comment.test.ts
 
+## TC-1009: 総合ランキング決勝順位 — 16人/Top-24 判定の matchNumber 閾値を明文化する
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #1009。`isSixteenPlayerOrTop24Bracket` は `generateBracketStructure(8)` と `generateBracketStructure(16)` の matchNumber 割り当て差分を使って、8人決勝ではなく16人決勝/Top-24経路の順位帯を選ぶ。閾値だけが残ると、ブラケット生成側の番号体系に依存していることが読めず、将来の構造変更で静かに壊れる。
+- **手順**:
+  1. `overall-ranking.ts` の `isSixteenPlayerOrTop24Bracket` を確認する
+  2. `generateBracketStructure(8)` と `generateBracketStructure(16)` の番号差分がコメントで説明されていることを確認する
+  3. losers_r1 / losers_r2 / losers_r3 / losers_sf / losers_final / grand_final / grand_final_reset の各閾値が 16人決勝側の matchNumber 範囲と対応していることを確認する
+- **期待結果**: 16人決勝/Top-24 判定の matchNumber 閾値が、8人決勝との差分として読み取れ、静的テストでコメントの脱落を検知できる
+- **スクリプト**: smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts
+
 ## TC-1080: MR 予選単体テスト — 8人ラウンドロビンの4試合/ラウンド前提を明記する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -469,6 +469,7 @@ describe('E2E case drift coverage', () => {
     ['TC-111', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts'],
     ['TC-726', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-finals-assigned-cups.test.ts'],
     ['TC-728', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-ranking.test.ts'],
+    ['TC-1009', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts'],
     ['TC-1080', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1080-qualification-route-comment.test.ts'],
     ['TC-1088', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1088-qualification-route-comment.test.ts'],
     ['TC-1090-1091', 'n/a (static/unit coverage)', 'smkc-score-app/__tests__/static/tc-1090-1091-overall-ranking.test.ts'],

--- a/smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts
@@ -1,0 +1,38 @@
+import { e2eCaseSection, readRepoFile, sectionBetween } from '../helpers/e2e-cases';
+
+describe('TC-1009 overall-ranking bracket threshold comments', () => {
+  it('documents the review follow-up scenario', () => {
+    const section = e2eCaseSection('TC-1009');
+
+    expect(section).toContain('issue #1009');
+    expect(section).toContain('isSixteenPlayerOrTop24Bracket');
+    expect(section).toContain('generateBracketStructure(8)');
+    expect(section).toContain('generateBracketStructure(16)');
+    expect(section).toContain('tc-1009-overall-ranking-bracket-threshold-comments.test.ts');
+  });
+
+  it('keeps each 16-player finals matchNumber threshold explained at the source site', () => {
+    const source = readRepoFile('smkc-score-app', 'src', 'lib', 'points', 'overall-ranking.ts');
+    const helper = sectionBetween(
+      source,
+      'function isSixteenPlayerOrTop24Bracket',
+      'function toMatchRecord',
+    );
+
+    expect(helper).toContain('generateBracketStructure(8)');
+    expect(helper).toContain('generateBracketStructure(16)');
+
+    for (const [round, lowerBound, range] of [
+      ['losers_r1', 16, '16-19'],
+      ['losers_r2', 20, '20-23'],
+      ['losers_r3', 24, '24-25'],
+      ['losers_sf', 28, '28'],
+      ['losers_final', 29, '29'],
+      ['grand_final', 30, '30'],
+      ['grand_final_reset', 31, '31'],
+    ] as const) {
+      expect(helper).toContain(`${round}: ${range}`);
+      expect(helper).toContain(`m.round === "${round}" && m.matchNumber >= ${lowerBound}`);
+    }
+  });
+});

--- a/smkc-score-app/src/lib/points/overall-ranking.ts
+++ b/smkc-score-app/src/lib/points/overall-ranking.ts
@@ -531,6 +531,25 @@ interface FinalsMatchRecord {
 function isSixteenPlayerOrTop24Bracket(matches: FinalsMatchRecord[]): boolean {
   return matches.some((m) => {
     if (m.stage === "playoff" || m.round?.startsWith("playoff_")) return true;
+    /*
+     * The placement table changes once finals are generated from the 16-player
+     * bracket used by both native Top-16 and Top-24 after the barrage. This
+     * helper intentionally detects that shape from persisted match rows instead
+     * of trusting tournament setup metadata, because older archived rows may not
+     * carry the same source flags.
+     *
+     * The thresholds below are the first matchNumber values that only appear in
+     * generateBracketStructure(16), while generateBracketStructure(8) ends the
+     * same rounds earlier:
+     *   losers_r1: 16-19 (8-player uses 8-9)
+     *   losers_r2: 20-23 (8-player uses 10-11)
+     *   losers_r3: 24-25 (8-player uses 12-13)
+     *   losers_r4: 26-27 (round does not exist in 8-player brackets)
+     *   losers_sf: 28 (8-player uses 14)
+     *   losers_final: 29 (8-player uses 15)
+     *   grand_final: 30 (8-player uses 16)
+     *   grand_final_reset: 31 (8-player uses 17)
+     */
     if (m.round === "losers_r4") return true;
     if (m.round === "losers_r1" && m.matchNumber >= 16) return true;
     if (m.round === "losers_r2" && m.matchNumber >= 20) return true;


### PR DESCRIPTION
Summary
- Add TC-1009 to the E2E scenario catalog as static/unit coverage for the overall-ranking bracket threshold comments.
- Add a static guard that verifies the TC-1009 scenario and the source-level matchNumber range explanations stay aligned.
- Document why the 16-player/Top-24 overall placement detector uses the persisted matchNumber thresholds from generateBracketStructure(16).

Issues: Closes #1009

Validation
- npm test -- --runTestsByPath __tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/points/overall-ranking.test.ts --runInBand
- npm run lint
- npm test -- --runInBand
