### PR TITLE
Guard TC-1009 losers r4 comment

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2241,6 +2241,17 @@
 - **期待結果**: 16人決勝/Top-24 判定の matchNumber 閾値が、8人決勝との差分として読み取れ、静的テストでコメントの脱落を検知できる
 - **スクリプト**: smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts
 
+## TC-1669: TC-1009 静的ガード — losers_r4 のコメント行も検証する
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #1669。`losers_r4` は8人決勝に存在しないラウンドなので、`isSixteenPlayerOrTop24Bracket` では `matchNumber` 閾値なしで検出する。TC-1009のループ型アサーションは閾値付きラウンドだけを検証するため、`losers_r4: 26-27` のコメント行を別アサーションで保護する必要がある。
+- **手順**:
+  1. TC-1009 の静的テストを実行する
+  2. `overall-ranking.ts` のコメントが `losers_r4: 26-27` を含むことを確認する
+  3. `m.round === "losers_r4"` の即時判定が静的ガード対象に含まれることを確認する
+- **期待結果**: `losers_r4` だけコメント保護から漏れず、16人決勝固有ラウンドの説明削除をCIで検出できる
+- **スクリプト**: smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts
+
 ## TC-1080: MR 予選単体テスト — 8人ラウンドロビンの4試合/ラウンド前提を明記する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -476,6 +476,7 @@ describe('E2E case drift coverage', () => {
     ['TC-1451-1452', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-1454-1455', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-1457', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
+    ['TC-1669', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts'],
     ['TC-1528', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/e2e/ta-phase-submit-helper.test.ts'],
     ['TC-803', 'TC-318 でカバー済み', 'TC-318'],
     ['TC-943', '.github/pull_request_template.md', '__tests__/docs/pr-template.test.ts'],

--- a/smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts
@@ -21,6 +21,8 @@ describe('TC-1009 overall-ranking bracket threshold comments', () => {
 
     expect(helper).toContain('generateBracketStructure(8)');
     expect(helper).toContain('generateBracketStructure(16)');
+    expect(helper).toContain('losers_r4: 26-27');
+    expect(helper).toContain('m.round === "losers_r4"');
 
     for (const [round, lowerBound, range] of [
       ['losers_r1', 16, '16-19'],


### PR DESCRIPTION
Summary
- Add TC-1669 to the E2E scenario catalog for the TC-1009 losers_r4 static guard follow-up.
- Extend the TC-1009 static test to assert both the losers_r4 comment row and the immediate losers_r4 branch are preserved.
- Register TC-1669 in the E2E drift classifier as static/unit coverage.

Issues: Closes #1669

Validation
- npm test -- --runTestsByPath __tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint
