### PR TITLE
Keep TC-1669 drift entry ordered

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2252,6 +2252,17 @@
 - **期待結果**: `losers_r4` だけコメント保護から漏れず、16人決勝固有ラウンドの説明削除をCIで検出できる
 - **スクリプト**: smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts
 
+## TC-1671: docs drift 分類 — TC-1669 を番号順に並べる
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #1671。`e2e-cases-drift.test.ts` の static-only 分類配列で TC-1669 が TC-1528 より前にあると、後続の追加時に同じ順序崩れが混入しやすい。分類表は検索性のため、近接ブロック内でTC番号順を維持する。
+- **手順**:
+  1. `e2e-cases-drift.test.ts` の standalone browser runner 対象外分類を確認する
+  2. TC-1451-1452 / TC-1454-1455 / TC-1457 / TC-1528 / TC-1669 / TC-1671 の順で並んでいることを確認する
+  3. 順序ガードが同じ分類ブロックを検査していることを確認する
+- **期待結果**: TC-1669 が TC-1528 の後ろにあり、以後の追加で局所的な番号順崩れを検出できる
+- **スクリプト**: smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+
 ## TC-1080: MR 予選単体テスト — 8人ラウンドロビンの4試合/ラウンド前提を明記する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -476,8 +476,9 @@ describe('E2E case drift coverage', () => {
     ['TC-1451-1452', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-1454-1455', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-1457', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
-    ['TC-1669', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts'],
     ['TC-1528', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/e2e/ta-phase-submit-helper.test.ts'],
+    ['TC-1669', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts'],
+    ['TC-1671', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts'],
     ['TC-803', 'TC-318 でカバー済み', 'TC-318'],
     ['TC-943', '.github/pull_request_template.md', '__tests__/docs/pr-template.test.ts'],
   ])('keeps %s explicitly classified outside standalone browser runner registration', (tc, marker, coverage) => {
@@ -485,6 +486,21 @@ describe('E2E case drift coverage', () => {
 
     expect(section).toContain(marker);
     expect(section).toContain(coverage);
+  });
+
+  it('keeps late static-only TC classifications ordered within their local block', () => {
+    const source = readRepoFile('smkc-score-app', '__tests__', 'docs', 'e2e-cases-drift.test.ts');
+    const block = sectionBetween(
+      source,
+      "['TC-1451-1452', 'n/a (static/doc coverage)'",
+      "['TC-803', 'TC-318 でカバー済み'",
+    );
+
+    const orderedTcs = ['TC-1451-1452', 'TC-1454-1455', 'TC-1457', 'TC-1528', 'TC-1669', 'TC-1671'];
+    const indexes = orderedTcs.map((tc) => block.indexOf(`['${tc}'`));
+
+    expect(indexes.every((index) => index >= 0)).toBe(true);
+    expect(indexes).toEqual([...indexes].sort((a, b) => a - b));
   });
 
   it('keeps TC-1090-1091 aligned with overall-ranking static and unit coverage', () => {


### PR DESCRIPTION
Summary
- Move the TC-1669 static-only drift classification after TC-1528 so the local classification block stays in TC order.
- Add TC-1671 to the E2E scenario catalog for this ordering follow-up.
- Add a focused docs drift guard that checks the local static-only TC ordering around TC-1669.

Issues: Closes #1671

Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint
