### PR TITLE
Avoid finals H2H query for empty orderBy

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1393,6 +1393,18 @@
 - **期待結果**: winners_qf 等のラウンドヘッダー下に startingCourseNumber が「バトルコース {n}」として表示される
 - **スクリプト**: tc-bm.js TC-531
 
+## TC-1011: BM 決勝生成 — 空の qualification orderBy では H2H クエリを発行しない
+- **URL**: /api/tournaments/[id]/bm/finals (POST)
+- **authRequired**: true (admin)
+- **背景**: issue #1011。`hasAutomaticRankTies` は決勝シード用の予選順位に自動同順位がある場合だけ H2H 用 qualification match を追加取得する。`qualificationOrderBy` が空なら比較基準がないため、JavaScript の `[].every()` の vacuous truth で全行を同順位扱いしてはいけない。
+- **手順**:
+  1. 8名分の BM qualification を用意する
+  2. テスト専用設定で `qualificationOrderBy: []` の finals handler を作る
+  3. `POST /api/tournaments/[id]/bm/finals` `{ topN: 8 }` を実行する
+  4. `stage: 'qualification'` の H2H match 取得が呼ばれず、決勝ブラケット作成だけが進むことを確認する
+- **期待結果**: 空の orderBy は「比較基準なし」として扱われ、不要な H2H クエリを発行しない
+- **スクリプト**: n/a（defensive server-side guard のため `smkc-score-app/__tests__/e2e/tc-1011-finals-h2h-guard.test.ts` + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts` で検証）
+
 ## TC-532: BM 予選順位表 — 0-1000 予選点列の表示
 - **URL**: /tournaments/[temp-id]/bm
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/e2e/tc-1011-finals-h2h-guard.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-1011-finals-h2h-guard.test.ts
@@ -1,0 +1,36 @@
+import { e2eCaseSection, readRepoFile } from '../helpers/e2e-cases';
+
+describe('TC-1011 finals H2H query guard coverage', () => {
+  const finalsRoute = readRepoFile(
+    'smkc-score-app',
+    'src',
+    'lib',
+    'api-factories',
+    'finals-route.ts',
+  );
+  const finalsRouteTest = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'lib',
+    'api-factories',
+    'finals-route.test.ts',
+  );
+
+  it('documents the empty qualificationOrderBy defensive finals scenario', () => {
+    const section = e2eCaseSection('TC-1011');
+
+    expect(section).toContain('issue #1011');
+    expect(section).toContain('qualificationOrderBy: []');
+    expect(section).toContain("stage: 'qualification'");
+    expect(section).toContain('vacuous truth');
+    expect(section).toContain('tc-1011-finals-h2h-guard.test.ts');
+    expect(section).toContain('finals-route.test.ts');
+  });
+
+  it('keeps the implementation and unit regression tied to the documented scenario', () => {
+    expect(finalsRoute).toContain('rankingOrder.length === 0');
+    expect(finalsRouteTest).toContain('does not fetch H2H matches when qualificationOrderBy is empty');
+    expect(finalsRouteTest).toContain('qualificationOrderBy: []');
+    expect(finalsRouteTest).toContain("args?.where?.stage === 'qualification'");
+  });
+});

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -929,6 +929,30 @@ describe('Finals Route Factory', () => {
       expect(json.data.seededPlayers[0].playerId).toBe('player-7');
     });
 
+    it('does not fetch H2H matches when qualificationOrderBy is empty', async () => {
+      (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(8));
+      (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 17 });
+      (prisma.bMMatch as any).findMany.mockResolvedValue([]);
+
+      const config = createMockConfig({ qualificationOrderBy: [] });
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 8 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(201);
+      const h2hFetch = (prisma.bMMatch as any).findMany.mock.calls.find(
+        ([args]) => args?.where?.stage === 'qualification',
+      );
+      expect(h2hFetch).toBeUndefined();
+    });
+
     it('should still create bracket after qualification is confirmed', async () => {
       (prisma.tournament as any).findUnique.mockResolvedValue({
         id: 'tournament-123',

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -751,6 +751,11 @@ export function createFinalsHandlers(config: FinalsConfig) {
   ): boolean {
     const firstOrderField = Object.keys(orderBy[0] ?? {})[0];
     const rankingOrder = firstOrderField === 'group' ? orderBy.slice(1) : orderBy;
+    /* Without a ranking field there is no business rule for determining
+     * automatic ties. Returning false avoids JavaScript's [].every()
+     * vacuous truth from treating every adjacent row as tied and issuing an
+     * unnecessary qualification H2H query. */
+    if (rankingOrder.length === 0) return false;
     const byPartition = new Map<string, typeof qualifications>();
 
     for (const q of qualifications) {


### PR DESCRIPTION
## Summary
- Add TC-1011 coverage for the defensive finals seeding path where `qualificationOrderBy` is empty.
- Guard `hasAutomaticRankTies` so an empty ranking order does not trigger JavaScript `[].every()` vacuous truth and an unnecessary qualification H2H query.
- Add unit and static E2E coverage tying the scenario, regression, and implementation together.

## Issues
Closes #1011

## Validation
- `npm test -- --runTestsByPath __tests__/lib/api-factories/finals-route.test.ts --runInBand`
- `npm test -- --runTestsByPath __tests__/e2e/tc-1011-finals-h2h-guard.test.ts --runInBand`
- `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/api-factories/finals-route.test.ts __tests__/e2e/tc-1011-finals-h2h-guard.test.ts --runInBand`
- `npm run lint -- src/lib/api-factories/finals-route.ts __tests__/lib/api-factories/finals-route.test.ts __tests__/e2e/tc-1011-finals-h2h-guard.test.ts` (passes with pre-existing warnings in `finals-route.test.ts`)
