### PR TITLE
Move TC-1011 guard to static tests

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1403,7 +1403,7 @@
   3. `POST /api/tournaments/[id]/bm/finals` `{ topN: 8 }` を実行する
   4. `stage: 'qualification'` の H2H match 取得が呼ばれず、決勝ブラケット作成だけが進むことを確認する
 - **期待結果**: 空の orderBy は「比較基準なし」として扱われ、不要な H2H クエリを発行しない
-- **スクリプト**: n/a（defensive server-side guard のため `smkc-score-app/__tests__/e2e/tc-1011-finals-h2h-guard.test.ts` + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts` で検証）
+- **スクリプト**: n/a（defensive server-side guard のため `smkc-score-app/__tests__/static/tc-1011-finals-h2h-guard.test.ts` + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts` で検証）
 
 ## TC-532: BM 予選順位表 — 0-1000 予選点列の表示
 - **URL**: /tournaments/[temp-id]/bm

--- a/smkc-score-app/__tests__/static/tc-1011-finals-h2h-guard.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1011-finals-h2h-guard.test.ts
@@ -1,13 +1,6 @@
 import { e2eCaseSection, readRepoFile } from '../helpers/e2e-cases';
 
 describe('TC-1011 finals H2H query guard coverage', () => {
-  const finalsRoute = readRepoFile(
-    'smkc-score-app',
-    'src',
-    'lib',
-    'api-factories',
-    'finals-route.ts',
-  );
   const finalsRouteTest = readRepoFile(
     'smkc-score-app',
     '__tests__',
@@ -22,13 +15,11 @@ describe('TC-1011 finals H2H query guard coverage', () => {
     expect(section).toContain('issue #1011');
     expect(section).toContain('qualificationOrderBy: []');
     expect(section).toContain("stage: 'qualification'");
-    expect(section).toContain('vacuous truth');
-    expect(section).toContain('tc-1011-finals-h2h-guard.test.ts');
+    expect(section).toContain('__tests__/static/tc-1011-finals-h2h-guard.test.ts');
     expect(section).toContain('finals-route.test.ts');
   });
 
-  it('keeps the implementation and unit regression tied to the documented scenario', () => {
-    expect(finalsRoute).toContain('rankingOrder.length === 0');
+  it('keeps the documented scenario tied to the behavior-level unit regression', () => {
     expect(finalsRouteTest).toContain('does not fetch H2H matches when qualificationOrderBy is empty');
     expect(finalsRouteTest).toContain('qualificationOrderBy: []');
     expect(finalsRouteTest).toContain("args?.where?.stage === 'qualification'");


### PR DESCRIPTION
## Summary
- Move the TC-1011 drift guard from `__tests__/e2e` to `__tests__/static` so it is not mistaken for browser E2E coverage.
- Narrow the static guard to link the documented scenario to the behavior-level unit regression, without asserting on implementation strings.

## Issues
Closes #1674
Closes #1675

## Validation
- `npm test -- --runTestsByPath __tests__/static/tc-1011-finals-h2h-guard.test.ts __tests__/lib/api-factories/finals-route.test.ts`
- `git diff --check`
- `npm run lint` (exit 0; existing warnings only)
