### PR TITLE
Remove unused GroupSetupDialog groupCount prop

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2242,6 +2242,18 @@
 - **期待結果**: 4人 GP 予選で3ラウンドになる理由が単体テスト上で読み取れ、将来の fixture 変更時に前提の更新漏れを検知できる
 - **スクリプト**: smkc-score-app/__tests__/static/tc-1088-qualification-route-comment.test.ts
 
+## TC-1007: BM/MR/GP グループ設定 — 未使用 groupCount prop を親から渡さない
+- **背景**: issue #1007。`GroupSetupDialog` は内部の `LOCKED_GROUP_COUNT` と `setGroupCount` で2グループ固定を管理しており、親ページから渡す `groupCount` は読み取られない。未使用 prop を残すと、3+グループ再開時に親状態が効くように見える誤解を生む。
+- **手順**:
+  1. TC-1007 の静的 E2E guard を実行する
+  2. `GroupSetupDialogProps` と BM/MR/GP の `<GroupSetupDialog>` 呼び出しを検査する
+  3. 親ページが `setGroupCount` だけを渡し、読み取り側の `groupCount` state を保持していないことを確認する
+- **期待結果**:
+  - `GroupSetupDialogProps` に `groupCount: number` が存在しない
+  - BM/MR/GP の呼び出し元が `groupCount={groupCount}` を渡さない
+  - 2グループ固定の理由は `GroupSetupDialog` 内の `LOCKED_GROUP_COUNT` とコメントに集約される
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts`
+
 ## TC-1009: 総合ランキング決勝順位 — 16人/Top-24 判定の matchNumber 閾値を明文化する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -61,6 +61,22 @@ describe('E2E case drift coverage', () => {
     expect(scriptSource).toContain(`log('${tc}'`);
   });
 
+  it('keeps TC-1007 aligned with the GroupSetupDialog static guard', () => {
+    const section = e2eCaseSection('TC-1007');
+    const guard = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'static',
+      'tc-1007-group-setup-dialog-prop-contract.test.ts',
+    );
+
+    expect(section).toContain('issue #1007');
+    expect(section).toContain('GroupSetupDialog');
+    expect(section).toContain('tc-1007-group-setup-dialog-prop-contract.test.ts');
+    expect(guard).toContain("e2eCaseSection('TC-1007')");
+    expect(guard).toContain("not.toContain('groupCount={groupCount}')");
+  });
+
   it('keeps TC-702 aligned with direct driver-points JsonNull reporting coverage', () => {
     const section = e2eCaseSection('TC-702');
 

--- a/smkc-score-app/__tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts
@@ -1,0 +1,43 @@
+import { e2eCaseSection, readRepoFile, sectionBetween } from '../helpers/e2e-cases';
+
+const modeClients = [
+  ['BM', ['src', 'app', 'tournaments', '[id]', 'bm', 'page-client.tsx']],
+  ['MR', ['src', 'app', 'tournaments', '[id]', 'mr', 'page-client.tsx']],
+  ['GP', ['src', 'app', 'tournaments', '[id]', 'gp', 'page-client.tsx']],
+] as const;
+
+describe('TC-1007 GroupSetupDialog prop contract', () => {
+  it('documents the unused groupCount prop removal scenario', () => {
+    const section = e2eCaseSection('TC-1007');
+
+    expect(section).toContain('issue #1007');
+    expect(section).toContain('GroupSetupDialog');
+    expect(section).toContain('groupCount');
+    expect(section).toContain('tc-1007-group-setup-dialog-prop-contract.test.ts');
+  });
+
+  it('keeps GroupSetupDialog controlled by its own locked group count', () => {
+    const source = readRepoFile(
+      'smkc-score-app',
+      'src',
+      'components',
+      'tournament',
+      'group-setup-dialog.tsx',
+    );
+    const props = sectionBetween(source, 'interface GroupSetupDialogProps {', 'export function GroupSetupDialog');
+    const signature = sectionBetween(source, 'export function GroupSetupDialog({', '}: GroupSetupDialogProps)');
+
+    expect(source).toContain('const LOCKED_GROUP_COUNT = 2');
+    expect(props).not.toContain('groupCount: number');
+    expect(signature).not.toMatch(/\bgroupCount\b/);
+    expect(source).toContain('setGroupCount(LOCKED_GROUP_COUNT)');
+  });
+
+  it.each(modeClients)('does not pass the removed groupCount prop from %s', (_mode, path) => {
+    const source = readRepoFile('smkc-score-app', ...path);
+    const dialogUsage = sectionBetween(source, '<GroupSetupDialog', 'setGroupCount={setGroupCount}');
+
+    expect(dialogUsage).not.toContain('groupCount={groupCount}');
+    expect(source).toContain('const [, setGroupCount] = useState(2)');
+  });
+});

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page-client.tsx
@@ -156,7 +156,7 @@ export default function BattleModePageClient({
     { playerId: string; group: string; seeding?: number }[]
   >([]);
   /* Product default: 2 groups (§10.2). */
-  const [groupCount, setGroupCount] = useState(2);
+  const [, setGroupCount] = useState(2);
   const [setupSaving, setSetupSaving] = useState(false);
   /* State for match filters */
   const [matchGroupFilter, setMatchGroupFilter] = useState<string>("all");
@@ -579,7 +579,6 @@ export default function BattleModePageClient({
                 group: q.group,
                 seeding: q.seeding ?? undefined,
               }))}
-              groupCount={groupCount}
               setGroupCount={setGroupCount}
             />
           )}

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
@@ -179,7 +179,7 @@ export default function GrandPrixPageClient({
     { playerId: string; group: string; seeding?: number }[]
   >([]);
   /* Product default: 2 groups (§10.2). */
-  const [groupCount, setGroupCount] = useState(2);
+  const [, setGroupCount] = useState(2);
   const [setupSaving, setSetupSaving] = useState(false);
   const [manualScoreEnabled, setManualScoreEnabled] = useState(false);
   const [manualPoints1, setManualPoints1] = useState("");
@@ -732,7 +732,6 @@ export default function GrandPrixPageClient({
               group: q.group,
               seeding: q.seeding ?? undefined,
             }))}
-            groupCount={groupCount}
             setGroupCount={setGroupCount}
           />}
 

--- a/smkc-score-app/src/app/tournaments/[id]/mr/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/page-client.tsx
@@ -165,7 +165,7 @@ export default function MatchRacePageClient({
     { playerId: string; group: string; seeding?: number }[]
   >([]);
   /* Product default: 2 groups (§10.2). */
-  const [groupCount, setGroupCount] = useState(2);
+  const [, setGroupCount] = useState(2);
   const [setupSaving, setSetupSaving] = useState(false);
   const [generatingBracket, setGeneratingBracket] = useState(false);
   const [resettingBracket, setResettingBracket] = useState(false);
@@ -625,7 +625,6 @@ export default function MatchRacePageClient({
               group: q.group,
               seeding: q.seeding ?? undefined,
             }))}
-            groupCount={groupCount}
             setGroupCount={setGroupCount}
           />}
 

--- a/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
+++ b/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
@@ -86,8 +86,6 @@ interface GroupSetupDialogProps {
    * Pass an empty array when no qualifications exist yet.
    */
   existingAssignments: SetupPlayer[];
-  /** Number of groups (2, 3, or 4). Managed by parent component. */
-  groupCount: number;
   /** Callback to update group count */
   setGroupCount: (count: number) => void;
 }


### PR DESCRIPTION
## Summary
- Add TC-1007 E2E scenario coverage for the GroupSetupDialog prop contract
- Remove the unused `groupCount` prop from GroupSetupDialog and BM/MR/GP call sites
- Add static guard coverage to keep docs, dialog props, and mode page usages aligned

## Issues
Closes #1007

## Validation
- `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand`
- `npm run lint` (passes with existing warnings)
- `git diff --check`

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
