### PR TITLE
Remove GroupSetupDialog count callback

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2243,15 +2243,27 @@
 - **スクリプト**: smkc-score-app/__tests__/static/tc-1088-qualification-route-comment.test.ts
 
 ## TC-1007: BM/MR/GP グループ設定 — 未使用 groupCount prop を親から渡さない
-- **背景**: issue #1007。`GroupSetupDialog` は内部の `LOCKED_GROUP_COUNT` と `setGroupCount` で2グループ固定を管理しており、親ページから渡す `groupCount` は読み取られない。未使用 prop を残すと、3+グループ再開時に親状態が効くように見える誤解を生む。
+- **背景**: issue #1007。`GroupSetupDialog` は内部の `LOCKED_GROUP_COUNT` で2グループ固定を管理しており、親ページから渡す `groupCount` は読み取られない。未使用 prop を残すと、3+グループ再開時に親状態が効くように見える誤解を生む。
 - **手順**:
   1. TC-1007 の静的 E2E guard を実行する
   2. `GroupSetupDialogProps` と BM/MR/GP の `<GroupSetupDialog>` 呼び出しを検査する
-  3. 親ページが `setGroupCount` だけを渡し、読み取り側の `groupCount` state を保持していないことを確認する
+  3. 親ページが読み取り側の `groupCount` state を保持していないことを確認する
 - **期待結果**:
   - `GroupSetupDialogProps` に `groupCount: number` が存在しない
   - BM/MR/GP の呼び出し元が `groupCount={groupCount}` を渡さない
   - 2グループ固定の理由は `GroupSetupDialog` 内の `LOCKED_GROUP_COUNT` とコメントに集約される
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts`
+
+## TC-1678: BM/MR/GP グループ設定 — setGroupCount コールバックを親から渡さない
+- **背景**: issue #1678。TC-1007 で `groupCount` prop は削除済みだが、`setGroupCount` コールバックと親の `useState(2)` が残ると、ダイアログの2グループ固定が親 state に依存しているように読める。
+- **手順**:
+  1. TC-1678 の静的 E2E guard を実行する
+  2. `GroupSetupDialogProps` と BM/MR/GP の `<GroupSetupDialog>` 呼び出しを検査する
+  3. 親ページに `const [, setGroupCount] = useState(2)` が残っていないことを確認する
+- **期待結果**:
+  - `GroupSetupDialogProps` に `setGroupCount` が存在しない
+  - BM/MR/GP の呼び出し元が `setGroupCount={setGroupCount}` を渡さない
+  - 2グループ固定は `GroupSetupDialog` 内の `LOCKED_GROUP_COUNT` と表示上の固定ボタンだけで完結する
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts`
 
 ## TC-1009: 総合ランキング決勝順位 — 16人/Top-24 判定の matchNumber 閾値を明文化する

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -63,6 +63,7 @@ describe('E2E case drift coverage', () => {
 
   it('keeps TC-1007 aligned with the GroupSetupDialog static guard', () => {
     const section = e2eCaseSection('TC-1007');
+    const followupSection = e2eCaseSection('TC-1678');
     const guard = readRepoFile(
       'smkc-score-app',
       '__tests__',
@@ -73,8 +74,12 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #1007');
     expect(section).toContain('GroupSetupDialog');
     expect(section).toContain('tc-1007-group-setup-dialog-prop-contract.test.ts');
+    expect(followupSection).toContain('issue #1678');
+    expect(followupSection).toContain('setGroupCount');
     expect(guard).toContain("e2eCaseSection('TC-1007')");
+    expect(guard).toContain("e2eCaseSection('TC-1678')");
     expect(guard).toContain("not.toContain('groupCount={groupCount}')");
+    expect(guard).toContain("not.toContain('setGroupCount={setGroupCount}')");
   });
 
   it('keeps TC-702 aligned with direct driver-points JsonNull reporting coverage', () => {

--- a/smkc-score-app/__tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts
@@ -9,10 +9,13 @@ const modeClients = [
 describe('TC-1007 GroupSetupDialog prop contract', () => {
   it('documents the unused groupCount prop removal scenario', () => {
     const section = e2eCaseSection('TC-1007');
+    const followupSection = e2eCaseSection('TC-1678');
 
     expect(section).toContain('issue #1007');
     expect(section).toContain('GroupSetupDialog');
     expect(section).toContain('groupCount');
+    expect(followupSection).toContain('issue #1678');
+    expect(followupSection).toContain('setGroupCount');
     expect(section).toContain('tc-1007-group-setup-dialog-prop-contract.test.ts');
   });
 
@@ -29,15 +32,18 @@ describe('TC-1007 GroupSetupDialog prop contract', () => {
 
     expect(source).toContain('const LOCKED_GROUP_COUNT = 2');
     expect(props).not.toContain('groupCount: number');
+    expect(props).not.toContain('setGroupCount');
     expect(signature).not.toMatch(/\bgroupCount\b/);
-    expect(source).toContain('setGroupCount(LOCKED_GROUP_COUNT)');
+    expect(signature).not.toMatch(/\bsetGroupCount\b/);
+    expect(source).not.toContain('setGroupCount(LOCKED_GROUP_COUNT)');
   });
 
   it.each(modeClients)('does not pass the removed groupCount prop from %s', (_mode, path) => {
     const source = readRepoFile('smkc-score-app', ...path);
-    const dialogUsage = sectionBetween(source, '<GroupSetupDialog', 'setGroupCount={setGroupCount}');
+    const dialogUsage = sectionBetween(source, '<GroupSetupDialog', '/>');
 
     expect(dialogUsage).not.toContain('groupCount={groupCount}');
-    expect(source).toContain('const [, setGroupCount] = useState(2)');
+    expect(dialogUsage).not.toContain('setGroupCount={setGroupCount}');
+    expect(source).not.toMatch(/\bsetGroupCount\b/);
   });
 });

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page-client.tsx
@@ -155,8 +155,6 @@ export default function BattleModePageClient({
   const [setupPlayers, setSetupPlayers] = useState<
     { playerId: string; group: string; seeding?: number }[]
   >([]);
-  /* Product default: 2 groups (§10.2). */
-  const [, setGroupCount] = useState(2);
   const [setupSaving, setSetupSaving] = useState(false);
   /* State for match filters */
   const [matchGroupFilter, setMatchGroupFilter] = useState<string>("all");
@@ -579,7 +577,6 @@ export default function BattleModePageClient({
                 group: q.group,
                 seeding: q.seeding ?? undefined,
               }))}
-              setGroupCount={setGroupCount}
             />
           )}
 

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
@@ -178,8 +178,6 @@ export default function GrandPrixPageClient({
   const [setupPlayers, setSetupPlayers] = useState<
     { playerId: string; group: string; seeding?: number }[]
   >([]);
-  /* Product default: 2 groups (§10.2). */
-  const [, setGroupCount] = useState(2);
   const [setupSaving, setSetupSaving] = useState(false);
   const [manualScoreEnabled, setManualScoreEnabled] = useState(false);
   const [manualPoints1, setManualPoints1] = useState("");
@@ -732,7 +730,6 @@ export default function GrandPrixPageClient({
               group: q.group,
               seeding: q.seeding ?? undefined,
             }))}
-            setGroupCount={setGroupCount}
           />}
 
           {/* Per-mode independent publish toggle (issue #618) */}

--- a/smkc-score-app/src/app/tournaments/[id]/mr/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/page-client.tsx
@@ -164,8 +164,6 @@ export default function MatchRacePageClient({
   const [setupPlayers, setSetupPlayers] = useState<
     { playerId: string; group: string; seeding?: number }[]
   >([]);
-  /* Product default: 2 groups (§10.2). */
-  const [, setGroupCount] = useState(2);
   const [setupSaving, setSetupSaving] = useState(false);
   const [generatingBracket, setGeneratingBracket] = useState(false);
   const [resettingBracket, setResettingBracket] = useState(false);
@@ -625,7 +623,6 @@ export default function MatchRacePageClient({
               group: q.group,
               seeding: q.seeding ?? undefined,
             }))}
-            setGroupCount={setGroupCount}
           />}
 
           {/* Per-mode independent publish toggle (issue #618) */}

--- a/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
+++ b/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
@@ -86,8 +86,6 @@ interface GroupSetupDialogProps {
    * Pass an empty array when no qualifications exist yet.
    */
   existingAssignments: SetupPlayer[];
-  /** Callback to update group count */
-  setGroupCount: (count: number) => void;
 }
 
 export function GroupSetupDialog({
@@ -100,7 +98,6 @@ export function GroupSetupDialog({
   onSave,
   saving = false,
   existingAssignments,
-  setGroupCount,
 }: GroupSetupDialogProps) {
   /* Resolve translations internally using mode prop - avoids props drilling */
   const t = useTranslations(mode);
@@ -128,7 +125,6 @@ export function GroupSetupDialog({
           ? assignment
           : { ...assignment, group: availableGroups[availableGroups.length - 1] },
       ));
-      setGroupCount(LOCKED_GROUP_COUNT);
     } else if (!open) {
       /* Close: reset all form state */
       setSetupPlayers([]);
@@ -162,11 +158,6 @@ export function GroupSetupDialog({
   const handleAutoDistribute = () => {
     if (setupPlayers.length === 0 || !allHaveSeeding) return;
     setSetupPlayers(assignGroupsBySeeding(setupPlayers, LOCKED_GROUP_COUNT, minGroups));
-  };
-
-  /** Keep the parent state pinned to the temporary two-group-only mode. */
-  const handleGroupCountChange = () => {
-    setGroupCount(LOCKED_GROUP_COUNT);
   };
 
   /* Filter players by search query (name or nickname) */
@@ -320,7 +311,6 @@ export function GroupSetupDialog({
                       variant="default"
                       size="sm"
                       className="h-7 w-7 p-0 text-xs"
-                      onClick={handleGroupCountChange}
                     >
                       {n}
                     </Button>


### PR DESCRIPTION
## Summary
- Add TC-1678 E2E scenario coverage for removing the remaining GroupSetupDialog count callback
- Remove the unused `setGroupCount` prop from GroupSetupDialog and BM/MR/GP call sites
- Broaden the static guard so parent page clients cannot reintroduce the obsolete callback state

## Issues
Closes #1678

## Validation
- `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand`
- `npm run lint` (passes with existing warnings)
- `git diff --check`

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
