### PR TITLE
Disable fixed GroupSetupDialog count button

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2266,6 +2266,18 @@
   - 2グループ固定は `GroupSetupDialog` 内の `LOCKED_GROUP_COUNT` と表示上の固定ボタンだけで完結する
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts`
 
+## TC-1680: BM/MR/GP グループ設定 — 固定グループ数表示を disabled にする
+- **背景**: issue #1680。2グループ固定表示のボタンは `setGroupCount` 削除後にクリックしても何も起きないため、disabled 状態で固定値表示であることを明示する。
+- **手順**:
+  1. TC-1680 の静的 E2E guard を実行する
+  2. `GroupSetupDialog` の `LOCKED_GROUP_COUNT` 表示ボタンを検査する
+  3. ボタンに `disabled` があり、`onClick` がないことを確認する
+- **期待結果**:
+  - 固定グループ数の UI が押せる操作として誤認されない
+  - `LOCKED_GROUP_COUNT = 2` の固定仕様は維持される
+  - 将来 3+ グループ対応を戻す場合は guard 更新が必要になる
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts`
+
 ## TC-1009: 総合ランキング決勝順位 — 16人/Top-24 判定の matchNumber 閾値を明文化する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -64,6 +64,7 @@ describe('E2E case drift coverage', () => {
   it('keeps TC-1007 aligned with the GroupSetupDialog static guard', () => {
     const section = e2eCaseSection('TC-1007');
     const followupSection = e2eCaseSection('TC-1678');
+    const disabledButtonSection = e2eCaseSection('TC-1680');
     const guard = readRepoFile(
       'smkc-score-app',
       '__tests__',
@@ -76,10 +77,13 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('tc-1007-group-setup-dialog-prop-contract.test.ts');
     expect(followupSection).toContain('issue #1678');
     expect(followupSection).toContain('setGroupCount');
+    expect(disabledButtonSection).toContain('issue #1680');
+    expect(disabledButtonSection).toContain('disabled');
     expect(guard).toContain("e2eCaseSection('TC-1007')");
     expect(guard).toContain("e2eCaseSection('TC-1678')");
     expect(guard).toContain("not.toContain('groupCount={groupCount}')");
     expect(guard).toContain("not.toContain('setGroupCount={setGroupCount}')");
+    expect(guard).toContain("expect(groupCountButton).toContain('disabled')");
   });
 
   it('keeps TC-702 aligned with direct driver-points JsonNull reporting coverage', () => {

--- a/smkc-score-app/__tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts
@@ -10,12 +10,15 @@ describe('TC-1007 GroupSetupDialog prop contract', () => {
   it('documents the unused groupCount prop removal scenario', () => {
     const section = e2eCaseSection('TC-1007');
     const followupSection = e2eCaseSection('TC-1678');
+    const disabledButtonSection = e2eCaseSection('TC-1680');
 
     expect(section).toContain('issue #1007');
     expect(section).toContain('GroupSetupDialog');
     expect(section).toContain('groupCount');
     expect(followupSection).toContain('issue #1678');
     expect(followupSection).toContain('setGroupCount');
+    expect(disabledButtonSection).toContain('issue #1680');
+    expect(disabledButtonSection).toContain('disabled');
     expect(section).toContain('tc-1007-group-setup-dialog-prop-contract.test.ts');
   });
 
@@ -36,6 +39,14 @@ describe('TC-1007 GroupSetupDialog prop contract', () => {
     expect(signature).not.toMatch(/\bgroupCount\b/);
     expect(signature).not.toMatch(/\bsetGroupCount\b/);
     expect(source).not.toContain('setGroupCount(LOCKED_GROUP_COUNT)');
+
+    const groupCountButton = sectionBetween(
+      source,
+      '{[LOCKED_GROUP_COUNT].map((n) => (',
+      '</Button>',
+    );
+    expect(groupCountButton).toContain('disabled');
+    expect(groupCountButton).not.toContain('onClick');
   });
 
   it.each(modeClients)('does not pass the removed groupCount prop from %s', (_mode, path) => {

--- a/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
+++ b/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
@@ -311,6 +311,7 @@ export function GroupSetupDialog({
                       variant="default"
                       size="sm"
                       className="h-7 w-7 p-0 text-xs"
+                      disabled
                     >
                       {n}
                     </Button>


### PR DESCRIPTION
## Summary
- Add TC-1680 E2E scenario coverage for the fixed GroupSetupDialog group-count display
- Disable the fixed group-count button so it no longer appears clickable after callback removal
- Extend the static/doc drift guard to preserve the disabled, non-clickable contract

## Issues
Closes #1680

## Validation
- `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand`
- `npm run lint` (passes with existing warnings)
- `git diff --check`

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
