### PR TITLE
Use outline styling for fixed group count

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2278,6 +2278,18 @@
   - 将来 3+ グループ対応を戻す場合は guard 更新が必要になる
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts`
 
+## TC-1682: BM/MR/GP グループ設定 — disabled 固定グループ数を outline 表示にする
+- **背景**: issue #1682。固定値の disabled ボタンが `variant="default"` のままだと、環境によってはアクティブな選択ボタンに見える可能性がある。`variant="outline"` にして情報表示寄りの見た目にする。
+- **手順**:
+  1. TC-1682 の静的 E2E guard を実行する
+  2. `GroupSetupDialog` の `LOCKED_GROUP_COUNT` 表示ボタンを検査する
+  3. ボタンが `variant="outline"` かつ `disabled` で、`onClick` がないことを確認する
+- **期待結果**:
+  - 固定グループ数表示がアクティブ操作に見えにくい
+  - disabled と non-clickable の契約は維持される
+  - 将来 selectable UI に戻す場合は guard 更新が必要になる
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts`
+
 ## TC-1009: 総合ランキング決勝順位 — 16人/Top-24 判定の matchNumber 閾値を明文化する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -65,6 +65,7 @@ describe('E2E case drift coverage', () => {
     const section = e2eCaseSection('TC-1007');
     const followupSection = e2eCaseSection('TC-1678');
     const disabledButtonSection = e2eCaseSection('TC-1680');
+    const outlineButtonSection = e2eCaseSection('TC-1682');
     const guard = readRepoFile(
       'smkc-score-app',
       '__tests__',
@@ -79,11 +80,14 @@ describe('E2E case drift coverage', () => {
     expect(followupSection).toContain('setGroupCount');
     expect(disabledButtonSection).toContain('issue #1680');
     expect(disabledButtonSection).toContain('disabled');
+    expect(outlineButtonSection).toContain('issue #1682');
+    expect(outlineButtonSection).toContain('variant="outline"');
     expect(guard).toContain("e2eCaseSection('TC-1007')");
     expect(guard).toContain("e2eCaseSection('TC-1678')");
     expect(guard).toContain("not.toContain('groupCount={groupCount}')");
     expect(guard).toContain("not.toContain('setGroupCount={setGroupCount}')");
     expect(guard).toContain("expect(groupCountButton).toContain('disabled')");
+    expect(guard).toContain('expect(groupCountButton).toContain(\'variant="outline"\')');
   });
 
   it('keeps TC-702 aligned with direct driver-points JsonNull reporting coverage', () => {

--- a/smkc-score-app/__tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts
@@ -11,6 +11,7 @@ describe('TC-1007 GroupSetupDialog prop contract', () => {
     const section = e2eCaseSection('TC-1007');
     const followupSection = e2eCaseSection('TC-1678');
     const disabledButtonSection = e2eCaseSection('TC-1680');
+    const outlineButtonSection = e2eCaseSection('TC-1682');
 
     expect(section).toContain('issue #1007');
     expect(section).toContain('GroupSetupDialog');
@@ -19,6 +20,8 @@ describe('TC-1007 GroupSetupDialog prop contract', () => {
     expect(followupSection).toContain('setGroupCount');
     expect(disabledButtonSection).toContain('issue #1680');
     expect(disabledButtonSection).toContain('disabled');
+    expect(outlineButtonSection).toContain('issue #1682');
+    expect(outlineButtonSection).toContain('variant="outline"');
     expect(section).toContain('tc-1007-group-setup-dialog-prop-contract.test.ts');
   });
 
@@ -46,6 +49,7 @@ describe('TC-1007 GroupSetupDialog prop contract', () => {
       '</Button>',
     );
     expect(groupCountButton).toContain('disabled');
+    expect(groupCountButton).toContain('variant="outline"');
     expect(groupCountButton).not.toContain('onClick');
   });
 

--- a/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
+++ b/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
@@ -308,7 +308,7 @@ export function GroupSetupDialog({
                   {[LOCKED_GROUP_COUNT].map((n) => (
                     <Button
                       key={n}
-                      variant="default"
+                      variant="outline"
                       size="sm"
                       className="h-7 w-7 p-0 text-xs"
                       disabled


### PR DESCRIPTION
## Summary
- Add TC-1682 E2E scenario coverage for the fixed GroupSetupDialog count display variant
- Switch the disabled fixed group-count button from default to outline styling
- Extend the static/doc drift guard to preserve the disabled outline non-clickable contract

## Issues
Closes #1682

## Validation
- `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand`
- `npm run lint` (passes with existing warnings)
- `git diff --check`

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
