### PR TITLE
Remove unused TA course cycle count

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2254,6 +2254,21 @@
   - 2グループ固定の理由は `GroupSetupDialog` 内の `LOCKED_GROUP_COUNT` とコメントに集約される
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts`
 
+## TC-1004: TA コースサイクル — 未使用 availableCount フィールドを公開しない
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #1004。TA のコースサイクル表示は `availableCourses.length` を画面に出しており、`CourseCycleStatus.availableCount` は UI で参照されない。未使用フィールドを返すと将来の表示契約が増えたように見え、サーバー側の利用可能コース計算と二重管理になる。
+- **手順**:
+  1. TC-1004 の静的 E2E guard を実行する
+  2. `CourseCycleStatus` の公開フィールドを検査する
+  3. TA Finals と TA elimination のコースサイクル表示が `availableCourses.length` を使うことを確認する
+  4. `getCourseCycleStatus` の単体テストを実行し、cycle/played/total/totalPlayed のみが返ることを確認する
+- **期待結果**:
+  - `CourseCycleStatus` に `availableCount` が存在しない
+  - `getCourseCycleStatus` は UI が実際に使う cycle/played/total/totalPlayed だけを返す
+  - 利用可能コース数の表示は `availableCourses.length` から算出され、重複した派生値を持たない
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-1004-course-cycle-status-contract.test.ts __tests__/lib/ta/course-cycle-status.test.ts`
+
 ## TC-1678: BM/MR/GP グループ設定 — setGroupCount コールバックを親から渡さない
 - **背景**: issue #1678。TC-1007 で `groupCount` prop は削除済みだが、`setGroupCount` コールバックと親の `useState(2)` が残ると、ダイアログの2グループ固定が親 state に依存しているように読める。
 - **手順**:

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -90,6 +90,30 @@ describe('E2E case drift coverage', () => {
     expect(guard).toContain('expect(groupCountButton).toContain(\'variant="outline"\')');
   });
 
+  it('keeps TC-1004 aligned with the CourseCycleStatus YAGNI guard', () => {
+    const section = e2eCaseSection('TC-1004');
+    const guard = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'static',
+      'tc-1004-course-cycle-status-contract.test.ts',
+    );
+    const unitTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'lib',
+      'ta',
+      'course-cycle-status.test.ts',
+    );
+
+    expect(section).toContain('issue #1004');
+    expect(section).toContain('availableCourses.length');
+    expect(section).toContain('tc-1004-course-cycle-status-contract.test.ts');
+    expect(guard).toContain("e2eCaseSection('TC-1004')");
+    expect(guard).toContain("expect(helperSource).not.toContain('availableCount')");
+    expect(unitTest).not.toContain('availableCount');
+  });
+
   it('keeps TC-702 aligned with direct driver-points JsonNull reporting coverage', () => {
     const section = e2eCaseSection('TC-702');
 

--- a/smkc-score-app/__tests__/lib/ta/course-cycle-status.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/course-cycle-status.test.ts
@@ -7,7 +7,6 @@ describe("getCourseCycleStatus", () => {
       cycleNumber: 1,
       playedInCycle: 0,
       totalCourses: 20,
-      availableCount: 20,
       totalPlayed: 0,
     });
   });
@@ -17,7 +16,6 @@ describe("getCourseCycleStatus", () => {
       cycleNumber: 1,
       playedInCycle: 11,
       totalCourses: 20,
-      availableCount: 9,
       totalPlayed: 11,
     });
   });
@@ -27,7 +25,6 @@ describe("getCourseCycleStatus", () => {
       cycleNumber: 2,
       playedInCycle: 0,
       totalCourses: 20,
-      availableCount: 20,
       totalPlayed: 20,
     });
   });
@@ -39,7 +36,6 @@ describe("getCourseCycleStatus", () => {
       cycleNumber: 2,
       playedInCycle: 7,
       totalCourses: 20,
-      availableCount: 13,
       totalPlayed: 27,
     });
   });

--- a/smkc-score-app/__tests__/static/tc-1004-course-cycle-status-contract.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1004-course-cycle-status-contract.test.ts
@@ -1,0 +1,47 @@
+import { e2eCaseSection, readRepoFile } from '../helpers/e2e-cases';
+
+describe('TC-1004 CourseCycleStatus contract', () => {
+  const helperSource = readRepoFile('smkc-score-app', 'src', 'lib', 'ta', 'course-cycle-status.ts');
+  const finalsPageSource = readRepoFile(
+    'smkc-score-app',
+    'src',
+    'app',
+    'tournaments',
+    '[id]',
+    'ta',
+    'finals',
+    'page.tsx',
+  );
+  const eliminationSource = readRepoFile(
+    'smkc-score-app',
+    'src',
+    'components',
+    'tournament',
+    'ta-elimination-phase.tsx',
+  );
+
+  it('documents the YAGNI contract in the E2E scenario list', () => {
+    const section = e2eCaseSection('TC-1004');
+
+    expect(section).toContain('issue #1004');
+    expect(section).toContain('availableCount');
+    expect(section).toContain('availableCourses.length');
+    expect(section).toContain('tc-1004-course-cycle-status-contract.test.ts');
+  });
+
+  it('keeps CourseCycleStatus limited to fields that the TA UI consumes', () => {
+    expect(helperSource).toContain('export interface CourseCycleStatus');
+    expect(helperSource).not.toContain('availableCount');
+    expect(helperSource).toContain('cycleNumber: number');
+    expect(helperSource).toContain('playedInCycle: number');
+    expect(helperSource).toContain('totalCourses: number');
+    expect(helperSource).toContain('totalPlayed: number');
+  });
+
+  it('keeps available course count display sourced from the server-calculated list length', () => {
+    expect(finalsPageSource).toContain('count: availableCourses.length');
+    expect(eliminationSource).toContain('count: availableCourses.length');
+    expect(finalsPageSource).not.toContain('courseCycleStatus.availableCount');
+    expect(eliminationSource).not.toContain('courseCycleStatus.availableCount');
+  });
+});

--- a/smkc-score-app/src/lib/ta/course-cycle-status.ts
+++ b/smkc-score-app/src/lib/ta/course-cycle-status.ts
@@ -4,7 +4,6 @@ export interface CourseCycleStatus {
   cycleNumber: number;
   playedInCycle: number;
   totalCourses: number;
-  availableCount: number;
   totalPlayed: number;
 }
 
@@ -16,7 +15,8 @@ export function getCourseCycleStatus(playedCourses: string[]): CourseCycleStatus
     cycleNumber: Math.floor(totalPlayed / TOTAL_COURSES) + 1,
     playedInCycle,
     totalCourses: TOTAL_COURSES,
-    availableCount: TOTAL_COURSES - playedInCycle,
+    // The UI displays the server-calculated availableCourses.length instead of
+    // duplicating that derived value here, so this helper only exposes cycle progress.
     totalPlayed,
   };
 }


### PR DESCRIPTION
Summary
- Remove the unused CourseCycleStatus.availableCount field so TA course-cycle status only exposes fields the UI consumes.
- Add TC-1004 to E2E_TEST_CASES.md plus static/docs drift coverage proving the UI uses availableCourses.length for the displayed count.
- Update getCourseCycleStatus unit expectations to lock the slimmer return contract.

Issues: Closes #1004

Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/static/tc-1004-course-cycle-status-contract.test.ts __tests__/lib/ta/course-cycle-status.test.ts --runInBand
- npm run lint
- git diff --check
