### PR TITLE
Extract TA course cycle status panel

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2261,13 +2261,29 @@
 - **手順**:
   1. TC-1004 の静的 E2E guard を実行する
   2. `CourseCycleStatus` の公開フィールドを検査する
-  3. TA Finals と TA elimination のコースサイクル表示が `availableCourses.length` を使うことを確認する
+  3. TA Finals と TA elimination のコースサイクル表示が `availableCourses.length` を `CourseCycleStatusPanel` の `availableCoursesCount` に渡すことを確認する
   4. `getCourseCycleStatus` の単体テストを実行し、cycle/played/total/totalPlayed のみが返ることを確認する
 - **期待結果**:
   - `CourseCycleStatus` に `availableCount` が存在しない
   - `getCourseCycleStatus` は UI が実際に使う cycle/played/total/totalPlayed だけを返す
-  - 利用可能コース数の表示は `availableCourses.length` から算出され、重複した派生値を持たない
+  - 利用可能コース数の表示は `availableCourses.length` から渡され、重複した派生値を持たない
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-1004-course-cycle-status-contract.test.ts __tests__/lib/ta/course-cycle-status.test.ts`
+
+## TC-1005: TA コースサイクル — Finals/Elimination 表示を共有コンポーネントに集約
+- **URL**: `/tournaments/{id}/ta/phase1`, `/tournaments/{id}/ta/finals`
+- **authRequired**: true
+- **背景**: issue #1005。TA Finals と TA elimination phases のコースサイクル表示は同じ `courseCycleLabel` / `availableCoursesLabel` / `courseCycleHint` UI 契約を持つため、表示ブロックを別々に持つと文言・算出元・スタイルの片側だけが変わるリスクがある。
+- **手順**:
+  1. TA Phase 1 用の隔離トーナメントを作成し、予選順位 17-24 の8名を Phase 1 に昇格する
+  2. `/ta/phase1` にアクセスし、コースサイクルと利用可能コース数が表示されることを確認する
+  3. TA Finals 用の隔離トーナメントを作成し、予選上位の選手を Phase 3 に昇格する
+  4. `/ta/finals` にアクセスし、同じコースサイクル表示が出ることを確認する
+  5. 静的 E2E guard と `CourseCycleStatusPanel` の単体テストで、TA Finals と TA elimination が `availableCourses.length` を `availableCoursesCount` に渡すことを確認する
+- **期待結果**:
+  - TA Finals と TA elimination のコースサイクル表示は同じ `CourseCycleStatusPanel` に集約される
+  - `CourseCycleStatusPanel` は cycle/played/total/available/totalPlayed を表示する
+  - 表示ロジックの重複が残らず、今後の文言・スタイル変更が1箇所で済む
+- **スクリプト**: `E2E_TESTS=TC-1005 node e2e/tc-ta.js` + `npm test -- --runTestsByPath __tests__/static/tc-1005-course-cycle-panel-contract.test.ts __tests__/components/tournament/course-cycle-status-panel.test.tsx`
 
 ## TC-1678: BM/MR/GP グループ設定 — setGroupCount コールバックを親から渡さない
 - **背景**: issue #1678。TC-1007 で `groupCount` prop は削除済みだが、`setGroupCount` コールバックと親の `useState(2)` が残ると、ダイアログの2グループ固定が親 state に依存しているように読める。

--- a/smkc-score-app/__tests__/components/tournament/course-cycle-status-panel.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/course-cycle-status-panel.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { CourseCycleStatusPanel } from "@/components/tournament/course-cycle-status-panel";
+
+describe("CourseCycleStatusPanel", () => {
+  const translate = (key: string, values?: Record<string, number>) => {
+    if (key === "courseCycleLabel") return "Course Cycle:";
+    if (key === "courseCycleValue") return `Cycle ${values?.cycle} ${values?.played}/${values?.total}`;
+    if (key === "availableCoursesLabel") return "Available Courses:";
+    if (key === "availableCoursesValue") return `${values?.count}/${values?.total} courses`;
+    if (key === "courseCycleHint") return `${values?.totalPlayed} total played`;
+    return key;
+  };
+
+  it("renders the shared course-cycle display contract", () => {
+    render(
+      <CourseCycleStatusPanel
+        t={translate}
+        status={{
+          cycleNumber: 2,
+          playedInCycle: 7,
+          totalCourses: 20,
+          totalPlayed: 27,
+        }}
+        availableCoursesCount={13}
+      />,
+    );
+
+    expect(screen.getByText("Course Cycle:")).toBeInTheDocument();
+    expect(screen.getByText("Cycle 2 7/20")).toBeInTheDocument();
+    expect(screen.getByText("Available Courses:")).toBeInTheDocument();
+    expect(screen.getByText("13/20 courses")).toBeInTheDocument();
+    expect(screen.getByText("27 total played")).toBeInTheDocument();
+  });
+});

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -108,10 +108,39 @@ describe('E2E case drift coverage', () => {
 
     expect(section).toContain('issue #1004');
     expect(section).toContain('availableCourses.length');
+    expect(section).toContain('availableCoursesCount');
     expect(section).toContain('tc-1004-course-cycle-status-contract.test.ts');
     expect(guard).toContain("e2eCaseSection('TC-1004')");
     expect(guard).toContain("expect(helperSource).not.toContain('availableCount')");
+    expect(guard).toContain('availableCoursesCount={availableCourses.length}');
     expect(unitTest).not.toContain('availableCount');
+  });
+
+  it('keeps TC-1005 aligned with the shared TA course-cycle panel guard', () => {
+    const section = e2eCaseSection('TC-1005');
+    const guard = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'static',
+      'tc-1005-course-cycle-panel-contract.test.ts',
+    );
+    const componentTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'components',
+      'tournament',
+      'course-cycle-status-panel.test.tsx',
+    );
+
+    expect(section).toContain('issue #1005');
+    expect(section).toContain('CourseCycleStatusPanel');
+    expect(section).toContain('E2E_TESTS=TC-1005 node e2e/tc-ta.js');
+    expect(section).toContain('tc-1005-course-cycle-panel-contract.test.ts');
+    expect(guard).toContain("e2eCaseSection('TC-1005')");
+    expect(guard).toContain("expect(finalsPageSource).toContain('<CourseCycleStatusPanel')");
+    expect(componentTest).toContain('availableCoursesCount={13}');
+    expect(tcTa).toContain("{ name: 'TC-1005', fn: runTc1005 }");
+    expect(tcTa).toContain("log('TC-1005'");
   });
 
   it('keeps TC-702 aligned with direct driver-points JsonNull reporting coverage', () => {

--- a/smkc-score-app/__tests__/static/tc-1004-course-cycle-status-contract.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1004-course-cycle-status-contract.test.ts
@@ -26,6 +26,7 @@ describe('TC-1004 CourseCycleStatus contract', () => {
     expect(section).toContain('issue #1004');
     expect(section).toContain('availableCount');
     expect(section).toContain('availableCourses.length');
+    expect(section).toContain('availableCoursesCount');
     expect(section).toContain('tc-1004-course-cycle-status-contract.test.ts');
   });
 
@@ -39,8 +40,8 @@ describe('TC-1004 CourseCycleStatus contract', () => {
   });
 
   it('keeps available course count display sourced from the server-calculated list length', () => {
-    expect(finalsPageSource).toContain('count: availableCourses.length');
-    expect(eliminationSource).toContain('count: availableCourses.length');
+    expect(finalsPageSource).toContain('availableCoursesCount={availableCourses.length}');
+    expect(eliminationSource).toContain('availableCoursesCount={availableCourses.length}');
     expect(finalsPageSource).not.toContain('courseCycleStatus.availableCount');
     expect(eliminationSource).not.toContain('courseCycleStatus.availableCount');
   });

--- a/smkc-score-app/__tests__/static/tc-1005-course-cycle-panel-contract.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1005-course-cycle-panel-contract.test.ts
@@ -1,0 +1,48 @@
+import { e2eCaseSection, readRepoFile } from '../helpers/e2e-cases';
+
+describe('TC-1005 CourseCycleStatusPanel contract', () => {
+  const panelSource = readRepoFile(
+    'smkc-score-app',
+    'src',
+    'components',
+    'tournament',
+    'course-cycle-status-panel.tsx',
+  );
+  const finalsPageSource = readRepoFile(
+    'smkc-score-app',
+    'src',
+    'app',
+    'tournaments',
+    '[id]',
+    'ta',
+    'finals',
+    'page.tsx',
+  );
+  const eliminationSource = readRepoFile(
+    'smkc-score-app',
+    'src',
+    'components',
+    'tournament',
+    'ta-elimination-phase.tsx',
+  );
+
+  it('documents the shared TA course-cycle panel scenario', () => {
+    const section = e2eCaseSection('TC-1005');
+
+    expect(section).toContain('issue #1005');
+    expect(section).toContain('CourseCycleStatusPanel');
+    expect(section).toContain('availableCoursesCount');
+    expect(section).toContain('tc-1005-course-cycle-panel-contract.test.ts');
+  });
+
+  it('keeps the duplicated TA course-cycle markup in one component', () => {
+    expect(panelSource).toContain('export function CourseCycleStatusPanel');
+    expect(panelSource).toContain('t("courseCycleLabel")');
+    expect(panelSource).toContain('availableCoursesCount');
+
+    expect(finalsPageSource).toContain('<CourseCycleStatusPanel');
+    expect(eliminationSource).toContain('<CourseCycleStatusPanel');
+    expect(finalsPageSource).not.toContain("tTaFinals('courseCycleLabel')");
+    expect(eliminationSource).not.toContain("tElim('courseCycleLabel')");
+  });
+});

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -32,6 +32,7 @@
  *   TC-1033 Sudden-death API payload exposes only the actionable target ids,
  *           not the removed internal tie-break reason.
  *   TC-817  Phase 1 sudden-death courses remain consumed when Phase 2 starts.
+ *   TC-1005 TA Phase 1 and Finals render the shared course-cycle status panel.
  *
  * Setup:
  *   - Uses the shared Playwright persistent profile (/tmp/playwright-smkc-preview-profile by default).
@@ -131,14 +132,13 @@ async function seedTaQualificationRanks(adminPage, tournamentId, entries, startR
      * the desired rank (e.g. 17..24 for Phase 1 promotion tests) without
      * re-triggering rank recalculation (rank-only PUT skips recalculate). */
     await apiSeedTtEntry(adminPage, tournamentId, entries[i].entryId, times, totalMs, rank);
-    /* recalculateRanks (triggered inside the PUT route when `times` is present)
-     * reorders by actual time values and may derive a different rank than the
-     * requested one when fewer than 24 players are in the tournament. Force the
-     * desired rank with a separate rank-only PUT (no `times` → no recalculate)
-     * so the Finals Phases card sees ranks in the 17–24 range and shows the
-     * "Start Phase 1" button. Must run before uiFreezeTaQualification. */
-    await apiForceRankOnly(adminPage, tournamentId, entries[i].entryId, rank);
     seeded.push({ ...entries[i], rank, times, totalMs });
+  }
+  for (const entry of seeded) {
+    /* recalculateRanks runs for every time-seeding PUT and can rewrite ranks
+     * seeded earlier in this helper. Force all desired ranks after all timing
+     * writes finish so promotion tests get a stable 17-24 or 1-N field. */
+    await apiForceRankOnly(adminPage, tournamentId, entry.entryId, entry.rank);
   }
   return seeded;
 }
@@ -1795,6 +1795,59 @@ async function runTc817(adminPage) {
   }
 }
 
+/* ───────── TC-1005: Shared TA course-cycle status panel renders in phases ───────── */
+async function runTc1005(adminPage) {
+  let phase1Setup = null;
+  let finalsSetup = null;
+  try {
+    phase1Setup = await createIsolatedTaQualification(
+      adminPage,
+      'Course Cycle Panel Phase1',
+      sharedTaPlayers(8),
+      { seedTimes: false },
+    );
+    await seedTaQualificationRanks(adminPage, phase1Setup.tournamentId, phase1Setup.entries, 17);
+    const phase1Promote = await apiPromoteTaPhase(adminPage, phase1Setup.tournamentId, 'promote_phase1');
+    if (phase1Promote.s !== 200) {
+      throw new Error(`promote_phase1 failed (${phase1Promote.s}): ${JSON.stringify(phase1Promote.b).slice(0, 240)}`);
+    }
+
+    await nav(adminPage, `/tournaments/${phase1Setup.tournamentId}/ta/phase1`);
+    const phase1Text = await adminPage.locator('main').innerText({ timeout: 15000 });
+    const phase1HasCycle = /コースサイクル|Course Cycle/.test(phase1Text);
+    const phase1HasAvailable = /利用可能コース|Available Courses/.test(phase1Text);
+    const phase1HasValue = /1周目 0\/20|Cycle 1 0\/20/.test(phase1Text);
+
+    finalsSetup = await createIsolatedTaQualification(
+      adminPage,
+      'Course Cycle Panel Finals',
+      sharedTaPlayers(2),
+      { seedTimes: false },
+    );
+    await seedTaQualificationRanks(adminPage, finalsSetup.tournamentId, finalsSetup.entries, 1);
+    const finalsPromote = await apiPromoteTaPhase(adminPage, finalsSetup.tournamentId, 'promote_phase3');
+    if (finalsPromote.s !== 200) {
+      throw new Error(`promote_phase3 failed (${finalsPromote.s}): ${JSON.stringify(finalsPromote.b).slice(0, 240)}`);
+    }
+
+    await nav(adminPage, `/tournaments/${finalsSetup.tournamentId}/ta/finals`);
+    const finalsText = await adminPage.locator('main').innerText({ timeout: 15000 });
+    const finalsHasCycle = /コースサイクル|Course Cycle/.test(finalsText);
+    const finalsHasAvailable = /利用可能コース|Available Courses/.test(finalsText);
+    const finalsHasValue = /1周目 0\/20|Cycle 1 0\/20/.test(finalsText);
+
+    const ok = phase1HasCycle && phase1HasAvailable && phase1HasValue &&
+      finalsHasCycle && finalsHasAvailable && finalsHasValue;
+    log('TC-1005', ok ? 'PASS' : 'FAIL',
+      ok ? '' : `phase1 cycle=${phase1HasCycle} available=${phase1HasAvailable} value=${phase1HasValue}; finals cycle=${finalsHasCycle} available=${finalsHasAvailable} value=${finalsHasValue}`);
+  } catch (err) {
+    log('TC-1005', 'FAIL', err instanceof Error ? err.message : 'TA course-cycle panel render failed');
+  } finally {
+    if (finalsSetup) await finalsSetup.cleanup();
+    if (phase1Setup) await phase1Setup.cleanup();
+  }
+}
+
 /* See tc-bm.js::getSuite for the shared-fixture composition contract. TA has
  * an additional qualification seed step that must run inside beforeAll
  * regardless of whether the fixture is external, since TC-801 reads the
@@ -1865,6 +1918,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-1032', fn: runTc1032 },
       { name: 'TC-1033', fn: runTc1033 },
       { name: 'TC-817', fn: runTc817 },
+      { name: 'TC-1005', fn: runTc1005 },
     ],
   };
 }
@@ -1872,7 +1926,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 module.exports = {
   runTc801, runTc802, runTc839, runTc804, runTc805, runTc806, runTc807, runTc808, runTc809, runTc810, runTc811,
   runTc837, runTc840, runTc878, runTc896, runTc897, runTc913,
-  runTc812, runTc813, runTc814, runTc1032, runTc1033, runTc815, runTc816, runTc817,
+  runTc812, runTc813, runTc814, runTc1032, runTc1033, runTc815, runTc816, runTc817, runTc1005,
   getSuite,
   results,
   __testHooks: {

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -92,6 +92,7 @@ import { createLogger } from "@/lib/client-logger";
 import type { Player } from "@/lib/types";
 import { useTournamentDebugMode } from "@/lib/hooks/use-tournament-debug-mode";
 import { useBroadcastReflect } from "@/lib/hooks/use-broadcast-reflect";
+import { CourseCycleStatusPanel } from "@/components/tournament/course-cycle-status-panel";
 
 const logger = createLogger({ serviceName: 'tournaments-ta-finals' });
 
@@ -1138,30 +1139,11 @@ export default function TimeAttackFinals({
                     </span>
                   </div>
                 </div>
-                <div className="border border-foreground/15 bg-muted/30 p-3 text-sm space-y-2">
-                  <div className="flex justify-between gap-3">
-                    <span className="text-muted-foreground">{tTaFinals('courseCycleLabel')}</span>
-                    <span className="font-mono tabular-nums text-right">
-                      {tTaFinals('courseCycleValue', {
-                        cycle: courseCycleStatus.cycleNumber,
-                        played: courseCycleStatus.playedInCycle,
-                        total: courseCycleStatus.totalCourses,
-                      })}
-                    </span>
-                  </div>
-                  <div className="flex justify-between gap-3">
-                    <span className="text-muted-foreground">{tTaFinals('availableCoursesLabel')}</span>
-                    <span className="font-mono tabular-nums text-right">
-                      {tTaFinals('availableCoursesValue', {
-                        count: availableCourses.length,
-                        total: courseCycleStatus.totalCourses,
-                      })}
-                    </span>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    {tTaFinals('courseCycleHint', { totalPlayed: courseCycleStatus.totalPlayed })}
-                  </p>
-                </div>
+                <CourseCycleStatusPanel
+                  t={tTaFinals}
+                  status={courseCycleStatus}
+                  availableCoursesCount={availableCourses.length}
+                />
                 {/* Admin manual course override: selects a specific course instead of random.
                     Available courses come from the server-calculated 20-course cycle pool.
                     Leaving this on "ランダム" (default) preserves the existing random behaviour. */}

--- a/smkc-score-app/src/components/tournament/course-cycle-status-panel.tsx
+++ b/smkc-score-app/src/components/tournament/course-cycle-status-panel.tsx
@@ -1,0 +1,57 @@
+import type { CourseCycleStatus } from "@/lib/ta/course-cycle-status";
+
+type CourseCycleMessageKey =
+  | "courseCycleLabel"
+  | "courseCycleValue"
+  | "availableCoursesLabel"
+  | "availableCoursesValue"
+  | "courseCycleHint";
+
+export type CourseCycleStatusPanelTranslator = (
+  key: CourseCycleMessageKey,
+  values?: Record<string, number>,
+) => string;
+
+interface CourseCycleStatusPanelProps {
+  t: CourseCycleStatusPanelTranslator;
+  status: CourseCycleStatus;
+  availableCoursesCount: number;
+}
+
+export function CourseCycleStatusPanel({
+  t,
+  status,
+  availableCoursesCount,
+}: CourseCycleStatusPanelProps) {
+  /*
+   * Finals phase 3 and elimination phases 1/2 share the same course-cycle UI.
+   * The available count stays as an explicit prop because it is calculated by
+   * the server-backed course pool, not by the lightweight cycle-status helper.
+   */
+  return (
+    <div className="border border-foreground/15 bg-muted/30 p-3 text-sm space-y-2">
+      <div className="flex justify-between gap-3">
+        <span className="text-muted-foreground">{t("courseCycleLabel")}</span>
+        <span className="font-mono tabular-nums text-right">
+          {t("courseCycleValue", {
+            cycle: status.cycleNumber,
+            played: status.playedInCycle,
+            total: status.totalCourses,
+          })}
+        </span>
+      </div>
+      <div className="flex justify-between gap-3">
+        <span className="text-muted-foreground">{t("availableCoursesLabel")}</span>
+        <span className="font-mono tabular-nums text-right">
+          {t("availableCoursesValue", {
+            count: availableCoursesCount,
+            total: status.totalCourses,
+          })}
+        </span>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {t("courseCycleHint", { totalPlayed: status.totalPlayed })}
+      </p>
+    </div>
+  );
+}

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -75,6 +75,7 @@ import type { Player } from "@/lib/types";
 import { createLogger } from "@/lib/client-logger";
 import { useTournamentDebugMode } from "@/lib/hooks/use-tournament-debug-mode";
 import { useBroadcastReflect } from "@/lib/hooks/use-broadcast-reflect";
+import { CourseCycleStatusPanel } from "@/components/tournament/course-cycle-status-panel";
 
 /** Client-side logger for error tracking */
 const logger = createLogger({ serviceName: 'ta-elimination-phase' });
@@ -1062,30 +1063,11 @@ export default function TAEliminationPhase({
                     <span className="font-bold">{completedRoundsCount}</span>
                   </div>
                 </div>
-                <div className="border border-foreground/15 bg-muted/30 p-3 text-sm space-y-2">
-                  <div className="flex justify-between gap-3">
-                    <span className="text-muted-foreground">{tElim('courseCycleLabel')}</span>
-                    <span className="font-mono tabular-nums text-right">
-                      {tElim('courseCycleValue', {
-                        cycle: courseCycleStatus.cycleNumber,
-                        played: courseCycleStatus.playedInCycle,
-                        total: courseCycleStatus.totalCourses,
-                      })}
-                    </span>
-                  </div>
-                  <div className="flex justify-between gap-3">
-                    <span className="text-muted-foreground">{tElim('availableCoursesLabel')}</span>
-                    <span className="font-mono tabular-nums text-right">
-                      {tElim('availableCoursesValue', {
-                        count: availableCourses.length,
-                        total: courseCycleStatus.totalCourses,
-                      })}
-                    </span>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    {tElim('courseCycleHint', { totalPlayed: courseCycleStatus.totalPlayed })}
-                  </p>
-                </div>
+                <CourseCycleStatusPanel
+                  t={tElim}
+                  status={courseCycleStatus}
+                  availableCoursesCount={availableCourses.length}
+                />
                 {/* Admin manual course override: selects a specific course instead of random.
                     Available courses come from the server-calculated 20-course cycle pool.
                     Leaving this on "ランダム" (default) preserves the existing random behaviour. */}


### PR DESCRIPTION
Summary
- Extract the duplicated TA course-cycle display into a shared CourseCycleStatusPanel.
- Use the shared panel from TA Phase 1/2 elimination and TA Finals while preserving availableCourses.length as the displayed available count source.
- Add TC-1005 scenario coverage, runnable TA E2E registration, static contract coverage, and component unit coverage.
- Address the automated review follow-up by compressing the component comment to one line.

Issues: Closes #1005

Validation
- node --check e2e/tc-ta.js
- npm test -- --runTestsByPath __tests__/static/tc-1005-course-cycle-panel-contract.test.ts __tests__/components/tournament/course-cycle-status-panel.test.tsx __tests__/docs/e2e-cases-drift.test.ts __tests__/static/tc-1004-course-cycle-status-contract.test.ts __tests__/lib/ta/course-cycle-status.test.ts
- npm test -- --runTestsByPath __tests__/components/tournament/course-cycle-status-panel.test.tsx __tests__/static/tc-1005-course-cycle-panel-contract.test.ts
- npm run lint (passes with existing warnings)
- npm run build
- E2E_TESTS=TC-1005 node e2e/tc-ta.js (blocked before test execution by local Playwright/Crashpad permission error: bootstrap_check_in ... Permission denied (1100), open .../Crashpad/settings.dat Operation not permitted)
