### PR TITLE
Address TC-1010 E2E review followups

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -85,8 +85,6 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('losers_r3');
     expect(section).toContain('E2E_TESTS=TC-1010 node e2e/tc-bm.js');
     expect(tcBm).toContain("{ name: 'TC-1010', fn: runTc1010 }");
-    expect(tcBm).toContain('losersR4Points === 750');
-    expect(tcBm).toContain('losersR3Points === 550');
     expect(finalsRouteTest).toContain('uses finalized qualification ranks when seeding the bracket');
     expect(overallRankingTest).toContain('maps 16-player finals and Top24 playoff losses to standard point bands');
   });

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -1148,6 +1148,13 @@ async function runTc1010(adminPage) {
     const seededPlayers = gen.b?.data?.seededPlayers || [];
     const rankOverrideSeededFirst = seededPlayers[0]?.playerId === players[15].id;
 
+    /* The 16-player DE generator numbers prerequisite matches in dependency
+     * order through match 27. Completing 1..27 deterministically resolves the
+     * losers_r4 and losers_r3 placement bands that TC-1010 verifies; matches
+     * 28..31 are later finals-path matches and would add runtime without
+     * affecting the rankOverride seeding or 5th/7th-place Overall points
+     * contract. If bracket numbering changes, the readiness assertion below
+     * fails at the first unresolved prerequisite instead of silently passing. */
     for (let matchNumber = 1; matchNumber <= 27; matchNumber++) {
       const matches = await apiFetchBmFinalsMatches(adminPage, tournamentId);
       const match = matches.find((m) => m.matchNumber === matchNumber);


### PR DESCRIPTION
Summary
- Document why TC-1010's 16-player BM finals E2E only advances matches 1..27 before checking losers_r4/losers_r3 placement bands.
- Remove brittle TC-1010 drift assertions that searched for E2E internal variable names and leave point-band behavior to focused unit coverage.

Issues: Closes #1689, Closes #1690, Closes #1692

Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
- Scoped review and re-review completed; re-review found no remaining issues.
