### PR TITLE
Compress TC-1010 match loop comment

### DIFF
--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -1148,13 +1148,7 @@ async function runTc1010(adminPage) {
     const seededPlayers = gen.b?.data?.seededPlayers || [];
     const rankOverrideSeededFirst = seededPlayers[0]?.playerId === players[15].id;
 
-    /* The 16-player DE generator numbers prerequisite matches in dependency
-     * order through match 27. Completing 1..27 deterministically resolves the
-     * losers_r4 and losers_r3 placement bands that TC-1010 verifies; matches
-     * 28..31 are later finals-path matches and would add runtime without
-     * affecting the rankOverride seeding or 5th/7th-place Overall points
-     * contract. If bracket numbering changes, the readiness assertion below
-     * fails at the first unresolved prerequisite instead of silently passing. */
+    // Matches 1..27 resolve losers_r4/r3 bands; 28..31 are finals-path and do not affect the verified TC-1010 contracts.
     for (let matchNumber = 1; matchNumber <= 27; matchNumber++) {
       const matches = await apiFetchBmFinalsMatches(adminPage, tournamentId);
       const match = matches.find((m) => m.matchNumber === matchNumber);


### PR DESCRIPTION
Summary
- Compress the TC-1010 match loop rationale from a multi-line block comment into a single line.
- Preserve the reason for stopping at matches 1..27 while matching the comment style follow-up.

Issues: Closes #1694

Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
- Scoped review completed; no issues found.
