### PR TITLE
Restore TC-1010 failfast comment

### DIFF
--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -1149,6 +1149,7 @@ async function runTc1010(adminPage) {
     const rankOverrideSeededFirst = seededPlayers[0]?.playerId === players[15].id;
 
     // Matches 1..27 resolve losers_r4/r3 bands; 28..31 are finals-path and do not affect the verified TC-1010 contracts.
+    // If bracket numbering changes, the readiness assertion below fails at the first unresolved prerequisite.
     for (let matchNumber = 1; matchNumber <= 27; matchNumber++) {
       const matches = await apiFetchBmFinalsMatches(adminPage, tournamentId);
       const match = matches.find((m) => m.matchNumber === matchNumber);


### PR DESCRIPTION
Summary
- Restore the TC-1010 fail-fast rationale as a second one-line comment.
- Keep the match 1..27 explanation concise while documenting what happens if bracket numbering drifts.

Issues: Closes #1696

Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
- Scoped review completed; no issues found.
