### PR TITLE
Address TC-1002 review followups

### DIFF
--- a/smkc-score-app/__tests__/e2e/overlay-toast-assertions.test.ts
+++ b/smkc-score-app/__tests__/e2e/overlay-toast-assertions.test.ts
@@ -1,6 +1,4 @@
-// This helper is a CommonJS module used by the runtime E2E scripts, so the
-// Jest contract test loads it synchronously instead of adding an async setup
-// hook that would hide simple module-load failures behind a Promise boundary.
+// Load the CJS helper through the E2E scripts' synchronous require path (TC-1002).
 // eslint-disable-next-line @typescript-eslint/no-require-imports -- TC-1002 intentionally verifies the CJS helper through the same synchronous loader shape as the E2E scripts.
 const helper = require('../../e2e/lib/overlay-toast-assertions.js') as {
   OVERLAY_TOAST_TITLE_CASES: string[];

--- a/smkc-score-app/__tests__/static/tc-1002-overlay-toast-require-contract.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1002-overlay-toast-require-contract.test.ts
@@ -7,8 +7,7 @@ describe('TC-1002 overlay toast require contract', () => {
     const section = e2eCaseSection('TC-1002');
 
     expect(section).toContain('issue #1002');
-    expect(section).toContain('CommonJS helper');
-    expect(section).toContain('require()');
+    expect(section).toContain('overlay-toast-assertions.test.ts');
     expect(section).toContain('tc-1002-overlay-toast-require-contract.test.ts');
   });
 
@@ -16,5 +15,10 @@ describe('TC-1002 overlay toast require contract', () => {
     expect(testSource).toContain("require('../../e2e/lib/overlay-toast-assertions.js')");
     expect(testSource).not.toContain('beforeAll(async');
     expect(testSource).not.toContain('await import(');
+  });
+
+  it('keeps the require rationale comment concise', () => {
+    expect(testSource).toContain('TC-1002');
+    expect(testSource).not.toContain('Promise boundary');
   });
 });


### PR DESCRIPTION
## Summary
- Compress the TC-1002 require rationale comment to one line.
- Narrow the TC-1002 static guard away from brittle documentation phrasing.
- Keep focused coverage for synchronous CommonJS helper loading.

## Issues
Closes #1699
Closes #1700

## Validation
- Red: `npm test -- --runTestsByPath __tests__/static/tc-1002-overlay-toast-require-contract.test.ts --runInBand` failed before comment compression.
- `npm test -- --runTestsByPath __tests__/static/tc-1002-overlay-toast-require-contract.test.ts __tests__/e2e/overlay-toast-assertions.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand`
- `npm test -- --runTestsByPath __tests__/static/tc-1002-overlay-toast-require-contract.test.ts __tests__/e2e/overlay-toast-assertions.test.ts --runInBand`
- `npm run lint` (passes with existing warnings)
- `git diff --check`

## PR Body Diff Check
- [x] Summary only describes changes that are present in this PR diff.
- [x] Future or follow-up work is not described as already implemented.
