### PR TITLE
Keep preview login polling across OAuth redirects

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -236,14 +236,16 @@
 ## TC-110: Preview 管理者ログイン補助スクリプトの要素待機
 - **URL**: /auth/signin
 - **authRequired**: false (ログイン準備)
-- **背景**: preview E2E は永続プロファイルの Discord 管理者セッションを前提にする。`npm run e2e:preview:login` は手動ログイン用にサインイン画面を開くため、ページロード後の固定 sleep ではなく、実際の Admin タブと Discord ログインボタンの表示を待つ必要がある。
+- **背景**: preview E2E は永続プロファイルの Discord 管理者セッションを前提にする。`npm run e2e:preview:login` は手動ログイン用にサインイン画面を開くため、ページロード後の固定 sleep ではなく、実際の Admin タブと Discord ログインボタンの表示を待つ必要がある。Discord OAuth 遷移中は Playwright の実行コンテキストが一時的に破棄されるため、認証確認ポーリングはその一時エラーで終了してはいけない。
 - **手順**:
   1. `smkc-score-app/` で `npm run e2e:preview:login` を実行する
   2. script が `/auth/signin` を開くことを確認する
   3. Admin タブが表示されるまで待ち、Admin タブを選択することを確認する
   4. Discord ログインボタンが表示されるまで待つことを確認する
   5. 固定の `waitForTimeout(1500)` に依存しないことを確認する
+  6. OAuth 遷移中の `Execution context was destroyed` や一時的な page close は未認証扱いにして、手動ログイン待ちを続けることを確認する
 - **期待結果**: preview ログイン補助はページ描画速度に左右されず、Discord 管理者ログイン操作を開始できる
+- **補助検証**: `smkc-score-app/__tests__/e2e/login-preview-admin.test.ts`
 
 ## TC-359: CDM Export 失敗時の原因ヒント表示
 - **URL**: /tournaments/[id]

--- a/smkc-score-app/__tests__/e2e/login-preview-admin.test.ts
+++ b/smkc-score-app/__tests__/e2e/login-preview-admin.test.ts
@@ -98,6 +98,49 @@ describe('preview admin login helper', () => {
     });
   });
 
+  it('keeps waiting when the OAuth navigation destroys the current execution context', async () => {
+    const page = {
+      evaluate: jest.fn(async () => {
+        throw new Error('Execution context was destroyed, most likely because of a navigation');
+      }),
+    };
+
+    const helper = loadLoginPreviewAdmin();
+    await expect(helper.isAuthenticated(page)).resolves.toMatchObject({
+      status: 0,
+      authenticated: false,
+      body: null,
+      error: 'Execution context was destroyed, most likely because of a navigation',
+    });
+  });
+
+  it('keeps waiting when the page is temporarily closed during login redirect handling', async () => {
+    const page = {
+      evaluate: jest.fn(async () => {
+        throw new Error('Target page, context or browser has been closed');
+      }),
+    };
+
+    const helper = loadLoginPreviewAdmin();
+    await expect(helper.isAuthenticated(page)).resolves.toMatchObject({
+      status: 0,
+      authenticated: false,
+      body: null,
+      error: 'Target page, context or browser has been closed',
+    });
+  });
+
+  it('does not hide unexpected Playwright failures while polling auth status', async () => {
+    const page = {
+      evaluate: jest.fn(async () => {
+        throw new Error('selector engine crashed');
+      }),
+    };
+
+    const helper = loadLoginPreviewAdmin();
+    await expect(helper.isAuthenticated(page)).rejects.toThrow('selector engine crashed');
+  });
+
   it('waits for the admin tab and Discord button instead of a fixed sleep', async () => {
     const adminTab = {
       waitFor: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),

--- a/smkc-score-app/e2e/login-preview-admin.js
+++ b/smkc-score-app/e2e/login-preview-admin.js
@@ -1,26 +1,47 @@
 const { launchPersistentChromiumContext, resolveE2EProfileDir } = require('./lib/common');
 const { buildPreviewRuntimeEnv, assertBaseUrlResolvable } = require('./run-preview');
 
+function isTransientLoginPollingError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return /Execution context was destroyed/i.test(message) ||
+    /Target page, context or browser has been closed/i.test(message);
+}
+
 async function isAuthenticated(page) {
-  const result = await page.evaluate(async () => {
-    try {
-      const response = await fetch('/api/auth/session-status', { credentials: 'same-origin' });
-      const body = await response.json().catch(() => null);
-      return {
-        status: response.status,
-        authenticated: body?.data?.authenticated === true,
-        body,
-      };
-    } catch (error) {
-      return {
-        status: 0,
-        authenticated: false,
-        body: null,
-        error: error instanceof Error ? error.message : String(error),
-      };
+  try {
+    const result = await page.evaluate(async () => {
+      try {
+        const response = await fetch('/api/auth/session-status', { credentials: 'same-origin' });
+        const body = await response.json().catch(() => null);
+        return {
+          status: response.status,
+          authenticated: body?.data?.authenticated === true,
+          body,
+        };
+      } catch (error) {
+        return {
+          status: 0,
+          authenticated: false,
+          body: null,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    });
+    return result;
+  } catch (error) {
+    if (!isTransientLoginPollingError(error)) {
+      throw error;
     }
-  });
-  return result;
+    // Discord OAuth redirects can destroy the current page execution context
+    // while the helper is polling. Treat those transient Playwright errors the
+    // same as "not authenticated yet" so the manual login window remains open.
+    return {
+      status: 0,
+      authenticated: false,
+      body: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 async function waitForPreviewAdminLoginReady(page) {
@@ -87,6 +108,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  isTransientLoginPollingError,
   isAuthenticated,
   waitForPreviewAdminLoginReady,
   main,


### PR DESCRIPTION
## Summary
- Keep the preview admin login helper waiting when Discord OAuth navigation destroys the current Playwright execution context
- Restrict swallowed Playwright errors to known transient redirect/page-close cases so unexpected polling failures still fail fast
- Update TC-110 documentation and unit coverage for the login helper behavior

## Issues
Related to #1329

## Validation
- npm test -- --runTestsByPath __tests__/e2e/login-preview-admin.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint (passes with existing warnings)

## Review
- Requested subagent review, but the reviewer failed with usage-limit exhaustion; performed a second manual review and tightened the implementation to avoid hiding unexpected Playwright failures.