### PR TITLE
Align group setup mock lookup diagnostics

### DIFF
--- a/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
@@ -102,7 +102,10 @@ describe('group setup E2E helper', () => {
       waitForTimeout: jest.fn(async () => undefined),
       getByRole: jest.fn((_role: string, options: { name?: RegExp } = {}) => {
         const name = options.name?.source ?? '';
-        const expectedLookups = ['role=button name includes Setup Groups', 'role=dialog'];
+        const expectedLookups = [
+          'role=button name=Setup Groups|Edit Groups|グループ設定|グループ編集',
+          'role=dialog name=',
+        ];
         if (name.includes('Setup Groups')) {
           return { first: jest.fn(() => ({ click: jest.fn(async () => undefined) })) };
         }


### PR DESCRIPTION
## Summary
- Align page.getByRole fixture expected lookup strings with the actual role/name diagnostic format
- Keep the group setup mock failure output consistent across locator and role mocks

## Validation
- npm run lint -- __tests__/e2e/group-setup-helper.test.ts
- npm test -- --runTestsByPath '__tests__/e2e/group-setup-helper.test.ts' --runInBand
- git diff --check

Refs #1723