### PR TITLE
Cover archive browser isolation contracts

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-archive-fixtures.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-archive-fixtures.test.ts
@@ -98,6 +98,49 @@ describe('archive E2E fixtures', () => {
     )).toBeNull();
   });
 
+  it('uses the status field when summarizing archive failures', async () => {
+    const { suite } = await loadArchiveSuite();
+
+    expect(suite.countArchiveFailures([
+      { tc: 'TC-ARC-01', status: 'PASS' },
+      { tc: 'TC-ARC-02', status: 'FAIL' },
+      { tc: 'TC-ARC-03', s: 'FAIL' },
+    ])).toBe(1);
+  });
+
+  it('runs TA qualification hydration on an isolated fresh page and closes it', async () => {
+    const { suite } = await loadArchiveSuite({ BASE: 'https://preview.example.test' });
+    const targetPage = {
+      bringToFront: jest.fn(async () => undefined),
+      goto: jest.fn(async () => undefined),
+      waitForFunction: jest.fn(async () => undefined),
+      close: jest.fn(async () => undefined),
+    };
+    const newPage = jest.fn(async () => targetPage);
+    const rootPage = {
+      context: jest.fn(() => ({ newPage })),
+      goto: jest.fn(async () => undefined),
+    };
+
+    await expect(suite.assertQualificationFetchesStartInParallel(rootPage, 'tournament-1', 'ta'))
+      .resolves.toBe(0);
+
+    expect(rootPage.context).toHaveBeenCalled();
+    expect(newPage).toHaveBeenCalled();
+    expect(rootPage.goto).not.toHaveBeenCalled();
+    expect(targetPage.bringToFront).toHaveBeenCalled();
+    expect(targetPage.goto).toHaveBeenCalledWith(
+      'https://preview.example.test/tournaments/tournament-1/ta',
+      { waitUntil: 'domcontentloaded' },
+    );
+    expect(targetPage.waitForFunction).toHaveBeenCalledWith(
+      expect.any(Function),
+      null,
+      { timeout: suite.QUALIFICATION_FETCH_TIMEOUT_MS },
+    );
+    expect(targetPage.close).toHaveBeenCalled();
+  });
+
   it('waits for both qualification requests before fulfilling either response', async () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2026-05-11T00:00:00.000Z'));

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -459,6 +459,10 @@ async function tcArc09(page) {
   }
 }
 
+function countArchiveFailures(testResults) {
+  return testResults.filter((result) => result.status === 'FAIL').length;
+}
+
 async function runArchiveTests(page) {
   await tcArc01(page);
   await tcArc02(page);
@@ -469,7 +473,7 @@ async function runArchiveTests(page) {
   await tcArc08(page);
   await tcArc09(page);
 
-  const failed = results.filter((result) => result.status === 'FAIL');
+  const failed = { length: countArchiveFailures(results) };
   console.log(`\nTC-ARC summary: ${results.length - failed.length}/${results.length} passed`);
   return { failed: failed.length };
 }
@@ -513,5 +517,6 @@ module.exports = {
   cleanupArchiveFixture,
   QUALIFICATION_FETCH_TIMEOUT_MS,
   assertQualificationFetchesStartInParallel,
+  countArchiveFailures,
   requestKindForQualificationFetch,
 };


### PR DESCRIPTION
## Summary
- Add behavior coverage for TC-ARC-09 TA hydration using an isolated fresh page
- Verify archive failure counting uses the status field rather than stale shorthand fields
- Export a small failure-count helper so the archive summary contract is directly testable

## Validation
- npm test -- --runTestsByPath '__tests__/e2e/tc-archive-fixtures.test.ts' '__tests__/e2e/tc-all-registration.test.ts' --runInBand
- node --check e2e/tc-archive.js
- git diff --check
- npm run lint -- __tests__/e2e/tc-archive-fixtures.test.ts
- npm test -- --runInBand

Refs #1720