### PR TITLE
Use numeric archive failure count

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -28,11 +28,14 @@ describe('tc-all focused suite registration', () => {
   });
 
   it('keeps focused suite failure counts numeric', () => {
-    for (const script of ['tc-archive.js', 'tc-debug-fill.js']) {
-      const scriptSource = fs.readFileSync(path.join(process.cwd(), 'e2e', script), 'utf8');
-      expect(scriptSource).toContain('return { failed: failed.length }');
-      expect(scriptSource).not.toContain('return { failed: failed.length > 0 }');
-    }
+    const archiveSource = fs.readFileSync(path.join(process.cwd(), 'e2e', 'tc-archive.js'), 'utf8');
+    expect(archiveSource).toContain('const failedCount = countArchiveFailures(results)');
+    expect(archiveSource).toContain('return { failed: failedCount }');
+    expect(archiveSource).not.toContain('return { failed: failedCount > 0 }');
+
+    const debugFillSource = fs.readFileSync(path.join(process.cwd(), 'e2e', 'tc-debug-fill.js'), 'utf8');
+    expect(debugFillSource).toContain('return { failed: failed.length }');
+    expect(debugFillSource).not.toContain('return { failed: failed.length > 0 }');
   });
 
   it('keeps retired TC-401/TC-402 comments in one language', () => {

--- a/smkc-score-app/e2e/tc-archive.js
+++ b/smkc-score-app/e2e/tc-archive.js
@@ -473,9 +473,9 @@ async function runArchiveTests(page) {
   await tcArc08(page);
   await tcArc09(page);
 
-  const failed = { length: countArchiveFailures(results) };
-  console.log(`\nTC-ARC summary: ${results.length - failed.length}/${results.length} passed`);
-  return { failed: failed.length };
+  const failedCount = countArchiveFailures(results);
+  console.log(`\nTC-ARC summary: ${results.length - failedCount}/${results.length} passed`);
+  return { failed: failedCount };
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- Replace the archive failure pseudo-array with a direct numeric failedCount
- Keep the focused-suite registration guard aligned with archive/debug-fill implementation shapes

## Validation
- npm test -- --runTestsByPath '__tests__/e2e/tc-archive-fixtures.test.ts' '__tests__/e2e/tc-all-registration.test.ts' --runInBand
- node --check e2e/tc-archive.js
- git diff --check
- npm run lint -- __tests__/e2e/tc-all-registration.test.ts __tests__/e2e/tc-archive-fixtures.test.ts
- npm test -- --runInBand

Refs #1731