### PR TITLE
Use numeric debug-fill failure count

### DIFF
--- a/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
@@ -21,6 +21,7 @@ import {
   requestKindForQualificationFetch,
 } from '../../e2e/tc-archive';
 import {
+  countDebugFillFailures,
   taEntriesFromFetch,
 } from '../../e2e/tc-debug-fill';
 
@@ -212,5 +213,13 @@ describe('group setup E2E helper', () => {
       .toEqual([{ id: 'entry-1' }]);
     expect(taEntriesFromFetch({ entries: [{ id: 'entry-2' }] }))
       .toEqual([{ id: 'entry-2' }]);
+  });
+
+  it('counts debug-fill failures as a numeric value', () => {
+    expect(countDebugFillFailures([
+      { tc: 'TC-DBG-01', s: 'PASS' },
+      { tc: 'TC-DBG-02', s: 'FAIL' },
+      { tc: 'TC-DBG-03', status: 'FAIL' },
+    ])).toBe(1);
   });
 });

--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -34,8 +34,9 @@ describe('tc-all focused suite registration', () => {
     expect(archiveSource).not.toContain('return { failed: failedCount > 0 }');
 
     const debugFillSource = fs.readFileSync(path.join(process.cwd(), 'e2e', 'tc-debug-fill.js'), 'utf8');
-    expect(debugFillSource).toContain('return { failed: failed.length }');
-    expect(debugFillSource).not.toContain('return { failed: failed.length > 0 }');
+    expect(debugFillSource).toContain('const failedCount = countDebugFillFailures(results)');
+    expect(debugFillSource).toContain('return { failed: failedCount }');
+    expect(debugFillSource).not.toContain('return { failed: failedCount > 0 }');
   });
 
   it('keeps retired TC-401/TC-402 comments in one language', () => {

--- a/smkc-score-app/e2e/tc-debug-fill.js
+++ b/smkc-score-app/e2e/tc-debug-fill.js
@@ -121,6 +121,10 @@ function taEntriesFromFetch(response) {
   return unwrapData(response?.b)?.entries ?? response?.entries ?? [];
 }
 
+function countDebugFillFailures(testResults) {
+  return testResults.filter((result) => result.s === 'FAIL').length;
+}
+
 async function tcDbg01(page) {
   let tournamentId = null;
   const players = [];
@@ -268,9 +272,9 @@ async function runDebugFillTests(page) {
   await tcDbg03(page);
   await tcDbg04(page);
 
-  const failed = results.filter((result) => result.s === 'FAIL');
-  console.log(`\nTC-DBG summary: ${results.length - failed.length}/${results.length} passed`);
-  return { failed: failed.length };
+  const failedCount = countDebugFillFailures(results);
+  console.log(`\nTC-DBG summary: ${results.length - failedCount}/${results.length} passed`);
+  return { failed: failedCount };
 }
 
 async function main() {
@@ -308,5 +312,6 @@ if (require.main === module) {
 
 module.exports = {
   runDebugFillTests,
+  countDebugFillFailures,
   taEntriesFromFetch,
 };


### PR DESCRIPTION
## Summary
- Align debug-fill failure counting with the archive failedCount helper pattern
- Update focused-suite registration guard for the new numeric count shape
- Add behavior coverage for countDebugFillFailures

## Validation
- npm test -- --runTestsByPath '__tests__/e2e/group-setup-helper.test.ts' '__tests__/e2e/tc-all-registration.test.ts' --runInBand
- node --check e2e/tc-debug-fill.js
- git diff --check
- npm run lint -- __tests__/e2e/group-setup-helper.test.ts __tests__/e2e/tc-all-registration.test.ts
- npm test -- --runInBand

Refs #1733