### PR TITLE
Remove duplicate finals tab comments

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -572,7 +572,6 @@ export default function BattleModeFinals({
    * finals rows are created. If the tabs default to "finals" in that state,
    * admins land on an empty/non-actionable preview while the required Phase-2
    * "Create Upper Bracket" control is hidden under the playoff tab. */
-  // Top-24 Phase 1 only has playoff rows; defaulting to the playoff tab keeps the actionable bracket visible.
   const defaultBracketTab: BracketTab = matches.length > 0 ? BRACKET_TABS.finals : BRACKET_TABS.playoff;
 
   /* Loading skeleton for initial page load */

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -585,7 +585,6 @@ export default function MatchRaceFinals({
   /* Top-24 Phase 1 can expose a bracket preview before finals matches exist.
    * Keep the playoff tab selected until Phase 2 materializes finals rows, so
    * the admin sees the completed playoff and the required creation action. */
-  // Top-24 Phase 1 only has playoff rows; defaulting to the playoff tab keeps the actionable bracket visible.
   const defaultBracketTab: BracketTab = matches.length > 0 ? BRACKET_TABS.finals : BRACKET_TABS.playoff;
 
   /* Loading skeleton */


### PR DESCRIPTION
## Summary
- remove duplicate inline comments in BM and MR finals pages
- keep the existing block comments as the single explanation for the tab default

## Validation
- npm run lint -- 'src/app/tournaments/[id]/bm/finals/page.tsx' 'src/app/tournaments/[id]/mr/finals/page.tsx'
- git diff --check
- reviewer: no findings for comment-only diff

Refs #1717