### PR TITLE
Share finals bracket tab constants

### DIFF
--- a/smkc-score-app/__tests__/lib/bracket-tabs.test.ts
+++ b/smkc-score-app/__tests__/lib/bracket-tabs.test.ts
@@ -1,0 +1,10 @@
+import { BRACKET_TABS } from "../../src/lib/bracket-tabs";
+
+describe("BRACKET_TABS", () => {
+  it("provides the shared finals/playoff tab values used by finals pages", () => {
+    expect(BRACKET_TABS).toEqual({
+      finals: "finals",
+      playoff: "playoff",
+    });
+  });
+});

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -72,6 +72,7 @@ import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
 import { canResetFinalsFromQualification } from "@/lib/finals-action-availability";
 import { parseManualScore } from "@/lib/parse-manual-score";
+import { BRACKET_TABS, type BracketTab } from "@/lib/bracket-tabs";
 
 /**
  * Client-side logger for the finals page.
@@ -82,12 +83,6 @@ import type { Player } from "@/lib/types";
 import { buildMatchLabel } from "@/lib/overlay/phase";
 
 const logger = createLogger({ serviceName: 'tournaments-bm-finals' });
-
-const BRACKET_TABS = {
-  finals: "finals",
-  playoff: "playoff",
-} as const;
-type BracketTab = typeof BRACKET_TABS[keyof typeof BRACKET_TABS];
 
 /** BM Match data with player relations */
 interface BMMatch {

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -88,15 +88,10 @@ import { getCupForFormIndex, isRemovableCupForm, removeCupFormAt } from "@/lib/g
 import { getAssignedCupLabelsForMatch } from "@/lib/gp-finals-assigned-cups";
 import { isValidGpFinalsSimpleScore } from "@/lib/gp-finals-simple-score";
 import { GP_DRIVER_POINTS_INPUT_PROPS, parseGpDriverPointsInput } from "@/lib/gp-driver-points-input";
+import { BRACKET_TABS, type BracketTab } from "@/lib/bracket-tabs";
 
 /** Client-side logger for error tracking */
 const logger = createLogger({ serviceName: 'tournaments-gp-finals' });
-
-const BRACKET_TABS = {
-  finals: "finals",
-  playoff: "playoff",
-} as const;
-type BracketTab = typeof BRACKET_TABS[keyof typeof BRACKET_TABS];
 
 /** Individual race entry in the finals score form */
 interface Race {

--- a/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/finals/page.tsx
@@ -83,15 +83,10 @@ import { canResetFinalsFromQualification } from "@/lib/finals-action-availabilit
 import { parseManualScore } from "@/lib/parse-manual-score";
 import type { Player } from "@/lib/types";
 import { buildMatchLabel } from "@/lib/overlay/phase";
+import { BRACKET_TABS, type BracketTab } from "@/lib/bracket-tabs";
 
 /** Client-side logger for error tracking */
 const logger = createLogger({ serviceName: 'tournaments-mr-finals' });
-
-const BRACKET_TABS = {
-  finals: "finals",
-  playoff: "playoff",
-} as const;
-type BracketTab = typeof BRACKET_TABS[keyof typeof BRACKET_TABS];
 
 /** MR finals match record */
 interface MRMatch {

--- a/smkc-score-app/src/lib/bracket-tabs.ts
+++ b/smkc-score-app/src/lib/bracket-tabs.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared tab values for finals bracket pages.
+ *
+ * These strings are persisted only in the rendered Radix Tabs value contract,
+ * so keeping one exported object prevents BM/GP/MR finals pages from drifting
+ * while avoiding a larger abstraction around their mode-specific page logic.
+ */
+export const BRACKET_TABS = {
+  finals: "finals",
+  playoff: "playoff",
+} as const;
+
+export type BracketTab = typeof BRACKET_TABS[keyof typeof BRACKET_TABS];


### PR DESCRIPTION
## Summary
- move the BM/GP/MR finals bracket tab values and type into a shared lib module
- update all three finals pages to import the shared contract
- add focused coverage for the exported tab values

## Validation
- npm test -- --runTestsByPath __tests__/lib/bracket-tabs.test.ts --runInBand
- npm run lint -- __tests__/lib/bracket-tabs.test.ts src/lib/bracket-tabs.ts 'src/app/tournaments/[id]/bm/finals/page.tsx' 'src/app/tournaments/[id]/gp/finals/page.tsx' 'src/app/tournaments/[id]/mr/finals/page.tsx'
- npm test -- --runInBand
- npm run build
- git diff --cached --check
- reviewer: no findings

Refs #1716