### PR TITLE
Document preview login transient errors

### DIFF
--- a/smkc-score-app/e2e/login-preview-admin.js
+++ b/smkc-score-app/e2e/login-preview-admin.js
@@ -1,10 +1,17 @@
 const { launchPersistentChromiumContext, resolveE2EProfileDir } = require('./lib/common');
 const { buildPreviewRuntimeEnv, assertBaseUrlResolvable } = require('./run-preview');
 
+// Playwright 1.59.1 internal interruption messages observed during Discord
+// OAuth redirects. Re-check these patterns when upgrading Playwright because
+// they are message-based fallbacks, not a stable public error-code contract.
+const TRANSIENT_LOGIN_POLLING_ERROR_PATTERNS = [
+  /Execution context was destroyed/i,
+  /Target page, context or browser has been closed/i,
+];
+
 function isTransientLoginPollingError(error) {
   const message = error instanceof Error ? error.message : String(error);
-  return /Execution context was destroyed/i.test(message) ||
-    /Target page, context or browser has been closed/i.test(message);
+  return TRANSIENT_LOGIN_POLLING_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }
 
 async function isAuthenticated(page) {


### PR DESCRIPTION
## Summary
- name the preview login transient Playwright error patterns
- document that the regexes are Playwright 1.59.1 message-based fallbacks to revisit on upgrades

## Validation
- npm test -- --runTestsByPath __tests__/e2e/login-preview-admin.test.ts --runInBand
- npm run lint -- e2e/login-preview-admin.js __tests__/e2e/login-preview-admin.test.ts (exits 0; login helper is ignored by existing config)
- ./node_modules/.bin/eslint --no-ignore e2e/login-preview-admin.js (fails only on pre-existing CommonJS require rule at lines 1-2)
- node --check e2e/login-preview-admin.js
- git diff --check
- reviewer: no findings

Refs #1711