### PR TITLE
Fix BM finals rankOverride seeding

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -956,6 +956,43 @@ describe('Finals Route Factory', () => {
       expect(json.data.seededPlayers[0].playerId).toBe('player-15');
     });
 
+    it('prioritizes rankOverride over equal group-local ranks when seeding a 16-player bracket', async () => {
+      const qualifications = Array.from({ length: 16 }, (_, index) => {
+        const group = index < 8 ? 'A' : 'B';
+        const groupIndex = index % 8;
+        return {
+          id: `qual-${index}`,
+          playerId: `player-${index}`,
+          group,
+          score: 8 - groupIndex,
+          points: 8 - groupIndex,
+          rankOverride: index === 15 ? 1 : null,
+          player: { id: `player-${index}`, name: `Player ${index + 1}` },
+        };
+      });
+      (prisma.bMQualification as any).findMany.mockResolvedValue(qualifications);
+      (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 31 });
+      (prisma.bMMatch as any).findMany.mockResolvedValue([]);
+
+      const config = createMockConfig({
+        qualificationOrderBy: [{ group: 'asc' }, { score: 'desc' }, { points: 'desc' }],
+      });
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 16 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(201);
+      const json = await response.json();
+      expect(json.data.seededPlayers[0].playerId).toBe('player-15');
+    });
+
     it('does not fetch H2H matches when qualificationOrderBy is empty', async () => {
       (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(8));
       (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -817,6 +817,33 @@ export function createFinalsHandlers(config: FinalsConfig) {
     );
   }
 
+  function orderQualificationsForFinalsSeeding<
+    TQualification extends { _rank: number; _rankOverridden?: boolean; rankOverride?: number | null }
+  >(qualifications: TQualification[]): TQualification[] {
+    /*
+     * Finals seeding is a tournament-wide bracket contract, not a grouped
+     * standings display contract. `computeQualificationRanks()` intentionally
+     * resets `_rank` inside each qualification group so UI labels can remain
+     * A1/B1/etc.; when a director enters a manual `rankOverride`, that finalized
+     * rank must still win globally for bracket seed order. This mirrors standard
+     * seeded-bracket practice: published/manual seed numbers are authoritative,
+     * while equal automatic group ranks fall back to the existing stable group
+     * order to avoid reshuffling normal A/B standings.
+     */
+    return qualifications
+      .map((qualification, index) => ({ qualification, index }))
+      .sort((a, b) => {
+        if (a.qualification._rank !== b.qualification._rank) {
+          return a.qualification._rank - b.qualification._rank;
+        }
+        const aOverride = a.qualification.rankOverride != null || a.qualification._rankOverridden === true;
+        const bOverride = b.qualification.rankOverride != null || b.qualification._rankOverridden === true;
+        if (aOverride !== bOverride) return aOverride ? -1 : 1;
+        return a.index - b.index;
+      })
+      .map(({ qualification }) => qualification);
+  }
+
   function getRoundAssignmentData(
     round: string,
     mrAssignments?: Map<string, string[]>,
@@ -1376,7 +1403,8 @@ export function createFinalsHandlers(config: FinalsConfig) {
         tournamentId,
         qualifications,
       );
-      const selectedQualifications = rankedQualifications.slice(0, topN);
+      const finalsSeedQualifications = orderQualificationsForFinalsSeeding(rankedQualifications);
+      const selectedQualifications = finalsSeedQualifications.slice(0, topN);
       const qualificationRankLabels = buildQualificationRankLabelMap(rankedQualifications);
 
       if (selectedQualifications.length < topN) {


### PR DESCRIPTION
## Summary
- prioritize finalized rankOverride rows when creating BM/MR/GP 8/16-player finals seeds
- keep group rank labels based on grouped qualification ranks while making bracket seeding tournament-wide
- add a regression test for BM 16-player two-group seeding where rankOverride=1 must become seed 1

## Validation
- npm test -- --runTestsByPath __tests__/lib/api-factories/finals-route.test.ts --runInBand
- npm run lint -- src/lib/api-factories/finals-route.ts __tests__/lib/api-factories/finals-route.test.ts
- npm run build
- git diff --check

Preview E2E note: npm run e2e:preview:all on latest main passed preflight/auth and exposed TC-1010 failing before this fix: rankOverride seed first=cmovk63ch000x5g1v71y9iai1.