### PR TITLE
Handle duplicate finals rankOverride seeds

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -993,6 +993,46 @@ describe('Finals Route Factory', () => {
       expect(json.data.seededPlayers[0].playerId).toBe('player-15');
     });
 
+    it('uses the latest manual rankOverride when duplicate override ranks collide', async () => {
+      const earlyOverride = new Date('2026-01-01T00:00:00Z');
+      const latestOverride = new Date('2026-01-02T00:00:00Z');
+      const qualifications = Array.from({ length: 16 }, (_, index) => {
+        const group = index < 8 ? 'A' : 'B';
+        const groupIndex = index % 8;
+        return {
+          id: `qual-${index}`,
+          playerId: `player-${index}`,
+          group,
+          score: 8 - groupIndex,
+          points: 8 - groupIndex,
+          rankOverride: index === 0 || index === 15 ? 1 : null,
+          rankOverrideAt: index === 0 ? earlyOverride : index === 15 ? latestOverride : null,
+          player: { id: `player-${index}`, name: `Player ${index + 1}` },
+        };
+      });
+      (prisma.bMQualification as any).findMany.mockResolvedValue(qualifications);
+      (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 31 });
+      (prisma.bMMatch as any).findMany.mockResolvedValue([]);
+
+      const config = createMockConfig({
+        qualificationOrderBy: [{ group: 'asc' }, { score: 'desc' }, { points: 'desc' }],
+      });
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 16 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(201);
+      const json = await response.json();
+      expect(json.data.seededPlayers[0].playerId).toBe('player-15');
+    });
+
     it('does not fetch H2H matches when qualificationOrderBy is empty', async () => {
       (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(8));
       (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -818,7 +818,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
   }
 
   function orderQualificationsForFinalsSeeding<
-    TQualification extends { _rank: number; _rankOverridden?: boolean; rankOverride?: number | null }
+    TQualification extends {
+      _rank: number;
+      _rankOverridden?: boolean;
+      rankOverride?: number | null;
+      rankOverrideAt?: Date | string | null;
+    }
   >(qualifications: TQualification[]): TQualification[] {
     /*
      * Finals seeding is a tournament-wide bracket contract, not a grouped
@@ -828,7 +833,9 @@ export function createFinalsHandlers(config: FinalsConfig) {
      * rank must still win globally for bracket seed order. This mirrors standard
      * seeded-bracket practice: published/manual seed numbers are authoritative,
      * while equal automatic group ranks fall back to the existing stable group
-     * order to avoid reshuffling normal A/B standings.
+     * order to avoid reshuffling normal A/B standings. If two manual overrides
+     * collide on the same seed number, prefer the most recent `rankOverrideAt`
+     * because it represents the director's latest explicit correction.
      */
     return qualifications
       .map((qualification, index) => ({ qualification, index }))
@@ -839,6 +846,15 @@ export function createFinalsHandlers(config: FinalsConfig) {
         const aOverride = a.qualification.rankOverride != null || a.qualification._rankOverridden === true;
         const bOverride = b.qualification.rankOverride != null || b.qualification._rankOverridden === true;
         if (aOverride !== bOverride) return aOverride ? -1 : 1;
+        if (aOverride && bOverride) {
+          const aOverrideAt = a.qualification.rankOverrideAt
+            ? new Date(a.qualification.rankOverrideAt).getTime()
+            : 0;
+          const bOverrideAt = b.qualification.rankOverrideAt
+            ? new Date(b.qualification.rankOverrideAt).getTime()
+            : 0;
+          if (aOverrideAt !== bOverrideAt) return bOverrideAt - aOverrideAt;
+        }
         return a.index - b.index;
       })
       .map(({ qualification }) => qualification);


### PR DESCRIPTION
## Summary
- resolve duplicate manual rankOverride seed collisions by preferring the latest rankOverrideAt
- keep stable group order for non-colliding automatic ranks
- add a regression test matching TC-1010 after resolveAllTies has already assigned rankOverride=1 elsewhere

## Validation
- npm test -- --runTestsByPath __tests__/lib/api-factories/finals-route.test.ts --runInBand
- npm run lint -- src/lib/api-factories/finals-route.ts __tests__/lib/api-factories/finals-route.test.ts
- npm run build
- git diff --check

Preview E2E note: after PR #1738 deploy, E2E_TESTS=TC-1010 npm run e2e:preview:bm still failed because duplicate rankOverride=1 rows selected the earlier override first.