### PR TITLE
Simplify finals override comparator

### DIFF
--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -846,7 +846,10 @@ export function createFinalsHandlers(config: FinalsConfig) {
         const aOverride = a.qualification.rankOverride != null || a.qualification._rankOverridden === true;
         const bOverride = b.qualification.rankOverride != null || b.qualification._rankOverridden === true;
         if (aOverride !== bOverride) return aOverride ? -1 : 1;
-        if (aOverride && bOverride) {
+        // After the inequality guard above, `aOverride` and `bOverride` are equal.
+        // Checking only `aOverride` keeps the collision rule readable while still
+        // limiting timestamp comparison to the "both manually overridden" case.
+        if (aOverride) {
           const aOverrideAt = a.qualification.rankOverrideAt
             ? new Date(a.qualification.rankOverrideAt).getTime()
             : 0;


### PR DESCRIPTION
## Summary
- Simplifies the finals seeding override comparator after the override-mismatch guard.
- Adds a short comment documenting why checking only `aOverride` still means both sides are manual override cases.

Issues: #1742

## Validation
- `npm test -- --runInBand __tests__/lib/api-factories/finals-route.test.ts`
- `git diff --check`
- Reviewer pass: no findings
