### PR TITLE
Clarify finals override detection

### DIFF
--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -843,8 +843,15 @@ export function createFinalsHandlers(config: FinalsConfig) {
         if (a.qualification._rank !== b.qualification._rank) {
           return a.qualification._rank - b.qualification._rank;
         }
-        const aOverride = a.qualification.rankOverride != null || a.qualification._rankOverridden === true;
-        const bOverride = b.qualification.rankOverride != null || b.qualification._rankOverridden === true;
+        /*
+         * `computeQualificationRanks()` sets `_rankOverridden` from
+         * `rankOverride != null`, so the persisted override value is the source
+         * of truth here. Depending on `_rankOverridden` as a second source would
+         * hide inconsistent inputs instead of letting the stable fallback expose
+         * them during tests or review.
+         */
+        const aOverride = a.qualification.rankOverride != null;
+        const bOverride = b.qualification.rankOverride != null;
         if (aOverride !== bOverride) return aOverride ? -1 : 1;
         // After the inequality guard above, `aOverride` and `bOverride` are equal.
         // Checking only `aOverride` keeps the collision rule readable while still


### PR DESCRIPTION
## Summary
- Uses `rankOverride != null` as the single source of truth for finals override collision detection.
- Documents the `computeQualificationRanks()` invariant so `_rankOverridden` does not become an independent fallback signal.

Issues: #1739

## Validation
- `npm test -- --runInBand __tests__/lib/api-factories/finals-route.test.ts __tests__/lib/server-ranking.test.ts`
- `git diff --check`
- Reviewer pass: no findings
