### PR TITLE
Harden finals manual docs test

### DIFF
--- a/smkc-score-app/__tests__/docs/operation-finals-target-wins.test.ts
+++ b/smkc-score-app/__tests__/docs/operation-finals-target-wins.test.ts
@@ -7,7 +7,7 @@ function readRootDoc(relativePath: string): string {
 }
 
 function extractFinalsFormatSection(manual: string): string {
-  const sectionMatch = manual.match(/### 7\.3 決勝の試合形式[\s\S]*?(?=\n---|\n## 8\.)/);
+  const sectionMatch = manual.match(/### .*決勝の試合形式[\s\S]*?(?=\n---|\n## )/);
   expect(sectionMatch).not.toBeNull();
   return sectionMatch![0];
 }


### PR DESCRIPTION
Summary:
- Remove section-number coupling from the finals manual docs test.
- Extract the finals format section by heading text so section renumbering does not break the test.

Issues: #1752

Validation:
- npm test -- --runInBand __tests__/docs/operation-finals-target-wins.test.ts
- git diff --check -- smkc-score-app/__tests__/docs/operation-finals-target-wins.test.ts
- Plato review: no findings