### PR TITLE
Remove stale MR report stats mocks

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
@@ -127,9 +127,6 @@ describe('MR Score Report API Route - /api/tournaments/[id]/mr/match/[matchId]/r
     (prisma.scoreEntryLog.create as jest.Mock).mockResolvedValue({});
     (prisma.matchCharacterUsage.create as jest.Mock).mockResolvedValue({});
     (prisma.mRMatch.update as jest.Mock).mockResolvedValue({});
-    /* Mocks for recalculatePlayersStats (called after auto-confirm) */
-    (prisma.mRMatch.findMany as jest.Mock).mockResolvedValue([]);
-    (prisma.mRQualification.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
   });
 
   describe('POST - Report match score', () => {


### PR DESCRIPTION
Summary:
- Remove unused MR report route test setup for stats recalculation DB calls.
- Keep the route test focused on helper delegation; bulk SQL stats behavior remains a helper-level concern.

Issues: #982

Validation:
- npm test -- --runInBand --runTestsByPath '__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts'
- git diff --check -- 'smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts'
- Plato review + re-review: no findings