### PR TITLE
Test unknown qualification stats model

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/score-report-helpers.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/score-report-helpers.test.ts
@@ -26,6 +26,7 @@ import {
   createCharacterUsageLog,
   recalculatePlayerStats,
   recalculatePlayersStats,
+  bulkUpdateQualificationStats,
 } from '@/lib/api-factories/score-report-helpers';
 
 import { NextRequest } from 'next/server';
@@ -542,6 +543,14 @@ describe('Score Report Helpers', () => {
           score: 1,
         },
       ]);
+    });
+
+    it('should throw for an unknown qualificationModel before issuing bulk SQL', async () => {
+      await expect(
+        bulkUpdateQualificationStats('unknownModel' as any, 'tourney-1', [{ playerId: 'p1' }]),
+      ).rejects.toThrow('Unsupported qualification stats bulk update model: unknownModel');
+
+      expect(mockExecuteRawUnsafe).not.toHaveBeenCalled();
     });
   });
 });

--- a/smkc-score-app/src/lib/api-factories/score-report-helpers.ts
+++ b/smkc-score-app/src/lib/api-factories/score-report-helpers.ts
@@ -379,6 +379,9 @@ export async function bulkUpdateQualificationStats(
 ): Promise<void> {
   if (updates.length === 0) return;
 
+  /* Every qualification model that uses score-report stat recalculation must
+   * have an explicit SQL template here; D1 cannot safely infer table names from
+   * dynamic identifiers in raw SQL parameters. */
   const sql = QUALIFICATION_STATS_UPDATE_SQL[qualificationModel];
   if (!sql) {
     throw new Error(`Unsupported qualification stats bulk update model: ${qualificationModel}`);


### PR DESCRIPTION
Summary:
- Add coverage for unsupported bulk qualification stats models.
- Document why score-report stats recalculation requires explicit SQL templates per qualification model.

Issues: #981

Validation:
- npm test -- --runInBand __tests__/lib/api-factories/score-report-helpers.test.ts
- git diff --check -- smkc-score-app/__tests__/lib/api-factories/score-report-helpers.test.ts smkc-score-app/src/lib/api-factories/score-report-helpers.ts
- Plato review: no findings