### PR TITLE
Share BM MR match lean select

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
@@ -38,23 +38,11 @@ jest.mock('@/lib/qualification-confirmed-check', () => ({
 }));
 
 import prisma from '@/lib/prisma';
-import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
+import { BM_MR_MATCH_LEAN_SELECT, PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { auth } from '@/lib/auth';
 import { createLogger } from '@/lib/logger';
 import { GET, POST, PUT } from '@/app/api/tournaments/[id]/bm/route';
 import { configureNextResponseMock } from '../../../../../helpers/next-response-mock';
-
-const EXPECTED_MATCH_UPDATE_SELECT = {
-  id: true,
-  tournamentId: true,
-  player1Id: true,
-  player2Id: true,
-  score1: true,
-  score2: true,
-  rounds: true,
-  completed: true,
-  isBye: true,
-};
 
 const requestUtilsMock = jest.requireMock('@/lib/request-utils') as { getServerSideIdentifier: jest.Mock };
 const _sanitizeMock = jest.requireMock('@/lib/sanitize') as { sanitizeInput: jest.Mock };
@@ -439,7 +427,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       expect(prisma.bMMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: null, completed: true },
-        select: EXPECTED_MATCH_UPDATE_SELECT,
+        select: BM_MR_MATCH_LEAN_SELECT,
       });
       expect(prisma.$executeRawUnsafe).toHaveBeenCalledTimes(1);
     });
@@ -469,7 +457,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       expect(prisma.bMMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 2, score2: 2, rounds: null, completed: true },
-        select: EXPECTED_MATCH_UPDATE_SELECT,
+        select: BM_MR_MATCH_LEAN_SELECT,
       });
     });
 
@@ -506,7 +494,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       expect(prisma.bMMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: [1, 2, 3, 4], completed: true },
-        select: EXPECTED_MATCH_UPDATE_SELECT,
+        select: BM_MR_MATCH_LEAN_SELECT,
       });
     });
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
@@ -33,23 +33,11 @@ jest.mock('@/lib/qualification-confirmed-check', () => ({
 }));
 
 import prisma from '@/lib/prisma';
-import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
+import { BM_MR_MATCH_LEAN_SELECT, PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { auth } from '@/lib/auth';
 import { createLogger } from '@/lib/logger';
 import { GET, POST, PUT } from '@/app/api/tournaments/[id]/mr/route';
 import { configureNextResponseMock } from '../../../../../helpers/next-response-mock';
-
-const EXPECTED_MATCH_UPDATE_SELECT = {
-  id: true,
-  tournamentId: true,
-  player1Id: true,
-  player2Id: true,
-  score1: true,
-  score2: true,
-  rounds: true,
-  completed: true,
-  isBye: true,
-};
 
 const _rateLimitMock = jest.requireMock('@/lib/rate-limit') as { getServerSideIdentifier: jest.Mock };
 const sanitizeMock = jest.requireMock('@/lib/sanitize') as { sanitizeInput: jest.Mock };
@@ -362,7 +350,7 @@ describe('MR API Route - /api/tournaments/[id]/mr', () => {
       expect(prisma.mRMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: null, completed: true },
-        select: EXPECTED_MATCH_UPDATE_SELECT,
+        select: BM_MR_MATCH_LEAN_SELECT,
       });
       expect(prisma.$executeRawUnsafe).toHaveBeenCalledTimes(1);
     });
@@ -415,7 +403,7 @@ describe('MR API Route - /api/tournaments/[id]/mr', () => {
       expect(prisma.mRMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: validRounds, completed: true },
-        select: EXPECTED_MATCH_UPDATE_SELECT,
+        select: BM_MR_MATCH_LEAN_SELECT,
       });
     });
 

--- a/smkc-score-app/__tests__/lib/prisma-selects.test.ts
+++ b/smkc-score-app/__tests__/lib/prisma-selects.test.ts
@@ -1,0 +1,17 @@
+import { BM_MR_MATCH_LEAN_SELECT } from '@/lib/prisma-selects';
+
+describe('prisma select shapes', () => {
+  it('keeps the BM/MR match lean select sufficient for score updates', () => {
+    expect(BM_MR_MATCH_LEAN_SELECT).toEqual({
+      id: true,
+      tournamentId: true,
+      player1Id: true,
+      player2Id: true,
+      score1: true,
+      score2: true,
+      rounds: true,
+      completed: true,
+      isBye: true,
+    });
+  });
+});

--- a/smkc-score-app/src/lib/event-types/bm-config.ts
+++ b/smkc-score-app/src/lib/event-types/bm-config.ts
@@ -8,6 +8,7 @@
 
 import { EventTypeConfig, MatchResult } from './types';
 import { AUDIT_ACTIONS } from '@/lib/audit-log';
+import { BM_MR_MATCH_LEAN_SELECT } from '@/lib/prisma-selects';
 import { validateBattleModeScores } from '@/lib/score-validation';
 
 /**
@@ -88,17 +89,7 @@ export const bmConfig: EventTypeConfig = {
         rounds: data.rounds || null,
         completed: true,
       },
-      select: {
-        id: true,
-        tournamentId: true,
-        player1Id: true,
-        player2Id: true,
-        score1: true,
-        score2: true,
-        rounds: true,
-        completed: true,
-        isBye: true,
-      },
+      select: BM_MR_MATCH_LEAN_SELECT,
     });
     return { match, score1OrPoints1: data.score1!, score2OrPoints2: data.score2! };
   },

--- a/smkc-score-app/src/lib/event-types/mr-config.ts
+++ b/smkc-score-app/src/lib/event-types/mr-config.ts
@@ -14,6 +14,7 @@
 
 import { EventTypeConfig, MatchResult } from './types';
 import { AUDIT_ACTIONS } from '@/lib/audit-log';
+import { BM_MR_MATCH_LEAN_SELECT } from '@/lib/prisma-selects';
 import { validateMatchRaceScores } from '@/lib/score-validation';
 
 /**
@@ -101,17 +102,7 @@ export const mrConfig: EventTypeConfig = {
         rounds: data.rounds || null,
         completed: true,
       },
-      select: {
-        id: true,
-        tournamentId: true,
-        player1Id: true,
-        player2Id: true,
-        score1: true,
-        score2: true,
-        rounds: true,
-        completed: true,
-        isBye: true,
-      },
+      select: BM_MR_MATCH_LEAN_SELECT,
     });
     return { match, score1OrPoints1: data.score1!, score2OrPoints2: data.score2! };
   },

--- a/smkc-score-app/src/lib/prisma-selects.ts
+++ b/smkc-score-app/src/lib/prisma-selects.ts
@@ -37,3 +37,20 @@ export const PLAYER_AUTH_SELECT = {
   ...PLAYER_PUBLIC_SELECT,
   userId: true,
 } as const;
+
+/**
+ * Shared lean select for BM/MR qualification match score updates.
+ * Both modes persist the same score/round fields, and standings recalculation
+ * only needs these identifiers plus the completed/BYE state.
+ */
+export const BM_MR_MATCH_LEAN_SELECT = {
+  id: true,
+  tournamentId: true,
+  player1Id: true,
+  player2Id: true,
+  score1: true,
+  score2: true,
+  rounds: true,
+  completed: true,
+  isBye: true,
+} as const;


### PR DESCRIPTION
Summary:
- Move the shared BM/MR qualification match update select into prisma-selects.ts.
- Use the shared select in BM/MR event configs and route tests.
- Add independent coverage for the shared select field set.

Issues: #953

Validation:
- npm test -- --runInBand --runTestsByPath '__tests__/app/api/tournaments/[id]/bm/route.test.ts' '__tests__/app/api/tournaments/[id]/mr/route.test.ts' __tests__/lib/prisma-selects.test.ts
- git diff --check -- smkc-score-app/src/lib/prisma-selects.ts smkc-score-app/src/lib/event-types/bm-config.ts smkc-score-app/src/lib/event-types/mr-config.ts 'smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts' 'smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts' smkc-score-app/__tests__/lib/prisma-selects.test.ts
- Plato review + re-review: no findings