### PR TITLE
Clarify BM/MR select type contract

### DIFF
--- a/smkc-score-app/src/lib/prisma-selects.ts
+++ b/smkc-score-app/src/lib/prisma-selects.ts
@@ -56,6 +56,9 @@ type BmMrMatchLeanSelectRequiredField =
  * field set. Route tests verify BM/MR both pass this shared object into Prisma;
  * this type contract prevents accidental removal of fields that the shared PUT
  * response and qualification recalculation path read immediately after update.
+ * The broad `Record<string, true>` half keeps future entries in this shared
+ * constant as plain all-true scalar selects, rather than `false` or nested
+ * select objects that would change its lean payload contract.
  */
 export const BM_MR_MATCH_LEAN_SELECT = {
   id: true,


### PR DESCRIPTION
Summary:
- Clarify why the BM/MR lean select uses the broad Record<string, true> type contract.
- Document that the contract keeps this shared select as an all-true scalar payload.

Issues: #1761

Validation:
- npm run lint -- src/lib/prisma-selects.ts
- git diff --check
- Review: Plato no findings after revision