### PR TITLE
Stabilize PR template test setup

### DIFF
--- a/smkc-score-app/__tests__/docs/pr-template.test.ts
+++ b/smkc-score-app/__tests__/docs/pr-template.test.ts
@@ -2,8 +2,12 @@ import fs from 'fs';
 import path from 'path';
 
 describe('pull request template', () => {
-  const templatePath = path.join(process.cwd(), '..', '.github', 'pull_request_template.md');
-  const template = fs.readFileSync(templatePath, 'utf8');
+  const templatePath = path.resolve(__dirname, '..', '..', '..', '.github', 'pull_request_template.md');
+  let template: string;
+
+  beforeAll(() => {
+    template = fs.readFileSync(templatePath, 'utf8');
+  });
 
   it('keeps the required automation sections', () => {
     expect(template).toContain('## Summary');


### PR DESCRIPTION
Summary:
- Resolve the PR template fixture path from __dirname instead of process.cwd().
- Move template file loading into beforeAll so file-read failures occur during test setup.

Issues: #945, #946

Validation:
- npm test -- --runInBand __tests__/docs/pr-template.test.ts
- git diff --check
- Review: Plato no findings