### PR TITLE
Harden TC-939 static link guard

### DIFF
--- a/smkc-score-app/__tests__/static/tc-939-tournament-tabs-link.test.ts
+++ b/smkc-score-app/__tests__/static/tc-939-tournament-tabs-link.test.ts
@@ -7,7 +7,6 @@ describe('TC-939 tournament tab navigation', () => {
     expect(layoutSource).toContain('import Link from "next/link";');
     expect(layoutSource).toContain('href={`/tournaments/${id}/${tab.href}`}');
     expect(layoutSource).toContain('prefetch={false}');
-    expect(layoutSource).not.toContain('<a\n                    href={`/tournaments/${id}/${tab.href}`}');
-    expect(layoutSource).not.toContain('<a\n                      href={`/tournaments/${id}/${tab.href}`}');
+    expect(layoutSource).not.toMatch(/<a\s+href=\{`\/tournaments\/\$\{id\}\/\$\{tab\.href\}`\}/);
   });
 });


### PR DESCRIPTION
Summary:
- Replace indentation-specific negative string assertions with a regex guard for the plain-anchor regression.

Issues: #1766

Validation:
- npm test -- --runInBand __tests__/static/tc-939-tournament-tabs-link.test.ts
- git diff --check
- Review: Plato no findings