### PR TITLE
Document TA phase sequential reads

### DIFF
--- a/smkc-score-app/__tests__/static/tc-938-ta-phases-sequential-read-comment.test.ts
+++ b/smkc-score-app/__tests__/static/tc-938-ta-phases-sequential-read-comment.test.ts
@@ -1,0 +1,14 @@
+import { readRepoFile } from '../helpers/e2e-cases';
+
+describe('TC-938 TA phases sequential read comment', () => {
+  const source = readRepoFile('smkc-score-app', 'src', 'app', 'api', 'tournaments', '[id]', 'ta', 'phases', 'route.ts');
+
+  it('documents why phase detail reads stay sequential', () => {
+    expect(source).toContain('D1 concurrent fan-out');
+    expect(source).toContain('request-hung');
+    expect(source).toContain('latency trade-off');
+    expect(source).toContain('const entries = await retryDbRead');
+    expect(source).toContain('const rounds = await retryDbRead');
+    expect(source).toContain('const playedCourses = await retryDbRead');
+  });
+});

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
@@ -463,6 +463,14 @@ export async function GET(
     if (phase?.success) {
       const phaseValue = phase.data;
 
+      /*
+       * Keep these phase-detail reads sequential even though Promise.all would
+       * reduce happy-path latency. Preview D1 has repeatedly produced
+       * request-hung failures under D1 concurrent fan-out from this endpoint, so
+       * the extra latency trade-off is intentional: each read gets its own
+       * retryDbRead boundary and avoids piling multiple D1 reads onto the same
+       * request at once.
+       */
       const entries = await retryDbRead(
         () => prisma.tTEntry.findMany({
           where: { tournamentId, stage: phaseValue },


### PR DESCRIPTION
Summary:
- Add the D1 concurrent fan-out rationale above the sequential TA phase detail reads.
- Add a static guard so the request-hung/latency trade-off comment remains with the retryDbRead sequence.

Issues: #938

Validation:
- npm test -- --runInBand __tests__/static/tc-938-ta-phases-sequential-read-comment.test.ts
- git diff --check
- Review: Plato no findings