### PR TITLE
Harden TC-938 static guard

### DIFF
--- a/smkc-score-app/__tests__/static/tc-938-ta-phases-sequential-read-comment.test.ts
+++ b/smkc-score-app/__tests__/static/tc-938-ta-phases-sequential-read-comment.test.ts
@@ -4,11 +4,18 @@ describe('TC-938 TA phases sequential read comment', () => {
   const source = readRepoFile('smkc-score-app', 'src', 'app', 'api', 'tournaments', '[id]', 'ta', 'phases', 'route.ts');
 
   it('documents why phase detail reads stay sequential', () => {
+    const commentStart = source.indexOf('Keep these phase-detail reads sequential');
+    const commentEnd = source.indexOf('*/', commentStart);
+    const blockEnd = source.indexOf('const normalizedRounds = rounds.map(normalizePhaseRound);', commentEnd);
+    const phaseDetailReadBlock = source.slice(commentEnd, blockEnd);
+
+    expect(commentStart).toBeGreaterThanOrEqual(0);
+    expect(commentEnd).toBeGreaterThan(commentStart);
+    expect(blockEnd).toBeGreaterThan(commentEnd);
     expect(source).toContain('D1 concurrent fan-out');
     expect(source).toContain('request-hung');
     expect(source).toContain('latency trade-off');
-    expect(source).toContain('const entries = await retryDbRead');
-    expect(source).toContain('const rounds = await retryDbRead');
-    expect(source).toContain('const playedCourses = await retryDbRead');
+    expect(phaseDetailReadBlock).toContain('retryDbRead');
+    expect(phaseDetailReadBlock).not.toContain('Promise.all');
   });
 });


### PR DESCRIPTION
Summary:
- Remove variable-name coupling from the TC-938 static guard.
- Check the implementation block after the comment for retryDbRead usage and absence of Promise.all.

Issues: #1769

Validation:
- npm test -- --runInBand __tests__/static/tc-938-ta-phases-sequential-read-comment.test.ts
- git diff --check
- Review: Plato no findings