### PR TITLE
Harden TC-938 read-section landmark

### DIFF
--- a/smkc-score-app/__tests__/static/tc-938-ta-phases-sequential-read-comment.test.ts
+++ b/smkc-score-app/__tests__/static/tc-938-ta-phases-sequential-read-comment.test.ts
@@ -6,7 +6,7 @@ describe('TC-938 TA phases sequential read comment', () => {
   it('documents why phase detail reads stay sequential', () => {
     const commentStart = source.indexOf('Keep these phase-detail reads sequential');
     const commentEnd = source.indexOf('*/', commentStart);
-    const blockEnd = source.indexOf('const normalizedRounds = rounds.map(normalizePhaseRound);', commentEnd);
+    const blockEnd = source.indexOf('End of the D1 read section', commentEnd);
     const phaseDetailReadBlock = source.slice(commentEnd, blockEnd);
 
     expect(commentStart).toBeGreaterThanOrEqual(0);

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
@@ -521,6 +521,7 @@ export async function GET(
         },
       );
 
+      // End of the D1 read section; the remaining work only normalizes and sorts in memory.
       const normalizedRounds = rounds.map(normalizePhaseRound);
 
       response.entries = sortPhaseEntriesForDisplay(entries, normalizedRounds);


### PR DESCRIPTION
## Summary
- Add an explicit source marker for the end of the sequential D1 read section in the TA phases route
- Update the TC-938 static guard to use that marker instead of the normalizedRounds variable declaration

Issues: #1771

## Validation
- npm test -- --runInBand __tests__/static/tc-938-ta-phases-sequential-read-comment.test.ts
- git diff --check
- Reviewer: Plato, no findings