### PR TITLE
Document GP TC-831 ordering

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -63,6 +63,18 @@ describe('E2E case drift coverage', () => {
     expect(scriptSource).toContain(`log('${tc}'`);
   });
 
+  it('documents why GP TC-831 stays before TC-832 in the suite order', () => {
+    const tc831Entry = tcGp.indexOf("{ name: 'TC-831', fn: runTc831 }");
+    const tc832Entry = tcGp.indexOf("{ name: 'TC-832', fn: runTc832 }");
+    const orderComment = tcGp.indexOf('TC-831 stays before TC-832');
+
+    expect(tc831Entry).toBeGreaterThanOrEqual(0);
+    expect(tc832Entry).toBeGreaterThanOrEqual(0);
+    expect(orderComment).toBeGreaterThanOrEqual(0);
+    expect(orderComment).toBeLessThan(tc831Entry);
+    expect(tc831Entry).toBeLessThan(tc832Entry);
+  });
+
   it('keeps TC-1010 aligned with the BM 16-player finals regression coverage', () => {
     const section = e2eCaseSection('TC-1010');
     const finalsRouteTest = readRepoFile(

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -1837,6 +1837,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-712', fn: runTc712 },
       { name: 'TC-719', fn: runTc719 },
       { name: 'TC-720', fn: runTc720 },
+      // TC-831 stays before TC-832 so GP suite logs remain readable in numeric TC order.
       { name: 'TC-831', fn: runTc831 },
       { name: 'TC-832', fn: runTc832 },
       { name: 'TC-721', fn: runTc721 },


### PR DESCRIPTION
## Summary
- Add an inline comment explaining why TC-831 stays before TC-832 in the GP suite registration
- Add a drift guard that checks the comment appears before TC-831 and that TC-831 still precedes TC-832

Issues: #1774

## Validation
- npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/group-setup-helper.test.ts
- git diff --check
- Reviewer: Plato, no findings