### PR TITLE
Harden GP TC order drift guard

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -64,15 +64,9 @@ describe('E2E case drift coverage', () => {
   });
 
   it('documents why GP TC-831 stays before TC-832 in the suite order', () => {
-    const tc831Entry = tcGp.indexOf("{ name: 'TC-831', fn: runTc831 }");
-    const tc832Entry = tcGp.indexOf("{ name: 'TC-832', fn: runTc832 }");
-    const orderComment = tcGp.indexOf('TC-831 stays before TC-832');
-
-    expect(tc831Entry).toBeGreaterThanOrEqual(0);
-    expect(tc832Entry).toBeGreaterThanOrEqual(0);
-    expect(orderComment).toBeGreaterThanOrEqual(0);
-    expect(orderComment).toBeLessThan(tc831Entry);
-    expect(tc831Entry).toBeLessThan(tc832Entry);
+    expect(tcGp).toMatch(
+      /\/\/\s*TC-831 stays before TC-832[^\n]*\n\s*\{\s*name:\s*['"]TC-831['"]\s*,\s*fn:\s*runTc831\s*\}\s*,\s*\n\s*\{\s*name:\s*['"]TC-832['"]\s*,\s*fn:\s*runTc832\s*\}/,
+    );
   });
 
   it('keeps TC-1010 aligned with the BM 16-player finals regression coverage', () => {


### PR DESCRIPTION
## Summary
- Replace exact string index checks for the TC-831/TC-832 drift guard with a whitespace- and quote-tolerant regex
- Keep the guard focused on the comment immediately preceding TC-831 and TC-831 immediately preceding TC-832

Issues: #1776

## Validation
- npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/group-setup-helper.test.ts
- git diff --check
- Reviewer: Plato, no findings