### PR TITLE
Document GP TC order guard regex

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -64,6 +64,7 @@ describe('E2E case drift coverage', () => {
   });
 
   it('documents why GP TC-831 stays before TC-832 in the suite order', () => {
+    // Allow whitespace/quote formatting drift while requiring comment -> TC-831 -> TC-832 adjacency.
     expect(tcGp).toMatch(
       /\/\/\s*TC-831 stays before TC-832[^\n]*\n\s*\{\s*name:\s*['"]TC-831['"]\s*,\s*fn:\s*runTc831\s*\}\s*,\s*\n\s*\{\s*name:\s*['"]TC-832['"]\s*,\s*fn:\s*runTc832\s*\}/,
     );


### PR DESCRIPTION
## Summary
- Add a concise comment explaining the TC-831/TC-832 drift guard regex tolerance and adjacency requirement

Issues: #1778

## Validation
- npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
- Reviewer: Plato, no findings