### PR TITLE
Simplify TA course history ordering

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
@@ -139,6 +139,7 @@ describe("getPlayedCoursesWithSuddenDeath", () => {
     expect(prisma.tTPhaseRound.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { tournamentId: "t1", phase: { in: ["phase1", "phase2"] } },
+        orderBy: [{ roundNumber: "asc" }],
       })
     );
     expect(played).toEqual(["KB1", "DP1"]);

--- a/smkc-score-app/src/lib/ta/course-selection.ts
+++ b/smkc-score-app/src/lib/ta/course-selection.ts
@@ -75,7 +75,7 @@ export async function getPlayedCoursesWithSuddenDeath(
   const phases = getCourseHistoryPhases(phase);
   const rounds = await prisma.tTPhaseRound.findMany({
     where: { tournamentId, phase: { in: phases } },
-    orderBy: [{ phase: "asc" }, { roundNumber: "asc" }],
+    orderBy: [{ roundNumber: "asc" }],
     select: {
       id: true,
       phase: true,


### PR DESCRIPTION
## Summary
- Remove redundant DB-side phase sorting from TA course history reads
- Keep semantic phase ordering in the existing in-memory sort and pin the query contract with a unit test

Issues: #921

## Validation
- npm test -- --runInBand __tests__/lib/ta/course-selection.test.ts
- git diff --check
- Reviewer: Plato, no findings