### PR TITLE
Remove obsolete TA played courses helper

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
@@ -98,9 +98,8 @@ jest.mock('@/lib/ta/freeze-check', () => ({
   checkStageFrozen: jest.fn(),
 }));
 
-// Mock course-selection: getPlayedCourses and getAvailableCourses used by GET handler
+// Mock course-selection helpers used by GET handler
 jest.mock('@/lib/ta/course-selection', () => ({
-  getPlayedCourses: jest.fn(),
   getPlayedCoursesWithSuddenDeath: jest.fn(),
   getAvailableCourses: jest.fn(),
 }));

--- a/smkc-score-app/__tests__/static/course-selection-dead-export.test.ts
+++ b/smkc-score-app/__tests__/static/course-selection-dead-export.test.ts
@@ -1,0 +1,21 @@
+import { readRepoFile } from '../helpers/e2e-cases';
+
+describe('TA course-selection public API', () => {
+  it('does not expose the obsolete single-phase getPlayedCourses helper', () => {
+    const helper = readRepoFile('smkc-score-app', 'src', 'lib', 'ta', 'course-selection.ts');
+    const phasesRouteTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'app',
+      'api',
+      'tournaments',
+      '[id]',
+      'ta',
+      'phases',
+      'route.test.ts',
+    );
+
+    expect(helper).not.toMatch(/\bexport\s+async\s+function\s+getPlayedCourses\s*\(/);
+    expect(phasesRouteTest).not.toContain('getPlayedCourses: jest.fn()');
+  });
+});

--- a/smkc-score-app/src/lib/ta/course-selection.ts
+++ b/smkc-score-app/src/lib/ta/course-selection.ts
@@ -32,29 +32,6 @@ function getCourseHistoryPhases(phase: string): string[] {
 }
 
 /**
- * Fetch the ordered list of courses already played in the current phase.
- * Queries TTPhaseRound records sorted by roundNumber ascending.
- *
- * @param prisma - Prisma client instance
- * @param tournamentId - Tournament to query
- * @param phase - Phase stage ("phase1", "phase2", "phase3")
- * @returns Array of course abbreviations in play order
- */
-export async function getPlayedCourses(
-  prisma: DbClient,
-  tournamentId: string,
-  phase: string
-): Promise<string[]> {
-  const rounds = await prisma.tTPhaseRound.findMany({
-    where: { tournamentId, phase },
-    orderBy: { roundNumber: "asc" },
-    select: { course: true },
-  });
-
-  return rounds.map((r) => r.course);
-}
-
-/**
  * Fetch played courses including adopted sudden-death courses.
  *
  * Course history is shared across TA finals phases. Asking for phase2 includes


### PR DESCRIPTION
## Summary
- Remove the unused single-phase getPlayedCourses export from TA course selection
- Remove the stale getPlayedCourses Jest mock from the TA phases route test
- Add a static guard preventing the obsolete export/mock from returning

Issues: #920

## Validation
- npm test -- --runInBand __tests__/static/course-selection-dead-export.test.ts __tests__/lib/ta/course-selection.test.ts
- npm test -- --runInBand --runTestsByPath '__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts'
- git diff --check
- Reviewer: Plato, no findings