### PR TITLE
Simplify TA dead export guard

### DIFF
--- a/smkc-score-app/__tests__/static/course-selection-dead-export.test.ts
+++ b/smkc-score-app/__tests__/static/course-selection-dead-export.test.ts
@@ -3,19 +3,7 @@ import { readRepoFile } from '../helpers/e2e-cases';
 describe('TA course-selection public API', () => {
   it('does not expose the obsolete single-phase getPlayedCourses helper', () => {
     const helper = readRepoFile('smkc-score-app', 'src', 'lib', 'ta', 'course-selection.ts');
-    const phasesRouteTest = readRepoFile(
-      'smkc-score-app',
-      '__tests__',
-      'app',
-      'api',
-      'tournaments',
-      '[id]',
-      'ta',
-      'phases',
-      'route.test.ts',
-    );
 
     expect(helper).not.toMatch(/\bexport\s+async\s+function\s+getPlayedCourses\s*\(/);
-    expect(phasesRouteTest).not.toContain('getPlayedCourses: jest.fn()');
   });
 });


### PR DESCRIPTION
## Summary
- Remove the route-test mock meta assertion from the TA course-selection dead export guard
- Keep the guard focused on the obsolete getPlayedCourses source export

Issues: #1782

## Validation
- npm test -- --runInBand __tests__/static/course-selection-dead-export.test.ts
- git diff --check
- Reviewer: Plato, no findings