### PR TITLE
Memoize TA time input props

### DIFF
--- a/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
+++ b/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
@@ -1,0 +1,36 @@
+import { readRepoFile } from '../helpers/e2e-cases';
+
+const targets = [
+  {
+    label: 'TA participant page',
+    path: ['src', 'app', 'tournaments', '[id]', 'ta', 'participant', 'page.tsx'],
+    translationCall: "tTa('timeInputTitle')",
+  },
+  {
+    label: 'TA finals phase 3 page',
+    path: ['src', 'app', 'tournaments', '[id]', 'ta', 'finals', 'page.tsx'],
+    translationCall: "tTaFinals('timeInputTitle')",
+  },
+  {
+    label: 'TA elimination phase component',
+    path: ['src', 'components', 'tournament', 'ta-elimination-phase.tsx'],
+    translationCall: "tElim('timeInputTitle')",
+  },
+] as const;
+
+describe('TA time input props memoization', () => {
+  it.each(targets)('memoizes getTaTimeInputProps in $label', ({ path, translationCall }) => {
+    const source = readRepoFile('smkc-score-app', ...path);
+    const memoizedDeclaration = new RegExp(
+      `const\\s+taTimeInputProps\\s*=\\s*useMemo\\(\\s*\\(\\)\\s*=>\\s*getTaTimeInputProps\\(\\s*${escapeRegExp(translationCall)}\\s*\\),\\s*\\[[^\\]]+\\]\\s*\\)`,
+      's',
+    );
+
+    expect(source).toMatch(/import\s*\{[^}]*\buseMemo\b[^}]*\}\s*from ['"]react['"]/s);
+    expect(source).toMatch(memoizedDeclaration);
+  });
+});
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -27,7 +27,7 @@
  * - 3-second auto-refresh for live tracking
  */
 
-import { useState, useEffect, useCallback, use } from "react";
+import { useState, useEffect, useCallback, use, useMemo } from "react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -165,7 +165,8 @@ export default function TimeAttackFinals({
   const tTaFinals = useTranslations('taFinals');
   const tFinals = useTranslations('finals');
   const tCommon = useTranslations('common');
-  const taTimeInputProps = getTaTimeInputProps(tTaFinals('timeInputTitle'));
+  // Keep the shared input props object stable across polling-driven re-renders.
+  const taTimeInputProps = useMemo(() => getTaTimeInputProps(tTaFinals('timeInputTitle')), [tTaFinals]);
 
   /**
    * Admin role check: only admin users can start rounds, enter times,

--- a/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
@@ -25,7 +25,7 @@
  * - Namespaces: participant, ta, common
  */
 
-import { useState, useEffect, useCallback, use } from 'react';
+import { useState, useEffect, useCallback, use, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSession } from 'next-auth/react';
 import { usePolling } from '@/lib/hooks/usePolling';
@@ -106,7 +106,8 @@ export default function TimeAttackParticipantPage({
   const tPart = useTranslations('participant');
   const tTa = useTranslations('ta');
   const tCommon = useTranslations('common');
-  const taTimeInputProps = getTaTimeInputProps(tTa('timeInputTitle'));
+  // Keep the shared input props object stable across polling-driven re-renders.
+  const taTimeInputProps = useMemo(() => getTaTimeInputProps(tTa('timeInputTitle')), [tTa]);
 
   const { data: session, status: sessionStatus } = useSession();
 

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -20,7 +20,7 @@
  * - Auto-refresh every 3 seconds for live tournament tracking
  */
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -136,7 +136,8 @@ export default function TAEliminationPhase({
   // 'common' namespace for shared UI labels (e.g., "Player")
   const tElim = useTranslations('taElimination');
   const tCommon = useTranslations('common');
-  const taTimeInputProps = getTaTimeInputProps(tElim('timeInputTitle'));
+  // Keep the shared input props object stable across polling-driven re-renders.
+  const taTimeInputProps = useMemo(() => getTaTimeInputProps(tElim('timeInputTitle')), [tElim]);
 
   /**
    * Admin role check: only admin users can start rounds, enter times,


### PR DESCRIPTION
Summary
- Memoize getTaTimeInputProps in the TA participant, finals, and elimination views
- Add a static regression guard for the three TA time input call sites

Issues: #918

Validation
- npm test -- --runInBand __tests__/static/ta-time-input-props-usememo.test.ts
- npm test -- --runInBand __tests__/static/ta-time-input-props-usememo.test.ts __tests__/lib/ta/time-entry-layout.test.ts
- git diff --check
- Reviewer agent: no findings