### PR TITLE
Clarify TA time input memoization

### DIFF
--- a/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
+++ b/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
@@ -28,6 +28,8 @@ describe('TA time input props memoization', () => {
 
     expect(source).toMatch(/import\s*\{[^}]*\buseMemo\b[^}]*\}\s*from ['"]react['"]/s);
     expect(source).toMatch(memoizedDeclaration);
+    expect(source).toContain('Input is a native element, so this does not skip rendering by reference equality.');
+    expect(source).toContain('avoids rebuilding identical spread props during polling refreshes.');
   });
 });
 

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -165,7 +165,8 @@ export default function TimeAttackFinals({
   const tTaFinals = useTranslations('taFinals');
   const tFinals = useTranslations('finals');
   const tCommon = useTranslations('common');
-  // Keep the shared input props object stable across polling-driven re-renders.
+  // Input is a native element, so this does not skip rendering by reference equality.
+  // The memo keeps TA pages consistent and avoids rebuilding identical spread props during polling refreshes.
   const taTimeInputProps = useMemo(() => getTaTimeInputProps(tTaFinals('timeInputTitle')), [tTaFinals]);
 
   /**

--- a/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
@@ -106,7 +106,8 @@ export default function TimeAttackParticipantPage({
   const tPart = useTranslations('participant');
   const tTa = useTranslations('ta');
   const tCommon = useTranslations('common');
-  // Keep the shared input props object stable across polling-driven re-renders.
+  // Input is a native element, so this does not skip rendering by reference equality.
+  // The memo keeps TA pages consistent and avoids rebuilding identical spread props during polling refreshes.
   const taTimeInputProps = useMemo(() => getTaTimeInputProps(tTa('timeInputTitle')), [tTa]);
 
   const { data: session, status: sessionStatus } = useSession();

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -136,7 +136,8 @@ export default function TAEliminationPhase({
   // 'common' namespace for shared UI labels (e.g., "Player")
   const tElim = useTranslations('taElimination');
   const tCommon = useTranslations('common');
-  // Keep the shared input props object stable across polling-driven re-renders.
+  // Input is a native element, so this does not skip rendering by reference equality.
+  // The memo keeps TA pages consistent and avoids rebuilding identical spread props during polling refreshes.
   const taTimeInputProps = useMemo(() => getTaTimeInputProps(tElim('timeInputTitle')), [tElim]);
 
   /**


### PR DESCRIPTION
Summary
- Clarify that TA time input props memoization does not skip native input rendering by reference equality
- Extend the static guard to preserve the narrower memoization rationale

Issues: #1785

Validation
- npm test -- --runInBand __tests__/static/ta-time-input-props-usememo.test.ts
- npm test -- --runInBand __tests__/static/ta-time-input-props-usememo.test.ts __tests__/lib/ta/time-entry-layout.test.ts
- git diff --check
- Reviewer agent: no findings