### PR TITLE
Cover TA page-client time input memoization

### DIFF
--- a/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
+++ b/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
@@ -2,6 +2,11 @@ import { readRepoFile } from '../helpers/e2e-cases';
 
 const targets = [
   {
+    label: 'TA admin qualification page',
+    path: ['src', 'app', 'tournaments', '[id]', 'ta', 'page-client.tsx'],
+    translationCall: "t('timeInputTitle')",
+  },
+  {
     label: 'TA participant page',
     path: ['src', 'app', 'tournaments', '[id]', 'ta', 'participant', 'page.tsx'],
     translationCall: "tTa('timeInputTitle')",

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
@@ -122,6 +122,8 @@ export default function TimeAttackPageClient({
   const { data: session } = useSession();
   const t = useTranslations('ta');
   const tc = useTranslations('common');
+  // Input is a native element, so this does not skip rendering by reference equality.
+  // The memo keeps TA pages consistent and avoids rebuilding identical spread props during polling refreshes.
   const taTimeInputProps = useMemo(() => getTaTimeInputProps(t('timeInputTitle')), [t]);
 
   /**


### PR DESCRIPTION
Summary
- Add ta/page-client.tsx to the TA time input memoization static guard
- Document the actual memoization effect on the existing admin qualification TA input props memo

Issues: #1787

Validation
- npm test -- --runInBand __tests__/static/ta-time-input-props-usememo.test.ts
- npm test -- --runInBand __tests__/static/ta-time-input-props-usememo.test.ts __tests__/lib/ta/time-entry-layout.test.ts
- git diff --check
- Reviewer agent: no findings