### PR TITLE
Document phase3 reset fallback

### DIFF
--- a/smkc-score-app/__tests__/static/phase3-reset-threshold-fallback-comment.test.ts
+++ b/smkc-score-app/__tests__/static/phase3-reset-threshold-fallback-comment.test.ts
@@ -1,0 +1,17 @@
+import { readRepoFile, sectionBetween } from '../helpers/e2e-cases';
+
+describe('TA phase3 reset threshold fallback comment', () => {
+  it('documents why phase3 falls back to one survivor below configured reset thresholds', () => {
+    const source = readRepoFile('smkc-score-app', 'src', 'lib', 'ta', 'finals-phase-manager.ts');
+    const helper = sectionBetween(
+      source,
+      'function getNextPhase3ResetThreshold(activeCount: number): number | null {',
+      'function getPhase3EliminationLimit(activeCount: number): number {',
+    );
+
+    expect(helper).toContain('no configured reset threshold remains below activeCount');
+    expect(helper).toContain('fallback to one survivor');
+    expect(helper).toContain('protects the last remaining player');
+    expect(helper).toContain('activeCount - 1');
+  });
+});

--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -76,6 +76,8 @@ function getNextPhase3ResetThreshold(activeCount: number): number | null {
   const thresholds = [...PHASE_CONFIG.phase3.lifeResetThresholds]
     .filter((threshold) => threshold < activeCount)
     .sort((a, b) => b - a);
+  // When no configured reset threshold remains below activeCount, fallback to one survivor.
+  // This makes the elimination limit activeCount - 1 and protects the last remaining player.
   return thresholds[0] ?? (activeCount > 1 ? 1 : null);
 }
 


### PR DESCRIPTION
Summary
- Document why phase3 reset threshold selection falls back to one survivor
- Add a narrow static guard preserving that fallback rationale

Issues: #917

Validation
- npm test -- --runInBand __tests__/static/phase3-reset-threshold-fallback-comment.test.ts
- npm test -- --runInBand __tests__/static/phase3-reset-threshold-fallback-comment.test.ts __tests__/lib/ta/finals-phase-manager.test.ts
- git diff --check
- Reviewer agent: no findings