### PR TITLE
Clarify phase3 threshold tests

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -299,10 +299,13 @@ describe("TA Finals Phase Manager", () => {
   });
 
   describe("getNextPhase3ResetThreshold", () => {
-    it("falls back to one survivor when no configured threshold remains below activeCount", () => {
+    it("returns the highest configured reset threshold below activeCount", () => {
       expect(getNextPhase3ResetThreshold(9)).toBe(8);
       expect(getNextPhase3ResetThreshold(5)).toBe(4);
       expect(getNextPhase3ResetThreshold(3)).toBe(2);
+    });
+
+    it("falls back to one survivor when no configured threshold remains below activeCount", () => {
       expect(getNextPhase3ResetThreshold(2)).toBe(1);
       expect(getNextPhase3ResetThreshold(1)).toBeNull();
     });


### PR DESCRIPTION
Summary
- Split getNextPhase3ResetThreshold coverage into configured-threshold and fallback cases

Issues: #1793

Validation
- npm test -- --runInBand __tests__/lib/ta/finals-phase-manager.test.ts
- git diff --check
- Reviewer agent: no findings