### PR TITLE
test: cover TA sudden death continuation

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -9,6 +9,7 @@
 
 import {
   PHASE_CONFIG,
+  getSuddenDeathContinuationTargets,
   getNextPhase3ResetThreshold,
   processEliminationPhaseResult,
   processPhase3Result,
@@ -108,6 +109,44 @@ describe("TA Finals Phase Manager", () => {
         initialLives: 3,
         lifeResetThresholds: [8, 4, 2],
       });
+    });
+  });
+
+  describe("getSuddenDeathContinuationTargets", () => {
+    const phase3BoundaryResults = [
+      { playerId: "p1", timeMs: 80000 },
+      { playerId: "p2", timeMs: 90000 },
+      { playerId: "p3", timeMs: 90000 },
+      { playerId: "p4", timeMs: 90000 },
+    ];
+
+    it("does not continue phase3 sudden death after the life-loss boundary is resolved without a new slowest tie", () => {
+      const targets = getSuddenDeathContinuationTargets("phase3", phase3BoundaryResults, [
+        { playerId: "p2", timeMs: 87000 },
+        { playerId: "p3", timeMs: 88000 },
+        { playerId: "p4", timeMs: 91000 },
+      ]);
+
+      expect(targets).toEqual([]);
+    });
+
+    it("continues phase3 sudden death with all players still tied for the slowest sudden-death time", () => {
+      const targets = getSuddenDeathContinuationTargets("phase3", phase3BoundaryResults, [
+        { playerId: "p2", timeMs: 87000 },
+        { playerId: "p3", timeMs: 91000 },
+        { playerId: "p4", timeMs: 91000 },
+      ]);
+
+      expect(targets).toEqual(["p3", "p4"]);
+    });
+
+    it("falls back to the slowest sudden-death tie when a phase3 boundary player did not race in the sudden-death round", () => {
+      const targets = getSuddenDeathContinuationTargets("phase3", phase3BoundaryResults, [
+        { playerId: "p3", timeMs: 91000 },
+        { playerId: "p4", timeMs: 91000 },
+      ]);
+
+      expect(targets).toEqual(["p3", "p4"]);
     });
   });
 

--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -990,7 +990,7 @@ function applySuddenDeathOrder(
   });
 }
 
-function getSuddenDeathContinuationTargets(
+export function getSuddenDeathContinuationTargets(
   phase: "phase1" | "phase2" | "phase3",
   baseResults: CourseResult[],
   suddenDeathResults: CourseResult[]
@@ -1013,6 +1013,9 @@ function getSuddenDeathContinuationTargets(
   const safeSuddenTime = suddenByPlayer.get(safeBoundary.playerId);
   const unsafeSuddenTime = suddenByPlayer.get(unsafeBoundary.playerId);
   if (safeSuddenTime === undefined || unsafeSuddenTime === undefined || safeSuddenTime !== unsafeSuddenTime) {
+    // Phase 3 sudden death is only repeated when the life-loss boundary is still unresolved.
+    // If the boundary was resolved, there can still be a separate tie among the slowest
+    // sudden-death players; those players must race again so one life-loss target can be chosen.
     const slowestSuddenTime = Math.max(...suddenDeathResults.map((result) => result.timeMs));
     const stillTiedForElimination = suddenDeathResults.filter((result) => result.timeMs === slowestSuddenTime);
     return stillTiedForElimination.length > 1 ? stillTiedForElimination.map((result) => result.playerId) : [];


### PR DESCRIPTION
Summary:
- Add direct coverage for Phase 3 sudden-death continuation boundaries.
- Export the pure continuation-target helper for focused tests and document the fallback tie behavior.

Issues: #916

Validation:
- npm test -- --runInBand __tests__/lib/ta/finals-phase-manager.test.ts
- git diff --check