### PR TITLE
test: add MR TC-604 click diagnostics

### DIFF
--- a/smkc-score-app/__tests__/e2e/ui-create-player.test.ts
+++ b/smkc-score-app/__tests__/e2e/ui-create-player.test.ts
@@ -1,4 +1,5 @@
 import {
+  clickWithDiagnostics,
   readResponseSummary,
   summarizeResponseBody,
   uiCreatePlayer,
@@ -128,5 +129,31 @@ describe('ui player-create response helpers', () => {
 
   it('keeps failure-body summaries bounded for E2E logs', () => {
     expect(summarizeResponseBody({ error: 'x'.repeat(1000) }).length).toBeLessThanOrEqual(500);
+  });
+});
+
+describe('clickWithDiagnostics', () => {
+  it('adds locator state and covering element details when a click fails', async () => {
+    const locator = {
+      click: jest.fn().mockRejectedValue(new Error('locator.click: Timeout 30000ms exceeded')),
+      count: jest.fn().mockResolvedValue(1),
+      isVisible: jest.fn().mockResolvedValue(true),
+      isEnabled: jest.fn().mockResolvedValue(false),
+      boundingBox: jest.fn().mockResolvedValue({ x: 10, y: 20, width: 100, height: 40 }),
+      textContent: jest.fn().mockResolvedValue('Save'),
+      evaluate: jest.fn().mockResolvedValue({
+        targetTag: 'BUTTON',
+        targetText: 'Save',
+        topTag: 'DIV',
+        topText: 'Loading',
+        topPointerEvents: 'auto',
+        targetPointerEvents: 'auto',
+        activeTag: 'BODY',
+      }),
+    };
+
+    await expect(clickWithDiagnostics(locator, 'TC-604 save finals score')).rejects.toThrow(
+      /TC-604 save finals score click failed: locator\.click: Timeout 30000ms exceeded; count=1 visible=true enabled=false box=10,20,100,40 text="Save" top=DIV "Loading" topPointerEvents=auto target=BUTTON "Save" targetPointerEvents=auto active=BODY/,
+    );
   });
 });

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -433,6 +433,100 @@ async function loginPlayerBrowser(nickname, password) {
   return { browser, context, page };
 }
 
+function truncateDiagnosticText(value, max = 80) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim().slice(0, max);
+}
+
+function formatClickDiagnosticValue(value) {
+  if (value === null || value === undefined) return 'n/a';
+  if (typeof value === 'string') return value.length > 0 ? `"${value}"` : '""';
+  return String(value);
+}
+
+async function collectClickDiagnostics(locator) {
+  const read = async (label, fn) => {
+    try {
+      return await fn();
+    } catch (err) {
+      return `${label}_error:${err instanceof Error ? err.message : String(err)}`;
+    }
+  };
+
+  const [count, visible, enabled, box, text] = await Promise.all([
+    typeof locator.count === 'function' ? read('count', () => locator.count()) : Promise.resolve('n/a'),
+    typeof locator.isVisible === 'function' ? read('visible', () => locator.isVisible()) : Promise.resolve('n/a'),
+    typeof locator.isEnabled === 'function' ? read('enabled', () => locator.isEnabled()) : Promise.resolve('n/a'),
+    typeof locator.boundingBox === 'function' ? read('box', () => locator.boundingBox()) : Promise.resolve(null),
+    typeof locator.textContent === 'function' ? read('text', () => locator.textContent()) : Promise.resolve('n/a'),
+  ]);
+
+  let elementState = null;
+  if (box && typeof box === 'object' && typeof locator.evaluate === 'function') {
+    elementState = await read('element', () => locator.evaluate((element, rect) => {
+      const centerX = rect.x + rect.width / 2;
+      const centerY = rect.y + rect.height / 2;
+      const topElement = document.elementFromPoint(centerX, centerY);
+      const targetStyle = window.getComputedStyle(element);
+      const topStyle = topElement ? window.getComputedStyle(topElement) : null;
+      const describe = (node) => node ? {
+        tag: node.tagName,
+        text: (node.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 80),
+      } : { tag: 'null', text: '' };
+
+      const target = describe(element);
+      const top = describe(topElement);
+      return {
+        targetTag: target.tag,
+        targetText: target.text,
+        topTag: top.tag,
+        topText: top.text,
+        topPointerEvents: topStyle?.pointerEvents ?? 'n/a',
+        targetPointerEvents: targetStyle.pointerEvents,
+        activeTag: document.activeElement?.tagName ?? 'null',
+      };
+    }, box));
+  }
+
+  const boxText = box && typeof box === 'object'
+    ? `${Math.round(box.x)},${Math.round(box.y)},${Math.round(box.width)},${Math.round(box.height)}`
+    : formatClickDiagnosticValue(box);
+  const parts = [
+    `count=${formatClickDiagnosticValue(count)}`,
+    `visible=${formatClickDiagnosticValue(visible)}`,
+    `enabled=${formatClickDiagnosticValue(enabled)}`,
+    `box=${boxText}`,
+    `text=${formatClickDiagnosticValue(truncateDiagnosticText(text))}`,
+  ];
+
+  if (elementState && typeof elementState === 'object') {
+    parts.push(
+      `top=${elementState.topTag ?? 'n/a'} ${formatClickDiagnosticValue(elementState.topText)}`,
+      `topPointerEvents=${elementState.topPointerEvents ?? 'n/a'}`,
+      `target=${elementState.targetTag ?? 'n/a'} ${formatClickDiagnosticValue(elementState.targetText)}`,
+      `targetPointerEvents=${elementState.targetPointerEvents ?? 'n/a'}`,
+      `active=${elementState.activeTag ?? 'n/a'}`,
+    );
+  } else if (elementState) {
+    parts.push(`element=${formatClickDiagnosticValue(elementState)}`);
+  }
+
+  return parts.join(' ');
+}
+
+async function clickWithDiagnostics(locator, label, options = {}) {
+  try {
+    await locator.click(options);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const diagnostics = await collectClickDiagnostics(locator);
+    /* Playwright's raw timeout only names "locator.click"; TC-604 has several
+     * click targets and long setup, so preserving element state here is the
+     * fastest way to distinguish disabled controls, overlays, and bad selectors
+     * without rerunning the full 28-player MR fixture blindly. */
+    throw new Error(`${label} click failed: ${message}; ${diagnostics}`);
+  }
+}
+
 /* ───────── Retry wrapper for transient API failures ─────────
  * D1 occasionally returns 5xx under burst load. Retry idempotent operations
  * (PUT score input is safe to retry — it sets a final state, not an increment).
@@ -2750,6 +2844,7 @@ module.exports = {
   apiDeletePlayer,
   apiDeleteTournament,
   /* UI helpers */
+  clickWithDiagnostics,
   uiCreatePlayer,
   summarizeResponseBody,
   readResponseSummary,

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -41,6 +41,7 @@
 const {
   makeResults, makeLog, nav, escapeRegex,
   matchUpdateUsesLeanPayload,
+  clickWithDiagnostics,
   uiCreatePlayer: createPlayer,
   uiCreateTournament: createTournament,
   apiDeletePlayer: deletePlayer,
@@ -441,10 +442,10 @@ async function runTc604(adminPage) {
     const generateButton = adminPage.getByRole('button', { name: /Generate finals bracket|Generate Bracket|ブラケット生成/i });
     await generateButton.waitFor({ state: 'visible', timeout: 40000 });
     await generateButton.scrollIntoViewIfNeeded();
-    await generateButton.click({ timeout: 40000 });
+    await clickWithDiagnostics(generateButton, 'TC-604 generate finals bracket', { timeout: 40000 });
     const confirmButton = adminPage.getByRole('button', { name: /生成 \(8 players\)|Generate \(8 players\)/ });
     await confirmButton.waitFor({ state: 'visible', timeout: 40000 });
-    await confirmButton.click({ timeout: 40000 });
+    await clickWithDiagnostics(confirmButton, 'TC-604 confirm finals bracket generation', { timeout: 40000 });
     /* Wait for the bracket to render. The MR finals page only displays an
      * "X / Y matches" counter for the playoff stage (line 683 in
      * mr/finals/page.tsx); the regular winners/losers bracket has no such
@@ -469,7 +470,7 @@ async function runTc604(adminPage) {
     // Valid MR finals: first-to-3 via UI dialog (tests race entry workflow)
     const matchOneCard = adminPage.locator(`[aria-label^="Match 1:"]`).first();
     await matchOneCard.scrollIntoViewIfNeeded();
-    await matchOneCard.click({ timeout: 40000 });
+    await clickWithDiagnostics(matchOneCard, 'TC-604 open Match 1 score dialog', { timeout: 40000 });
     await adminPage.waitForTimeout(500);
 
     // MR finals dialog: max race rows are pre-rendered with course select + P1/P2 winner buttons.
@@ -483,11 +484,11 @@ async function runTc604(adminPage) {
       // Select course if combobox present
       const combobox = row.locator('button[role="combobox"]');
       if (await combobox.count() > 0) {
-        await combobox.first().click();
+        await clickWithDiagnostics(combobox.first(), `TC-604 row ${i + 1} course selector`);
         await adminPage.waitForTimeout(200);
         const option = adminPage.locator('[role="option"]').nth(i);
         if (await option.count() > 0) {
-          await option.click();
+          await clickWithDiagnostics(option, `TC-604 row ${i + 1} course option`);
           await adminPage.waitForTimeout(200);
         }
       }
@@ -496,7 +497,7 @@ async function runTc604(adminPage) {
 
       const winnerBtns = row.locator('button.w-10');
       if (await winnerBtns.count() >= 2) {
-        await winnerBtns.first().click();
+        await clickWithDiagnostics(winnerBtns.first(), `TC-604 row ${i + 1} player1 winner button`);
         await adminPage.waitForTimeout(200);
       }
     }
@@ -505,7 +506,7 @@ async function runTc604(adminPage) {
     const saveButton = adminPage.getByRole('button', { name: /^(Save|結果保存)$/ });
     await saveButton.waitFor({ state: 'visible', timeout: 40000 });
     await saveButton.scrollIntoViewIfNeeded();
-    await saveButton.click({ timeout: 40000 });
+    await clickWithDiagnostics(saveButton, 'TC-604 save finals score', { timeout: 40000 });
     await adminPage.waitForTimeout(3000);
 
     // Poll for bracket update


### PR DESCRIPTION
Summary:
- Add a shared E2E clickWithDiagnostics helper that preserves locator state and covering-element details when Playwright click times out.
- Wrap TC-604's bracket generation, dialog, race-row, and save clicks with labeled diagnostics.
- Cover the diagnostic error payload with a focused Jest test.

Issues: #893

Validation:
- npm test -- --runInBand __tests__/e2e/ui-create-player.test.ts __tests__/e2e/tc-all-registration.test.ts
- node --check e2e/lib/common.js
- node --check e2e/tc-mr.js
- git diff --check