### PR TITLE
test: cover enabled reader diagnostics

### DIFF
--- a/smkc-score-app/__tests__/e2e/click-diagnostics.test.ts
+++ b/smkc-score-app/__tests__/e2e/click-diagnostics.test.ts
@@ -50,11 +50,12 @@ describe('clickWithDiagnostics', () => {
       click: jest.fn().mockRejectedValue(new Error('locator.click: Timeout 30000ms exceeded')),
       count: jest.fn().mockRejectedValue(new Error('detached')),
       isVisible: jest.fn().mockRejectedValue(new Error('not attached')),
+      isEnabled: jest.fn().mockRejectedValue(new Error('enabled detached')),
       boundingBox: jest.fn().mockResolvedValue(null),
     });
 
     await expect(clickWithDiagnostics(locator, 'TC-604 reader errors')).rejects.toThrow(
-      /count="count_error:detached" visible="visible_error:not attached" enabled=true box=n\/a text="Save"/,
+      /count="count_error:detached" visible="visible_error:not attached" enabled="enabled_error:enabled detached" box=n\/a text="Save"/,
     );
   });
 


### PR DESCRIPTION
Summary:
- Cover the clickWithDiagnostics reader-error path when isEnabled() rejects.
- Clear the review suggestion from PR #1801 without changing runtime code.

Issues: none

Validation:
- npm test -- --runInBand __tests__/e2e/click-diagnostics.test.ts
- git diff --check