### PR TITLE
fix: truncate BM score dialog names

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -20,6 +20,7 @@ describe('E2E case drift coverage', () => {
   const tcTaFlow = readE2eScript('tc-ta-flow.js');
   const taFlowRankAssertionsTypes = readE2eLib('ta-flow-rank-assertions.d.ts');
   const gpFinalsValidators = readE2eLib('gp-finals-validators.js');
+  const bmFinalsPage = readRepoFile('smkc-score-app', 'src', 'app', 'tournaments', '[id]', 'bm', 'finals', 'page.tsx');
   const tc1073Lr2Slots = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'tc-1073-16p-lr2-slots.test.ts');
   const taPhasesRouteTest = readRepoFile(
     'smkc-score-app',
@@ -278,6 +279,17 @@ describe('E2E case drift coverage', () => {
     expect(helper).toContain("require('../../messages/ja.json').common");
     expect(helper).toContain("require('../../messages/en.json').common");
     expect(helper).toContain('qualification points header missing tooltip title');
+  });
+
+  it('keeps TC-521 aligned with BM finals score-dialog long-name truncation', () => {
+    const section = e2eCaseSection('TC-521');
+
+    expect(section).toContain('長いプレイヤー名');
+    expect(tcBm).toContain('labelsStayCapped');
+    expect(bmFinalsPage).toContain('className="flex min-w-0 max-w-full flex-wrap items-center gap-x-1"');
+    expect(bmFinalsPage).toContain('className="min-w-0 max-w-[180px] truncate align-bottom sm:max-w-[240px]"');
+    expect(bmFinalsPage).toContain('className="block max-w-[140px] truncate"');
+    expect(bmFinalsPage).toContain('className="min-w-0 text-center"');
   });
 
   it('keeps TC-1063 aligned with the combined standings memoization guard', () => {

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -838,9 +838,16 @@ export default function BattleModeFinals({
             <DialogDescription>
               {selectedMatch && (
                 <>
-                  Match #{selectedMatch.matchNumber}:{" "}
-                  {selectedMatch.player1.nickname} vs{" "}
-                  {selectedMatch.player2.nickname}
+                  <span className="flex min-w-0 max-w-full flex-wrap items-center gap-x-1">
+                    <span className="shrink-0">Match #{selectedMatch.matchNumber}:</span>
+                    <span className="min-w-0 max-w-[180px] truncate align-bottom sm:max-w-[240px]">
+                      {selectedMatch.player1.nickname}
+                    </span>
+                    <span className="shrink-0">vs</span>
+                    <span className="min-w-0 max-w-[180px] truncate align-bottom sm:max-w-[240px]">
+                      {selectedMatch.player2.nickname}
+                    </span>
+                  </span>
                   {/* Show the round name if available */}
                   {selectedMatch.round && (
                     <span className="block text-xs mt-1">
@@ -855,8 +862,8 @@ export default function BattleModeFinals({
           <div className="space-y-4 py-4">
             <div className="flex items-center justify-center gap-4">
                {/* Player 1 score input with accessible label */}
-               <div className="text-center">
-                 <Label htmlFor={`score1-${selectedMatch?.id}`}>
+               <div className="min-w-0 text-center">
+                 <Label htmlFor={`score1-${selectedMatch?.id}`} className="block max-w-[140px] truncate">
                    {selectedMatch?.player1.nickname}
                  </Label>
                  <Input
@@ -879,8 +886,8 @@ export default function BattleModeFinals({
                </div>
                <span className="text-2xl" aria-hidden="true">-</span>
                {/* Player 2 score input with accessible label */}
-               <div className="text-center">
-                 <Label htmlFor={`score2-${selectedMatch?.id}`}>
+               <div className="min-w-0 text-center">
+                 <Label htmlFor={`score2-${selectedMatch?.id}`} className="block max-w-[140px] truncate">
                    {selectedMatch?.player2.nickname}
                  </Label>
                  <Input


### PR DESCRIPTION
Summary:
- Cap and truncate long player names in the BM finals score dialog header and score labels.
- Preserve wrapping in the dialog description so long unbroken nicknames cannot widen the dialog.
- Add a drift test that keeps TC-521 aligned with the truncation classes and E2E assertion.

Issues: #892

Validation:
- npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts
- git diff --check