### PR TITLE
test: relax BM dialog truncation guard

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -283,13 +283,17 @@ describe('E2E case drift coverage', () => {
 
   it('keeps TC-521 aligned with BM finals score-dialog long-name truncation', () => {
     const section = e2eCaseSection('TC-521');
+    const classTokenSets = Array.from(bmFinalsPage.matchAll(/className="([^"]+)"/g))
+      .map((match) => new Set(match[1].split(/\s+/).filter(Boolean)));
+    const hasClassSet = (tokens: string[]) =>
+      classTokenSets.some((classSet) => tokens.every((token) => classSet.has(token)));
 
     expect(section).toContain('長いプレイヤー名');
     expect(tcBm).toContain('labelsStayCapped');
-    expect(bmFinalsPage).toContain('className="flex min-w-0 max-w-full flex-wrap items-center gap-x-1"');
-    expect(bmFinalsPage).toContain('className="min-w-0 max-w-[180px] truncate align-bottom sm:max-w-[240px]"');
-    expect(bmFinalsPage).toContain('className="block max-w-[140px] truncate"');
-    expect(bmFinalsPage).toContain('className="min-w-0 text-center"');
+    expect(hasClassSet(['flex', 'min-w-0', 'max-w-full', 'flex-wrap', 'items-center'])).toBe(true);
+    expect(hasClassSet(['min-w-0', 'max-w-[180px]', 'truncate', 'sm:max-w-[240px]'])).toBe(true);
+    expect(hasClassSet(['block', 'max-w-[140px]', 'truncate'])).toBe(true);
+    expect(hasClassSet(['min-w-0', 'text-center'])).toBe(true);
   });
 
   it('keeps TC-1063 aligned with the combined standings memoization guard', () => {

--- a/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/finals/page.tsx
@@ -840,11 +840,11 @@ export default function BattleModeFinals({
                 <>
                   <span className="flex min-w-0 max-w-full flex-wrap items-center gap-x-1">
                     <span className="shrink-0">Match #{selectedMatch.matchNumber}:</span>
-                    <span className="min-w-0 max-w-[180px] truncate align-bottom sm:max-w-[240px]">
+                    <span className="min-w-0 max-w-[180px] truncate sm:max-w-[240px]">
                       {selectedMatch.player1.nickname}
                     </span>
                     <span className="shrink-0">vs</span>
-                    <span className="min-w-0 max-w-[180px] truncate align-bottom sm:max-w-[240px]">
+                    <span className="min-w-0 max-w-[180px] truncate sm:max-w-[240px]">
                       {selectedMatch.player2.nickname}
                     </span>
                   </span>


### PR DESCRIPTION
Summary:
- Remove redundant align-bottom from BM score dialog truncated player-name spans.
- Make the TC-521 drift guard check class token sets instead of exact Tailwind class string ordering.

Issues: #1804, #1805

Validation:
- npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts
- git diff --check