### PR TITLE
test: include TC-519 M9 card diagnostics

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -305,6 +305,8 @@ describe('E2E case drift coverage', () => {
     expect(tcBm).toContain('await Promise.all([');
     expect(tcBm).toContain("m8Card.waitFor({ state: 'visible', timeout: 40000 })");
     expect(tcBm).toContain("m9Card.waitFor({ state: 'visible', timeout: 40000 })");
+    expect(tcBm).toContain('M8 does not show both players as TBD (text: ${m8Text.slice(0, 120)}; cards=${JSON.stringify(cardTexts)})');
+    expect(tcBm).toContain('M9 does not show both players as TBD (text: ${m9Text.slice(0, 120)}; cards=${JSON.stringify(cardTexts)})');
     expect(tcBm).not.toContain('const hasM8 = await m8Card.count() > 0');
     expect(tcBm).not.toContain('const hasM9 = await m9Card.count() > 0');
   });

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -1666,7 +1666,7 @@ async function runTc519(adminPage) {
 
     log('TC-519', m8Tbd && m9Tbd ? 'PASS' : 'FAIL',
       !m8Tbd ? `M8 does not show both players as TBD (text: ${m8Text.slice(0, 120)}; cards=${JSON.stringify(cardTexts)})`
-      : !m9Tbd ? `M9 does not show both players as TBD (text: ${m9Text.slice(0, 120)})`
+      : !m9Tbd ? `M9 does not show both players as TBD (text: ${m9Text.slice(0, 120)}; cards=${JSON.stringify(cardTexts)})`
       : '');
   } catch (err) {
     log('TC-519', 'FAIL', err instanceof Error ? err.message : 'BM 519 failed');


### PR DESCRIPTION
Summary:
- Add cards diagnostics to the TC-519 M9 TBD failure message.
- Extend the drift guard so both M8 and M9 failure branches keep card summaries.

Issues: #1811

Validation:
- npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts
- git diff --check