### PR TITLE
Inline TC-513 one-use helpers

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -322,6 +322,8 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('未認証/管理者/プレイヤー');
     expect(tcBm).toContain('BM_MATCH_GUIDANCE_TIMEOUT_MS');
     expect(tcBm).toContain('async function waitForBmMatchGuidance');
+    expect(tcBm).not.toContain('function bmMatchGuidanceRegex');
+    expect(tcBm).not.toContain('function compactBodyText');
     expect(tc513Source).toMatch(/waitForBmMatchGuidance\(\s*anonPage/);
     expect(tc513Source).toMatch(/waitForBmMatchGuidance\(\s*adminPage/);
     expect(tc513Source).toMatch(/waitForBmMatchGuidance\(\s*playerPage/);

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -85,20 +85,13 @@ async function loginSharedPlayer(adminPage, player) {
   return loginPlayerBrowser(player.nickname, player.password);
 }
 
-function bmMatchGuidanceRegex(labels) {
-  return new RegExp(labels.map((label) => escapeRegex(label)).join('|'));
-}
-
-async function compactBodyText(page) {
-  const bodyText = await readBodyText(page);
-  return bodyText.replace(/\s+/g, ' ').slice(0, 360);
-}
-
 async function readBodyText(page) {
   return page.locator('body').innerText({ timeout: 5_000 }).catch(() => '');
 }
 
 async function waitForBmMatchGuidance(page, labels, contextLabel) {
+  const guidanceTextPattern = new RegExp(labels.map((label) => escapeRegex(label)).join('|'));
+
   try {
     /* Use a locator wait on the rendered body text so Playwright keeps its
      * normal auto-retry behavior. TC-513 depends on NextAuth session resolution,
@@ -106,11 +99,11 @@ async function waitForBmMatchGuidance(page, labels, contextLabel) {
      * ordinary UI waits; a single shared timeout keeps all three session branches
      * consistent while still failing fast enough for the suite. */
     await page.locator('body')
-      .filter({ hasText: bmMatchGuidanceRegex(labels) })
+      .filter({ hasText: guidanceTextPattern })
       .waitFor({ timeout: BM_MATCH_GUIDANCE_TIMEOUT_MS });
   } catch (err) {
     const readyState = await page.evaluate(() => document.readyState).catch(() => 'unknown');
-    const body = await compactBodyText(page);
+    const body = (await readBodyText(page)).replace(/\s+/g, ' ').slice(0, 360);
     const reason = err instanceof Error ? err.message.split('\n')[0] : String(err);
     throw new Error(
       `${contextLabel} guidance did not appear within ${BM_MATCH_GUIDANCE_TIMEOUT_MS}ms; ` +


### PR DESCRIPTION
Summary:
- Inline the one-use TC-513 guidance regex and compact-body helpers into the diagnostic wait.
- Keep the shared diagnostic wait, cleanup guards, and drift coverage from #1813.
- Add a narrow drift assertion that the one-use helpers do not return.

Issues: #1814

Validation:
- npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts
- node --check e2e/tc-bm.js
- E2E_TESTS=TC-513 npm run e2e:bm
- npm run e2e:cleanup

Review:
- Plato: no findings.