### PR TITLE
Guard TC-531 base URL navigation

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1414,7 +1414,7 @@
 ## TC-531: BM 決勝ブラケット — ラウンド名の下に startingCourseNumber が表示される (issue #731)
 - **URL**: /tournaments/[id]/bm/finals (UI)
 - **authRequired**: true (admin)
-- **背景**: issue #731 の要求に基づき、BM 決勝・プレイオフブラケットの各ラウンドヘッダー下に「バトルコース {n}」を表示するようになった。ブラケット生成後に UI ページを開き、コース番号が正しく表示されているかを確認する。
+- **背景**: issue #731 の要求に基づき、BM 決勝・プレイオフブラケットの各ラウンドヘッダー下に「バトルコース {n}」を表示するようになった。ブラケット生成後に UI ページを開き、コース番号が正しく表示されているかを確認する。issue #889 の回帰防止として、Playwright の相対 URL `goto` ではなく、preview/base URL を付与する `nav` ヘルパー経由で `/bm/finals` を開く。
 - **手順**:
   1. 8名 BM 決勝ブラケットを生成（TC-524 と同じ手順）
   2. /tournaments/[id]/bm/finals を開く

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -335,6 +335,20 @@ describe('E2E case drift coverage', () => {
     expect(tc513Source).not.toContain('waitForFunction(');
   });
 
+  it('keeps TC-531 BM finals navigation routed through the BASE-aware nav helper', () => {
+    const section = e2eCaseSection('TC-531');
+    const tc531Source = sectionBetween(
+      tcBm,
+      'async function runTc531',
+      '/**\n * Builds the BM suite spec',
+    );
+
+    expect(section).toContain('issue #889');
+    expect(section).toContain('`nav`');
+    expect(tc531Source).toContain('await nav(adminPage, `/tournaments/${tournamentId}/bm/finals`)');
+    expect(tc531Source).not.toMatch(/\.goto\(\s*`?\/tournaments/);
+  });
+
   it('keeps TC-1063 aligned with the combined standings memoization guard', () => {
     const section = e2eCaseSection('TC-1063');
     const tc1555 = e2eCaseSection('TC-1555');


### PR DESCRIPTION
Summary:
- Document the TC-531 issue #889 navigation regression in the E2E scenario.
- Add a drift guard requiring TC-531 to use the BASE-aware nav helper.
- Block reintroducing relative /tournaments page.goto navigation inside TC-531.

Issues: #889

Validation:
- npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts
- E2E_TESTS=TC-531 npm run e2e:bm
- npm run e2e:cleanup
- git diff --check

Review:
- Plato: no findings.