### PR TITLE
Guard TC-858 MR reset sequence

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1883,13 +1883,15 @@
 - **期待結果**: MR の合算順位タブが全グループの参加者を表示し、順位列が昇順で描画される
 - **スクリプト**: tc-mr.js TC-623
 
-## TC-858: MR Top-24 決勝 Winners R1 敗者の Losers R1 反映 (issue #858)
-- **背景**: Top-24 から生成される16人決勝では Winners R1 の敗者が Losers R1 に落ちる。偶数側の Winners R1 敗者は Losers R1 の player2 スロットに入る必要がある
+## TC-858: MR Top-24 決勝 Winners R1 敗者の Losers R1 反映 (issue #858/#888)
+- **背景**: Top-24 から生成される16人決勝では Winners R1 の敗者が Losers R1 に落ちる。偶数側の Winners R1 敗者は Losers R1 の player2 スロットに入る必要がある。issue #888 の 409 conflict 再発を防ぐため、Top-24 playoff 生成前に `mrQualificationConfirmed` を解除し、MR finals を `reset` してから再確定する。
 - **手順**:
-  1. 28名予選完了済みフィクスチャで MR Top-24 playoff を生成する
-  2. playoff_r1/playoff_r2 を完了し、16人決勝ブラケットを生成する
-  3. Winners R1 M2 を player1 勝利で完了する
-  4. Losers R1 M16 の `player2Id` が Winners R1 M2 の敗者になっていることを確認
+  1. 28名予選完了済みフィクスチャで `mrQualificationConfirmed` を false に戻す
+  2. MR finals API に `{ reset: true }` を送信し、既存の playoff/finals 状態を空にする
+  3. `mrQualificationConfirmed` を true に戻し、MR Top-24 playoff を生成する
+  4. playoff_r1/playoff_r2 を完了し、16人決勝ブラケットを生成する
+  5. Winners R1 M2 を player1 勝利で完了する
+  6. Losers R1 M16 の `player2Id` が Winners R1 M2 の敗者になっていることを確認
 - **期待結果**: Winners R1 M2 の敗者が M16 `player2Id` に反映され、`player1Id` を上書きしない
 - **スクリプト**: tc-mr.js TC-858
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -349,6 +349,28 @@ describe('E2E case drift coverage', () => {
     expect(tc531Source).not.toMatch(/\.goto\(\s*`?\/tournaments/);
   });
 
+  it('keeps TC-858 MR Top-24 generation protected by an explicit reset cycle', () => {
+    const section = e2eCaseSection('TC-858');
+    const tc858Source = sectionBetween(
+      tcMr,
+      'async function runTc858',
+      '/* See tc-bm.js::getSuite',
+    );
+    const unlockIdx = tc858Source.indexOf('apiUpdateTournament(adminPage, tournamentId, { mrQualificationConfirmed: false })');
+    const resetIdx = tc858Source.indexOf('body: JSON.stringify({ reset: true })');
+    const reconfirmIdx = tc858Source.indexOf('apiUpdateTournament(adminPage, tournamentId, { mrQualificationConfirmed: true })');
+    const generateIdx = tc858Source.indexOf('generateMrFinalsBracket(adminPage, tournamentId, 24)');
+
+    expect(section).toContain('issue #888');
+    expect(section).toContain('409');
+    expect(section).toContain('reset');
+    expect(section).toContain('mrQualificationConfirmed');
+    expect(unlockIdx).toBeGreaterThanOrEqual(0);
+    expect(resetIdx).toBeGreaterThan(unlockIdx);
+    expect(reconfirmIdx).toBeGreaterThan(resetIdx);
+    expect(generateIdx).toBeGreaterThan(reconfirmIdx);
+  });
+
   it('keeps TC-1063 aligned with the combined standings memoization guard', () => {
     const section = e2eCaseSection('TC-1063');
     const tc1555 = e2eCaseSection('TC-1555');


### PR DESCRIPTION
Summary:
- Document TC-858's MR Top-24 reset-before-generate flow for issue #888.
- Add a drift guard that verifies TC-858 unlocks MR qualification, sends reset, reconfirms, then generates the 24-player bracket.

Issues: #888

Validation:
- npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
- E2E_TESTS=TC-858 npm run e2e:mr (passed on current main before this docs/static guard change)
- npm run e2e:cleanup