### PR TITLE
Restore GP legacy sudden-death winner display

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2171,6 +2171,19 @@
 - **期待結果**: GP決勝APIは21件以上の `cupResults` を拒否し、マッチ状態を更新しない
 - **スクリプト**: tc-gp.js TC-832
 
+## TC-830: GP決勝 — 旧サドンデス勝者つき同点完了行を勝者表示できる
+- **URL**: /tournaments/[temp-id]/gp/finals
+- **authRequired**: true (admin)
+- **背景**: 旧仕様ではGP決勝の同点マッチを `suddenDeathWinnerId` で決着していた。現在の `cupResults` 方式へ移行後も、過去に完了済みの同点行は破壊的なデータ移行なしでブラケット勝者とチャンピオン表示を維持する必要がある。
+- **手順**:
+  1. GP決勝ページの勝者判定が専用ヘルパーを使っていることを確認する
+  2. GP決勝ページがブラケットコンポーネントへ同じ勝者判定を渡すことを確認する
+  3. ヘルパーが `points1 === points2` の完了済み行で `suddenDeathWinnerId` を参照することを確認する
+  4. `suddenDeathWinnerId` が player1/player2 のどちらにも一致しない場合は勝者なしになることを確認する
+  5. 新仕様の通常行では `points1/points2` のカップ勝数で勝者判定されることを確認する
+- **期待結果**: 新仕様のカップ勝数表示を保ちつつ、旧サドンデス決着済みデータでも勝者表示が欠落しない
+- **スクリプト**: tc-gp.js TC-830 / `__tests__/lib/gp-finals-match-winner.test.ts`
+
 ## TC-831: GP決勝 — 上位ブラケットはカップ勝数のシンプル入力で保存できる
 - **URL**: /tournaments/[temp-id]/gp/finals
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/double-elimination-bracket.test.tsx
@@ -261,6 +261,37 @@ describe("DoubleEliminationBracket TBD rendering (issue #574)", () => {
   });
 });
 
+describe("DoubleEliminationBracket winner resolver", () => {
+  const player1 = { id: "p1", name: "Alice A", nickname: "Alice" };
+  const player2 = { id: "p2", name: "Bob B", nickname: "Bob" };
+
+  it("uses getWinnerId for completed tied matches instead of score ordering only", () => {
+    render(
+      <DoubleEliminationBracket
+        matches={[{
+          id: "m1",
+          matchNumber: 1,
+          round: "winners_qf",
+          stage: "finals",
+          player1Id: player1.id,
+          player2Id: player2.id,
+          score1: 2,
+          score2: 2,
+          completed: true,
+          player1,
+          player2,
+        }]}
+        bracketStructure={[build8PlayerStructure()[0]]}
+        roundNames={{}}
+        getWinnerId={() => player2.id}
+      />,
+    );
+
+    expect(screen.getByText("Bob").closest("div")?.className).toContain("bg-primary/10");
+    expect(screen.getByText("Alice").closest("div")?.className).not.toContain("bg-primary/10");
+  });
+});
+
 describe("DoubleEliminationBracket startingCourseNumber display (issue #731)", () => {
   /* Verify that when matches carry a startingCourseNumber, the round header
    * shows the battle course label below the round name. */

--- a/smkc-score-app/__tests__/components/tournament/playoff-bracket.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/playoff-bracket.test.tsx
@@ -63,3 +63,34 @@ describe("PlayoffBracket qualification rank labels", () => {
     expect(round1Match.textContent).not.toContain("[B12]");
   });
 });
+
+describe("PlayoffBracket winner resolver", () => {
+  const player1 = { id: "p1", name: "Alice A", nickname: "Alice" };
+  const player2 = { id: "p2", name: "Bob B", nickname: "Bob" };
+
+  it("uses getWinnerId for completed tied matches instead of score ordering only", () => {
+    render(
+      <PlayoffBracket
+        playoffMatches={[{
+          id: "m1",
+          matchNumber: 1,
+          round: "playoff_r1",
+          stage: "playoff",
+          player1Id: player1.id,
+          player2Id: player2.id,
+          score1: 1,
+          score2: 1,
+          completed: true,
+          player1,
+          player2,
+        }]}
+        playoffStructure={[playoffStructure[0]]}
+        roundNames={{ playoff_r1: "Round 1" }}
+        getWinnerId={() => player2.id}
+      />,
+    );
+
+    expect(screen.getByText("Bob").closest("div")?.className).toContain("bg-primary/10");
+    expect(screen.getByText("Alice").closest("div")?.className).not.toContain("bg-primary/10");
+  });
+});

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -48,6 +48,7 @@ describe('E2E case drift coverage', () => {
     ['TC-1087', tcGp],
     ['TC-1083', tcMr],
     ['TC-729', tcGp],
+    ['TC-830', tcGp],
     ['TC-926', tcOverlay],
     ['TC-817', tcTa],
     ['TC-1032', tcTa],

--- a/smkc-score-app/__tests__/lib/gp-finals-match-winner.test.ts
+++ b/smkc-score-app/__tests__/lib/gp-finals-match-winner.test.ts
@@ -1,0 +1,65 @@
+import { getGpFinalsMatchWinner } from "@/lib/gp-finals-match-winner";
+import type { Player } from "@/lib/types";
+
+function player(id: string, nickname: string): Player {
+  return {
+    id,
+    nickname,
+    name: nickname,
+    password: null,
+    isActive: true,
+    role: "participant",
+    discordId: null,
+    discordUsername: null,
+    avatarUrl: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  } as Player;
+}
+
+describe("getGpFinalsMatchWinner", () => {
+  const player1 = player("p1", "Player 1");
+  const player2 = player("p2", "Player 2");
+
+  it("returns null for unfinished matches", () => {
+    expect(getGpFinalsMatchWinner({
+      completed: false,
+      points1: 2,
+      points2: 0,
+      player1,
+      player2,
+    })).toBeNull();
+  });
+
+  it("uses cup-win points for current GP finals rows", () => {
+    expect(getGpFinalsMatchWinner({
+      completed: true,
+      points1: 2,
+      points2: 0,
+      player1,
+      player2,
+    })).toBe(player1);
+  });
+
+  it("falls back to suddenDeathWinnerId for completed legacy tied rows", () => {
+    expect(getGpFinalsMatchWinner({
+      completed: true,
+      points1: 2,
+      points2: 2,
+      player1,
+      player2,
+      suddenDeathWinnerId: "p2",
+    })).toBe(player2);
+  });
+
+  it("returns null for tied rows without a matching legacy winner", () => {
+    expect(getGpFinalsMatchWinner({
+      completed: true,
+      points1: 1,
+      points2: 1,
+      player1,
+      player2,
+      suddenDeathWinnerId: "missing-player",
+    })).toBeNull();
+  });
+});

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -23,6 +23,7 @@
  *           before the suite moves into the longer playoff UI flows.
  *   TC-1109 GP finals cup-form lock count uses the max-cups helper directly
  *   TC-719  GP tied cup extends non-grand-final bracket match
+ *   TC-830  GP finals legacy suddenDeathWinnerId keeps winner display
  *   TC-831  GP finals added cup form can be removed without stale scores
  *   TC-723  GP qualification standings show 0-1000 qualification points
  *   TC-724  GP combined standings tab shows rows with point headers and ascending ranks
@@ -939,6 +940,43 @@ async function runTc1109() {
   }
 }
 
+/* ───────── TC-830: GP finals legacy sudden-death winner display ───────── */
+async function runTc830() {
+  try {
+    const pageSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'app', 'tournaments', '[id]', 'gp', 'finals', 'page.tsx'), 'utf8');
+    const helperSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'lib', 'gp-finals-match-winner.ts'), 'utf8');
+    const unitTestSource = fs.readFileSync(path.join(__dirname, '..', '__tests__', 'lib', 'gp-finals-match-winner.test.ts'), 'utf8');
+    const doubleBracketSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'components', 'tournament', 'double-elimination-bracket.tsx'), 'utf8');
+    const playoffBracketSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'components', 'tournament', 'playoff-bracket.tsx'), 'utf8');
+
+    const pageUsesHelper = pageSource.includes('getGpFinalsMatchWinner(match)');
+    const pagePassesWinnerResolver = pageSource.includes('getWinnerId={getBracketWinnerId}');
+    const bracketSupportsWinnerResolver = doubleBracketSource.includes('getWinnerId?:') &&
+      doubleBracketSource.includes('customWinnerId') &&
+      playoffBracketSource.includes('getWinnerId?:') &&
+      playoffBracketSource.includes('customWinnerId');
+    const helperKeepsLegacyPath = helperSource.includes('suddenDeathWinnerId === match.player1.id') &&
+      helperSource.includes('suddenDeathWinnerId === match.player2.id');
+    const helperDocumentsCompatibility = helperSource.includes('Backward compatibility for GP finals rows');
+    const unitCoversLegacyTie = unitTestSource.includes('falls back to suddenDeathWinnerId for completed legacy tied rows');
+    const unitCoversInvalidLegacyWinner = unitTestSource.includes('without a matching legacy winner');
+
+    const ok = pageUsesHelper && pagePassesWinnerResolver && bracketSupportsWinnerResolver &&
+      helperKeepsLegacyPath && helperDocumentsCompatibility && unitCoversLegacyTie && unitCoversInvalidLegacyWinner;
+    log('TC-830', ok ? 'PASS' : 'FAIL',
+      !pageUsesHelper ? 'GP finals page does not delegate winner detection to getGpFinalsMatchWinner'
+      : !pagePassesWinnerResolver ? 'GP finals page does not pass getWinnerId to bracket components'
+      : !bracketSupportsWinnerResolver ? 'bracket components do not use a custom winner resolver'
+      : !helperKeepsLegacyPath ? 'legacy suddenDeathWinnerId fallback is missing'
+      : !helperDocumentsCompatibility ? 'legacy compatibility rationale comment is missing'
+      : !unitCoversLegacyTie ? 'unit test does not cover tied legacy suddenDeathWinnerId rows'
+      : !unitCoversInvalidLegacyWinner ? 'unit test does not cover invalid legacy winner ids'
+      : '');
+  } catch (err) {
+    log('TC-830', 'FAIL', err instanceof Error ? err.message : 'GP 830 failed');
+  }
+}
+
 /* ───────── TC-727: GP finals rejects score-only cup wins above FT target ───────── */
 async function runTc727(adminPage) {
   let setup = null;
@@ -1837,6 +1875,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-712', fn: runTc712 },
       { name: 'TC-719', fn: runTc719 },
       { name: 'TC-720', fn: runTc720 },
+      { name: 'TC-830', fn: runTc830 },
       // TC-831 stays before TC-832 so GP suite logs remain readable in numeric TC order.
       { name: 'TC-831', fn: runTc831 },
       { name: 'TC-832', fn: runTc832 },
@@ -1852,7 +1891,7 @@ module.exports = {
   runTc701, runTc702, runTc703, runTc704, runTc705, runTc706,
   runTc707, runTc708, runTc709, runTc710, runTc712, runTc713,
   runTc715, runTc716, runTc717, runTc718, runTc1103, runTc1106, runTc727, runTc729, runTc719,
-  runTc720, runTc721, runTc722, runTc724, runTc725, runTc1087, runTc821, runTc831, runTc832,
+  runTc720, runTc721, runTc722, runTc724, runTc725, runTc1087, runTc821, runTc830, runTc831, runTc832,
   gpAssignedCupSequence, gpFinalsUpdatedMatchFromPutResult, gpFinalsTargetWins,
   getSuite,
   results,

--- a/smkc-score-app/prisma/schema.prisma
+++ b/smkc-score-app/prisma/schema.prisma
@@ -373,7 +373,7 @@ model GPMatch {
   points1      Int        @default(0) // Driver points for player 1
   points2      Int        @default(0) // Driver points for player 2
   completed    Boolean    @default(false)
-  suddenDeathWinnerId String? // Tied cup resolved by a one-race sudden-death playoff
+  suddenDeathWinnerId String? // Legacy GP finals tie-break winner; retained for historical bracket display
   races        Json? // [{course: "MC1", position1: 1, position2: 2, points1: 9, points2: 6}, ...]
   assignedCups Json? // Finals/playoff: planned cup sequence for this matchup
   cupResults   Json? // Finals/playoff: [{cup, races, points1, points2, winner}], one entry per played cup

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -86,6 +86,7 @@ import { buildMatchLabel } from "@/lib/overlay/phase";
 import { getGpFinalsMaxCups, getGpFinalsTargetWins } from "@/lib/finals-target-wins";
 import { getCupForFormIndex, isRemovableCupForm, removeCupFormAt } from "@/lib/gp-finals-score-form";
 import { getAssignedCupLabelsForMatch } from "@/lib/gp-finals-assigned-cups";
+import { getGpFinalsMatchWinner } from "@/lib/gp-finals-match-winner";
 import { isValidGpFinalsSimpleScore } from "@/lib/gp-finals-simple-score";
 import { GP_DRIVER_POINTS_INPUT_PROPS, parseGpDriverPointsInput } from "@/lib/gp-driver-points-input";
 import { BRACKET_TABS, type BracketTab } from "@/lib/bracket-tabs";
@@ -187,12 +188,7 @@ function getGpScore(match: GPMatch, side: 1 | 2): number {
 }
 
 function getMatchWinner(match: GPMatch): Player | null {
-  if (!match.completed) return null;
-  const score1 = getGpScore(match, 1);
-  const score2 = getGpScore(match, 2);
-  if (score1 > score2) return match.player1;
-  if (score2 > score1) return match.player2;
-  return null;
+  return getGpFinalsMatchWinner(match);
 }
 
 function getCompletedChampion(matches: GPMatch[]): Player | null {
@@ -693,6 +689,10 @@ export default function GrandPrixFinals({
     () => playoffMatches.map((m) => ({ ...m, score1: m.points1, score2: m.points2 })),
     [playoffMatches],
   );
+  const getBracketWinnerId = useCallback(
+    (match: unknown) => getGpFinalsMatchWinner(match as GPMatch)?.id ?? null,
+    [],
+  );
   /* Top-24 Phase 1 can return a preview Upper Bracket before finals rows exist.
    * In that state the actionable control lives under the playoff tab, so keep
    * that tab open until Phase 2 has actually created finals matches. */
@@ -849,6 +849,7 @@ export default function GrandPrixFinals({
               roundNames={roundNames}
               seededPlayers={seededPlayers}
               getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
+              getWinnerId={getBracketWinnerId}
               onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
               onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
             />
@@ -860,6 +861,7 @@ export default function GrandPrixFinals({
               roundNames={roundNames}
               seededPlayers={playoffSeededPlayers}
               getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
+              getWinnerId={getBracketWinnerId}
               onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
               onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
             />
@@ -881,6 +883,7 @@ export default function GrandPrixFinals({
             roundNames={roundNames}
             seededPlayers={playoffSeededPlayers}
             getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
+            getWinnerId={getBracketWinnerId}
             onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
             onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
           />
@@ -899,6 +902,7 @@ export default function GrandPrixFinals({
           roundNames={roundNames}
           seededPlayers={seededPlayers}
           getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
+          getWinnerId={getBracketWinnerId}
           onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
           onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
         />

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -63,6 +63,8 @@ interface DoubleEliminationBracketProps {
   seededPlayers?: SeededPlayer[];
   /** Number of wins required to highlight a completed match winner. */
   getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
+  /** Optional winner resolver for modes whose persisted winner is not score-order only. */
+  getWinnerId?: (match: BMMatch, bracketMatch: BracketMatch) => string | null;
   /**
    * Optional callback fired the moment an admin picks a TV# from the
    * inline dropdown on the match card. When provided, the static "TV{n}"
@@ -90,6 +92,7 @@ function MatchCard({
   onClick,
   isTBD,
   getTargetWins,
+  getWinnerId,
   onTvNumberChange,
 }: {
   match?: BMMatch;
@@ -98,6 +101,7 @@ function MatchCard({
   onClick?: () => void;
   isTBD: { player1: boolean; player2: boolean };
   getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
+  getWinnerId?: (match: BMMatch, bracketMatch: BracketMatch) => string | null;
   onTvNumberChange?: (match: BMMatch, tvNumber: number | null) => void;
 }) {
   const tc = useTranslations("common");
@@ -116,8 +120,13 @@ function MatchCard({
   const player2: Player | undefined = match?.player2 || seededEntry2?.player;
 
   const targetWins = getTargetWins?.(match, bracketMatch) ?? 3;
-  const isWinner1 = !!match?.completed && match.score1 >= targetWins && match.score1 > match.score2;
-  const isWinner2 = !!match?.completed && match.score2 >= targetWins && match.score2 > match.score1;
+  const customWinnerId = match?.completed && getWinnerId ? getWinnerId(match, bracketMatch) : undefined;
+  const isWinner1 = customWinnerId !== undefined
+    ? customWinnerId === match?.player1Id
+    : !!match?.completed && match.score1 >= targetWins && match.score1 > match.score2;
+  const isWinner2 = customWinnerId !== undefined
+    ? customWinnerId === match?.player2Id
+    : !!match?.completed && match.score2 >= targetWins && match.score2 > match.score1;
 
   /*
    * Per-slot TBD display. First-round matches (seeded) always show real names.
@@ -308,6 +317,7 @@ export function DoubleEliminationBracket({
   onMatchClick,
   seededPlayers,
   getTargetWins,
+  getWinnerId,
   onTvNumberChange,
 }: DoubleEliminationBracketProps) {
   const tf = useTranslations("finals");
@@ -430,6 +440,7 @@ export function DoubleEliminationBracket({
                     }}
                     isTBD={isTBD(b.matchNumber)}
                     getTargetWins={getTargetWins}
+                    getWinnerId={getWinnerId}
                     onTvNumberChange={onTvNumberChange}
                   />
                 ))}
@@ -453,6 +464,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
+                    getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -475,6 +487,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
+                    getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -497,6 +510,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
+                    getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -527,6 +541,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
+                    getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -549,6 +564,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
+                    getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -571,6 +587,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
+                    getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -594,6 +611,7 @@ export function DoubleEliminationBracket({
                     }}
                     isTBD={isTBD(b.matchNumber)}
                     getTargetWins={getTargetWins}
+                    getWinnerId={getWinnerId}
                     onTvNumberChange={onTvNumberChange}
                   />
                 ))}
@@ -617,6 +635,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
+                    getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -639,6 +658,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
+                    getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -667,6 +687,7 @@ export function DoubleEliminationBracket({
                 }}
                 isTBD={isTBD(b.matchNumber)}
                 getTargetWins={getTargetWins}
+                    getWinnerId={getWinnerId}
                 onTvNumberChange={onTvNumberChange}
               />
             ))}
@@ -691,6 +712,7 @@ export function DoubleEliminationBracket({
                 }}
                 isTBD={isTBD(b.matchNumber)}
                 getTargetWins={getTargetWins}
+                    getWinnerId={getWinnerId}
                 onTvNumberChange={onTvNumberChange}
               />
             ))}

--- a/smkc-score-app/src/components/tournament/playoff-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/playoff-bracket.tsx
@@ -70,6 +70,8 @@ interface PlayoffBracketProps {
   seededPlayers?: SeededPlayer[];
   /** Number of wins required to highlight a completed match winner */
   getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
+  /** Optional winner resolver for modes whose persisted winner is not score-order only. */
+  getWinnerId?: (match: BMMatch, bracketMatch: BracketMatch) => string | null;
   /** See `DoubleEliminationBracket.onTvNumberChange` — same select-to-save UX. */
   onTvNumberChange?: (match: BMMatch, tvNumber: number | null) => void;
 }
@@ -87,6 +89,7 @@ function PlayoffMatchCard({
   isPlayer1TBD,
   isPlayer2TBD,
   getTargetWins,
+  getWinnerId,
   onTvNumberChange,
 }: {
   match?: BMMatch;
@@ -96,6 +99,7 @@ function PlayoffMatchCard({
   isPlayer1TBD: boolean;
   isPlayer2TBD: boolean;
   getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
+  getWinnerId?: (match: BMMatch, bracketMatch: BracketMatch) => string | null;
   onTvNumberChange?: (match: BMMatch, tvNumber: number | null) => void;
 }) {
   const tc = useTranslations("common");
@@ -113,8 +117,13 @@ function PlayoffMatchCard({
   const player2: Player | undefined = match?.player2 || seededEntry2?.player;
 
   const targetWins = getTargetWins?.(match, bracketMatch) ?? 3;
-  const isWinner1 = !!match?.completed && match.score1 >= targetWins && match.score1 > match.score2;
-  const isWinner2 = !!match?.completed && match.score2 >= targetWins && match.score2 > match.score1;
+  const customWinnerId = match?.completed && getWinnerId ? getWinnerId(match, bracketMatch) : undefined;
+  const isWinner1 = customWinnerId !== undefined
+    ? customWinnerId === match?.player1Id
+    : !!match?.completed && match.score1 >= targetWins && match.score1 > match.score2;
+  const isWinner2 = customWinnerId !== undefined
+    ? customWinnerId === match?.player2Id
+    : !!match?.completed && match.score2 >= targetWins && match.score2 > match.score1;
 
   const isTV1 = match?.tvNumber === 1;
 
@@ -236,6 +245,7 @@ export function PlayoffBracket({
   onMatchClick,
   seededPlayers,
   getTargetWins,
+  getWinnerId,
   onTvNumberChange,
 }: PlayoffBracketProps) {
   const tf = useTranslations("finals");
@@ -323,6 +333,7 @@ export function PlayoffBracket({
                   isPlayer1TBD={isTBD(b.matchNumber, 1)}
                   isPlayer2TBD={isTBD(b.matchNumber, 2)}
                   getTargetWins={getTargetWins}
+                  getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -349,6 +360,7 @@ export function PlayoffBracket({
                   isPlayer1TBD={isTBD(b.matchNumber, 1)}
                   isPlayer2TBD={isTBD(b.matchNumber, 2)}
                   getTargetWins={getTargetWins}
+                  getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}

--- a/smkc-score-app/src/lib/gp-finals-match-winner.ts
+++ b/smkc-score-app/src/lib/gp-finals-match-winner.ts
@@ -1,0 +1,40 @@
+import type { Player } from "@/lib/types";
+
+interface GpFinalsWinnerMatch {
+  completed: boolean;
+  points1?: number | null;
+  points2?: number | null;
+  score1?: number | null;
+  score2?: number | null;
+  player1: Player;
+  player2: Player;
+  suddenDeathWinnerId?: string | null;
+}
+
+function gpFinalsScore(match: GpFinalsWinnerMatch, side: 1 | 2): number {
+  return side === 1
+    ? match.points1 ?? match.score1 ?? 0
+    : match.points2 ?? match.score2 ?? 0;
+}
+
+export function getGpFinalsMatchWinner(match: GpFinalsWinnerMatch): Player | null {
+  if (!match.completed) return null;
+
+  const score1 = gpFinalsScore(match, 1);
+  const score2 = gpFinalsScore(match, 2);
+  if (score1 > score2) return match.player1;
+  if (score2 > score1) return match.player2;
+
+  /*
+   * Backward compatibility for GP finals rows saved before cupResults became
+   * the source of truth. Those legacy rows can be completed with tied
+   * points1/points2 and a suddenDeathWinnerId. New saves clear that field and
+   * resolve tied cups by additional cupResults, but historical brackets still
+   * need to highlight the winner and show the champion without requiring a
+   * destructive data migration.
+   */
+  if (match.suddenDeathWinnerId === match.player1.id) return match.player1;
+  if (match.suddenDeathWinnerId === match.player2.id) return match.player2;
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Add a GP finals winner helper that preserves legacy suddenDeathWinnerId display for completed tied rows
- Pass the same winner resolver into GP finals bracket components so champion display and row highlighting stay consistent
- Add TC-830 scenario, GP E2E guard, unit tests, and bracket component coverage

Issues: #830

## Validation
- npm test -- --runInBand __tests__/lib/gp-finals-match-winner.test.ts __tests__/components/tournament/double-elimination-bracket.test.tsx __tests__/components/tournament/playoff-bracket.test.tsx __tests__/docs/e2e-cases-drift.test.ts
- E2E_TESTS=TC-830 npm run e2e:gp
- npm run e2e:cleanup
- npm run lint
- npm run build:cf
- git diff --check

Notes:
- Initial non-escalated E2E launch failed with macOS Chromium Crashpad permission errors; the dedicated script passed when rerun with the approved external execution path.
- lint reports 42 existing warnings and 0 errors.