### PR TITLE
Address GP legacy winner review followups

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2174,7 +2174,7 @@
 ## TC-830: GP決勝 — 旧サドンデス勝者つき同点完了行を勝者表示できる
 - **URL**: /tournaments/[temp-id]/gp/finals
 - **authRequired**: true (admin)
-- **背景**: 旧仕様ではGP決勝の同点マッチを `suddenDeathWinnerId` で決着していた。現在の `cupResults` 方式へ移行後も、過去に完了済みの同点行は破壊的なデータ移行なしでブラケット勝者とチャンピオン表示を維持する必要がある。
+- **背景**: issue #830。旧仕様ではGP決勝の同点マッチを `suddenDeathWinnerId` で決着していた。現在の `cupResults` 方式へ移行後も、過去に完了済みの同点行は破壊的なデータ移行なしでブラケット勝者とチャンピオン表示を維持する必要がある。
 - **手順**:
   1. GP決勝ページの勝者判定が専用ヘルパーを使っていることを確認する
   2. GP決勝ページがブラケットコンポーネントへ同じ勝者判定を渡すことを確認する
@@ -2182,7 +2182,7 @@
   4. `suddenDeathWinnerId` が player1/player2 のどちらにも一致しない場合は勝者なしになることを確認する
   5. 新仕様の通常行では `points1/points2` のカップ勝数で勝者判定されることを確認する
 - **期待結果**: 新仕様のカップ勝数表示を保ちつつ、旧サドンデス決着済みデータでも勝者表示が欠落しない
-- **スクリプト**: tc-gp.js TC-830 / `__tests__/lib/gp-finals-match-winner.test.ts`
+- **スクリプト**: `__tests__/app/tournaments/gp-finals-page-wiring.test.tsx` / `__tests__/lib/gp-finals-match-winner.test.ts` / `__tests__/components/tournament/double-elimination-bracket.test.tsx` / `__tests__/components/tournament/playoff-bracket.test.tsx`
 
 ## TC-831: GP決勝 — 上位ブラケットはカップ勝数のシンプル入力で保存できる
 - **URL**: /tournaments/[temp-id]/gp/finals

--- a/smkc-score-app/__tests__/app/tournaments/gp-finals-page-wiring.test.tsx
+++ b/smkc-score-app/__tests__/app/tournaments/gp-finals-page-wiring.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, waitFor } from "@testing-library/react";
+import { Suspense } from "react";
+import GrandPrixFinals from "@/app/tournaments/[id]/gp/finals/page";
+
+const mockDoubleBracketProps: Record<string, unknown>[] = [];
+const mockPlayoffBracketProps: Record<string, unknown>[] = [];
+
+const legacyWinnerMatch = {
+  id: "m1",
+  matchNumber: 1,
+  round: "grand_final",
+  stage: "finals",
+  player1Id: "p1",
+  player2Id: "p2",
+  points1: 2,
+  points2: 2,
+  score1: 2,
+  score2: 2,
+  completed: true,
+  cup: "Mushroom",
+  assignedCups: ["Mushroom", "Flower", "Star"],
+  tvNumber: null,
+  player1: { id: "p1", name: "Player 1", nickname: "Player 1" },
+  player2: { id: "p2", name: "Player 2", nickname: "Player 2" },
+  suddenDeathWinnerId: "p2",
+};
+
+let mockPollData = {
+  matches: [legacyWinnerMatch],
+  playoffMatches: [],
+  bracketStructure: [
+    { matchNumber: 1, round: "grand_final", bracket: "grand_final" },
+  ],
+  playoffStructure: [],
+  roundNames: { grand_final: "Grand Final" },
+  qualificationConfirmed: true,
+  phase: "finals",
+  seededPlayers: [],
+  playoffSeededPlayers: [],
+  playoffComplete: false,
+};
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { role: "admin" } } }),
+}));
+
+jest.mock("react", () => {
+  const actual = jest.requireActual("react");
+  return {
+    ...actual,
+    use: () => ({ id: "t1" }),
+  };
+});
+
+jest.mock("next-intl", () => ({
+  useLocale: () => "en",
+  useTranslations: () => (key: string) => key,
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    error: jest.fn(),
+    warning: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/hooks/usePolling", () => ({
+  usePolling: () => ({
+    data: mockPollData,
+    isLoading: false,
+    lastUpdated: new Date("2026-01-01T00:00:00.000Z"),
+    isPolling: false,
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@/components/tournament/double-elimination-bracket", () => ({
+  DoubleEliminationBracket: (props: Record<string, unknown>) => {
+    mockDoubleBracketProps.push(props);
+    return <div data-testid="mock-double-elimination-bracket" />;
+  },
+}));
+
+jest.mock("@/components/tournament/playoff-bracket", () => ({
+  PlayoffBracket: (props: Record<string, unknown>) => {
+    mockPlayoffBracketProps.push(props);
+    return <div data-testid="mock-playoff-bracket" />;
+  },
+}));
+
+describe("GrandPrixFinals TC-830 legacy winner wiring", () => {
+  beforeEach(() => {
+    mockDoubleBracketProps.length = 0;
+    mockPlayoffBracketProps.length = 0;
+    mockPollData = {
+      matches: [legacyWinnerMatch],
+      playoffMatches: [],
+      bracketStructure: [
+        { matchNumber: 1, round: "grand_final", bracket: "grand_final" },
+      ],
+      playoffStructure: [],
+      roundNames: { grand_final: "Grand Final" },
+      qualificationConfirmed: true,
+      phase: "finals",
+      seededPlayers: [],
+      playoffSeededPlayers: [],
+      playoffComplete: false,
+    };
+  });
+
+  it("passes the GP legacy winner resolver into the finals bracket", async () => {
+    const params = Promise.resolve({ id: "t1" });
+
+    render(
+      <Suspense fallback={null}>
+        <GrandPrixFinals params={params} />
+      </Suspense>,
+    );
+
+    await waitFor(() => {
+      expect(mockDoubleBracketProps.length).toBeGreaterThan(0);
+    });
+
+    const props = mockDoubleBracketProps.at(-1)!;
+    const getWinnerId = props.getWinnerId as (match: typeof legacyWinnerMatch) => string | null;
+    const matches = props.matches as typeof legacyWinnerMatch[];
+
+    expect(getWinnerId).toBeDefined();
+    expect(matches[0].score1).toBe(2);
+    expect(matches[0].score2).toBe(2);
+    expect(getWinnerId(matches[0])).toBe("p2");
+  });
+
+  it("passes the GP legacy winner resolver into the playoff bracket", async () => {
+    const playoffMatch = {
+      ...legacyWinnerMatch,
+      stage: "playoff",
+      round: "playoff_r1",
+    };
+    mockPollData = {
+      matches: [],
+      playoffMatches: [playoffMatch],
+      bracketStructure: [],
+      playoffStructure: [
+        { matchNumber: 1, round: "playoff_r1", bracket: "winners" },
+      ],
+      roundNames: { playoff_r1: "Playoff Round 1" },
+      qualificationConfirmed: true,
+      phase: "playoff",
+      seededPlayers: [],
+      playoffSeededPlayers: [],
+      playoffComplete: false,
+    };
+    const params = Promise.resolve({ id: "t1" });
+
+    render(
+      <Suspense fallback={null}>
+        <GrandPrixFinals params={params} />
+      </Suspense>,
+    );
+
+    await waitFor(() => {
+      expect(mockPlayoffBracketProps.length).toBeGreaterThan(0);
+    });
+
+    const props = mockPlayoffBracketProps.at(-1)!;
+    const getWinnerId = props.getWinnerId as (match: typeof playoffMatch) => string | null;
+    const playoffMatches = props.playoffMatches as typeof playoffMatch[];
+
+    expect(getWinnerId).toBeDefined();
+    expect(playoffMatches[0].score1).toBe(2);
+    expect(playoffMatches[0].score2).toBe(2);
+    expect(getWinnerId(playoffMatches[0])).toBe("p2");
+  });
+});

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -48,7 +48,6 @@ describe('E2E case drift coverage', () => {
     ['TC-1087', tcGp],
     ['TC-1083', tcMr],
     ['TC-729', tcGp],
-    ['TC-830', tcGp],
     ['TC-926', tcOverlay],
     ['TC-817', tcTa],
     ['TC-1032', tcTa],
@@ -70,6 +69,37 @@ describe('E2E case drift coverage', () => {
     expect(tcGp).toMatch(
       /\/\/\s*TC-831 stays before TC-832[^\n]*\n\s*\{\s*name:\s*['"]TC-831['"]\s*,\s*fn:\s*runTc831\s*\}\s*,\s*\n\s*\{\s*name:\s*['"]TC-832['"]\s*,\s*fn:\s*runTc832\s*\}/,
     );
+  });
+
+  it('keeps TC-830 aligned with runtime unit and bracket component coverage', () => {
+    const section = e2eCaseSection('TC-830');
+    const pageWiringTest = readRepoFile('smkc-score-app', '__tests__', 'app', 'tournaments', 'gp-finals-page-wiring.test.tsx');
+    const winnerHelperTest = readRepoFile('smkc-score-app', '__tests__', 'lib', 'gp-finals-match-winner.test.ts');
+    const doubleBracketTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'components',
+      'tournament',
+      'double-elimination-bracket.test.tsx',
+    );
+    const playoffBracketTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'components',
+      'tournament',
+      'playoff-bracket.test.tsx',
+    );
+
+    expect(section).toContain('issue #830');
+    expect(section).toContain('gp-finals-page-wiring.test.tsx');
+    expect(section).toContain('gp-finals-match-winner.test.ts');
+    expect(section).toContain('double-elimination-bracket.test.tsx');
+    expect(section).toContain('playoff-bracket.test.tsx');
+    expect(pageWiringTest).toContain('passes the GP legacy winner resolver into the finals bracket');
+    expect(winnerHelperTest).toContain('falls back to suddenDeathWinnerId for completed legacy tied rows');
+    expect(doubleBracketTest).toContain('uses getWinnerId for completed tied matches');
+    expect(playoffBracketTest).toContain('uses getWinnerId for completed tied matches');
+    expect(tcGp).not.toMatch(/\{\s*name:\s*['"]TC-830['"]/);
   });
 
   it('keeps TC-1010 aligned with the BM 16-player finals regression coverage', () => {

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -23,7 +23,6 @@
  *           before the suite moves into the longer playoff UI flows.
  *   TC-1109 GP finals cup-form lock count uses the max-cups helper directly
  *   TC-719  GP tied cup extends non-grand-final bracket match
- *   TC-830  GP finals legacy suddenDeathWinnerId keeps winner display
  *   TC-831  GP finals added cup form can be removed without stale scores
  *   TC-723  GP qualification standings show 0-1000 qualification points
  *   TC-724  GP combined standings tab shows rows with point headers and ascending ranks
@@ -940,43 +939,6 @@ async function runTc1109() {
   }
 }
 
-/* ───────── TC-830: GP finals legacy sudden-death winner display ───────── */
-async function runTc830() {
-  try {
-    const pageSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'app', 'tournaments', '[id]', 'gp', 'finals', 'page.tsx'), 'utf8');
-    const helperSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'lib', 'gp-finals-match-winner.ts'), 'utf8');
-    const unitTestSource = fs.readFileSync(path.join(__dirname, '..', '__tests__', 'lib', 'gp-finals-match-winner.test.ts'), 'utf8');
-    const doubleBracketSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'components', 'tournament', 'double-elimination-bracket.tsx'), 'utf8');
-    const playoffBracketSource = fs.readFileSync(path.join(__dirname, '..', 'src', 'components', 'tournament', 'playoff-bracket.tsx'), 'utf8');
-
-    const pageUsesHelper = pageSource.includes('getGpFinalsMatchWinner(match)');
-    const pagePassesWinnerResolver = pageSource.includes('getWinnerId={getBracketWinnerId}');
-    const bracketSupportsWinnerResolver = doubleBracketSource.includes('getWinnerId?:') &&
-      doubleBracketSource.includes('customWinnerId') &&
-      playoffBracketSource.includes('getWinnerId?:') &&
-      playoffBracketSource.includes('customWinnerId');
-    const helperKeepsLegacyPath = helperSource.includes('suddenDeathWinnerId === match.player1.id') &&
-      helperSource.includes('suddenDeathWinnerId === match.player2.id');
-    const helperDocumentsCompatibility = helperSource.includes('Backward compatibility for GP finals rows');
-    const unitCoversLegacyTie = unitTestSource.includes('falls back to suddenDeathWinnerId for completed legacy tied rows');
-    const unitCoversInvalidLegacyWinner = unitTestSource.includes('without a matching legacy winner');
-
-    const ok = pageUsesHelper && pagePassesWinnerResolver && bracketSupportsWinnerResolver &&
-      helperKeepsLegacyPath && helperDocumentsCompatibility && unitCoversLegacyTie && unitCoversInvalidLegacyWinner;
-    log('TC-830', ok ? 'PASS' : 'FAIL',
-      !pageUsesHelper ? 'GP finals page does not delegate winner detection to getGpFinalsMatchWinner'
-      : !pagePassesWinnerResolver ? 'GP finals page does not pass getWinnerId to bracket components'
-      : !bracketSupportsWinnerResolver ? 'bracket components do not use a custom winner resolver'
-      : !helperKeepsLegacyPath ? 'legacy suddenDeathWinnerId fallback is missing'
-      : !helperDocumentsCompatibility ? 'legacy compatibility rationale comment is missing'
-      : !unitCoversLegacyTie ? 'unit test does not cover tied legacy suddenDeathWinnerId rows'
-      : !unitCoversInvalidLegacyWinner ? 'unit test does not cover invalid legacy winner ids'
-      : '');
-  } catch (err) {
-    log('TC-830', 'FAIL', err instanceof Error ? err.message : 'GP 830 failed');
-  }
-}
-
 /* ───────── TC-727: GP finals rejects score-only cup wins above FT target ───────── */
 async function runTc727(adminPage) {
   let setup = null;
@@ -1875,7 +1837,6 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-712', fn: runTc712 },
       { name: 'TC-719', fn: runTc719 },
       { name: 'TC-720', fn: runTc720 },
-      { name: 'TC-830', fn: runTc830 },
       // TC-831 stays before TC-832 so GP suite logs remain readable in numeric TC order.
       { name: 'TC-831', fn: runTc831 },
       { name: 'TC-832', fn: runTc832 },
@@ -1891,7 +1852,7 @@ module.exports = {
   runTc701, runTc702, runTc703, runTc704, runTc705, runTc706,
   runTc707, runTc708, runTc709, runTc710, runTc712, runTc713,
   runTc715, runTc716, runTc717, runTc718, runTc1103, runTc1106, runTc727, runTc729, runTc719,
-  runTc720, runTc721, runTc722, runTc724, runTc725, runTc1087, runTc821, runTc830, runTc831, runTc832,
+  runTc720, runTc721, runTc722, runTc724, runTc725, runTc1087, runTc821, runTc831, runTc832,
   gpAssignedCupSequence, gpFinalsUpdatedMatchFromPutResult, gpFinalsTargetWins,
   getSuite,
   results,

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -157,6 +157,11 @@ interface GPMatch {
   round: string | null;
 }
 
+type GPBracketMatch = GPMatch & {
+  score1: number;
+  score2: number;
+};
+
 /** Abstract bracket position from double-elimination library */
 interface BracketMatch {
   matchNumber: number;
@@ -682,15 +687,15 @@ export default function GrandPrixFinals({
   // DoubleEliminationBracket reads match.score1/score2 for winner highlighting (#759).
   // These must be declared before any early returns to satisfy rules-of-hooks.
   const gpBracketMatches = useMemo(
-    () => matches.map((m) => ({ ...m, score1: m.points1, score2: m.points2 })),
+    (): GPBracketMatch[] => matches.map((m) => ({ ...m, score1: m.points1, score2: m.points2 })),
     [matches],
   );
   const gpPlayoffBracketMatches = useMemo(
-    () => playoffMatches.map((m) => ({ ...m, score1: m.points1, score2: m.points2 })),
+    (): GPBracketMatch[] => playoffMatches.map((m) => ({ ...m, score1: m.points1, score2: m.points2 })),
     [playoffMatches],
   );
   const getBracketWinnerId = useCallback(
-    (match: unknown) => getGpFinalsMatchWinner(match as GPMatch)?.id ?? null,
+    (match: GPBracketMatch) => getGpFinalsMatchWinner(match)?.id ?? null,
     [],
   );
   /* Top-24 Phase 1 can return a preview Upper Bracket before finals rows exist.
@@ -848,7 +853,7 @@ export default function GrandPrixFinals({
               bracketStructure={bracketStructure}
               roundNames={roundNames}
               seededPlayers={seededPlayers}
-              getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
+              getTargetWins={(match) => getTargetWinsForMatch(match)}
               getWinnerId={getBracketWinnerId}
               onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
               onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
@@ -860,7 +865,7 @@ export default function GrandPrixFinals({
               playoffStructure={playoffStructure}
               roundNames={roundNames}
               seededPlayers={playoffSeededPlayers}
-              getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
+              getTargetWins={(match) => getTargetWinsForMatch(match)}
               getWinnerId={getBracketWinnerId}
               onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
               onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
@@ -882,7 +887,7 @@ export default function GrandPrixFinals({
             playoffStructure={playoffStructure}
             roundNames={roundNames}
             seededPlayers={playoffSeededPlayers}
-            getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
+            getTargetWins={(match) => getTargetWinsForMatch(match)}
             getWinnerId={getBracketWinnerId}
             onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
             onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
@@ -901,7 +906,7 @@ export default function GrandPrixFinals({
           bracketStructure={bracketStructure}
           roundNames={roundNames}
           seededPlayers={seededPlayers}
-          getTargetWins={(match) => getTargetWinsForMatch(match as GPMatch | undefined)}
+          getTargetWins={(match) => getTargetWinsForMatch(match)}
           getWinnerId={getBracketWinnerId}
           onMatchClick={isAdmin ? (openScoreDialog as unknown as (match: { id: string }) => void) : undefined}
           onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}

--- a/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/double-elimination-bracket.tsx
@@ -28,6 +28,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { TV_NUMBER_OPTIONS } from "@/lib/constants";
+import { resolveBracketWinnerFlags, type BracketWinnerResolver } from "@/lib/bracket-winner-flags";
 
 import type { Player } from "@/lib/types";
 import type { BracketMatch, SeededPlayer } from "@/types/bracket";
@@ -50,28 +51,28 @@ interface BMMatch {
 }
 
 /** Props for the main DoubleEliminationBracket component */
-interface DoubleEliminationBracketProps {
+interface DoubleEliminationBracketProps<TMatch extends BMMatch = BMMatch> {
   /** All finals matches from the database */
-  matches: BMMatch[];
+  matches: TMatch[];
   /** Bracket structure defining match positions and connections */
   bracketStructure: BracketMatch[];
   /** Human-readable round names mapping (e.g., "winners_qf" -> "Quarter Finals") */
   roundNames: Record<string, string>;
   /** Optional callback when a match card is clicked (for score entry) */
-  onMatchClick?: (match: BMMatch) => void;
+  onMatchClick?: (match: TMatch) => void;
   /** Optional seeded player data for displaying qualification labels */
   seededPlayers?: SeededPlayer[];
   /** Number of wins required to highlight a completed match winner. */
-  getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
+  getTargetWins?: (match: TMatch | undefined, bracketMatch: BracketMatch) => number;
   /** Optional winner resolver for modes whose persisted winner is not score-order only. */
-  getWinnerId?: (match: BMMatch, bracketMatch: BracketMatch) => string | null;
+  getWinnerId?: BracketWinnerResolver<TMatch>;
   /**
    * Optional callback fired the moment an admin picks a TV# from the
    * inline dropdown on the match card. When provided, the static "TV{n}"
    * badge becomes an editable `<select>` so the assignment saves on change
    * without having to open the score-entry dialog (issue: select-to-save TV#).
    */
-  onTvNumberChange?: (match: BMMatch, tvNumber: number | null) => void;
+  onTvNumberChange?: (match: TMatch, tvNumber: number | null) => void;
 }
 
 /**
@@ -85,7 +86,7 @@ interface DoubleEliminationBracketProps {
  * @param onClick - Click handler for score entry
  * @param isTBD - Per-slot TBD flags: whether player1/player2 slots are undetermined
  */
-function MatchCard({
+function MatchCard<TMatch extends BMMatch>({
   match,
   bracketMatch,
   seededPlayers,
@@ -95,14 +96,14 @@ function MatchCard({
   getWinnerId,
   onTvNumberChange,
 }: {
-  match?: BMMatch;
+  match?: TMatch;
   bracketMatch: BracketMatch;
   seededPlayers?: SeededPlayer[];
   onClick?: () => void;
   isTBD: { player1: boolean; player2: boolean };
-  getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
-  getWinnerId?: (match: BMMatch, bracketMatch: BracketMatch) => string | null;
-  onTvNumberChange?: (match: BMMatch, tvNumber: number | null) => void;
+  getTargetWins?: (match: TMatch | undefined, bracketMatch: BracketMatch) => number;
+  getWinnerId?: BracketWinnerResolver<TMatch>;
+  onTvNumberChange?: (match: TMatch, tvNumber: number | null) => void;
 }) {
   const tc = useTranslations("common");
   /* Look up seeded players for displaying names and qualification rank labels. */
@@ -120,13 +121,7 @@ function MatchCard({
   const player2: Player | undefined = match?.player2 || seededEntry2?.player;
 
   const targetWins = getTargetWins?.(match, bracketMatch) ?? 3;
-  const customWinnerId = match?.completed && getWinnerId ? getWinnerId(match, bracketMatch) : undefined;
-  const isWinner1 = customWinnerId !== undefined
-    ? customWinnerId === match?.player1Id
-    : !!match?.completed && match.score1 >= targetWins && match.score1 > match.score2;
-  const isWinner2 = customWinnerId !== undefined
-    ? customWinnerId === match?.player2Id
-    : !!match?.completed && match.score2 >= targetWins && match.score2 > match.score1;
+  const { isWinner1, isWinner2 } = resolveBracketWinnerFlags(match, bracketMatch, targetWins, getWinnerId);
 
   /*
    * Per-slot TBD display. First-round matches (seeded) always show real names.
@@ -311,7 +306,7 @@ function RoundHeader({ label, course }: { label: string; course: number | null }
  * The bracket uses aria-live="polite" to announce updates to screen readers
  * when match results change during real-time polling.
  */
-export function DoubleEliminationBracket({
+export function DoubleEliminationBracket<TMatch extends BMMatch = BMMatch>({
   matches,
   bracketStructure,
   onMatchClick,
@@ -319,7 +314,7 @@ export function DoubleEliminationBracket({
   getTargetWins,
   getWinnerId,
   onTvNumberChange,
-}: DoubleEliminationBracketProps) {
+}: DoubleEliminationBracketProps<TMatch>) {
   const tf = useTranslations("finals");
   /** Look up a match by its bracket match number */
   const getMatch = (matchNumber: number) =>
@@ -464,7 +459,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
-                    getWinnerId={getWinnerId}
+                  getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -487,7 +482,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
-                    getWinnerId={getWinnerId}
+                  getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -510,7 +505,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
-                    getWinnerId={getWinnerId}
+                  getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -541,7 +536,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
-                    getWinnerId={getWinnerId}
+                  getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -564,7 +559,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
-                    getWinnerId={getWinnerId}
+                  getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -587,7 +582,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
-                    getWinnerId={getWinnerId}
+                  getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -635,7 +630,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
-                    getWinnerId={getWinnerId}
+                  getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -658,7 +653,7 @@ export function DoubleEliminationBracket({
                   }}
                   isTBD={isTBD(b.matchNumber)}
                   getTargetWins={getTargetWins}
-                    getWinnerId={getWinnerId}
+                  getWinnerId={getWinnerId}
                   onTvNumberChange={onTvNumberChange}
                 />
               ))}
@@ -687,7 +682,7 @@ export function DoubleEliminationBracket({
                 }}
                 isTBD={isTBD(b.matchNumber)}
                 getTargetWins={getTargetWins}
-                    getWinnerId={getWinnerId}
+                getWinnerId={getWinnerId}
                 onTvNumberChange={onTvNumberChange}
               />
             ))}
@@ -712,7 +707,7 @@ export function DoubleEliminationBracket({
                 }}
                 isTBD={isTBD(b.matchNumber)}
                 getTargetWins={getTargetWins}
-                    getWinnerId={getWinnerId}
+                getWinnerId={getWinnerId}
                 onTvNumberChange={onTvNumberChange}
               />
             ))}

--- a/smkc-score-app/src/components/tournament/playoff-bracket.tsx
+++ b/smkc-score-app/src/components/tournament/playoff-bracket.tsx
@@ -23,9 +23,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { TV_NUMBER_OPTIONS } from "@/lib/constants";
+import { resolveBracketWinnerFlags, type BracketWinnerResolver } from "@/lib/bracket-winner-flags";
 
 import type { Player } from "@/lib/types";
-import type { SeededPlayer } from "@/types/bracket";
+import type { BracketMatch, SeededPlayer } from "@/types/bracket";
 
 /** BM match data from the database including player relations */
 interface BMMatch {
@@ -45,35 +46,24 @@ interface BMMatch {
   player2: Player;
 }
 
-/** Bracket structure definition for a single match position */
-interface BracketMatch {
-  matchNumber: number;
-  round: string;
-  bracket: "winners" | "losers" | "grand_final";
-  player1Seed?: number;
-  player2Seed?: number;
-  /** For playoff_r2 matches: which Upper Bracket seed the winner claims */
-  advancesToUpperSeed?: number;
-}
-
 /** Props for the PlayoffBracket component */
-interface PlayoffBracketProps {
+interface PlayoffBracketProps<TMatch extends BMMatch = BMMatch> {
   /** All playoff matches from the database (stage='playoff') */
-  playoffMatches: BMMatch[];
+  playoffMatches: TMatch[];
   /** Bracket structure defining match positions and connections */
   playoffStructure: BracketMatch[];
   /** Human-readable round names mapping */
   roundNames: Record<string, string>;
   /** Optional callback when a match card is clicked (for score entry) */
-  onMatchClick?: (match: BMMatch) => void;
+  onMatchClick?: (match: TMatch) => void;
   /** Seeded player data for displaying qualification labels */
   seededPlayers?: SeededPlayer[];
   /** Number of wins required to highlight a completed match winner */
-  getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
+  getTargetWins?: (match: TMatch | undefined, bracketMatch: BracketMatch) => number;
   /** Optional winner resolver for modes whose persisted winner is not score-order only. */
-  getWinnerId?: (match: BMMatch, bracketMatch: BracketMatch) => string | null;
+  getWinnerId?: BracketWinnerResolver<TMatch>;
   /** See `DoubleEliminationBracket.onTvNumberChange` — same select-to-save UX. */
-  onTvNumberChange?: (match: BMMatch, tvNumber: number | null) => void;
+  onTvNumberChange?: (match: TMatch, tvNumber: number | null) => void;
 }
 
 /**
@@ -81,7 +71,7 @@ interface PlayoffBracketProps {
  * Same visual style as DoubleEliminationBracket.MatchCard but includes
  * advancesToUpperSeed label for playoff_r2 completed matches.
  */
-function PlayoffMatchCard({
+function PlayoffMatchCard<TMatch extends BMMatch>({
   match,
   bracketMatch,
   seededPlayers,
@@ -92,15 +82,15 @@ function PlayoffMatchCard({
   getWinnerId,
   onTvNumberChange,
 }: {
-  match?: BMMatch;
+  match?: TMatch;
   bracketMatch: BracketMatch;
   seededPlayers?: SeededPlayer[];
   onClick?: () => void;
   isPlayer1TBD: boolean;
   isPlayer2TBD: boolean;
-  getTargetWins?: (match: BMMatch | undefined, bracketMatch: BracketMatch) => number;
-  getWinnerId?: (match: BMMatch, bracketMatch: BracketMatch) => string | null;
-  onTvNumberChange?: (match: BMMatch, tvNumber: number | null) => void;
+  getTargetWins?: (match: TMatch | undefined, bracketMatch: BracketMatch) => number;
+  getWinnerId?: BracketWinnerResolver<TMatch>;
+  onTvNumberChange?: (match: TMatch, tvNumber: number | null) => void;
 }) {
   const tc = useTranslations("common");
   const tf = useTranslations("finals");
@@ -117,13 +107,7 @@ function PlayoffMatchCard({
   const player2: Player | undefined = match?.player2 || seededEntry2?.player;
 
   const targetWins = getTargetWins?.(match, bracketMatch) ?? 3;
-  const customWinnerId = match?.completed && getWinnerId ? getWinnerId(match, bracketMatch) : undefined;
-  const isWinner1 = customWinnerId !== undefined
-    ? customWinnerId === match?.player1Id
-    : !!match?.completed && match.score1 >= targetWins && match.score1 > match.score2;
-  const isWinner2 = customWinnerId !== undefined
-    ? customWinnerId === match?.player2Id
-    : !!match?.completed && match.score2 >= targetWins && match.score2 > match.score1;
+  const { isWinner1, isWinner2 } = resolveBracketWinnerFlags(match, bracketMatch, targetWins, getWinnerId);
 
   const isTV1 = match?.tvNumber === 1;
 
@@ -238,7 +222,7 @@ function PlayoffMatchCard({
  * Playoff Bracket component.
  * Renders the 8-match pre-bracket playoff in two columns (R1 | R2).
  */
-export function PlayoffBracket({
+export function PlayoffBracket<TMatch extends BMMatch = BMMatch>({
   playoffMatches,
   playoffStructure,
   roundNames,
@@ -247,7 +231,7 @@ export function PlayoffBracket({
   getTargetWins,
   getWinnerId,
   onTvNumberChange,
-}: PlayoffBracketProps) {
+}: PlayoffBracketProps<TMatch>) {
   const tf = useTranslations("finals");
   const getMatch = (matchNumber: number) =>
     playoffMatches.find((m) => m.matchNumber === matchNumber);

--- a/smkc-score-app/src/lib/bracket-winner-flags.ts
+++ b/smkc-score-app/src/lib/bracket-winner-flags.ts
@@ -1,0 +1,44 @@
+import type { BracketMatch } from "@/types/bracket";
+
+export interface BracketWinnerMatch {
+  completed: boolean;
+  player1Id: string;
+  player2Id: string;
+  score1: number;
+  score2: number;
+}
+
+export type BracketWinnerResolver<TMatch extends BracketWinnerMatch> = (
+  match: TMatch,
+  bracketMatch: BracketMatch,
+) => string | null;
+
+export function resolveBracketWinnerFlags<TMatch extends BracketWinnerMatch>(
+  match: TMatch | undefined,
+  bracketMatch: BracketMatch,
+  targetWins: number,
+  getWinnerId?: BracketWinnerResolver<TMatch>,
+) {
+  if (!match?.completed) {
+    return { isWinner1: false, isWinner2: false };
+  }
+
+  /*
+   * Some modes need a persisted winner that is not recoverable from score
+   * ordering alone. GP legacy sudden-death rows are completed with tied
+   * score1/score2 after points1/points2 are mapped for bracket display, so an
+   * explicit resolver must take precedence when the page provides one.
+   */
+  const customWinnerId = getWinnerId?.(match, bracketMatch);
+  if (customWinnerId !== undefined) {
+    return {
+      isWinner1: customWinnerId === match.player1Id,
+      isWinner2: customWinnerId === match.player2Id,
+    };
+  }
+
+  return {
+    isWinner1: match.score1 >= targetWins && match.score1 > match.score2,
+    isWinner2: match.score2 >= targetWins && match.score2 > match.score1,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract shared bracket winner flag resolution and use it from both bracket components
- Genericize bracket match props so GP finals can pass a typed legacy winner resolver without unknown casts
- Replace fake static TC-830 E2E registration with Jest unit/component/page wiring coverage
- Fix getWinnerId JSX indentation and strengthen the drift guard against re-registering TC-830 as fake E2E

Issues: #1823, #1824, #1825, #1826

## Validation
- npm test -- --runInBand __tests__/app/tournaments/gp-finals-page-wiring.test.tsx
- npm test -- --runInBand __tests__/app/tournaments/gp-finals-page-wiring.test.tsx __tests__/components/tournament/double-elimination-bracket.test.tsx __tests__/components/tournament/playoff-bracket.test.tsx __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/gp-finals-match-winner.test.ts
- npm run lint
- npm run build:cf
- git diff --check

Notes:
- lint reports 42 existing warnings and 0 errors.