### PR TITLE
test: cover bracket resolver edges

### DIFF
--- a/smkc-score-app/__tests__/lib/bracket-winner-flags.test.ts
+++ b/smkc-score-app/__tests__/lib/bracket-winner-flags.test.ts
@@ -47,9 +47,23 @@ describe("resolveBracketWinnerFlags", () => {
     });
   });
 
+  it("marks player 2 as winner when the resolver returns player2Id", () => {
+    expect(resolveBracketWinnerFlags(finalsMatch({ score1: 5, score2: 0 }), bracketMatch, 5, (match) => match.player2Id)).toEqual({
+      isWinner1: false,
+      isWinner2: true,
+    });
+  });
+
   it("falls back to score comparison when player 1 reaches target wins", () => {
     expect(resolveBracketWinnerFlags(finalsMatch({ score1: 5, score2: 4 }), bracketMatch, 5)).toEqual({
       isWinner1: true,
+      isWinner2: false,
+    });
+  });
+
+  it("returns no score fallback winner for completed tied scores", () => {
+    expect(resolveBracketWinnerFlags(finalsMatch({ score1: 3, score2: 3 }), bracketMatch, 5)).toEqual({
+      isWinner1: false,
       isWinner2: false,
     });
   });


### PR DESCRIPTION
Summary:
- Add direct resolver coverage for player2Id overrides in resolveBracketWinnerFlags.
- Add a completed tied-score fallback case that verifies no winner is highlighted without a resolver.

Issues: #1830, #1831

Validation:
- npm test -- --runInBand __tests__/lib/bracket-winner-flags.test.ts
- npm run lint (0 errors, existing warnings)
- git diff --check

Review:
- Subagent review: no findings