### PR TITLE
test: simplify Prisma migration guard reads

### DIFF
--- a/smkc-score-app/__tests__/docs/prisma-migrations.test.ts
+++ b/smkc-score-app/__tests__/docs/prisma-migrations.test.ts
@@ -24,7 +24,7 @@ describe("Prisma migration compatibility", () => {
     // accepts SQLite-compatible storage classes. A global guard prevents future
     // generated migrations from reintroducing the unsupported type silently.
     const jsonbMigrations = migrationSqlFiles(migrationsDir)
-      .filter((file) => readMigration(path.relative(migrationsDir, file)).includes("JSONB"))
+      .filter((file) => fs.readFileSync(file, "utf8").includes("JSONB"))
       .map((file) => path.relative(migrationsDir, file));
 
     expect(jsonbMigrations).toEqual([]);


### PR DESCRIPTION
## Summary
- simplify the global Prisma migration JSONB guard by reading the discovered migration file path directly

Issues: #1840

## Validation
- npm test -- --runInBand __tests__/docs/prisma-migrations.test.ts
- npm test -- --runInBand __tests__/docs/prisma-migrations.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint (0 errors, existing 42 warnings)
- git diff --check

## Review
- Change is a one-line simplification of a review follow-up; subagent review is currently unavailable due the active usage limit, so PR CI/automated review is used as the external gate.