### PR TITLE
docs: clarify Phase3 sudden-death order fallback

### DIFF
--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -119,6 +119,13 @@ export interface CourseResult {
 
 type Phase3ResolvedOrder = ReadonlyMap<string, number>;
 
+/*
+ * resolvedOrder is intentionally treated as authoritative only when both
+ * compared players are present. The current sudden-death path builds it from
+ * the same full result list passed to processPhase3Result, so partial matches
+ * should not occur there. If a future caller supplies a partial map, falling
+ * back to time keeps normal Phase3 ordering rather than mixing two rank systems.
+ */
 function comparePhase3CourseResults(
   a: CourseResult,
   b: CourseResult,


### PR DESCRIPTION
## Summary
- document that resolvedOrder is authoritative only when both compared players are present
- clarify that partial maps intentionally fall back to normal Phase3 time ordering

Issues: #1843

## Validation
- npm test -- --runInBand __tests__/lib/ta/finals-phase-manager.test.ts
- npm run lint (0 errors, existing 42 warnings)
- git diff --check

## Review
- Comment-only review follow-up; subagent review is currently unavailable due the active usage limit, so PR CI/automated review is used as the external gate.