### PR TITLE
test: document TA course selection candidate order

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
@@ -129,6 +129,8 @@ describe("selectRandomAvailableCourse", () => {
     const course = selectRandomAvailableCourse(["MC1"], "DP1");
 
     expect(course).not.toBe("DP1");
+    // Math.random=0 picks index 0; after MC1 is played and DP1 is excluded as
+    // the immediately previous course, GV1 is the first remaining candidate.
     expect(course).toBe("GV1");
   });
 


### PR DESCRIPTION
## Summary
- add a short test comment explaining why the deterministic mocked random path returns GV1

Issues: #1846

## Validation
- npm test -- --runInBand __tests__/lib/ta/course-selection.test.ts
- npm run lint (0 errors, existing 42 warnings)
- git diff --check

## Review
- Comment-only test follow-up; subagent review is currently unavailable due the active usage limit, so PR CI/automated review is used as the external gate.