### PR TITLE
test: strengthen TA i18n guards

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -900,6 +900,7 @@ describe('E2E case drift coverage', () => {
     expect(taFinalsPage).not.toContain('Submit sudden death');
     expect(taFinalsPage).not.toContain('Sudden-death tiebreak');
     expect(taFinalsPage).not.toContain('Sudden-death course');
+    expect(taFinalsPage).not.toContain('Enter M:SS.mm format.');
     expect(taEliminationPhase).not.toContain('Submit sudden death');
     expect(taEliminationPhase).not.toContain('Sudden-death tiebreak');
     expect(taEliminationPhase).not.toContain('Sudden-death course');

--- a/smkc-score-app/__tests__/i18n/messages.test.ts
+++ b/smkc-score-app/__tests__/i18n/messages.test.ts
@@ -60,4 +60,14 @@ describe('translation messages', () => {
     expect(placeholders(enMessages.taElimination.invalidTimeFor)).toEqual(['name']);
     expect(placeholders(jaMessages.taElimination.invalidTimeFor)).toEqual(['name']);
   });
+
+  /**
+   * TA finals uses the same `{name}` nickname parameter as TA elimination.
+   * Guarding both namespaces prevents one finals page from regressing to the
+   * old `{player}` parameter while the other phase still renders correctly.
+   */
+  it('keeps TA finals invalid-time placeholders aligned with the UI contract', () => {
+    expect(placeholders(enMessages.taFinals.invalidTimeFor)).toEqual(['name']);
+    expect(placeholders(jaMessages.taFinals.invalidTimeFor)).toEqual(['name']);
+  });
 });


### PR DESCRIPTION
Summary:
- Cover taFinals.invalidTimeFor placeholder parity in i18n message tests
- Extend TC-822A drift guard to reject finals invalid-time hardcoded text

Issues: #1851, #1852

Validation:
- npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts __tests__/i18n/messages.test.ts
- npm run lint
- npm run build:cf