### PR TITLE
test: shorten TA finals placeholder comment

### DIFF
--- a/smkc-score-app/__tests__/i18n/messages.test.ts
+++ b/smkc-score-app/__tests__/i18n/messages.test.ts
@@ -61,11 +61,7 @@ describe('translation messages', () => {
     expect(placeholders(jaMessages.taElimination.invalidTimeFor)).toEqual(['name']);
   });
 
-  /**
-   * TA finals uses the same `{name}` nickname parameter as TA elimination.
-   * Guarding both namespaces prevents one finals page from regressing to the
-   * old `{player}` parameter while the other phase still renders correctly.
-   */
+  // TA finals also uses the `{name}` nickname parameter contract.
   it('keeps TA finals invalid-time placeholders aligned with the UI contract', () => {
     expect(placeholders(enMessages.taFinals.invalidTimeFor)).toEqual(['name']);
     expect(placeholders(jaMessages.taFinals.invalidTimeFor)).toEqual(['name']);


### PR DESCRIPTION
Summary:
- Replace the TA finals placeholder guard block comment with one short line

Issues: #1854

Validation:
- npm test -- --runInBand __tests__/i18n/messages.test.ts
- npm run lint
- npm run build:cf