### PR TITLE
test: guard TA i18n key references

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -889,7 +889,11 @@ describe('E2E case drift coverage', () => {
     for (const key of ['suddenDeathTiebreak', 'suddenDeathRoundDesc', 'suddenDeathCourse', 'submitSuddenDeath']) {
       expect(enMessages).toContain(`"${key}"`);
       expect(jaMessages).toContain(`"${key}"`);
+      expect(taFinalsPage).toContain(`'${key}'`);
+      expect(taEliminationPhase).toContain(`'${key}'`);
     }
+    expect(taFinalsPage).toContain("'invalidTimeFor'");
+    expect(taEliminationPhase).toContain("'invalidTimeFor'");
     expect(taFinalsPage).not.toContain('Submit sudden death');
     expect(taFinalsPage).not.toContain('Sudden-death tiebreak');
     expect(taFinalsPage).not.toContain('Sudden-death course');


### PR DESCRIPTION
Summary:
- Restore source-side TA i18n key reference coverage without depending on translation helper function names
- Guard sudden-death and invalid-time keys across finals and elimination source files

Issues: #1857

Validation:
- npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts __tests__/i18n/messages.test.ts
- npm run lint
- npm run build:cf