### PR TITLE
test: clarify TA sudden death drift guard

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -886,9 +886,11 @@ describe('E2E case drift coverage', () => {
 
     expect(section).toContain('issue #822');
     expect(section).toContain('suddenDeathTiebreak');
+    expect(enMessages).toContain('"taSuddenDeath"');
+    expect(jaMessages).toContain('"taSuddenDeath"');
+    expect(taFinalsPage).toContain("useTranslations('taSuddenDeath')");
+    expect(taEliminationPhase).toContain("useTranslations('taSuddenDeath')");
     for (const key of ['suddenDeathTiebreak', 'suddenDeathRoundDesc', 'suddenDeathCourse', 'submitSuddenDeath']) {
-      expect(enMessages).toContain('"taSuddenDeath"');
-      expect(jaMessages).toContain('"taSuddenDeath"');
       expect(enMessages).toContain(`"${key}"`);
       expect(jaMessages).toContain(`"${key}"`);
       expect(taFinalsPage).toContain(`'${key}'`);


### PR DESCRIPTION
Summary:
- Move repeated taSuddenDeath namespace assertions outside the key loop
- Explicitly assert both finals and elimination source files use the shared taSuddenDeath namespace

Issues: #1860, #1861

Validation:
- npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts __tests__/i18n/messages.test.ts
- npm run lint
- npm run build:cf