### PR TITLE
fix: split CDM export query shape

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -699,6 +699,35 @@
 - **期待結果**: 認証済み管理者の CDM エクスポートが `.xlsm` としてダウンロードされる。`download.path()` が取得できない場合は、永続コンテキストの `acceptDownloads` 設定を確認できる診断メッセージで FAIL する。
 - **スクリプト**: tc-all.js TC-358
 
+## TC-817B: CDM export — CSV では CDM 専用 include を取得しない
+- **URL**: /api/tournaments/[id]/export
+- **背景**: issue #817。CSV 出力は MR/GP qualification seed、TT phase rounds、overall playerScores を使用しないため、CDM 専用 include を無条件に付けると不要な JOIN が増える。
+- **手順**:
+  1. `GET /api/tournaments/:id/export` を呼ぶ
+  2. Prisma `findUnique` の include に `mrQualifications` / `gpQualifications` / `ttPhaseRounds` / `playerScores` が含まれないことを確認する
+  3. `GET /api/tournaments/:id/export?format=cdm` では上記 CDM 専用 include が含まれることを確認する
+- **期待結果**: CSV は軽量 include、CDM は workbook に必要な include を使い分ける
+- **スクリプト**: `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+
+## TC-818A: CDM export — timeValueForCDM の冗長 wrapper を削除する
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #818。`timeValueForCDM` は `parseTimeMs` と等価な wrapper で、CDM 時刻書き込みの意図を増やさず間接参照だけを増やしている。
+- **手順**:
+  1. export route に `timeValueForCDM` 関数が残っていないことを確認する
+  2. TT qualification の CDM コース時刻書き込みが `parseTimeMs(times[course])` を直接使うことを確認する
+- **期待結果**: CDM export の時刻変換は単一 helper `parseTimeMs` に集約される
+- **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
+
+## TC-819A: CDM export — テンプレート座標の固定値に根拠コメントを付ける
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #819。CDM 2025 テンプレートの行数・列ブロックは workbook 側の固定座標であり、コメントなしの数値にすると通常の大会上限と誤読されやすい。
+- **手順**:
+  1. export route に CDM 2025 workbook template coordinates のコメントがあることを確認する
+  2. Main Hub、qualification、finals block、`CDM_TT_ROUND_START_COLUMNS`、overall ranking の固定範囲が名前付き定数で表現されることを確認する
+  3. 書き込み処理がそれらの定数を使うことを確認する
+- **期待結果**: CDM テンプレート由来の固定値は、どの workbook 範囲を守るための値か読める
+- **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-348: キャラクター統計 API — admin のみアクセス可 (TC-328 と重複なし: 形式チェック)
 - **URL**: /api/players/[id]/character-stats
 - **authRequired**: true (admin) / false → 401

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -132,14 +132,10 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         where: { id: 't1' },
         include: {
           bmQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
-          mrQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
-          gpQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
           bmMatches: { include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } } },
           mrMatches: { include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } } },
           gpMatches: { include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } } },
           ttEntries: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
-          ttPhaseRounds: true,
-          playerScores: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
         },
       });
     });
@@ -219,6 +215,20 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       const result = await GET(request, { params });
 
       expect(assetFetch).toHaveBeenCalledWith(new URL('/templates/cdm-2025-template.xlsm', 'https://assets.local'));
+      expect(prisma.tournament.findUnique).toHaveBeenCalledWith({
+        where: { id: 't1' },
+        include: {
+          bmQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
+          bmMatches: { include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } } },
+          mrMatches: { include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } } },
+          gpMatches: { include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } } },
+          ttEntries: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
+          mrQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
+          gpQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
+          ttPhaseRounds: true,
+          playerScores: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
+        },
+      });
       expect(global.fetch).toBeUndefined();
       expect(result.data).toBeInstanceOf(Uint8Array);
       expect(result.headers['Content-Type']).toBe('application/vnd.ms-excel.sheet.macroEnabled.12');

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -80,6 +80,26 @@ describe('E2E case drift coverage', () => {
     'tournament',
     'ta-sudden-death-panel.test.tsx',
   );
+  const exportRoute = readRepoFile(
+    'smkc-score-app',
+    'src',
+    'app',
+    'api',
+    'tournaments',
+    '[id]',
+    'export',
+    'route.ts',
+  );
+  const exportRouteTest = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'app',
+    'api',
+    'tournaments',
+    '[id]',
+    'export',
+    'route.test.ts',
+  );
   const enMessages = readRepoFile('smkc-score-app', 'messages', 'en.json');
   const jaMessages = readRepoFile('smkc-score-app', 'messages', 'ja.json');
 
@@ -149,6 +169,47 @@ describe('E2E case drift coverage', () => {
     expect(doubleBracketTest).toContain('uses getWinnerId for completed tied matches');
     expect(playoffBracketTest).toContain('uses getWinnerId for completed tied matches');
     expect(tcGp).not.toMatch(/\{\s*name:\s*['"]TC-830['"]/);
+  });
+
+  it('documents TC-817B as CSV/CDM export include split coverage', () => {
+    const section = e2eCaseSection('TC-817B');
+
+    expect(section).toContain('issue #817');
+    expect(section).toContain('mrQualifications');
+    expect(section).toContain('playerScores');
+    expect(section).toContain('route.test.ts');
+    expect(exportRoute).toContain('BASE_EXPORT_INCLUDE');
+    expect(exportRoute).toContain('CDM_EXPORT_INCLUDE');
+    expect(exportRoute).toContain('include: CDM_EXPORT_INCLUDE');
+    expect(exportRoute).toContain('include: BASE_EXPORT_INCLUDE');
+    expect(exportRouteTest).toContain('should export tournament data with summary section');
+    expect(exportRouteTest).toContain('should export a populated CDM macro workbook when requested');
+    expect(exportRouteTest).toContain('ttPhaseRounds: true');
+    expect(exportRouteTest).toContain('playerScores: { include: { player: { select: PLAYER_PUBLIC_SELECT } } }');
+  });
+
+  it('documents TC-818A as direct CDM time parser usage coverage', () => {
+    const section = e2eCaseSection('TC-818A');
+
+    expect(section).toContain('issue #818');
+    expect(section).toContain('timeValueForCDM');
+    expect(section).toContain('parseTimeMs(times[course])');
+    expect(exportRoute).not.toContain('function timeValueForCDM');
+    expect(exportRoute).toContain('parseTimeMs(times[course])');
+  });
+
+  it('documents TC-819A as CDM template coordinate comment coverage', () => {
+    const section = e2eCaseSection('TC-819A');
+
+    expect(section).toContain('issue #819');
+    expect(section).toContain('CDM 2025 workbook template coordinates');
+    expect(section).toContain('CDM_TT_ROUND_START_COLUMNS');
+    expect(exportRoute).toContain('CDM 2025 workbook template coordinates');
+    expect(exportRoute).toContain('CDM_PLAYER_HUB_MAX_PLAYERS');
+    expect(exportRoute).toContain('CDM_QUALIFICATION_MAX_ROWS');
+    expect(exportRoute).toContain('CDM_FINALS_BLOCK_START_COLUMNS');
+    expect(exportRoute).toContain('CDM_TT_ROUND_START_COLUMNS');
+    expect(exportRoute).toContain('CDM_OVERALL_MAX_ROWS');
   });
 
   it('keeps TC-1010 aligned with the BM 16-player finals regression coverage', () => {

--- a/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
@@ -117,6 +117,42 @@ const CDM_COURSES = [
   "KB1", "CI2", "VL1", "BC3", "MC4", "DP3", "KB2", "GV3", "VL2", "RR",
 ] as const;
 
+const BASE_EXPORT_INCLUDE = {
+  bmQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
+  bmMatches: { include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } } },
+  mrMatches: { include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } } },
+  gpMatches: { include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } } },
+  ttEntries: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
+};
+
+const CDM_EXPORT_INCLUDE = {
+  ...BASE_EXPORT_INCLUDE,
+  mrQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
+  gpQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
+  ttPhaseRounds: true,
+  playerScores: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
+};
+
+/*
+ * CDM 2025 workbook template coordinates. These constants are fixed template
+ * ranges, not business limits; writing past them risks overwriting formula
+ * regions and hidden helper cells in the macro workbook.
+ */
+const CDM_PLAYER_HUB_FIRST_ROW = 2;
+const CDM_PLAYER_HUB_MAX_PLAYERS = 60;
+const CDM_QUALIFICATION_FIRST_ROW = 2;
+const CDM_QUALIFICATION_MAX_ROWS = 767;
+const CDM_FINALS_PLAYER_FIRST_ROW = 3;
+const CDM_FINALS_MAX_PLAYERS = 52;
+const CDM_FINALS_BLOCK_START_COLUMNS = [4, 11, 18, 25, 32, 39, 46, 53, 60, 67, 74, 81, 88, 95, 102];
+const CDM_FINALS_PAIR_ROWS = [5, 13, 21, 29, 37, 45];
+const CDM_TT_FINALIST_FIRST_ROW = 3;
+const CDM_TT_FINALIST_MAX_ROWS = 24;
+const CDM_TT_ROUND_START_COLUMNS = [7, 20, 33, 46, 59, 72, 85, 98];
+const CDM_TT_ROUND_MAX_RESULTS = 24;
+const CDM_OVERALL_FIRST_ROW = 2;
+const CDM_OVERALL_MAX_ROWS = 64;
+
 function setCell(ws: XLSX.WorkSheet, address: string, value: unknown) {
   if (value === null || value === undefined) {
     delete ws[address];
@@ -150,11 +186,6 @@ function parseTimeMs(value: unknown): number | null {
   const seconds = Number(match[2]);
   const ms = Number((match[3] ?? "0").padEnd(3, "0").slice(0, 3));
   return minutes * 60_000 + seconds * 1_000 + ms;
-}
-
-function timeValueForCDM(value: unknown): number | null {
-  const ms = parseTimeMs(value);
-  return ms === null ? null : ms;
 }
 
 function normalizeJsonRecord(value: unknown): Record<string, unknown> {
@@ -210,14 +241,14 @@ function writePlayerHub(
   const ws = workbook.Sheets["Main Hub"];
   if (!ws) return;
 
-  for (let row = 2; row <= 61; row++) {
+  for (let row = CDM_PLAYER_HUB_FIRST_ROW; row < CDM_PLAYER_HUB_FIRST_ROW + CDM_PLAYER_HUB_MAX_PLAYERS; row++) {
     for (const col of ["B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"]) {
       setCell(ws, `${col}${row}`, "");
     }
   }
 
-  players.slice(0, 60).forEach((player, index) => {
-    const row = index + 2;
+  players.slice(0, CDM_PLAYER_HUB_MAX_PLAYERS).forEach((player, index) => {
+    const row = index + CDM_PLAYER_HUB_FIRST_ROW;
     setCell(ws, `B${row}`, player.name);
     setCell(ws, `C${row}`, player.nickname);
     setCell(ws, `D${row}`, player.country ?? "");
@@ -236,7 +267,7 @@ function writeTTQualifications(workbook: XLSX.WorkBook, entries: TTEntryExport[]
   const ws = workbook.Sheets["TT Qualifications"];
   if (!ws) return;
 
-  for (let row = 2; row <= 61; row++) {
+  for (let row = CDM_PLAYER_HUB_FIRST_ROW; row < CDM_PLAYER_HUB_FIRST_ROW + CDM_PLAYER_HUB_MAX_PLAYERS; row++) {
     for (let col = 5; col <= 26; col++) {
       setCell(ws, `${toColumn(col)}${row}`, "");
     }
@@ -246,13 +277,13 @@ function writeTTQualifications(workbook: XLSX.WorkBook, entries: TTEntryExport[]
     .filter((entry) => entry.stage === "qualification")
     .sort((a, b) => (a.seeding ?? Number.MAX_SAFE_INTEGER) - (b.seeding ?? Number.MAX_SAFE_INTEGER));
 
-  qualificationEntries.slice(0, 60).forEach((entry, index) => {
-    const row = index + 2;
+  qualificationEntries.slice(0, CDM_PLAYER_HUB_MAX_PLAYERS).forEach((entry, index) => {
+    const row = index + CDM_PLAYER_HUB_FIRST_ROW;
     setCell(ws, `E${row}`, index + 1);
     setCell(ws, `F${row}`, entry.player.nickname);
     const times = normalizeJsonRecord(entry.times);
     CDM_COURSES.forEach((course, courseIndex) => {
-      setCell(ws, `${toColumn(7 + courseIndex)}${row}`, timeValueForCDM(times[course]));
+      setCell(ws, `${toColumn(7 + courseIndex)}${row}`, parseTimeMs(times[course]));
     });
   });
 }
@@ -267,7 +298,7 @@ function writeQualificationSheet(
   const ws = workbook.Sheets[sheetName];
   if (!ws) return;
 
-  for (let row = 2; row <= 768; row++) {
+  for (let row = CDM_QUALIFICATION_FIRST_ROW; row < CDM_QUALIFICATION_FIRST_ROW + CDM_QUALIFICATION_MAX_ROWS; row++) {
     for (const col of ["E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q"]) {
       setCell(ws, `${col}${row}`, "");
     }
@@ -276,8 +307,8 @@ function writeQualificationSheet(
     }
   }
 
-  sortQualifications(qualifications).slice(0, 767).forEach((qualification, index) => {
-    const row = index + 2;
+  sortQualifications(qualifications).slice(0, CDM_QUALIFICATION_MAX_ROWS).forEach((qualification, index) => {
+    const row = index + CDM_QUALIFICATION_FIRST_ROW;
     setCell(ws, `E${row}`, qualification.group);
     setCell(ws, `F${row}`, qualification.seeding ?? "");
     setCell(ws, `G${row}`, qualification.player.nickname);
@@ -302,9 +333,9 @@ function writeQualificationSheet(
   matches
     .filter((match) => match.stage === "qualification")
     .sort((a, b) => (a.roundNumber ?? 0) - (b.roundNumber ?? 0) || a.matchNumber - b.matchNumber)
-    .slice(0, 767)
+    .slice(0, CDM_QUALIFICATION_MAX_ROWS)
     .forEach((match, index) => {
-      const row = index + 2;
+      const row = index + CDM_QUALIFICATION_FIRST_ROW;
       setCell(ws, `S${row}`, match.matchNumber);
       setCell(ws, `T${row}`, match.tvNumber ?? "");
       setCell(ws, `U${row}`, match.player1Side ?? 1);
@@ -379,20 +410,20 @@ function writeMatchFinalsSheet(
     ? uniquePlayersFromMatches(finalsMatches)
     : sortQualifications(qualifications).slice(0, 24).map((qualification) => qualification.player);
 
-  clearRange(ws, 1, 2, 3, 54);
-  qualifiedPlayers.slice(0, 52).forEach((player, index) => {
-    const row = index + 3;
+  clearRange(ws, 1, 2, CDM_FINALS_PLAYER_FIRST_ROW, CDM_FINALS_PLAYER_FIRST_ROW + CDM_FINALS_MAX_PLAYERS - 1);
+  qualifiedPlayers.slice(0, CDM_FINALS_MAX_PLAYERS).forEach((player, index) => {
+    const row = index + CDM_FINALS_PLAYER_FIRST_ROW;
     setCell(ws, `A${row}`, index + 1);
     setCell(ws, `B${row}`, player.nickname);
   });
 
-  const blockStarts = [4, 11, 18, 25, 32, 39, 46, 53, 60, 67, 74, 81, 88, 95, 102];
-  const pairRows = [5, 13, 21, 29, 37, 45];
-  blockStarts.forEach((start) => clearRange(ws, start, Math.min(start + 6, 107), 5, 54));
+  CDM_FINALS_BLOCK_START_COLUMNS.forEach((start) =>
+    clearRange(ws, start, Math.min(start + 6, 107), 5, CDM_FINALS_PLAYER_FIRST_ROW + CDM_FINALS_MAX_PLAYERS - 1)
+  );
 
-  finalsMatches.slice(0, blockStarts.length * pairRows.length).forEach((match, index) => {
-    const blockStart = blockStarts[Math.floor(index / pairRows.length)];
-    const row = pairRows[index % pairRows.length];
+  finalsMatches.slice(0, CDM_FINALS_BLOCK_START_COLUMNS.length * CDM_FINALS_PAIR_ROWS.length).forEach((match, index) => {
+    const blockStart = CDM_FINALS_BLOCK_START_COLUMNS[Math.floor(index / CDM_FINALS_PAIR_ROWS.length)];
+    const row = CDM_FINALS_PAIR_ROWS[index % CDM_FINALS_PAIR_ROWS.length];
     const p1Score = mode === "gp" ? match.points1 ?? 0 : match.score1 ?? 0;
     const p2Score = mode === "gp" ? match.points2 ?? 0 : match.score2 ?? 0;
     const label = match.isGrandFinal ? "GF" : match.bracketPosition || match.round || `M${match.matchNumber}`;
@@ -439,9 +470,9 @@ function writeTTFinals(workbook: XLSX.WorkBook, entries: TTEntryExport[], rounds
       (a.totalTime ?? Number.MAX_SAFE_INTEGER) - (b.totalTime ?? Number.MAX_SAFE_INTEGER)
     );
 
-  clearRange(ws, 1, 5, 3, 26);
-  allFinalists.slice(0, 24).forEach((entry, index) => {
-    const row = index + 3;
+  clearRange(ws, 1, 5, CDM_TT_FINALIST_FIRST_ROW, CDM_TT_FINALIST_FIRST_ROW + CDM_TT_FINALIST_MAX_ROWS - 1);
+  allFinalists.slice(0, CDM_TT_FINALIST_MAX_ROWS).forEach((entry, index) => {
+    const row = index + CDM_TT_FINALIST_FIRST_ROW;
     setCell(ws, `A${row}`, index + 1);
     setCell(ws, `B${row}`, entry.player.nickname);
     setCell(ws, `C${row}`, entry.eliminated ? 0 : 1);
@@ -449,15 +480,14 @@ function writeTTFinals(workbook: XLSX.WorkBook, entries: TTEntryExport[], rounds
     setCell(ws, `E${row}`, entry.totalTime ?? "");
   });
 
-  const roundStarts = [7, 20, 33, 46, 59, 72, 85, 98];
-  roundStarts.forEach((start) => clearRange(ws, start, Math.min(start + 5, 524), 1, 26));
+  CDM_TT_ROUND_START_COLUMNS.forEach((start) => clearRange(ws, start, Math.min(start + 5, 524), 1, 26));
 
   rounds
     .filter((round) => round.phase === "phase1" || round.phase === "phase2" || round.phase === "phase3")
     .sort((a, b) => a.phase.localeCompare(b.phase) || a.roundNumber - b.roundNumber)
-    .slice(0, roundStarts.length)
+    .slice(0, CDM_TT_ROUND_START_COLUMNS.length)
     .forEach((round, index) => {
-      const start = roundStarts[index];
+      const start = CDM_TT_ROUND_START_COLUMNS[index];
       const results = Array.isArray(round.results) ? round.results as Array<{ playerId?: string; timeMs?: number; isRetry?: boolean }> : [];
       const entriesById = new Map(entries.map((entry) => [entry.playerId, entry]));
 
@@ -468,8 +498,8 @@ function writeTTFinals(workbook: XLSX.WorkBook, entries: TTEntryExport[], rounds
       setCell(ws, `${toColumn(start + 4)}2`, "Lost");
       setCell(ws, `${toColumn(start + 5)}2`, "Left");
 
-      results.slice(0, 24).forEach((result, resultIndex) => {
-        const row = resultIndex + 3;
+      results.slice(0, CDM_TT_ROUND_MAX_RESULTS).forEach((result, resultIndex) => {
+        const row = resultIndex + CDM_TT_FINALIST_FIRST_ROW;
         const entry = result.playerId ? entriesById.get(result.playerId) : null;
         setCell(ws, `${toColumn(start)}${row}`, resultIndex + 1);
         setCell(ws, `${toColumn(start + 1)}${row}`, entry?.player.nickname ?? result.playerId ?? "");
@@ -484,13 +514,13 @@ function writeOverallRanking(workbook: XLSX.WorkBook, scores: TournamentPlayerSc
   const ws = workbook.Sheets["Overall Ranking"];
   if (!ws) return;
 
-  clearRange(ws, 1, 24, 2, 65);
+  clearRange(ws, 1, 24, CDM_OVERALL_FIRST_ROW, CDM_OVERALL_FIRST_ROW + CDM_OVERALL_MAX_ROWS - 1);
   scores
     .slice()
     .sort((a, b) => (a.overallRank ?? Number.MAX_SAFE_INTEGER) - (b.overallRank ?? Number.MAX_SAFE_INTEGER) || b.totalPoints - a.totalPoints)
-    .slice(0, 64)
+    .slice(0, CDM_OVERALL_MAX_ROWS)
     .forEach((score, index) => {
-      const row = index + 2;
+      const row = index + CDM_OVERALL_FIRST_ROW;
       const rank = score.overallRank ?? index + 1;
       setCell(ws, `A${row}`, rank);
       setCell(ws, `B${row}`, score.player.nickname);
@@ -589,31 +619,16 @@ export async function GET(
       if (session.user.role !== "admin") {
         return handleAuthzError("Admin access required");
       }
-    }
 
-    // Fetch tournament with ALL related data across all match types.
-    // This is a heavy query but is acceptable for an export operation
-    // that is called infrequently (typically once after a tournament ends).
-    const tournament = await prisma.tournament.findUnique({
-      where: { id: tournamentId },
-      include: {
-        bmQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
-        mrQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
-        gpQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
-        bmMatches: { include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } } },
-        mrMatches: { include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } } },
-        gpMatches: { include: { player1: { select: PLAYER_PUBLIC_SELECT }, player2: { select: PLAYER_PUBLIC_SELECT } } },
-        ttEntries: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
-        ttPhaseRounds: true,
-        playerScores: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
-      },
-    });
+      const tournament = await prisma.tournament.findUnique({
+        where: { id: tournamentId },
+        include: CDM_EXPORT_INCLUDE,
+      });
 
-    if (!tournament) {
-      return createErrorResponse("Tournament not found", 404);
-    }
+      if (!tournament) {
+        return createErrorResponse("Tournament not found", 404);
+      }
 
-    if (exportFormat === "cdm") {
       const template = await loadCDMTemplate(request);
       if (!template.ok) {
         logger.error("Failed to load CDM export template", {
@@ -634,6 +649,18 @@ export async function GET(
           "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(filename)}; filename="${filename}"`,
         },
       });
+    }
+
+    // CSV does not read CDM-only qualification/phase/overall tables, so keep
+    // its include narrow. The CDM workbook path above opts into the heavier
+    // include set only when those workbook sheets need the extra data.
+    const tournament = await prisma.tournament.findUnique({
+      where: { id: tournamentId },
+      include: BASE_EXPORT_INCLUDE,
+    });
+
+    if (!tournament) {
+      return createErrorResponse("Tournament not found", 404);
     }
 
     // UTF-8 BOM (Byte Order Mark) ensures Excel correctly interprets


### PR DESCRIPTION
Summary:
- Split CSV and CDM export Prisma include shapes so CSV avoids CDM-only tables
- Remove the redundant timeValueForCDM wrapper in favor of parseTimeMs
- Name and document CDM template coordinate limits, with drift coverage for the follow-ups

Issues: #817, #818, #819

Validation:
- npm test -- --runInBand --runTestsByPath __tests__/app/api/tournaments/[id]/export/route.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint
- npm run build:cf