### PR TITLE
refactor: name remaining CDM export coordinates

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -728,6 +728,26 @@
 - **期待結果**: CDM テンプレート由来の固定値は、どの workbook 範囲を守るための値か読める
 - **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-1871A: CDM export — TT Qualifications の範囲定数を専用名にする
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #1871。TT Qualifications は Main Hub と同じ行レイアウトだが、`CDM_PLAYER_HUB_*` を直接使うと別シートの範囲が Main Hub に依存しているように読める。
+- **手順**:
+  1. `CDM_TT_QUAL_FIRST_ROW` / `CDM_TT_QUAL_MAX_PLAYERS` が存在することを確認する
+  2. `writeTTQualifications` が TT 専用定数を使って clear と slice を行うことを確認する
+  3. TT 専用定数が Main Hub と同じレイアウトである理由コメントを持つことを確認する
+- **期待結果**: TT Qualifications の固定範囲は、Main Hub の実装詳細ではなく TT シートの範囲として読める
+- **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
+
+## TC-1872A: CDM export — finals/TT round の残存座標を名前付き定数にする
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #1872。`writeMatchFinalsSheet` / `writeTTFinals` の clearRange に残った `107`, `5`, `524`, `1`, `26` は CDM 2025 テンプレート由来の固定座標であり、数値直書きのままだと根拠が追いにくい。
+- **手順**:
+  1. finals block の幅、最終列、match 開始行が `CDM_FINALS_*` 定数で表現されることを確認する
+  2. TT round block の幅、最終列、開始/終了行が `CDM_TT_ROUND_*` 定数で表現されることを確認する
+  3. `clearRange` がこれらの定数を使い、数値直書きを残していないことを確認する
+- **期待結果**: finals/TT round のテンプレート座標はすべて名前付き定数経由で参照される
+- **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-348: キャラクター統計 API — admin のみアクセス可 (TC-328 と重複なし: 形式チェック)
 - **URL**: /api/players/[id]/character-stats
 - **authRequired**: true (admin) / false → 401

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -212,6 +212,37 @@ describe('E2E case drift coverage', () => {
     expect(exportRoute).toContain('CDM_OVERALL_MAX_ROWS');
   });
 
+  it('documents TC-1871A as TT Qualifications sheet-specific range names', () => {
+    const section = e2eCaseSection('TC-1871A');
+
+    expect(section).toContain('issue #1871');
+    expect(section).toContain('CDM_TT_QUAL_FIRST_ROW');
+    expect(section).toContain('CDM_TT_QUAL_MAX_PLAYERS');
+    expect(section).toContain('Main Hub と同じ行レイアウト');
+    expect(exportRoute).toContain('const CDM_TT_QUAL_FIRST_ROW = CDM_PLAYER_HUB_FIRST_ROW');
+    expect(exportRoute).toContain('const CDM_TT_QUAL_MAX_PLAYERS = CDM_PLAYER_HUB_MAX_PLAYERS');
+    expect(exportRoute).toContain('TT Qualifications uses the same rows as Main Hub');
+    expect(exportRoute).toContain('CDM_TT_QUAL_FIRST_ROW + CDM_TT_QUAL_MAX_PLAYERS');
+    expect(exportRoute).toContain('qualificationEntries.slice(0, CDM_TT_QUAL_MAX_PLAYERS)');
+  });
+
+  it('documents TC-1872A as finals and TT round coordinate constants', () => {
+    const section = e2eCaseSection('TC-1872A');
+
+    expect(section).toContain('issue #1872');
+    expect(section).toContain('CDM_FINALS_*');
+    expect(section).toContain('CDM_TT_ROUND_*');
+    expect(exportRoute).toContain('CDM_FINALS_BLOCK_WIDTH');
+    expect(exportRoute).toContain('CDM_FINALS_LAST_COLUMN');
+    expect(exportRoute).toContain('CDM_FINALS_MATCH_FIRST_ROW');
+    expect(exportRoute).toContain('CDM_TT_ROUND_BLOCK_WIDTH');
+    expect(exportRoute).toContain('CDM_TT_ROUND_LAST_COLUMN');
+    expect(exportRoute).toContain('CDM_TT_ROUND_FIRST_ROW');
+    expect(exportRoute).toContain('CDM_TT_ROUND_LAST_ROW');
+    expect(exportRoute).toContain('Math.min(start + CDM_FINALS_BLOCK_WIDTH, CDM_FINALS_LAST_COLUMN)');
+    expect(exportRoute).toContain('Math.min(start + CDM_TT_ROUND_BLOCK_WIDTH, CDM_TT_ROUND_LAST_COLUMN)');
+  });
+
   it('keeps TC-1010 aligned with the BM 16-player finals regression coverage', () => {
     const section = e2eCaseSection('TC-1010');
     const finalsRouteTest = readRepoFile(

--- a/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
@@ -140,15 +140,26 @@ const CDM_EXPORT_INCLUDE = {
  */
 const CDM_PLAYER_HUB_FIRST_ROW = 2;
 const CDM_PLAYER_HUB_MAX_PLAYERS = 60;
+// TT Qualifications uses the same rows as Main Hub, but keep sheet-specific
+// aliases so the writeTTQualifications range does not look tied to Main Hub.
+const CDM_TT_QUAL_FIRST_ROW = CDM_PLAYER_HUB_FIRST_ROW;
+const CDM_TT_QUAL_MAX_PLAYERS = CDM_PLAYER_HUB_MAX_PLAYERS;
 const CDM_QUALIFICATION_FIRST_ROW = 2;
 const CDM_QUALIFICATION_MAX_ROWS = 767;
 const CDM_FINALS_PLAYER_FIRST_ROW = 3;
 const CDM_FINALS_MAX_PLAYERS = 52;
 const CDM_FINALS_BLOCK_START_COLUMNS = [4, 11, 18, 25, 32, 39, 46, 53, 60, 67, 74, 81, 88, 95, 102];
+const CDM_FINALS_BLOCK_WIDTH = 6;
+const CDM_FINALS_LAST_COLUMN = 107;
+const CDM_FINALS_MATCH_FIRST_ROW = 5;
 const CDM_FINALS_PAIR_ROWS = [5, 13, 21, 29, 37, 45];
 const CDM_TT_FINALIST_FIRST_ROW = 3;
 const CDM_TT_FINALIST_MAX_ROWS = 24;
 const CDM_TT_ROUND_START_COLUMNS = [7, 20, 33, 46, 59, 72, 85, 98];
+const CDM_TT_ROUND_BLOCK_WIDTH = 5;
+const CDM_TT_ROUND_LAST_COLUMN = 524;
+const CDM_TT_ROUND_FIRST_ROW = 1;
+const CDM_TT_ROUND_LAST_ROW = 26;
 const CDM_TT_ROUND_MAX_RESULTS = 24;
 const CDM_OVERALL_FIRST_ROW = 2;
 const CDM_OVERALL_MAX_ROWS = 64;
@@ -267,7 +278,7 @@ function writeTTQualifications(workbook: XLSX.WorkBook, entries: TTEntryExport[]
   const ws = workbook.Sheets["TT Qualifications"];
   if (!ws) return;
 
-  for (let row = CDM_PLAYER_HUB_FIRST_ROW; row < CDM_PLAYER_HUB_FIRST_ROW + CDM_PLAYER_HUB_MAX_PLAYERS; row++) {
+  for (let row = CDM_TT_QUAL_FIRST_ROW; row < CDM_TT_QUAL_FIRST_ROW + CDM_TT_QUAL_MAX_PLAYERS; row++) {
     for (let col = 5; col <= 26; col++) {
       setCell(ws, `${toColumn(col)}${row}`, "");
     }
@@ -277,8 +288,8 @@ function writeTTQualifications(workbook: XLSX.WorkBook, entries: TTEntryExport[]
     .filter((entry) => entry.stage === "qualification")
     .sort((a, b) => (a.seeding ?? Number.MAX_SAFE_INTEGER) - (b.seeding ?? Number.MAX_SAFE_INTEGER));
 
-  qualificationEntries.slice(0, CDM_PLAYER_HUB_MAX_PLAYERS).forEach((entry, index) => {
-    const row = index + CDM_PLAYER_HUB_FIRST_ROW;
+  qualificationEntries.slice(0, CDM_TT_QUAL_MAX_PLAYERS).forEach((entry, index) => {
+    const row = index + CDM_TT_QUAL_FIRST_ROW;
     setCell(ws, `E${row}`, index + 1);
     setCell(ws, `F${row}`, entry.player.nickname);
     const times = normalizeJsonRecord(entry.times);
@@ -418,7 +429,13 @@ function writeMatchFinalsSheet(
   });
 
   CDM_FINALS_BLOCK_START_COLUMNS.forEach((start) =>
-    clearRange(ws, start, Math.min(start + 6, 107), 5, CDM_FINALS_PLAYER_FIRST_ROW + CDM_FINALS_MAX_PLAYERS - 1)
+    clearRange(
+      ws,
+      start,
+      Math.min(start + CDM_FINALS_BLOCK_WIDTH, CDM_FINALS_LAST_COLUMN),
+      CDM_FINALS_MATCH_FIRST_ROW,
+      CDM_FINALS_PLAYER_FIRST_ROW + CDM_FINALS_MAX_PLAYERS - 1
+    )
   );
 
   finalsMatches.slice(0, CDM_FINALS_BLOCK_START_COLUMNS.length * CDM_FINALS_PAIR_ROWS.length).forEach((match, index) => {
@@ -480,7 +497,15 @@ function writeTTFinals(workbook: XLSX.WorkBook, entries: TTEntryExport[], rounds
     setCell(ws, `E${row}`, entry.totalTime ?? "");
   });
 
-  CDM_TT_ROUND_START_COLUMNS.forEach((start) => clearRange(ws, start, Math.min(start + 5, 524), 1, 26));
+  CDM_TT_ROUND_START_COLUMNS.forEach((start) =>
+    clearRange(
+      ws,
+      start,
+      Math.min(start + CDM_TT_ROUND_BLOCK_WIDTH, CDM_TT_ROUND_LAST_COLUMN),
+      CDM_TT_ROUND_FIRST_ROW,
+      CDM_TT_ROUND_LAST_ROW
+    )
+  );
 
   rounds
     .filter((round) => round.phase === "phase1" || round.phase === "phase2" || round.phase === "phase3")


### PR DESCRIPTION
Summary:
- Add TT Qualifications-specific range aliases instead of reusing Main Hub names in that writer
- Replace remaining CDM finals and TT round clearRange literals with named template-coordinate constants
- Add TC-1871A and TC-1872A drift coverage for the coordinate naming follow-ups

Issues: #1871, #1872

Validation:
- npm test -- --runInBand --runTestsByPath __tests__/app/api/tournaments/[id]/export/route.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint
- npm run build:cf