### PR TITLE
fix: clarify CDM export range offsets

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -748,6 +748,16 @@
 - **期待結果**: finals/TT round のテンプレート座標はすべて名前付き定数経由で参照される
 - **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-1874A: CDM export — clearRange の inclusive end を offset 命名で表現する
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #1874。`clearRange` の end column は inclusive なので、`start + 6` / `start + 5` を幅として命名すると実際のクリア列数とずれて読める。
+- **手順**:
+  1. `clearRange` が end column / row を inclusive に扱うことをコメントで確認する
+  2. finals block と TT round block の派生 end column が `*_BLOCK_END_OFFSET` 定数で表現されることを確認する
+  3. `CDM_FINALS_BLOCK_WIDTH` / `CDM_TT_ROUND_BLOCK_WIDTH` が残っていないことを確認する
+- **期待結果**: CDM テンプレートのブロック終端は「幅」ではなく inclusive end offset として読める
+- **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-348: キャラクター統計 API — admin のみアクセス可 (TC-328 と重複なし: 形式チェック)
 - **URL**: /api/players/[id]/character-stats
 - **authRequired**: true (admin) / false → 401

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -232,15 +232,30 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #1872');
     expect(section).toContain('CDM_FINALS_*');
     expect(section).toContain('CDM_TT_ROUND_*');
-    expect(exportRoute).toContain('CDM_FINALS_BLOCK_WIDTH');
+    expect(exportRoute).toContain('CDM_FINALS_BLOCK_END_OFFSET');
     expect(exportRoute).toContain('CDM_FINALS_LAST_COLUMN');
     expect(exportRoute).toContain('CDM_FINALS_MATCH_FIRST_ROW');
-    expect(exportRoute).toContain('CDM_TT_ROUND_BLOCK_WIDTH');
+    expect(exportRoute).toContain('CDM_TT_ROUND_BLOCK_END_OFFSET');
     expect(exportRoute).toContain('CDM_TT_ROUND_LAST_COLUMN');
     expect(exportRoute).toContain('CDM_TT_ROUND_FIRST_ROW');
     expect(exportRoute).toContain('CDM_TT_ROUND_LAST_ROW');
-    expect(exportRoute).toContain('Math.min(start + CDM_FINALS_BLOCK_WIDTH, CDM_FINALS_LAST_COLUMN)');
-    expect(exportRoute).toContain('Math.min(start + CDM_TT_ROUND_BLOCK_WIDTH, CDM_TT_ROUND_LAST_COLUMN)');
+    expect(exportRoute).toContain('Math.min(start + CDM_FINALS_BLOCK_END_OFFSET, CDM_FINALS_LAST_COLUMN)');
+    expect(exportRoute).toContain('Math.min(start + CDM_TT_ROUND_BLOCK_END_OFFSET, CDM_TT_ROUND_LAST_COLUMN)');
+  });
+
+  it('documents TC-1874A as inclusive clearRange end-offset naming', () => {
+    const section = e2eCaseSection('TC-1874A');
+
+    expect(section).toContain('issue #1874');
+    expect(section).toContain('end column は inclusive');
+    expect(section).toContain('*_BLOCK_END_OFFSET');
+    expect(exportRoute).toContain('The end column and row are inclusive');
+    expect(exportRoute).toContain('const CDM_FINALS_BLOCK_END_OFFSET = 6');
+    expect(exportRoute).toContain('const CDM_TT_ROUND_BLOCK_END_OFFSET = 5');
+    expect(exportRoute).toContain('Math.min(start + CDM_FINALS_BLOCK_END_OFFSET, CDM_FINALS_LAST_COLUMN)');
+    expect(exportRoute).toContain('Math.min(start + CDM_TT_ROUND_BLOCK_END_OFFSET, CDM_TT_ROUND_LAST_COLUMN)');
+    expect(exportRoute).not.toContain('CDM_FINALS_BLOCK_WIDTH');
+    expect(exportRoute).not.toContain('CDM_TT_ROUND_BLOCK_WIDTH');
   });
 
   it('keeps TC-1010 aligned with the BM 16-player finals regression coverage', () => {

--- a/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
@@ -149,14 +149,14 @@ const CDM_QUALIFICATION_MAX_ROWS = 767;
 const CDM_FINALS_PLAYER_FIRST_ROW = 3;
 const CDM_FINALS_MAX_PLAYERS = 52;
 const CDM_FINALS_BLOCK_START_COLUMNS = [4, 11, 18, 25, 32, 39, 46, 53, 60, 67, 74, 81, 88, 95, 102];
-const CDM_FINALS_BLOCK_WIDTH = 6;
+const CDM_FINALS_BLOCK_END_OFFSET = 6;
 const CDM_FINALS_LAST_COLUMN = 107;
 const CDM_FINALS_MATCH_FIRST_ROW = 5;
 const CDM_FINALS_PAIR_ROWS = [5, 13, 21, 29, 37, 45];
 const CDM_TT_FINALIST_FIRST_ROW = 3;
 const CDM_TT_FINALIST_MAX_ROWS = 24;
 const CDM_TT_ROUND_START_COLUMNS = [7, 20, 33, 46, 59, 72, 85, 98];
-const CDM_TT_ROUND_BLOCK_WIDTH = 5;
+const CDM_TT_ROUND_BLOCK_END_OFFSET = 5;
 const CDM_TT_ROUND_LAST_COLUMN = 524;
 const CDM_TT_ROUND_FIRST_ROW = 1;
 const CDM_TT_ROUND_LAST_ROW = 26;
@@ -377,6 +377,9 @@ function uniquePlayersFromMatches(matches: MatchWithPlayers[]): PlayerPublic[] {
   return [...players.values()].sort((a, b) => a.nickname.localeCompare(b.nickname));
 }
 
+// The end column and row are inclusive because XLSX cells are addressed one by
+// one here; callers that derive an end column from a start column must pass an
+// explicit end offset, not a count/width, to avoid off-by-one mistakes.
 function clearRange(ws: XLSX.WorkSheet, startCol: number, endCol: number, startRow: number, endRow: number) {
   for (let row = startRow; row <= endRow; row++) {
     for (let col = startCol; col <= endCol; col++) {
@@ -432,7 +435,7 @@ function writeMatchFinalsSheet(
     clearRange(
       ws,
       start,
-      Math.min(start + CDM_FINALS_BLOCK_WIDTH, CDM_FINALS_LAST_COLUMN),
+      Math.min(start + CDM_FINALS_BLOCK_END_OFFSET, CDM_FINALS_LAST_COLUMN),
       CDM_FINALS_MATCH_FIRST_ROW,
       CDM_FINALS_PLAYER_FIRST_ROW + CDM_FINALS_MAX_PLAYERS - 1
     )
@@ -501,7 +504,7 @@ function writeTTFinals(workbook: XLSX.WorkBook, entries: TTEntryExport[], rounds
     clearRange(
       ws,
       start,
-      Math.min(start + CDM_TT_ROUND_BLOCK_WIDTH, CDM_TT_ROUND_LAST_COLUMN),
+      Math.min(start + CDM_TT_ROUND_BLOCK_END_OFFSET, CDM_TT_ROUND_LAST_COLUMN),
       CDM_TT_ROUND_FIRST_ROW,
       CDM_TT_ROUND_LAST_ROW
     )


### PR DESCRIPTION
Summary:
- Rename CDM finals and TT round block constants from width to inclusive end-offset terminology
- Document clearRange inclusive end column/row behavior to prevent off-by-one reuse
- Add TC-1874A drift coverage for the naming contract

Issues: #1874

Validation:
- npm test -- --runInBand --runTestsByPath __tests__/app/api/tournaments/[id]/export/route.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint
- npm run build:cf