### PR TITLE
fix: map CDM finals exports to bracket slots

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -699,6 +699,16 @@
 - **期待結果**: 認証済み管理者の CDM エクスポートが `.xlsm` としてダウンロードされる。`download.path()` が取得できない場合は、永続コンテキストの `acceptDownloads` 設定を確認できる診断メッセージで FAIL する。
 - **スクリプト**: tc-all.js TC-358
 
+## TC-816A: CDM export — finals をテンプレートの bracket 座標へ配置する
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #816。CDM Finals シートは dense table ではなく固定 bracket レイアウトなので、match を順番に詰めると Barrage / Top 16 / Upper / Lower / GF / Reset の位置がずれる。
+- **手順**:
+  1. playoff、winners、losers、grand final、reset の各 round を含む CDM export fixture を作る
+  2. BM/MR/GP Finals の round が `CDM_FINALS_BRACKET_SLOTS` の block/row 座標へ配置されることを確認する
+  3. GP Finals の cupResults summary が移動先の bracket slot に残ることを確認する
+- **期待結果**: finals match は CDM 2025 テンプレートの native bracket coordinates に配置され、GP の cup/points 補足情報も失われない
+- **スクリプト**: `tc-all.js TC-816A`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-817B: CDM export — CSV では CDM 専用 include を取得しない
 - **URL**: /api/tournaments/[id]/export
 - **背景**: issue #817。CSV 出力は MR/GP qualification seed、TT phase rounds、overall playerScores を使用しないため、CDM 専用 include を無条件に付けると不要な JOIN が増える。

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -235,6 +235,88 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       expect(result.headers['Content-Disposition']).toContain('.xlsm');
     });
 
+    it('should place CDM finals matches in native bracket coordinates', async () => {
+      const player = (id: string) => ({ id, name: `Name ${id}`, nickname: id.toUpperCase() });
+      const match = (round: string, matchNumber: number, p1: string, p2: string, stage = 'finals') => ({
+        matchNumber,
+        stage,
+        round,
+        bracketPosition: round === 'gf' ? 'gf' : round,
+        isGrandFinal: round === 'gf',
+        player1: player(p1),
+        player2: player(p2),
+        score1: 2,
+        score2: 1,
+        points1: 2,
+        points2: 1,
+        completed: true,
+      });
+      const finalsMatches = [
+        match('playoff_r1', 1, 'p1', 'p2', 'playoff'),
+        match('playoff_r2', 5, 'p3', 'p4', 'playoff'),
+        match('winners_r1', 1, 'p5', 'p6'),
+        match('winners_qf', 9, 'p7', 'p8'),
+        match('winners_sf', 13, 'p9', 'p10'),
+        match('winners_final', 15, 'p11', 'p12'),
+        match('losers_r1', 16, 'p13', 'p14'),
+        match('losers_r2', 20, 'p15', 'p16'),
+        match('losers_r3', 24, 'p17', 'p18'),
+        match('losers_r4', 26, 'p19', 'p20'),
+        match('losers_sf', 28, 'p21', 'p22'),
+        match('losers_final', 29, 'p23', 'p24'),
+        match('gf', 30, 'p25', 'p26'),
+        match('grand_final_reset', 31, 'p27', 'p28'),
+      ];
+      const mockTournament = {
+        id: 't1',
+        name: 'CDM Bracket Coordinates',
+        date: new Date('2024-01-15'),
+        status: 'completed',
+        bmQualifications: [],
+        mrQualifications: [],
+        gpQualifications: [],
+        bmMatches: finalsMatches,
+        mrMatches: finalsMatches,
+        gpMatches: finalsMatches,
+        ttEntries: [],
+        ttPhaseRounds: [],
+        playerScores: [],
+      };
+
+      (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
+      });
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
+      const params = Promise.resolve({ id: 't1' });
+      await GET(request, { params });
+
+      const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
+      const sheet = workbook.Sheets["BM Finals"];
+      expect(sheet.D5.v).toBe('playoff_r1');
+      expect(sheet.K5.v).toBe('playoff_r2');
+      expect(sheet.R5.v).toBe('winners_r1');
+      expect(sheet.Y7.v).toBe('winners_qf');
+      expect(sheet.AF11.v).toBe('winners_sf');
+      expect(sheet.AM19.v).toBe('winners_final');
+      expect(sheet.AT19.v).toBe('GF');
+      expect(sheet.BA19.v).toBe('GF Reset');
+      expect(sheet.R41.v).toBe('losers_r1');
+      expect(sheet.Y41.v).toBe('losers_r2');
+      expect(sheet.AF43.v).toBe('losers_r3');
+      expect(sheet.AM43.v).toBe('losers_r4');
+      expect(sheet.AT47.v).toBe('losers_sf');
+      expect(sheet.BA47.v).toBe('losers_final');
+      expect(sheet.AC7.v).toBe(2);
+      expect(sheet.AC8.v).toBe(1);
+      expect(workbook.Sheets["MR Finals"].Y7.v).toBe('winners_qf');
+      expect(workbook.Sheets["MR Finals"].AT19.v).toBe('GF');
+      expect(workbook.Sheets["GP Finals"].Y7.v).toBe('winners_qf');
+      expect(workbook.Sheets["GP Finals"].BA47.v).toBe('losers_final');
+    });
+
     it('should return 401 when CDM export is requested without authentication', async () => {
       (auth as jest.Mock).mockResolvedValue(null);
 
@@ -473,9 +555,9 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       await GET(request, { params });
 
       const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
-      expect(workbook.Sheets["GP Finals"].H5.v).toBe(2);
-      expect(workbook.Sheets["GP Finals"].H6.v).toBe(1);
-      expect(workbook.Sheets["GP Finals"].I5.v).toBe('Mushroom: 45-30; Flower: 24-45; Star: 48-21');
+      expect(workbook.Sheets["GP Finals"].AQ19.v).toBe(2);
+      expect(workbook.Sheets["GP Finals"].AQ20.v).toBe(1);
+      expect(workbook.Sheets["GP Finals"].AR19.v).toBe('Mushroom: 45-30; Flower: 24-45; Star: 48-21');
     });
 
     it('should export BM qualification data grouped by group', async () => {

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -171,6 +171,34 @@ describe('E2E case drift coverage', () => {
     expect(tcGp).not.toMatch(/\{\s*name:\s*['"]TC-830['"]/);
   });
 
+  it('documents TC-816A as CDM finals native bracket coordinate coverage', () => {
+    const section = e2eCaseSection('TC-816A');
+
+    expect(section).toContain('issue #816');
+    expect(section).toContain('CDM_FINALS_BRACKET_SLOTS');
+    expect(section).toContain('native bracket coordinates');
+    expect(exportRoute).toContain('const CDM_FINALS_BRACKET_SLOTS');
+    expect(exportRoute).toContain('playoff_r1');
+    expect(exportRoute).toContain('winners_r1');
+    expect(exportRoute).toContain('losers_final');
+    expect(exportRoute).toContain('cdmFinalsSlotRound');
+    expect(exportRoute).toContain('cdmFinalsSlotForMatch');
+    expect(exportRoute).toContain('cdmFinalsMatchLabel');
+    expect(tcAll).toContain('TC-816A');
+    expect(tcAll).toContain('CDM_FINALS_E2E_SLOTS');
+    expect(tcAll).toContain('XLSX.read(Buffer.from(exportResp.bytes)');
+    expect(tcAll).toContain('cdmE2eGpCupResultsSummary');
+    expect(tcAll).toContain('gpCupResultsChecked');
+    expect(tcAll).toContain('checkedByMode');
+    expect(tcAll).toContain('slot.blockStart + 5');
+    expect(exportRouteTest).toContain('should place CDM finals matches in native bracket coordinates');
+    expect(exportRouteTest).toContain('sheet.Y7.v');
+    expect(exportRouteTest).toContain('sheet.BA47.v');
+    expect(exportRouteTest).toContain('workbook.Sheets["MR Finals"].AT19.v');
+    expect(exportRouteTest).toContain('workbook.Sheets["GP Finals"].BA47.v');
+    expect(exportRouteTest).toContain('workbook.Sheets["GP Finals"].AR19.v');
+  });
+
   it('documents TC-817B as CSV/CDM export include split coverage', () => {
     const section = e2eCaseSection('TC-817B');
 

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -10,6 +10,7 @@
  */
 const fs = require('fs');
 const https = require('https');
+const XLSX = require('@e965/xlsx');
 const {
   apiActivateTournament,
   apiUpdateTournament,
@@ -35,6 +36,9 @@ const {
   makeTaTimesForRank,
   apiPutAllGpQualScores,
   apiGenerateGpFinals,
+  apiFetchBmFinalsState,
+  apiFetchMrFinalsState,
+  apiFetchGpFinalsState,
   resolveAllTies,
   launchChromium,
   launchPersistentChromiumContext,
@@ -65,6 +69,59 @@ let TID = null;
 const WAIT = 8000;
 const results = [];
 let progressWatchdog = null;
+
+const CDM_FINALS_E2E_SLOTS = {
+  playoff_r1: [5, 13, 21, 29].map((row) => ({ blockStart: 4, row })),
+  playoff_r2: [5, 13, 21, 29].map((row) => ({ blockStart: 11, row })),
+  winners_r1: [5, 9, 13, 17, 21, 25, 29, 33].map((row) => ({ blockStart: 18, row })),
+  winners_qf: [7, 15, 23, 31].map((row) => ({ blockStart: 25, row })),
+  winners_sf: [11, 27].map((row) => ({ blockStart: 32, row })),
+  winners_final: [{ blockStart: 39, row: 19 }],
+  grand_final: [{ blockStart: 46, row: 19 }],
+  grand_final_reset: [{ blockStart: 53, row: 19 }],
+  losers_r1: [41, 45, 49, 53].map((row) => ({ blockStart: 18, row })),
+  losers_r2: [41, 45, 49, 53].map((row) => ({ blockStart: 25, row })),
+  losers_r3: [43, 51].map((row) => ({ blockStart: 32, row })),
+  losers_r4: [43, 51].map((row) => ({ blockStart: 39, row })),
+  losers_sf: [{ blockStart: 46, row: 47 }],
+  losers_final: [{ blockStart: 53, row: 47 }],
+};
+
+function cdmE2eSlotRound(match) {
+  const round = match?.round || '';
+  const bracketPosition = String(match?.bracketPosition || '').toLowerCase();
+  if (Object.prototype.hasOwnProperty.call(CDM_FINALS_E2E_SLOTS, round)) return round;
+  if (round === 'grand_final_reset' || bracketPosition.includes('reset')) return 'grand_final_reset';
+  if (round === 'gf' || bracketPosition === 'gf' || match?.isGrandFinal) return 'grand_final';
+  return null;
+}
+
+function cdmE2eMatchLabel(match) {
+  const slotRound = cdmE2eSlotRound(match);
+  if (slotRound === 'grand_final_reset') return 'GF Reset';
+  if (slotRound === 'grand_final') return 'GF';
+  return match.bracketPosition || match.round || `M${match.matchNumber}`;
+}
+
+function cdmE2eCell(col, row) {
+  return XLSX.utils.encode_cell({ c: col - 1, r: row - 1 });
+}
+
+function cdmE2eFinalsMatches(state) {
+  return [
+    ...(state?.playoffMatches || []),
+    ...(state?.matches || []),
+  ].filter((match) => cdmE2eSlotRound(match));
+}
+
+function cdmE2eGpCupResultsSummary(match) {
+  return (match.cupResults || []).map((result, index) => {
+    const cup = typeof result?.cup === 'string' && result.cup ? result.cup : `Cup ${index + 1}`;
+    const points1 = Number.isFinite(result?.points1) ? result.points1 : '';
+    const points2 = Number.isFinite(result?.points2) ? result.points2 : '';
+    return `${cup}: ${points1}-${points2}`;
+  }).join('; ');
+}
 
 function log(tc, s, d = '') {
   console.log(`${s === 'PASS' ? '✅' : s === 'SKIP' ? '⏭️' : '❌'} [${tc}] ${s}${d ? ' — ' + d : ''}`);
@@ -3195,6 +3252,87 @@ async function main() {
       }
     } else {
       log('TC-358', 'SKIP', 'No tournament ID available');
+    }
+  }
+
+  // TC-816A: CDM export finals coordinate mapping is covered by the automated E2E runner.
+  {
+    const exportTid = sharedFixture?.tournamentId ?? TID;
+    if (exportTid) {
+      try {
+        const [bmState, mrState, gpState, exportResp] = await Promise.all([
+          apiFetchBmFinalsState(page, exportTid),
+          apiFetchMrFinalsState(page, exportTid),
+          apiFetchGpFinalsState(page, exportTid),
+          page.evaluate(async (url) => {
+            const response = await fetch(url, { credentials: 'same-origin' });
+            const buffer = await response.arrayBuffer();
+            return {
+              status: response.status,
+              bytes: Array.from(new Uint8Array(buffer)),
+              contentType: response.headers.get('content-type') || '',
+            };
+          }, `${BASE}/api/tournaments/${exportTid}/export?format=cdm`),
+        ]);
+
+        if (exportResp.status !== 200) {
+          log('TC-816A', 'FAIL', `CDM export HTTP ${exportResp.status}`);
+        } else {
+          const workbook = XLSX.read(Buffer.from(exportResp.bytes), { type: 'buffer' });
+          const modeStates = [
+            { mode: 'BM', sheetName: 'BM Finals', state: bmState },
+            { mode: 'MR', sheetName: 'MR Finals', state: mrState },
+            { mode: 'GP', sheetName: 'GP Finals', state: gpState },
+          ];
+          const failures = [];
+          let checked = 0;
+          let gpCupResultsChecked = false;
+          const checkedByMode = { BM: 0, MR: 0, GP: 0 };
+
+          for (const { mode, sheetName, state } of modeStates) {
+            const sheet = workbook.Sheets[sheetName];
+            const roundIndexes = new Map();
+            for (const match of cdmE2eFinalsMatches(state)) {
+              const slotRound = cdmE2eSlotRound(match);
+              const roundIndex = roundIndexes.get(slotRound) || 0;
+              roundIndexes.set(slotRound, roundIndex + 1);
+              const slot = CDM_FINALS_E2E_SLOTS[slotRound]?.[roundIndex];
+              if (!slot) continue;
+              const labelCell = cdmE2eCell(slot.blockStart, slot.row);
+              const actual = sheet?.[labelCell]?.v;
+              const expected = cdmE2eMatchLabel(match);
+              checked++;
+              checkedByMode[mode]++;
+              if (actual !== expected) {
+                failures.push(`${mode} ${slotRound} ${labelCell}: expected ${expected}, got ${actual ?? '<blank>'}`);
+              }
+              if (mode === 'GP' && Array.isArray(match.cupResults) && match.cupResults.length > 0 && !gpCupResultsChecked) {
+                const summaryCell = cdmE2eCell(slot.blockStart + 5, slot.row);
+                const expectedSummary = cdmE2eGpCupResultsSummary(match);
+                const actualSummary = sheet?.[summaryCell]?.v;
+                gpCupResultsChecked = true;
+                if (actualSummary !== expectedSummary) {
+                  failures.push(`GP cupResults ${summaryCell}: expected ${expectedSummary}, got ${actualSummary ?? '<blank>'}`);
+                }
+              }
+            }
+          }
+          const missingModes = Object.entries(checkedByMode)
+            .filter(([, count]) => count === 0)
+            .map(([mode]) => mode);
+
+          log('TC-816A',
+            checked > 0 && missingModes.length === 0 && gpCupResultsChecked && failures.length === 0 ? 'PASS' : 'FAIL',
+            checked === 0 ? 'No finals matches available for CDM coordinate verification'
+            : missingModes.length > 0 ? `No finals matches checked for modes: ${missingModes.join(', ')}`
+            : !gpCupResultsChecked ? 'No GP finals cupResults available for CDM coordinate verification'
+            : failures.slice(0, 3).join('; '));
+        }
+      } catch (err) {
+        log('TC-816A', 'FAIL', err instanceof Error ? err.message : 'CDM finals coordinate workbook check failed');
+      }
+    } else {
+      log('TC-816A', 'SKIP', 'No tournament ID available');
     }
   }
 

--- a/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
@@ -153,6 +153,25 @@ const CDM_FINALS_BLOCK_END_OFFSET = 6;
 const CDM_FINALS_LAST_COLUMN = 107;
 const CDM_FINALS_MATCH_FIRST_ROW = 5;
 const CDM_FINALS_PAIR_ROWS = [5, 13, 21, 29, 37, 45];
+// CDM Finals sheets are laid out as fixed bracket regions, not as a dense
+// table. Map the app's canonical round ids to the template's native block and
+// top-row coordinates so exports preserve the bracket shape operators expect.
+const CDM_FINALS_BRACKET_SLOTS: Record<string, Array<{ blockStart: number; row: number }>> = {
+  playoff_r1: [5, 13, 21, 29].map((row) => ({ blockStart: 4, row })),
+  playoff_r2: [5, 13, 21, 29].map((row) => ({ blockStart: 11, row })),
+  winners_r1: [5, 9, 13, 17, 21, 25, 29, 33].map((row) => ({ blockStart: 18, row })),
+  winners_qf: [7, 15, 23, 31].map((row) => ({ blockStart: 25, row })),
+  winners_sf: [11, 27].map((row) => ({ blockStart: 32, row })),
+  winners_final: [{ blockStart: 39, row: 19 }],
+  grand_final: [{ blockStart: 46, row: 19 }],
+  grand_final_reset: [{ blockStart: 53, row: 19 }],
+  losers_r1: [41, 45, 49, 53].map((row) => ({ blockStart: 18, row })),
+  losers_r2: [41, 45, 49, 53].map((row) => ({ blockStart: 25, row })),
+  losers_r3: [43, 51].map((row) => ({ blockStart: 32, row })),
+  losers_r4: [43, 51].map((row) => ({ blockStart: 39, row })),
+  losers_sf: [{ blockStart: 46, row: 47 }],
+  losers_final: [{ blockStart: 53, row: 47 }],
+};
 const CDM_TT_FINALIST_FIRST_ROW = 3;
 const CDM_TT_FINALIST_MAX_ROWS = 24;
 const CDM_TT_ROUND_START_COLUMNS = [7, 20, 33, 46, 59, 72, 85, 98];
@@ -163,6 +182,19 @@ const CDM_TT_ROUND_LAST_ROW = 26;
 const CDM_TT_ROUND_MAX_RESULTS = 24;
 const CDM_OVERALL_FIRST_ROW = 2;
 const CDM_OVERALL_MAX_ROWS = 64;
+
+// Older generators and manual fixtures can still store grand finals as
+// round="gf" with bracketPosition="gf"; normalize those aliases before slot
+// lookup so legacy rows land in the same native CDM bracket cell as current
+// round="grand_final" rows.
+function cdmFinalsSlotRound(match: MatchWithPlayers): string | null {
+  const round = match.round ?? "";
+  const bracketPosition = (match.bracketPosition ?? "").toLowerCase();
+  if (round in CDM_FINALS_BRACKET_SLOTS) return round;
+  if (round === "grand_final_reset" || bracketPosition.includes("reset")) return "grand_final_reset";
+  if (round === "gf" || bracketPosition === "gf" || match.isGrandFinal) return "grand_final";
+  return null;
+}
 
 function setCell(ws: XLSX.WorkSheet, address: string, value: unknown) {
   if (value === null || value === undefined) {
@@ -402,6 +434,29 @@ function gpCupResultsSummary(match: MatchWithPlayers): string {
   }).join("; ");
 }
 
+function cdmFinalsSlotForMatch(
+  match: MatchWithPlayers,
+  roundIndex: number,
+  fallbackIndex: number
+): { blockStart: number; row: number } | null {
+  const slotRound = cdmFinalsSlotRound(match);
+  const slots = slotRound ? CDM_FINALS_BRACKET_SLOTS[slotRound] : undefined;
+  if (slots?.[roundIndex]) {
+    return slots[roundIndex];
+  }
+
+  const fallbackBlockStart = CDM_FINALS_BLOCK_START_COLUMNS[Math.floor(fallbackIndex / CDM_FINALS_PAIR_ROWS.length)];
+  const fallbackRow = CDM_FINALS_PAIR_ROWS[fallbackIndex % CDM_FINALS_PAIR_ROWS.length];
+  return fallbackBlockStart && fallbackRow ? { blockStart: fallbackBlockStart, row: fallbackRow } : null;
+}
+
+function cdmFinalsMatchLabel(match: MatchWithPlayers): string {
+  const slotRound = cdmFinalsSlotRound(match);
+  if (slotRound === "grand_final_reset") return "GF Reset";
+  if (slotRound === "grand_final") return "GF";
+  return match.bracketPosition || match.round || `M${match.matchNumber}`;
+}
+
 function writeMatchFinalsSheet(
   workbook: XLSX.WorkBook,
   sheetName: string,
@@ -414,11 +469,14 @@ function writeMatchFinalsSheet(
 
   const finalsMatches = matches
     .filter((match) =>
+      match.stage === "playoff" ||
       match.stage === "finals" ||
-      match.stage === "grand_final" ||
-      (mode === "gp" && match.stage === "playoff")
+      match.stage === "grand_final"
     )
-    .sort((a, b) => a.matchNumber - b.matchNumber);
+    .sort((a, b) =>
+      (a.round ?? "").localeCompare(b.round ?? "") ||
+      a.matchNumber - b.matchNumber
+    );
 
   const qualifiedPlayers = finalsMatches.length > 0
     ? uniquePlayersFromMatches(finalsMatches)
@@ -441,12 +499,20 @@ function writeMatchFinalsSheet(
     )
   );
 
-  finalsMatches.slice(0, CDM_FINALS_BLOCK_START_COLUMNS.length * CDM_FINALS_PAIR_ROWS.length).forEach((match, index) => {
-    const blockStart = CDM_FINALS_BLOCK_START_COLUMNS[Math.floor(index / CDM_FINALS_PAIR_ROWS.length)];
-    const row = CDM_FINALS_PAIR_ROWS[index % CDM_FINALS_PAIR_ROWS.length];
+  const roundIndexes = new Map<string, number>();
+  let fallbackIndex = 0;
+  finalsMatches.forEach((match) => {
+    const roundKey = match.round ?? "";
+    const roundIndex = roundIndexes.get(roundKey) ?? 0;
+    roundIndexes.set(roundKey, roundIndex + 1);
+    const slot = cdmFinalsSlotForMatch(match, roundIndex, fallbackIndex);
+    fallbackIndex++;
+    if (!slot) return;
+
+    const { blockStart, row } = slot;
     const p1Score = mode === "gp" ? match.points1 ?? 0 : match.score1 ?? 0;
     const p2Score = mode === "gp" ? match.points2 ?? 0 : match.score2 ?? 0;
-    const label = match.isGrandFinal ? "GF" : match.bracketPosition || match.round || `M${match.matchNumber}`;
+    const label = cdmFinalsMatchLabel(match);
 
     setCell(ws, `${toColumn(blockStart)}${row}`, label);
     setCell(ws, `${toColumn(blockStart + 1)}${row}`, match.player1.nickname);


### PR DESCRIPTION
Summary:
- Map CDM finals exports into the native template bracket coordinates for playoff, winners, losers, GF, and reset rounds
- Normalize legacy gf/isGrandFinal rows to the grand-final slot and preserve GP cupResults summaries at the moved coordinates
- Add TC-816A scenario coverage, route tests, drift coverage, and tc-all workbook verification

Issues: #816

Validation:
- npm test -- --runInBand --runTestsByPath __tests__/app/api/tournaments/[id]/export/route.test.ts __tests__/docs/e2e-cases-drift.test.ts
- node --check e2e/tc-all.js
- npm run lint
- npm run build:cf