### PR TITLE
fix: tighten CDM finals export follow-ups

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -709,6 +709,43 @@
 - **期待結果**: finals match は CDM 2025 テンプレートの native bracket coordinates に配置され、GP の cup/points 補足情報も失われない
 - **スクリプト**: `tc-all.js TC-816A`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-1877A: CDM export — grand_final_reset の正規化で到達不能条件を残さない
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #1877。`grand_final_reset` は native slot table で先に解決されるため、同じ round 文字列を後段の別条件に残すと読み手に誤解を与える。
+- **手順**:
+  1. `cdmFinalsSlotRound` が slot table lookup 後に `bracketPosition.includes("reset")` だけで reset alias を扱うことを確認する
+  2. `round === "grand_final_reset" || bracketPosition.includes("reset")` が残っていないことを確認する
+- **期待結果**: grand_final_reset の正規化条件に到達不能な round 判定が残らない
+- **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
+
+## TC-1878A: CDM export — fallback 座標カウンタは unknown round だけで進める
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #1878。既知 round が native slot に配置された後で unknown round が来ても、fallback の最初の空き座標から配置される必要がある。
+- **手順**:
+  1. `winners_qf` と、sort 順で `winners_qf` より後に来る `zz_custom_showmatch` を含む CDM export fixture を作る
+  2. `winners_qf` が native slot `Y7` に配置されることを確認する
+  3. `zz_custom_showmatch` が既知 round 数に影響されず fallback slot `D5` に配置されることを確認する
+- **期待結果**: fallbackIndex は fallback 使用時だけ増え、unknown round の fallback 座標がずれない
+- **スクリプト**: `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+
+## TC-1879A: CDM export — E2E の座標期待値は route.ts と同期する前提を明記する
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #1879。E2E は workbook を実際に読むが、期待セルの座標表は production の slot table と同期していないと誤検知を起こす。
+- **手順**:
+  1. `tc-all.js` の CDM Finals E2E slot table 付近に route.ts の `CDM_FINALS_BRACKET_SLOTS` と同期する旨のコメントがあることを確認する
+  2. TC-816A が XLSM workbook を読み、座標表に基づいて BM/MR/GP のセル値を検証することを確認する
+- **期待結果**: E2E の重複座標表は同期前提が明示され、乖離時のレビュー観点が残る
+- **スクリプト**: `tc-all.js TC-816A`, `__tests__/docs/e2e-cases-drift.test.ts`
+
+## TC-1880A: CDM export — GP cupResults がない環境でも座標検証を false failure にしない
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #1880。GP finals に cupResults がない fixture でも、ブラケット座標自体が正しければ TC-816A は失敗すべきではない。
+- **手順**:
+  1. TC-816A の PASS 条件が `gpCupResultsChecked` を必須にしていないことを確認する
+  2. `gpCupResultsChecked` が false の場合は detail に summary-cell check skipped として記録することを確認する
+- **期待結果**: cupResults 検証は補助チェックになり、BM/MR/GP 座標検証が通れば TC-816A は PASS できる
+- **スクリプト**: `tc-all.js TC-816A`, `__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-817B: CDM export — CSV では CDM 専用 include を取得しない
 - **URL**: /api/tournaments/[id]/export
 - **背景**: issue #817。CSV 出力は MR/GP qualification seed、TT phase rounds、overall playerScores を使用しないため、CDM 専用 include を無条件に付けると不要な JOIN が増える。

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -317,6 +317,61 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       expect(workbook.Sheets["GP Finals"].BA47.v).toBe('losers_final');
     });
 
+    it('should use the first fallback CDM finals slot only for unknown rounds', async () => {
+      const player = (id: string) => ({ id, name: `Name ${id}`, nickname: id.toUpperCase() });
+      const mockTournament = {
+        id: 't1',
+        name: 'CDM Unknown Round Fallback',
+        date: new Date('2024-01-15'),
+        status: 'completed',
+        bmQualifications: [],
+        mrQualifications: [],
+        gpQualifications: [],
+        bmMatches: [
+          {
+            matchNumber: 9,
+            stage: 'finals',
+            round: 'winners_qf',
+            player1: player('p1'),
+            player2: player('p2'),
+            score1: 2,
+            score2: 1,
+            completed: true,
+          },
+          {
+            matchNumber: 99,
+            stage: 'finals',
+            round: 'zz_custom_showmatch',
+            player1: player('p3'),
+            player2: player('p4'),
+            score1: 1,
+            score2: 0,
+            completed: true,
+          },
+        ],
+        mrMatches: [],
+        gpMatches: [],
+        ttEntries: [],
+        ttPhaseRounds: [],
+        playerScores: [],
+      };
+
+      (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
+      });
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
+      const params = Promise.resolve({ id: 't1' });
+      await GET(request, { params });
+
+      const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
+      const sheet = workbook.Sheets["BM Finals"];
+      expect(sheet.Y7.v).toBe('winners_qf');
+      expect(sheet.D5.v).toBe('zz_custom_showmatch');
+    });
+
     it('should return 401 when CDM export is requested without authentication', async () => {
       (auth as jest.Mock).mockResolvedValue(null);
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -199,6 +199,46 @@ describe('E2E case drift coverage', () => {
     expect(exportRouteTest).toContain('workbook.Sheets["GP Finals"].AR19.v');
   });
 
+  it('documents TC-1877A as reachable grand-final reset alias coverage', () => {
+    const section = e2eCaseSection('TC-1877A');
+
+    expect(section).toContain('issue #1877');
+    expect(section).toContain('bracketPosition.includes("reset")');
+    expect(exportRoute).toContain('if (bracketPosition.includes("reset")) return "grand_final_reset"');
+    expect(exportRoute).not.toContain('round === "grand_final_reset" || bracketPosition.includes("reset")');
+  });
+
+  it('documents TC-1878A as unknown-round fallback counter coverage', () => {
+    const section = e2eCaseSection('TC-1878A');
+
+    expect(section).toContain('issue #1878');
+    expect(section).toContain('zz_custom_showmatch');
+    expect(exportRoute).toContain('isFallback: true');
+    expect(exportRoute).toContain('if (slot.isFallback) fallbackIndex++');
+    expect(exportRouteTest).toContain('should use the first fallback CDM finals slot only for unknown rounds');
+    expect(exportRouteTest).toContain('zz_custom_showmatch');
+    expect(exportRouteTest).toContain('sheet.D5.v');
+  });
+
+  it('documents TC-1879A as E2E slot table synchronization coverage', () => {
+    const section = e2eCaseSection('TC-1879A');
+
+    expect(section).toContain('issue #1879');
+    expect(section).toContain('CDM_FINALS_BRACKET_SLOTS');
+    expect(tcAll).toContain('Keep this expectation map synchronized with route.ts CDM_FINALS_BRACKET_SLOTS');
+    expect(tcAll).toContain('XLSX.read(Buffer.from(exportResp.bytes)');
+  });
+
+  it('documents TC-1880A as optional GP cupResults E2E coverage', () => {
+    const section = e2eCaseSection('TC-1880A');
+
+    expect(section).toContain('issue #1880');
+    expect(section).toContain('gpCupResultsChecked');
+    expect(tcAll).toContain('GP cupResults not available; skipped summary-cell check');
+    expect(tcAll).toContain('checked > 0 && missingModes.length === 0 && failures.length === 0');
+    expect(tcAll).not.toContain('missingModes.length === 0 && gpCupResultsChecked && failures.length === 0');
+  });
+
   it('documents TC-817B as CSV/CDM export include split coverage', () => {
     const section = e2eCaseSection('TC-817B');
 

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -87,11 +87,14 @@ const CDM_FINALS_E2E_SLOTS = {
   losers_final: [{ blockStart: 53, row: 47 }],
 };
 
+// Keep this expectation map synchronized with route.ts CDM_FINALS_BRACKET_SLOTS.
+// TC-816A intentionally reads the exported workbook, but it still needs the
+// template's native coordinates to know which cell each round should occupy.
 function cdmE2eSlotRound(match) {
   const round = match?.round || '';
   const bracketPosition = String(match?.bracketPosition || '').toLowerCase();
   if (Object.prototype.hasOwnProperty.call(CDM_FINALS_E2E_SLOTS, round)) return round;
-  if (round === 'grand_final_reset' || bracketPosition.includes('reset')) return 'grand_final_reset';
+  if (bracketPosition.includes('reset')) return 'grand_final_reset';
   if (round === 'gf' || bracketPosition === 'gf' || match?.isGrandFinal) return 'grand_final';
   return null;
 }
@@ -3322,11 +3325,12 @@ async function main() {
             .map(([mode]) => mode);
 
           log('TC-816A',
-            checked > 0 && missingModes.length === 0 && gpCupResultsChecked && failures.length === 0 ? 'PASS' : 'FAIL',
+            checked > 0 && missingModes.length === 0 && failures.length === 0 ? 'PASS' : 'FAIL',
             checked === 0 ? 'No finals matches available for CDM coordinate verification'
             : missingModes.length > 0 ? `No finals matches checked for modes: ${missingModes.join(', ')}`
-            : !gpCupResultsChecked ? 'No GP finals cupResults available for CDM coordinate verification'
-            : failures.slice(0, 3).join('; '));
+            : failures.length > 0 ? failures.slice(0, 3).join('; ')
+            : !gpCupResultsChecked ? 'GP cupResults not available; skipped summary-cell check'
+            : '');
         }
       } catch (err) {
         log('TC-816A', 'FAIL', err instanceof Error ? err.message : 'CDM finals coordinate workbook check failed');

--- a/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
@@ -191,7 +191,7 @@ function cdmFinalsSlotRound(match: MatchWithPlayers): string | null {
   const round = match.round ?? "";
   const bracketPosition = (match.bracketPosition ?? "").toLowerCase();
   if (round in CDM_FINALS_BRACKET_SLOTS) return round;
-  if (round === "grand_final_reset" || bracketPosition.includes("reset")) return "grand_final_reset";
+  if (bracketPosition.includes("reset")) return "grand_final_reset";
   if (round === "gf" || bracketPosition === "gf" || match.isGrandFinal) return "grand_final";
   return null;
 }
@@ -438,16 +438,16 @@ function cdmFinalsSlotForMatch(
   match: MatchWithPlayers,
   roundIndex: number,
   fallbackIndex: number
-): { blockStart: number; row: number } | null {
+): { blockStart: number; row: number; isFallback: boolean } | null {
   const slotRound = cdmFinalsSlotRound(match);
   const slots = slotRound ? CDM_FINALS_BRACKET_SLOTS[slotRound] : undefined;
   if (slots?.[roundIndex]) {
-    return slots[roundIndex];
+    return { ...slots[roundIndex], isFallback: false };
   }
 
   const fallbackBlockStart = CDM_FINALS_BLOCK_START_COLUMNS[Math.floor(fallbackIndex / CDM_FINALS_PAIR_ROWS.length)];
   const fallbackRow = CDM_FINALS_PAIR_ROWS[fallbackIndex % CDM_FINALS_PAIR_ROWS.length];
-  return fallbackBlockStart && fallbackRow ? { blockStart: fallbackBlockStart, row: fallbackRow } : null;
+  return fallbackBlockStart && fallbackRow ? { blockStart: fallbackBlockStart, row: fallbackRow, isFallback: true } : null;
 }
 
 function cdmFinalsMatchLabel(match: MatchWithPlayers): string {
@@ -506,8 +506,8 @@ function writeMatchFinalsSheet(
     const roundIndex = roundIndexes.get(roundKey) ?? 0;
     roundIndexes.set(roundKey, roundIndex + 1);
     const slot = cdmFinalsSlotForMatch(match, roundIndex, fallbackIndex);
-    fallbackIndex++;
     if (!slot) return;
+    if (slot.isFallback) fallbackIndex++;
 
     const { blockStart, row } = slot;
     const p1Score = mode === "gp" ? match.points1 ?? 0 : match.score1 ?? 0;


### PR DESCRIPTION
Summary:
- Remove unreachable grand_final_reset normalization and increment CDM fallback slots only when fallback is used
- Make TC-816A GP cupResults summary validation optional while keeping BM/MR/GP coordinate checks required
- Add E2E scenarios and drift/unit coverage for issues #1877 through #1880

Issues: #1877, #1878, #1879, #1880

Validation:
- npm test -- --runInBand --runTestsByPath __tests__/app/api/tournaments/[id]/export/route.test.ts __tests__/docs/e2e-cases-drift.test.ts
- node --check e2e/tc-all.js
- npm run lint
- npm run build:cf