### PR TITLE
test: tighten E2E mode guard assertions

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -924,8 +924,8 @@
 - **authRequired**: true (admin)
 - **背景**: RSC streaming / PPR の待機中でも E2E セレクタと利用者の初期表示が安定するよう、BM/MR/GP/TA の qualification fallback はモード名見出しを先に描画する必要がある。
 - **手順**:
-  1. 共有トーナメント ID を使って BM/MR/GP/TA の各予選ページへ順に遷移する
-  2. 各ページで `h1` / `h2` / `h3` のいずれかを即時確認する
+  1. 共有トーナメント ID を使って BM/MR/GP/TA の各予選ページへ順に遷移し、`domcontentloaded` 直後に確認する
+  2. 各ページで `h1` を即時確認する
   3. BM は `バトルモード` または `Battle Mode`、MR は `マッチレース` または `Match Race`、GP は `グランプリ` または `Grand Prix`、TA は `タイムアタック` または `Time Attack` を含む見出しがあることを確認する
 - **期待結果**: 4モードすべてで fallback 期間中もモード名見出しが存在し、遅いデータ取得でも見出しセレクタが安定する
 - **スクリプト**: tc-all.js TC-357

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -80,6 +80,7 @@ describe('E2E case drift coverage', () => {
     'tournament',
     'ta-sudden-death-panel.test.tsx',
   );
+  const qualificationFallback = readRepoFile('smkc-score-app', 'src', 'components', 'ui', 'loading-skeleton.tsx');
   const exportRoute = readRepoFile(
     'smkc-score-app',
     'src',
@@ -105,6 +106,7 @@ describe('E2E case drift coverage', () => {
 
   it.each([
     ['TC-352', tcAll],
+    ['TC-356', tcAll],
     ['TC-357', tcAll],
     ['TC-702', tcGp],
     ['TC-717', tcGp],
@@ -169,6 +171,41 @@ describe('E2E case drift coverage', () => {
     expect(doubleBracketTest).toContain('uses getWinnerId for completed tied matches');
     expect(playoffBracketTest).toContain('uses getWinnerId for completed tied matches');
     expect(tcGp).not.toMatch(/\{\s*name:\s*['"]TC-830['"]/);
+  });
+
+  it('keeps TC-356 scoped to the GP finals dialog and failing on mobile layout regressions', () => {
+    const section = e2eCaseSection('TC-356');
+    const tc356Block = sectionBetween(tcAll, '// TC-356:', '// TC-357:');
+
+    expect(section).toContain('ダイアログ幅内に収まる');
+    expect(tc356Block).toContain("const dialog = document.querySelector('[role=\"dialog\"]')");
+    expect(tc356Block).toContain('dialog.querySelector(\'#gp-finals-simple-score1\')');
+    expect(tc356Block).toContain('dialog.querySelector(\'#gp-finals-simple-score2\')');
+    expect(tc356Block).toContain("log('TC-356', mobileLayoutUsable ? 'PASS' : 'FAIL'");
+    expect(tc356Block).not.toContain("log('TC-356', hasScrollWrapper ? 'PASS' : 'SKIP'");
+    expect(tc356Block).not.toContain('document.querySelector("div.overflow-x-auto")');
+  });
+
+  it('keeps TC-357 checking exact mode-title h1 fallback headings', () => {
+    const section = e2eCaseSection('TC-357');
+    const tc357Block = sectionBetween(tcAll, '// TC-357:', '// TC-104:');
+
+    expect(section).toContain('`h1` を即時確認する');
+    expect(section).toContain('`domcontentloaded` 直後に確認する');
+    expect(section).toContain('`バトルモード` または `Battle Mode`');
+    expect(section).toContain('`マッチレース` または `Match Race`');
+    expect(section).toContain('`グランプリ` または `Grand Prix`');
+    expect(section).toContain('`タイムアタック` または `Time Attack`');
+    expect(qualificationFallback).toContain('{title && <h1');
+    expect(tc357Block).toContain("waitUntil: 'domcontentloaded'");
+    expect(tc357Block).toContain("page.goto(`${BASE}/tournaments/${TID}/${mode}`");
+    expect(tc357Block).not.toContain("await nav(page, `/tournaments/${TID}/${mode}`)");
+    expect(tc357Block).toContain("document.querySelectorAll('h1')");
+    expect(tc357Block).not.toContain("document.querySelectorAll('h1, h2, h3')");
+    expect(tc357Block).toContain("bm: ['バトルモード', 'Battle Mode']");
+    expect(tc357Block).toContain("mr: ['マッチレース', 'Match Race']");
+    expect(tc357Block).toContain("gp: ['グランプリ', 'Grand Prix']");
+    expect(tc357Block).toContain("ta: ['タイムアタック', 'Time Attack']");
   });
 
   it('documents TC-816A as CDM finals native bracket coordinate coverage', () => {

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -4243,18 +4243,21 @@ async function main() {
     }
   }
 
-  // TC-357: PPR mode page fallback renders a heading immediately (before streaming)
-  // Verifies that the QualificationFallback Suspense skeleton includes an h1
-  // element with the mode title so E2E selectors pass even on slow D1 fetches
+  // TC-357: PPR mode page fallback renders a mode-title h1 immediately (before streaming)
+  // Verifies that the QualificationFallback Suspense skeleton includes the
+  // exact mode title in an h1, not just any heading on the page, so regressions
+  // in the fallback title prop are detected even on slow D1 fetches
   // (issue #809). Tests the static shell by checking HTTP response HTML.
   if (TID) {
     const modes357 = ['bm', 'mr', 'gp', 'ta'];
     const results357 = [];
     for (const mode of modes357) {
       try {
-        // Navigate with a very short timeout to catch the skeleton phase
-        await nav(page, `/tournaments/${TID}/${mode}`);
-        // Check immediately — the h1 should be in the static shell
+        // Use a bare domcontentloaded navigation instead of nav(): nav() waits
+        // for the post-load retry window, which can let the fully rendered page
+        // hide a missing Suspense fallback title regression.
+        await page.goto(`${BASE}/tournaments/${TID}/${mode}`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+        // Check immediately — the h1 should be in the static shell.
         const expectedTitles = {
           bm: ['バトルモード', 'Battle Mode'],
           mr: ['マッチレース', 'Match Race'],
@@ -4262,7 +4265,7 @@ async function main() {
           ta: ['タイムアタック', 'Time Attack'],
         };
         const hasExpectedTitle = await page.evaluate((titles) => {
-          const headings = Array.from(document.querySelectorAll('h1, h2, h3'));
+          const headings = Array.from(document.querySelectorAll('h1'));
           return headings.some((heading) =>
             titles.some((title) => (heading.textContent || '').includes(title))
           );


### PR DESCRIPTION
Summary:
- tighten TC-357 to verify exact mode-title h1 immediately after domcontentloaded
- add drift coverage for TC-356 dialog-scoped FAIL behavior and TC-357 title assertions
- align the E2E scenario text with the stricter h1 check

Issues: #813, #814

Validation:
- node --check smkc-score-app/e2e/tc-all.js
- npm test -- --runInBand --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts
- npm run lint (passes with existing warnings)
- npm run build:cf