### PR TITLE
test: harden qualification fallback test coverage

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -930,18 +930,6 @@
 - **期待結果**: 4モードすべてで fallback 期間中もモード名見出しが存在し、遅いデータ取得でも見出しセレクタが安定する
 - **スクリプト**: tc-all.js TC-357
 
-## TC-1883A: QualificationFallback — drift guard は JSX 構文ではなく render output を検証する
-- **authRequired**: false
-- **背景**: issue #1883。TC-357 の drift guard が `{title && <h1` のような JSX 構文文字列に依存すると、同じ render output を保つリファクタリングでもテストが壊れる。
-- **手順**:
-  1. `loading-skeleton.test.tsx` で `QualificationFallback title="グランプリ"` を描画する
-  2. `role=heading`, `level=1`, `name=グランプリ` の見出しが存在することを確認する
-  3. title なしでは level 1 heading が描画されないことを確認する
-- **期待結果**:
-  - テストは JSX の書き方ではなく、利用者に見える render output を固定する
-  - TC-357 の drift guard は `loading-skeleton.test.tsx` の意味的カバレッジを参照する
-- **スクリプト**: loading-skeleton.test.tsx / e2e-cases-drift.test.ts
-
 ## TC-401: 全モードトーナメント — TA/BM/MR/GP の予選データが正しく存在する
 - **authRequired**: true (admin)
 - **背景**: `setupAllModes28PlayerQualification` で28名 × 4モードの予選を完了させた後、各モード API が有効なデータを返すことを確認する統合テスト。

--- a/smkc-score-app/__tests__/components/ui/loading-skeleton.test.tsx
+++ b/smkc-score-app/__tests__/components/ui/loading-skeleton.test.tsx
@@ -18,4 +18,10 @@ describe('QualificationFallback', () => {
 
     expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
   });
+
+  it('omits the heading when title is an empty string', () => {
+    render(<QualificationFallback title="" />);
+
+    expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+  });
 });

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -203,8 +203,9 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('`グランプリ` または `Grand Prix`');
     expect(section).toContain('`タイムアタック` または `Time Attack`');
     expect(qualificationFallbackTest).toContain('QualificationFallback');
-    expect(qualificationFallbackTest).toMatch(/getByRole\(\s*["']heading["'][\s\S]*level:\s*1[\s\S]*name:\s*["']グランプリ["']/);
-    expect(qualificationFallbackTest).toMatch(/queryByRole\(\s*["']heading["'][\s\S]*level:\s*1/);
+    expect(qualificationFallbackTest).toMatch(/getByRole\(\s*["']heading["']\s*,\s*\{[^}]*level:\s*1[^}]*name:\s*["']グランプリ["'][^}]*\}/);
+    expect(qualificationFallbackTest).toMatch(/queryByRole\(\s*["']heading["']\s*,\s*\{[^}]*level:\s*1[^}]*\}/);
+    expect(qualificationFallbackTest).toContain('title=""');
     expect(tc357Block).toContain("waitUntil: 'domcontentloaded'");
     expect(tc357Block).toContain("page.goto(`${BASE}/tournaments/${TID}/${mode}`");
     expect(tc357Block).not.toContain("await nav(page, `/tournaments/${TID}/${mode}`)");
@@ -214,16 +215,6 @@ describe('E2E case drift coverage', () => {
     expect(tc357Block).toContain("mr: ['マッチレース', 'Match Race']");
     expect(tc357Block).toContain("gp: ['グランプリ', 'Grand Prix']");
     expect(tc357Block).toContain("ta: ['タイムアタック', 'Time Attack']");
-  });
-
-  it('documents TC-1883A as semantic QualificationFallback heading coverage', () => {
-    const section = e2eCaseSection('TC-1883A');
-
-    expect(section).toContain('issue #1883');
-    expect(section).toContain('render output');
-    expect(section).toContain('loading-skeleton.test.tsx');
-    expect(qualificationFallbackTest).toMatch(/getByRole\(\s*["']heading["'][\s\S]*level:\s*1[\s\S]*name:\s*["']グランプリ["']/);
-    expect(qualificationFallbackTest).not.toContain('{title && <h1');
   });
 
   it('documents TC-816A as CDM finals native bracket coordinate coverage', () => {


### PR DESCRIPTION
Summary:
- add explicit empty-string title coverage for QualificationFallback
- constrain drift regexes to matcher option objects instead of broad file-spanning matches
- remove unit-only TC-1883A from the E2E scenario catalog

Issues: #1885, #1886, #1887

Validation:
- npm test -- --runInBand --runTestsByPath __tests__/components/ui/loading-skeleton.test.tsx __tests__/docs/e2e-cases-drift.test.ts
- npm run lint (passes with existing warnings)
- npm run build:cf