### PR TITLE
test: refine heading role drift helper

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -11,7 +11,7 @@ function readE2eLib(script: string) {
 
 function expectHeadingRoleOptions(source: string, method: 'getByRole' | 'queryByRole', assertions: RegExp[]) {
   const match = source.match(new RegExp(`${method}\\(\\s*["']heading["']\\s*,\\s*\\{([^}]*)\\}`));
-  expect(match?.[1] ?? '').toEqual(expect.stringContaining('level: 1'));
+  expect(match?.[1] ?? '').toMatch(/level:\s*1\b/);
   for (const assertion of assertions) {
     expect(match?.[1] ?? '').toMatch(assertion);
   }


### PR DESCRIPTION
Summary:
- make heading level matching precise with a word-boundary regex
- keep the drift helper assertion style consistent with toMatch

Issues: #1891

Validation:
- npm test -- --runInBand --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts
- npm run lint (passes with existing warnings)
- npm run build:cf