### PR TITLE
fix: clean up broadcast reflect reset timer

### DIFF
--- a/smkc-score-app/__tests__/lib/hooks/use-broadcast-reflect.test.ts
+++ b/smkc-score-app/__tests__/lib/hooks/use-broadcast-reflect.test.ts
@@ -88,6 +88,59 @@ describe('useBroadcastReflect', () => {
       expect(result.current.broadcastStatus).toBe('idle');
     });
 
+    it('clears the pending idle reset timer on unmount', async () => {
+      mockFetchOk();
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      const { result, unmount } = renderHook(() =>
+        useBroadcastReflect(TOURNAMENT_ID, { p1: 1 }, entries)
+      );
+
+      await act(async () => {
+        await result.current.handleBroadcastReflect();
+      });
+
+      unmount();
+
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('replaces the previous idle reset timer when reflecting again', async () => {
+      mockFetchOk();
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      const { result } = renderHook(() =>
+        useBroadcastReflect(TOURNAMENT_ID, { p1: 1 }, entries)
+      );
+
+      await act(async () => {
+        await result.current.handleBroadcastReflect();
+      });
+      await act(async () => {
+        await result.current.handleBroadcastReflect();
+      });
+
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not schedule an idle reset when unmounted before the request settles', async () => {
+      let resolveFetch!: (response: Response) => void;
+      global.fetch = jest.fn(() => new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      }));
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      const { result, unmount } = renderHook(() =>
+        useBroadcastReflect(TOURNAMENT_ID, { p1: 1 }, entries)
+      );
+
+      const reflectPromise = result.current.handleBroadcastReflect();
+      unmount();
+      await act(async () => {
+        resolveFetch({ ok: true } as Response);
+        await reflectPromise;
+      });
+
+      expect(setTimeoutSpy).not.toHaveBeenCalled();
+    });
+
     it('transitions to error on non-ok response', async () => {
       mockFetchError();
       const { result } = renderHook(() =>

--- a/smkc-score-app/src/lib/hooks/use-broadcast-reflect.ts
+++ b/smkc-score-app/src/lib/hooks/use-broadcast-reflect.ts
@@ -15,7 +15,7 @@
  * in ta-elimination-phase.tsx and ta/finals/page.tsx (issue #807).
  */
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface BroadcastEntry {
   playerId: string;
@@ -32,6 +32,32 @@ export function useBroadcastReflect(
 ) {
   const [broadcastStatus, setBroadcastStatus] =
     useState<BroadcastStatus>("idle");
+  // The status reset is delayed for operator feedback, so keep the timer handle
+  // to prevent stale setState work after unmount or after a newer reflect action.
+  const idleResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isMountedRef = useRef(true);
+
+  const clearIdleResetTimer = useCallback(() => {
+    if (idleResetTimerRef.current === null) return;
+    clearTimeout(idleResetTimerRef.current);
+    idleResetTimerRef.current = null;
+  }, []);
+
+  const scheduleIdleReset = useCallback(() => {
+    clearIdleResetTimer();
+    idleResetTimerRef.current = setTimeout(() => {
+      idleResetTimerRef.current = null;
+      setBroadcastStatus("idle");
+    }, 3000);
+  }, [clearIdleResetTimer]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      clearIdleResetTimer();
+    };
+  }, [clearIdleResetTimer]);
 
   /** Push TV1→player1Name / TV2→player2Name to the broadcast overlay. */
   const handleBroadcastReflect = async () => {
@@ -49,16 +75,21 @@ export function useBroadcastReflect(
           player2NoCamera: tv2Player?.player.noCamera === true,
         }),
       });
+      if (!isMountedRef.current) return;
       setBroadcastStatus(res.ok ? "success" : "error");
-      setTimeout(() => setBroadcastStatus("idle"), 3000);
+      scheduleIdleReset();
     } catch {
+      if (!isMountedRef.current) return;
       setBroadcastStatus("error");
-      setTimeout(() => setBroadcastStatus("idle"), 3000);
+      scheduleIdleReset();
     }
   };
 
   /** Reset the status indicator (call when starting/cancelling/undoing rounds). */
-  const resetBroadcastStatus = () => setBroadcastStatus("idle");
+  const resetBroadcastStatus = () => {
+    clearIdleResetTimer();
+    setBroadcastStatus("idle");
+  };
 
   /**
    * True when any active player is assigned TV3 or TV4, which will NOT be


### PR DESCRIPTION
Summary:
- track the delayed broadcast status reset timer and clear it on unmount/reset/retry
- guard async fetch continuations so no timer is scheduled after unmount
- add hook regression tests for timer replacement, unmount cleanup, and in-flight unmount

Issues: #812

Validation:
- npm test -- --runInBand --runTestsByPath __tests__/lib/hooks/use-broadcast-reflect.test.ts
- npm run lint (passes with existing warnings)
- npm run build:cf