### PR TITLE
test: memoize broadcast reflect callbacks

### DIFF
--- a/smkc-score-app/__tests__/lib/hooks/use-broadcast-reflect.test.ts
+++ b/smkc-score-app/__tests__/lib/hooks/use-broadcast-reflect.test.ts
@@ -51,6 +51,34 @@ afterEach(() => {
 });
 
 describe('useBroadcastReflect', () => {
+  describe('returned callbacks', () => {
+    it('keeps public callback references stable when inputs do not change', () => {
+      const tvAssignments = { p1: 1, p2: 2 };
+      const { result, rerender } = renderHook(
+        ({ tournamentId, assignments, hookEntries }) =>
+          useBroadcastReflect(tournamentId, assignments, hookEntries),
+        {
+          initialProps: {
+            tournamentId: TOURNAMENT_ID,
+            assignments: tvAssignments,
+            hookEntries: entries,
+          },
+        }
+      );
+      const initialHandle = result.current.handleBroadcastReflect;
+      const initialReset = result.current.resetBroadcastStatus;
+
+      rerender({
+        tournamentId: TOURNAMENT_ID,
+        assignments: tvAssignments,
+        hookEntries: entries,
+      });
+
+      expect(result.current.handleBroadcastReflect).toBe(initialHandle);
+      expect(result.current.resetBroadcastStatus).toBe(initialReset);
+    });
+  });
+
   describe('broadcastStatus', () => {
     it('starts as idle', () => {
       const { result } = renderHook(() =>

--- a/smkc-score-app/src/lib/hooks/use-broadcast-reflect.ts
+++ b/smkc-score-app/src/lib/hooks/use-broadcast-reflect.ts
@@ -60,7 +60,7 @@ export function useBroadcastReflect(
   }, [clearIdleResetTimer]);
 
   /** Push TV1→player1Name / TV2→player2Name to the broadcast overlay. */
-  const handleBroadcastReflect = async () => {
+  const handleBroadcastReflect = useCallback(async () => {
     const activeEntries = entries.filter((e) => !e.eliminated);
     const tv1Player = activeEntries.find((e) => tvAssignments[e.playerId] === 1);
     const tv2Player = activeEntries.find((e) => tvAssignments[e.playerId] === 2);
@@ -83,13 +83,13 @@ export function useBroadcastReflect(
       setBroadcastStatus("error");
       scheduleIdleReset();
     }
-  };
+  }, [entries, scheduleIdleReset, tournamentId, tvAssignments]);
 
   /** Reset the status indicator (call when starting/cancelling/undoing rounds). */
-  const resetBroadcastStatus = () => {
+  const resetBroadcastStatus = useCallback(() => {
     clearIdleResetTimer();
     setBroadcastStatus("idle");
-  };
+  }, [clearIdleResetTimer]);
 
   /**
    * True when any active player is assigned TV3 or TV4, which will NOT be


### PR DESCRIPTION
Summary:
- memoize useBroadcastReflect public callbacks with useCallback
- add a regression test for stable callback references when inputs do not change

Issues: #1894

Validation:
- npm test -- --runInBand --runTestsByPath __tests__/lib/hooks/use-broadcast-reflect.test.ts
- npm run lint (passes with existing warnings)
- npm run build:cf