### PR TITLE
test: cover TA TV3 TV4 broadcast warning

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2872,6 +2872,18 @@
   4. `/api/tournaments/[id]/broadcast` の player1Name / player2Name が選択した2名に更新されることを確認する
 - **期待結果**: TA予選中でもTV番号選択から配信オーバーレイへプレイヤー名を反映できる
 
+## TC-808A: TA配信反映 — TV3/TV4 は配信に反映されないことを明示する
+- **URL**: /tournaments/[temp-id]/ta, /tournaments/[temp-id]/ta/finals
+- **authRequired**: true (admin)
+- **背景**: issue #808。TA の TV3/TV4 は進行上の割り当てとして保存されるが、broadcast API が反映するのは TV1/TV2 の選手名だけである。オペレーターが「配信に反映」成功表示を TV3/TV4 まで反映されたと誤解しないよう、対象外であることを画面上に明示する。
+- **手順**:
+  1. `tc-ta.js` の共有 TA 予選 fixture で、TA予選タイム入力画面のアクティブな選手を TV3 に割り当てる
+  2. `TV3/TV4 のプレイヤーは配信に反映されません` / `TV3/TV4 players are not reflected in the broadcast` が表示されることを確認する
+  3. drift guard で TA決勝 Phase 1/2/3 の各ラウンド入力にも、TV3/TV4 割り当て時の同じ注意文が残っていることを確認する
+  4. hook unit test で、`配信に反映` は TV1/TV2 のみを broadcast API に送ることを固定する
+- **期待結果**: TV3/TV4 が選ばれている状態で「配信に反映」を押しても、利用者は TV3/TV4 がOBS表示対象外であることを画面上で確認できる
+- **スクリプト**: tc-ta.js TC-808A / e2e-cases-drift.test.ts / use-broadcast-reflect.test.ts
+
 ## TC-897: TAタイム入力欄フォーカス時にスマホ数字キーボードを出す
 - **URL**: /auth/signin -> /tournaments/[temp-id]/ta
 - **authRequired**: true (player)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -67,6 +67,15 @@ describe('E2E case drift coverage', () => {
     'finals',
     'page.tsx',
   );
+  const taPageClient = readRepoFile(
+    'smkc-score-app',
+    'src',
+    'app',
+    'tournaments',
+    '[id]',
+    'ta',
+    'page-client.tsx',
+  );
   const taEliminationPhase = readRepoFile(
     'smkc-score-app',
     'src',
@@ -137,6 +146,7 @@ describe('E2E case drift coverage', () => {
     ['TC-817', tcTa],
     ['TC-1032', tcTa],
     ['TC-1033', tcTa],
+    ['TC-808A', tcTa],
     ['TC-939', tcAll],
     ['TC-1010', tcBm],
     ['TC-TA-FLOW-24', tcTaFlow],
@@ -251,6 +261,21 @@ describe('E2E case drift coverage', () => {
     expect(exportRouteTest).toContain('workbook.Sheets["MR Finals"].AT19.v');
     expect(exportRouteTest).toContain('workbook.Sheets["GP Finals"].BA47.v');
     expect(exportRouteTest).toContain('workbook.Sheets["GP Finals"].AR19.v');
+  });
+
+  it('documents TC-808A as TA TV3/TV4 broadcast warning coverage', () => {
+    const section = e2eCaseSection('TC-808A');
+
+    expect(section).toContain('issue #808');
+    expect(section).toContain('TV3/TV4');
+    expect(tcTa).toContain('runTc808A');
+    expect(tcTa).toContain('ta-tv-select-${player.id}');
+    expect(jaMessages).toContain('TV3/TV4 のプレイヤーは配信に反映されません');
+    expect(enMessages).toContain('TV3/TV4 players are not reflected in the broadcast');
+    for (const source of [taPageClient, taFinalsPage, taEliminationPhase]) {
+      expect(source).toContain('hasUnbroadcastedTvAssignment');
+      expect(source).toContain('broadcastTv12Only');
+    }
   });
 
   it('documents TC-1877A as reachable grand-final reset alias coverage', () => {

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -562,6 +562,26 @@ async function runTc878(adminPage) {
   }
 }
 
+/* ───────── TC-808A: TA qualification warns that TV3/TV4 are not broadcast ───────── */
+async function runTc808A(adminPage) {
+  try {
+    const tournamentId = sharedTaTournamentId;
+    if (!tournamentId) throw new Error('Shared TA tournament not initialized');
+    const [player] = sharedTaPlayers(1);
+
+    await nav(adminPage, `/tournaments/${tournamentId}/ta`);
+    await adminPage.getByRole('tab', { name: /^(Time Entry|Time List|タイム入力|タイム一覧)$/ }).first().click();
+    await adminPage.locator(`[data-testid="ta-tv-select-${player.id}"]`).selectOption('3');
+
+    const warning = adminPage.getByText(/TV3\/TV4.*(配信に反映されません|not reflected in the broadcast)/).first();
+    await warning.waitFor({ state: 'visible', timeout: 10000 });
+
+    log('TC-808A', 'PASS', 'TV3/TV4 broadcast exclusion warning is visible on TA qualification');
+  } catch (err) {
+    log('TC-808A', 'FAIL', err instanceof Error ? err.message : 'TA TV3/TV4 broadcast warning failed');
+  }
+}
+
 /* ───────── TC-897: TA time inputs request mobile numeric keyboard ───────── */
 async function runTc897(adminPage) {
   let playerBrowser = null;
@@ -1864,7 +1884,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       sharedFixture = externalFixture ?? await createSharedE2eFixture(adminPage);
       const selected = new Set(selectedTestNames());
       const needsSharedTaSeed = selected.size === 0 || [
-        'TC-801', 'TC-802', 'TC-837', 'TC-839', 'TC-840', 'TC-878', 'TC-897', 'TC-913',
+        'TC-801', 'TC-802', 'TC-837', 'TC-839', 'TC-840', 'TC-878', 'TC-808A', 'TC-897', 'TC-913',
         'TC-804', 'TC-805', 'TC-806', 'TC-807', 'TC-808', 'TC-816',
       ].some((name) => selected.has(name));
 
@@ -1899,6 +1919,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-839', fn: runTc839 },
       { name: 'TC-840', fn: runTc840 },
       { name: 'TC-878', fn: runTc878 },
+      { name: 'TC-808A', fn: runTc808A },
       { name: 'TC-897', fn: runTc897 },
       { name: 'TC-913', fn: runTc913 },
       { name: 'TC-896', fn: runTc896 },
@@ -1924,7 +1945,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 }
 
 module.exports = {
-  runTc801, runTc802, runTc839, runTc804, runTc805, runTc806, runTc807, runTc808, runTc809, runTc810, runTc811,
+  runTc801, runTc802, runTc839, runTc804, runTc805, runTc806, runTc807, runTc808, runTc808A, runTc809, runTc810, runTc811,
   runTc837, runTc840, runTc878, runTc896, runTc897, runTc913,
   runTc812, runTc813, runTc814, runTc1032, runTc1033, runTc815, runTc816, runTc817, runTc1005,
   getSuite,


### PR DESCRIPTION
Summary:
- add TC-808A scripted TA qualification E2E coverage for the TV3/TV4 broadcast warning
- drift-guard TA qualification/finals/elimination warning surfaces and i18n messages
- document the TV3/TV4 non-broadcast warning scenario in E2E_TEST_CASES.md

Issues: #808

Validation:
- node --check smkc-score-app/e2e/tc-ta.js
- npm test -- --runInBand --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/hooks/use-broadcast-reflect.test.ts
- npm run lint (passes with existing 42 warnings)
- npm run build:cf
- E2E_TESTS=TC-808A npm run e2e:preview:ta