### PR TITLE
test: assert TA broadcast omits TV3 payload

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2875,12 +2875,13 @@
 ## TC-808A: TA配信反映 — TV3/TV4 は配信に反映されないことを明示する
 - **URL**: /tournaments/[temp-id]/ta, /tournaments/[temp-id]/ta/finals
 - **authRequired**: true (admin)
-- **背景**: issue #808。TA の TV3/TV4 は進行上の割り当てとして保存されるが、broadcast API が反映するのは TV1/TV2 の選手名だけである。オペレーターが「配信に反映」成功表示を TV3/TV4 まで反映されたと誤解しないよう、対象外であることを画面上に明示する。
+- **背景**: issue #808 / #1897。TA の TV3/TV4 は進行上の割り当てとして保存されるが、broadcast API が反映するのは TV1/TV2 の選手名だけである。オペレーターが「配信に反映」成功表示を TV3/TV4 まで反映されたと誤解しないよう、対象外であることを画面上に明示し、UI から送信される payload にも TV3/TV4 が含まれないことを確認する。
 - **手順**:
-  1. `tc-ta.js` の共有 TA 予選 fixture で、TA予選タイム入力画面のアクティブな選手を TV3 に割り当てる
+  1. `tc-ta.js` の共有 TA 予選 fixture で、TA予選タイム入力画面のアクティブな選手を TV1 / TV2 / TV3 に割り当てる
   2. `TV3/TV4 のプレイヤーは配信に反映されません` / `TV3/TV4 players are not reflected in the broadcast` が表示されることを確認する
-  3. drift guard で TA決勝 Phase 1/2/3 の各ラウンド入力にも、TV3/TV4 割り当て時の同じ注意文が残っていることを確認する
-  4. hook unit test で、`配信に反映` は TV1/TV2 のみを broadcast API に送ることを固定する
+  3. `配信に反映` を押し、`page.route()` で `/api/tournaments/[id]/broadcast` の PUT body を捕捉して TV1/TV2 の選手名だけが含まれ、TV3 の選手名が含まれないことを確認する
+  4. drift guard で TA決勝 Phase 1/2/3 の各ラウンド入力にも、TV3/TV4 割り当て時の同じ注意文が残っていることを確認する
+  5. hook unit test で、`配信に反映` は TV1/TV2 のみを broadcast API に送ることを固定する
 - **期待結果**: TV3/TV4 が選ばれている状態で「配信に反映」を押しても、利用者は TV3/TV4 がOBS表示対象外であることを画面上で確認できる
 - **スクリプト**: tc-ta.js TC-808A / e2e-cases-drift.test.ts / use-broadcast-reflect.test.ts
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -267,9 +267,12 @@ describe('E2E case drift coverage', () => {
     const section = e2eCaseSection('TC-808A');
 
     expect(section).toContain('issue #808');
+    expect(section).toContain('#1897');
     expect(section).toContain('TV3/TV4');
     expect(tcTa).toContain('runTc808A');
-    expect(tcTa).toContain('ta-tv-select-${player.id}');
+    expect(tcTa).toContain('ta-tv-select-${tv3Player.id}');
+    expect(tcTa).toContain('request.postDataJSON()');
+    expect(tcTa).toContain('!serializedPayload.includes(tv3Player.nickname)');
     expect(jaMessages).toContain('TV3/TV4 のプレイヤーは配信に反映されません');
     expect(enMessages).toContain('TV3/TV4 players are not reflected in the broadcast');
     for (const source of [taPageClient, taFinalsPage, taEliminationPhase]) {

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -567,16 +567,64 @@ async function runTc808A(adminPage) {
   try {
     const tournamentId = sharedTaTournamentId;
     if (!tournamentId) throw new Error('Shared TA tournament not initialized');
-    const [player] = sharedTaPlayers(1);
+    const [tv1Player, tv2Player, tv3Player] = sharedTaPlayers(3);
 
     await nav(adminPage, `/tournaments/${tournamentId}/ta`);
     await adminPage.getByRole('tab', { name: /^(Time Entry|Time List|タイム入力|タイム一覧)$/ }).first().click();
-    await adminPage.locator(`[data-testid="ta-tv-select-${player.id}"]`).selectOption('3');
+    await adminPage.locator(`[data-testid="ta-tv-select-${tv1Player.id}"]`).selectOption('1');
+    await adminPage.locator(`[data-testid="ta-tv-select-${tv2Player.id}"]`).selectOption('2');
+    await adminPage.locator(`[data-testid="ta-tv-select-${tv3Player.id}"]`).selectOption('3');
 
     const warning = adminPage.getByText(/TV3\/TV4.*(配信に反映されません|not reflected in the broadcast)/).first();
     await warning.waitFor({ state: 'visible', timeout: 10000 });
 
-    log('TC-808A', 'PASS', 'TV3/TV4 broadcast exclusion warning is visible on TA qualification');
+    const broadcastApiPattern = `**/api/tournaments/${tournamentId}/broadcast`;
+    let resolvePayload;
+    let rejectPayload;
+    const broadcastPayload = new Promise((resolve, reject) => {
+      resolvePayload = resolve;
+      rejectPayload = reject;
+    });
+    const payloadTimeout = setTimeout(() => {
+      rejectPayload(new Error('Broadcast API PUT was not captured'));
+    }, 10000);
+
+    // Keep this at the browser boundary: issue #1897 asks for UI-to-API proof
+    // that TV3/TV4 are omitted from the actual payload, not only hook-level
+    // unit coverage of the same mapping.
+    await adminPage.route(broadcastApiPattern, async (route) => {
+      const request = route.request();
+      if (request.method() !== 'PUT') {
+        await route.continue();
+        return;
+      }
+      try {
+        resolvePayload(request.postDataJSON());
+      } catch (err) {
+        rejectPayload(err);
+      }
+      await route.continue();
+    });
+
+    let payload;
+    try {
+      await adminPage.getByRole('button', { name: /^(Broadcast|配信に反映)$/ }).click();
+      payload = await broadcastPayload;
+    } finally {
+      clearTimeout(payloadTimeout);
+      await adminPage.unroute(broadcastApiPattern).catch(() => {});
+    }
+
+    const serializedPayload = JSON.stringify(payload);
+    const reflectedOnlyTv12 =
+      payload.player1Name === tv1Player.nickname
+      && payload.player2Name === tv2Player.nickname
+      && !serializedPayload.includes(tv3Player.nickname);
+
+    log('TC-808A', reflectedOnlyTv12 ? 'PASS' : 'FAIL',
+      reflectedOnlyTv12
+        ? 'TV3/TV4 warning is visible and broadcast PUT only includes TV1/TV2'
+        : `broadcast payload unexpectedly included TV3/TV4 data: ${serializedPayload}`);
   } catch (err) {
     log('TC-808A', 'FAIL', err instanceof Error ? err.message : 'TA TV3/TV4 broadcast warning failed');
   }


### PR DESCRIPTION
Summary:
- extend TC-808A to assign TV1/TV2/TV3 and capture the broadcast PUT body from the browser
- assert the payload reflects only TV1/TV2 and omits the TV3 player name
- update the TC-808A scenario and drift guard for the E2E payload assertion

Issues: #1897

Validation:
- node --check smkc-score-app/e2e/tc-ta.js
- npm test -- --runInBand --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/hooks/use-broadcast-reflect.test.ts
- npm run lint (passes with existing 42 warnings)
- npm run build:cf
- E2E_TESTS=TC-808A npm run e2e:preview:ta