### PR TITLE
test: derive TA broadcast name fields

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2879,7 +2879,7 @@
 - **手順**:
   1. `tc-ta.js` の共有 TA 予選 fixture で、TA予選タイム入力画面のアクティブな選手を TV1 / TV2 / TV3 に割り当てる
   2. `TV3/TV4 のプレイヤーは配信に反映されません` / `TV3/TV4 players are not reflected in the broadcast` が表示されることを確認する
-  3. `配信に反映` を押し、`page.route()` で `/api/tournaments/[id]/broadcast` の PUT body を捕捉して `player1Name` / `player2Name` が TV1/TV2 の選手名であり、既知の配信名フィールドに TV3 の選手名が含まれないことを確認する
+  3. `配信に反映` を押し、`page.route()` で `/api/tournaments/[id]/broadcast` の PUT body を捕捉して `player1Name` / `player2Name` が TV1/TV2 の選手名であり、`playerNName` 形式の配信名フィールドに TV3 の選手名が含まれないことを確認する
   4. drift guard で TA決勝 Phase 1/2/3 の各ラウンド入力にも、TV3/TV4 割り当て時の同じ注意文が残っていることを確認する
   5. hook unit test で、`配信に反映` は TV1/TV2 のみを broadcast API に送ることを固定する
 - **期待結果**: TV3/TV4 が選ばれている状態で「配信に反映」を押しても、利用者は TV3/TV4 がOBS表示対象外であることを画面上で確認できる

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -273,6 +273,7 @@ describe('E2E case drift coverage', () => {
     expect(tcTa).toContain('ta-tv-select-${tv3Player.id}');
     expect(tcTa).toContain('request.postDataJSON()');
     expect(tcTa).toContain('broadcastNameFields');
+    expect(tcTa).toContain('Object.entries(payload).filter(([key]) => /^player\\d+Name$/.test(key))');
     expect(tcTa).toContain('Object.values(broadcastNameFields).every((name) => name !== tv3Player.nickname)');
     expect(jaMessages).toContain('TV3/TV4 のプレイヤーは配信に反映されません');
     expect(enMessages).toContain('TV3/TV4 players are not reflected in the broadcast');

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -615,12 +615,9 @@ async function runTc808A(adminPage) {
       await adminPage.unroute(broadcastApiPattern).catch(() => {});
     }
 
-    const broadcastNameFields = {
-      player1Name: payload.player1Name,
-      player2Name: payload.player2Name,
-      player3Name: payload.player3Name,
-      player4Name: payload.player4Name,
-    };
+    const broadcastNameFields = Object.fromEntries(
+      Object.entries(payload).filter(([key]) => /^player\d+Name$/.test(key)),
+    );
     const reflectedOnlyTv12 =
       payload.player1Name === tv1Player.nickname
       && payload.player2Name === tv2Player.nickname


### PR DESCRIPTION
Summary:
- derive TC-808A broadcast name fields from payload keys matching playerNName
- keep exact TV1/TV2 checks and TV3 exclusion while avoiding a hardcoded field list
- update the scenario and drift guard to document dynamic playerNName coverage

Issues: #1901

Validation:
- node --check smkc-score-app/e2e/tc-ta.js
- npm test -- --runInBand --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/hooks/use-broadcast-reflect.test.ts
- npm run lint (passes with existing 42 warnings)
- npm run build:cf
- E2E_TESTS=TC-808A npm run e2e:preview:ta