### PR TITLE
Clarify sudden-death fallback comment in finals phase manager

### DIFF
--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -22,6 +22,7 @@
  *   TC-839  TA qualification time-entry dialog stacks cup cards on mobile.
  *   TC-840  TA partner can edit the paired player's times from the TA list UI.
  *   TC-878  TA qualification TV assignment reflects TV1/TV2 to broadcast.
+ *   TC-808A TA qualification TV3/TV4 warning is visible and not sent to broadcast.
  *   TC-896  TA finals mobile admin input rows keep player names visible.
  *   TC-897  TA time inputs request the mobile numeric keyboard.
  *   TC-913  TA time input hint/title/placeholder are localized.
@@ -567,7 +568,7 @@ async function runTc808A(adminPage) {
   try {
     const tournamentId = sharedTaTournamentId;
     if (!tournamentId) throw new Error('Shared TA tournament not initialized');
-    const [tv1Player, tv2Player, tv3Player] = sharedTaPlayers(3);
+    const [tv1Player, tv2Player, tv3Player, tv4Player] = sharedTaPlayers(4);
 
     await nav(adminPage, `/tournaments/${tournamentId}/ta`);
     await adminPage.getByRole('tab', { name: /^(Time Entry|Time List|タイム入力|タイム一覧)$/ }).first().click();
@@ -621,7 +622,9 @@ async function runTc808A(adminPage) {
     const reflectedOnlyTv12 =
       payload.player1Name === tv1Player.nickname
       && payload.player2Name === tv2Player.nickname
-      && Object.values(broadcastNameFields).every((name) => name !== tv3Player.nickname);
+      && Object.values(broadcastNameFields).every((name) =>
+        name !== tv3Player.nickname && name !== tv4Player.nickname
+      );
 
     log('TC-808A', reflectedOnlyTv12 ? 'PASS' : 'FAIL',
       reflectedOnlyTv12

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -941,7 +941,7 @@ export default function TimeAttackFinals({
                     (which only supports TV1/TV2). Inform the operator so
                     they know the button won't affect those players (issue #808). */}
                 {hasUnbroadcastedTvAssignment && (
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-xs text-amber-600" role="status" aria-live="polite">
                     {tCommon('broadcastTv12Only')}
                   </p>
                 )}

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -867,7 +867,7 @@ export default function TAEliminationPhase({
                     note so operators know the button won't affect those
                     players (issue #808). */}
                 {hasUnbroadcastedTvAssignment && (
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-xs text-amber-600" role="status" aria-live="polite">
                     {tCommon('broadcastTv12Only')}
                   </p>
                 )}

--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -1043,8 +1043,7 @@ export function getSuddenDeathContinuationTargets(
   const safeSuddenTime = suddenByPlayer.get(safeBoundary.playerId);
   const unsafeSuddenTime = suddenByPlayer.get(unsafeBoundary.playerId);
   if (safeSuddenTime === undefined || unsafeSuddenTime === undefined || safeSuddenTime !== unsafeSuddenTime) {
-    // Phase 1 and 2 returned above, so this branch handles the Phase 3 life-loss boundary.
-    // Phase 3 sudden death is only repeated when that boundary is still unresolved.
+    // Sudden death is only repeated when the life-loss boundary is still unresolved.
     // If the boundary was resolved, there can still be a separate tie among the slowest
     // sudden-death players; those players must race again so one life-loss target can be chosen.
     const slowestSuddenTime = Math.max(...suddenDeathResults.map((result) => result.timeMs));


### PR DESCRIPTION
This updates a misleading comment in finals-phase-manager to reflect that the fallback branch applies to life-loss tie handling across all phases.

Refs: #1796