### PR TITLE
test: split phase3 reset threshold cases

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -274,7 +274,9 @@ describe('E2E case drift coverage', () => {
     expect(tcTa).toContain('request.postDataJSON()');
     expect(tcTa).toContain('broadcastNameFields');
     expect(tcTa).toContain('Object.entries(payload).filter(([key]) => /^player\\d+Name$/.test(key))');
-    expect(tcTa).toContain('Object.values(broadcastNameFields).every((name) => name !== tv3Player.nickname)');
+    expect(tcTa).toContain('Object.values(broadcastNameFields).every((name) =>');
+    expect(tcTa).toContain('name !== tv3Player.nickname');
+    expect(tcTa).toContain('name !== tv4Player.nickname');
     expect(jaMessages).toContain('TV3/TV4 のプレイヤーは配信に反映されません');
     expect(enMessages).toContain('TV3/TV4 players are not reflected in the broadcast');
     for (const source of [taPageClient, taFinalsPage, taEliminationPhase]) {

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1033,6 +1033,42 @@ describe('Finals Route Factory', () => {
       expect(json.data.seededPlayers[0].playerId).toBe('player-15');
     });
 
+    it('uses manual rankOverride values before timestamps when both overridden players are tied', async () => {
+      const latestOverride = new Date('2026-01-02T00:00:00Z');
+      const earliestOverride = new Date('2026-01-01T00:00:00Z');
+      const qualifications = Array.from({ length: 16 }, (_, index) => ({
+        id: `qual-${index}`,
+        playerId: `player-${index}`,
+        group: 'A',
+        score: 10,
+        points: 10,
+        rankOverride: index === 0 ? 1 : index === 1 ? 2 : null,
+        rankOverrideAt: index === 0 ? latestOverride : index === 1 ? earliestOverride : null,
+        player: { id: `player-${index}`, name: `Player ${index + 1}` },
+      }));
+      (prisma.bMQualification as any).findMany.mockResolvedValue(qualifications);
+      (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 31 });
+      (prisma.bMMatch as any).findMany.mockResolvedValue([]);
+
+      const config = createMockConfig({
+        qualificationOrderBy: [{ score: 'desc' }, { points: 'desc' }],
+      });
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 16 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(201);
+      const json = await response.json();
+      expect(json.data.seededPlayers[0].playerId).toBe('player-0');
+    });
+
     it('does not fetch H2H matches when qualificationOrderBy is empty', async () => {
       (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(8));
       (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -399,8 +399,11 @@ describe("TA Finals Phase Manager", () => {
       expect(getNextPhase3ResetThreshold(3)).toBe(2);
     });
 
-    it("falls back to one survivor when no configured threshold remains below activeCount", () => {
+    it("falls back to activeCount-1 when no configured threshold remains", () => {
       expect(getNextPhase3ResetThreshold(2)).toBe(1);
+    });
+
+    it("returns null when activeCount is already at one survivor", () => {
       expect(getNextPhase3ResetThreshold(1)).toBeNull();
     });
   });

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -853,10 +853,13 @@ export function createFinalsHandlers(config: FinalsConfig) {
         const aOverride = a.qualification.rankOverride != null;
         const bOverride = b.qualification.rankOverride != null;
         if (aOverride !== bOverride) return aOverride ? -1 : 1;
-        // After the inequality guard above, `aOverride` and `bOverride` are equal.
-        // Checking only `aOverride` keeps the collision rule readable while still
-        // limiting timestamp comparison to the "both manually overridden" case.
         if (aOverride) {
+          const aRankOverride = a.qualification.rankOverride ?? Number.POSITIVE_INFINITY;
+          const bRankOverride = b.qualification.rankOverride ?? Number.POSITIVE_INFINITY;
+          if (aRankOverride !== bRankOverride) return aRankOverride - bRankOverride;
+
+          // When manual overrides collide on the same rank value, prefer the
+          // latest manual correction timestamp.
           const aOverrideAt = a.qualification.rankOverrideAt
             ? new Date(a.qualification.rankOverrideAt).getTime()
             : 0;


### PR DESCRIPTION
## Summary
- Split  unit tests in  into two focused scenarios:
  - happy path for configured thresholds
  - fallback/null behavior when no configured threshold remains

## Issue
- Addresses #1793