### PR TITLE
Add invariant comments to finals rankOverride sort

### DIFF
--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -854,8 +854,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
         const bOverride = b.qualification.rankOverride != null;
         if (aOverride !== bOverride) return aOverride ? -1 : 1;
         if (aOverride) {
+          // After the inequality guard above, `aOverride` and `bOverride` are both true
+          // only when both qualifications have non-null `rankOverride` values.
           const aRankOverride = a.qualification.rankOverride ?? Number.POSITIVE_INFINITY;
           const bRankOverride = b.qualification.rankOverride ?? Number.POSITIVE_INFINITY;
+          // `Number.POSITIVE_INFINITY` is defensive; nullish values here should not occur
+          // after the above guard, but this keeps ordering logic type-safe.
           if (aRankOverride !== bRankOverride) return aRankOverride - bRankOverride;
 
           // When manual overrides collide on the same rank value, prefer the


### PR DESCRIPTION
## Summary
- Restore the invariant comment for finals seeding tie-break logic in `smkc-score-app/src/lib/api-factories/finals-route.ts`.
- Add an explicit note that `Number.POSITIVE_INFINITY` is a defensive fallback and should not be reached after the override presence guard.
- Keep behavior unchanged; this is readability/comment-only follow-up hardening.

## Issues
- 1913

## Validation
- Not run in this cycle (comment-only change).
