### PR TITLE
test: add unit tests for TA memoized time entry rows

### DIFF
--- a/smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { TaFinalsTimeEntryRow } from '@/app/tournaments/[id]/ta/finals/page';
+import { TAEliminationPhaseRow } from '@/components/tournament/ta-elimination-phase';
+import { TaParticipantTimeInputRow } from '@/app/tournaments/[id]/ta/participant/page';
+
+const timeInputProps = {
+  inputMode: 'decimal',
+  autoComplete: 'off',
+} as const;
+
+describe('TaFinalsTimeEntryRow', () => {
+  it('renders props and calls callbacks with correct arguments', () => {
+    const onTvChange = jest.fn();
+    const onTimeChange = jest.fn();
+    const onTimeBlur = jest.fn();
+    const onRetryToggle = jest.fn();
+
+    render(
+      <TaFinalsTimeEntryRow
+        playerId="player-1"
+        playerName="Alice"
+        livesLabel="L3"
+        tvNumber={2}
+        tvLabel="TV number"
+        timeValue="1:23.45"
+        timePlaceholder="Time"
+        isRetry={true}
+        isEditingDisabled={false}
+        retryLabel="Retry"
+        retryTitle="Retry time"
+        timeInputProps={timeInputProps}
+        onTvChange={onTvChange}
+        onTimeChange={onTimeChange}
+        onTimeBlur={onTimeBlur}
+        onRetryToggle={onRetryToggle}
+      />
+    );
+
+    const tvSelect = screen.getByLabelText('TV number');
+    fireEvent.change(tvSelect, { target: { value: '3' } });
+    expect(onTvChange).toHaveBeenCalledWith('player-1', 3);
+
+    const timeInput = screen.getByPlaceholderText('Time');
+    fireEvent.change(timeInput, { target: { value: '1:10.00' } });
+    expect(onTimeChange).toHaveBeenCalledWith('player-1', '1:10.00');
+
+    fireEvent.blur(timeInput);
+    expect(onTimeBlur).toHaveBeenCalledWith('player-1');
+    expect(timeInput).toBeDisabled();
+
+    const retryButton = screen.getByRole('button', { name: 'Retry' });
+    fireEvent.click(retryButton);
+    expect(onRetryToggle).toHaveBeenCalledWith('player-1');
+  });
+
+  it('disables retry button when editing is disabled', () => {
+    render(
+      <TaFinalsTimeEntryRow
+        playerId="player-1"
+        playerName="Alice"
+        livesLabel="L3"
+        tvNumber={null}
+        tvLabel="TV number"
+        timeValue="1:23.45"
+        timePlaceholder="Time"
+        isRetry={false}
+        isEditingDisabled={true}
+        retryLabel="Retry"
+        retryTitle="Retry time"
+        timeInputProps={timeInputProps}
+        onTvChange={jest.fn()}
+        onTimeChange={jest.fn()}
+        onTimeBlur={jest.fn()}
+        onRetryToggle={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeDisabled();
+  });
+});
+
+describe('TAEliminationPhaseRow', () => {
+  it('renders props and calls callbacks with correct arguments', () => {
+    const onTvChange = jest.fn();
+    const onTimeChange = jest.fn();
+    const onTimeBlur = jest.fn();
+    const onRetryToggle = jest.fn();
+
+    render(
+      <TAEliminationPhaseRow
+        playerId="player-2"
+        playerName="Bob"
+        tvNumber={1}
+        tvLabel="TV number for phase"
+        timeValue="0:59.99"
+        timePlaceholder="Time"
+        isRetry={false}
+        isEditingDisabled={false}
+        retryLabel="Penalty"
+        retryTitle="Toggle penalty"
+        timeInputProps={timeInputProps}
+        onTvChange={onTvChange}
+        onTimeChange={onTimeChange}
+        onTimeBlur={onTimeBlur}
+        onRetryToggle={onRetryToggle}
+      />
+    );
+
+    const tvSelect = screen.getByLabelText('TV number for phase');
+    fireEvent.change(tvSelect, { target: { value: '4' } });
+    expect(onTvChange).toHaveBeenCalledWith('player-2', 4);
+
+    const timeInput = screen.getByPlaceholderText('Time');
+    fireEvent.change(timeInput, { target: { value: '0:58.12' } });
+    fireEvent.blur(timeInput);
+    expect(onTimeChange).toHaveBeenCalledWith('player-2', '0:58.12');
+    expect(onTimeBlur).toHaveBeenCalledWith('player-2');
+    expect(screen.getByRole('button', { name: 'Penalty' })).not.toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Penalty' }));
+    expect(onRetryToggle).toHaveBeenCalledWith('player-2');
+  });
+
+  it('disables retry button when editing is disabled', () => {
+    render(
+      <TAEliminationPhaseRow
+        playerId="player-2"
+        playerName="Bob"
+        tvNumber={null}
+        tvLabel="TV number for phase"
+        timeValue="0:59.99"
+        timePlaceholder="Time"
+        isRetry={false}
+        isEditingDisabled={true}
+        retryLabel="Penalty"
+        retryTitle="Toggle penalty"
+        timeInputProps={timeInputProps}
+        onTvChange={jest.fn()}
+        onTimeChange={jest.fn()}
+        onTimeBlur={jest.fn()}
+        onRetryToggle={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Penalty' })).toBeDisabled();
+  });
+});
+
+describe('TaParticipantTimeInputRow', () => {
+  it('renders props and calls callbacks with correct arguments', () => {
+    const onChange = jest.fn();
+    const onBlur = jest.fn();
+
+    render(
+      <TaParticipantTimeInputRow
+        courseAbbr="GV1"
+        value="1:23.45"
+        placeholder="GV1"
+        disabled={false}
+        inputClassName="test-class"
+        timeInputProps={timeInputProps}
+        onChange={onChange}
+        onBlur={onBlur}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('GV1');
+    fireEvent.change(input, { target: { value: '1:22.00' } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith('GV1', '1:22.00');
+    expect(onBlur).toHaveBeenCalledWith('GV1');
+    expect(input).not.toBeDisabled();
+  });
+
+  it('forwards disabled prop', () => {
+    render(
+      <TaParticipantTimeInputRow
+        courseAbbr="GV1"
+        value="1:23.45"
+        placeholder="GV1"
+        disabled={true}
+        inputClassName="test-class"
+        timeInputProps={timeInputProps}
+        onChange={jest.fn()}
+        onBlur={jest.fn()}
+      />
+    );
+
+    expect(screen.getByPlaceholderText('GV1')).toBeDisabled();
+  });
+});

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -403,8 +403,9 @@ describe("TA Finals Phase Manager", () => {
       expect(getNextPhase3ResetThreshold(2)).toBe(1);
     });
 
-    it("returns null when activeCount is already at one survivor", () => {
+    it("returns null when the active player count is one or fewer", () => {
       expect(getNextPhase3ResetThreshold(1)).toBeNull();
+      expect(getNextPhase3ResetThreshold(0)).toBeNull();
     });
   });
 

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -192,6 +192,7 @@ const TaFinalsTimeEntryRow = memo(function TaFinalsTimeEntryRow({
   onTimeBlur,
   onRetryToggle,
 }: TaFinalsTimeEntryRowProps) {
+  // Keep the memoized row output stable while remaining responsive to submission state.
   return (
     <div
       className={TA_FINALS_ROUND_ENTRY_ROW_CLASS}

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -27,7 +27,7 @@
  * - 3-second auto-refresh for live tracking
  */
 
-import { useState, useEffect, useCallback, use, useMemo } from "react";
+import { memo, useState, useEffect, useCallback, use, useMemo } from "react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -154,6 +154,102 @@ function renderLives(lives: number, eliminated: boolean, eliminatedLabel: string
   }
   return <span>{hearts}</span>;
 }
+
+type TaFinalsTimeEntryRowProps = {
+  playerId: string;
+  playerName: string;
+  livesLabel: React.ReactNode;
+  tvNumber: number | null;
+  tvLabel: string;
+  timeValue: string;
+  timePlaceholder: string;
+  isRetry: boolean;
+  isEditingDisabled: boolean;
+  retryLabel: string;
+  retryTitle: string;
+  timeInputProps: Record<string, unknown>;
+  onTvChange: (playerId: string, value: number | null) => void;
+  onTimeChange: (playerId: string, value: string) => void;
+  onTimeBlur: (playerId: string) => void;
+  onRetryToggle: (playerId: string) => void;
+};
+
+const TaFinalsTimeEntryRow = memo(function TaFinalsTimeEntryRow({
+  playerId,
+  playerName,
+  livesLabel,
+  tvNumber,
+  tvLabel,
+  timeValue,
+  timePlaceholder,
+  isRetry,
+  isEditingDisabled,
+  retryLabel,
+  retryTitle,
+  timeInputProps,
+  onTvChange,
+  onTimeChange,
+  onTimeBlur,
+  onRetryToggle,
+}: TaFinalsTimeEntryRowProps) {
+  return (
+    <div
+      className={TA_FINALS_ROUND_ENTRY_ROW_CLASS}
+      data-testid="ta-finals-round-entry-row"
+    >
+      <div className={TA_FINALS_ROUND_PLAYER_LABEL_CLASS}>
+        <Label
+          className={TA_FINALS_ROUND_PLAYER_NAME_CLASS}
+          data-testid="ta-finals-round-player-name"
+        >
+          {playerName}
+        </Label>
+        <div className="text-xs text-muted-foreground">
+          {livesLabel}
+        </div>
+      </div>
+      <div
+        className={TA_FINALS_ROUND_CONTROLS_CLASS}
+        data-testid="ta-finals-round-controls"
+      >
+        <select
+          className="h-9 w-full rounded border bg-background px-2 text-center text-sm sm:h-8 sm:w-16 sm:shrink-0"
+          value={tvNumber ?? ""}
+          onChange={(e) =>
+            onTvChange(playerId, e.target.value ? parseInt(e.target.value) : null)
+          }
+          aria-label={tvLabel}
+        >
+          <option value="">-</option>
+          {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>TV{n}</option>)}
+        </select>
+        <Input
+          type="text"
+          {...timeInputProps}
+          placeholder={timePlaceholder}
+          value={timeValue}
+          onChange={(e) =>
+            onTimeChange(playerId, e.target.value)
+          }
+          onBlur={() => onTimeBlur(playerId)}
+          disabled={isRetry}
+          className={TA_FINALS_TIME_INPUT_CLASS}
+        />
+        <Button
+          variant={isRetry ? "destructive" : "outline"}
+          size="sm"
+          onClick={() => onRetryToggle(playerId)}
+          title={retryTitle}
+          disabled={isEditingDisabled}
+        >
+          {retryLabel}
+        </Button>
+      </div>
+    </div>
+  );
+});
+
+TaFinalsTimeEntryRow.displayName = 'TaFinalsTimeEntryRow';
 
 export default function TimeAttackFinals({
   params,
@@ -481,36 +577,41 @@ export default function TimeAttackFinals({
   };
 
   /** Handle time input change for a specific player */
-  const handleTimeChange = (playerId: string, value: string) => {
+  const handleTimeChange = useCallback((playerId: string, value: string) => {
     setIsEditing(true);
     setCourseTimes((prev) => ({ ...prev, [playerId]: value }));
-    if (retryFlags[playerId]) {
-      setRetryFlags((prev) => ({ ...prev, [playerId]: false }));
-    }
-  };
+    setRetryFlags((prev) => (prev[playerId] ? { ...prev, [playerId]: false } : prev));
+  }, []);
 
-  const handleTimeBlur = (playerId: string) => {
-    const raw = courseTimes[playerId];
-    if (!raw || raw.trim() === "") return;
-    const formatted = autoFormatTime(raw);
-    if (formatted !== null && formatted !== raw) {
-      setCourseTimes((prev) => ({ ...prev, [playerId]: formatted }));
-    }
-  };
+  const handleTimeBlur = useCallback((playerId: string) => {
+    setCourseTimes((prev) => {
+      const raw = prev[playerId];
+      if (!raw || raw.trim() === "") return prev;
+      const formatted = autoFormatTime(raw);
+      if (formatted !== null && formatted !== raw) {
+        return { ...prev, [playerId]: formatted };
+      }
+      return prev;
+    });
+  }, []);
 
   /** Toggle retry penalty: sets time to 9:59.990 and marks isRetry flag */
-  const handleRetryToggle = (playerId: string) => {
-    const isCurrentlyRetry = retryFlags[playerId];
-    setRetryFlags((prev) => ({ ...prev, [playerId]: !isCurrentlyRetry }));
-    if (!isCurrentlyRetry) {
-      setCourseTimes((prev) => ({
-        ...prev,
-        [playerId]: RETRY_PENALTY_DISPLAY,
+  const handleRetryToggle = useCallback((playerId: string) => {
+    setRetryFlags((prev) => {
+      const isCurrentlyRetry = prev[playerId];
+      setIsEditing(true);
+      setCourseTimes((prevTimes) => ({
+        ...prevTimes,
+        [playerId]: isCurrentlyRetry ? "" : RETRY_PENALTY_DISPLAY,
       }));
-    } else {
-      setCourseTimes((prev) => ({ ...prev, [playerId]: "" }));
-    }
-  };
+      return { ...prev, [playerId]: !isCurrentlyRetry };
+    });
+  }, []);
+
+  const handleTvChange = useCallback((playerId: string, value: number | null) => {
+    setTvAssignments((prev) => ({ ...prev, [playerId]: value }));
+    resetBroadcastStatus();
+  }, [resetBroadcastStatus]);
 
   /**
    * Submit round results: sends player times to the API.
@@ -850,68 +951,25 @@ export default function TimeAttackFinals({
                   {tTaFinals('timeInputHelp')}
                 </p>
                 {activeEntries.map((entry) => (
-                  <div
+                  <TaFinalsTimeEntryRow
                     key={entry.id}
-                    className={TA_FINALS_ROUND_ENTRY_ROW_CLASS}
-                    data-testid="ta-finals-round-entry-row"
-                  >
-                    <div className={TA_FINALS_ROUND_PLAYER_LABEL_CLASS}>
-                      <Label
-                        className={TA_FINALS_ROUND_PLAYER_NAME_CLASS}
-                        data-testid="ta-finals-round-player-name"
-                      >
-                        {entry.player.nickname}
-                      </Label>
-                      <div className="text-xs text-muted-foreground">
-                        {renderLives(entry.lives, entry.eliminated, tTaFinals('eliminated'))}
-                      </div>
-                    </div>
-                    <div
-                      className={TA_FINALS_ROUND_CONTROLS_CLASS}
-                      data-testid="ta-finals-round-controls"
-                    >
-                    {/* Per-player TV number selector: assign which screen this player uses */}
-                    <select
-                      className="h-9 w-full rounded border bg-background px-2 text-center text-sm sm:h-8 sm:w-16 sm:shrink-0"
-                      value={tvAssignments[entry.playerId] ?? ""}
-                      onChange={(e) => {
-                        setTvAssignments((prev) => ({
-                          ...prev,
-                          [entry.playerId]: e.target.value ? parseInt(e.target.value) : null,
-                        }));
-                        resetBroadcastStatus();
-                      }}
-                      aria-label={`${tCommon('tvNumber')} ${entry.player.nickname}`}
-                    >
-                      <option value="">-</option>
-                      {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>TV{n}</option>)}
-                    </select>
-                    <Input
-                      type="text"
-                      {...taTimeInputProps}
-                      placeholder={tTaFinals('timePlaceholder')}
-                      value={courseTimes[entry.playerId] || ""}
-                      onChange={(e) =>
-                        handleTimeChange(entry.playerId, e.target.value)
-                      }
-                      onBlur={() => handleTimeBlur(entry.playerId)}
-                      disabled={retryFlags[entry.playerId]}
-                      className={TA_FINALS_TIME_INPUT_CLASS}
-                    />
-                    <Button
-                      variant={
-                        retryFlags[entry.playerId]
-                          ? "destructive"
-                          : "outline"
-                      }
-                      size="sm"
-                      onClick={() => handleRetryToggle(entry.playerId)}
-                      title={tTaFinals('retryPenalty')}
-                    >
-                      {tCommon('retry')}
-                    </Button>
-                    </div>
-                  </div>
+                    playerId={entry.playerId}
+                    playerName={entry.player.nickname}
+                    livesLabel={renderLives(entry.lives, entry.eliminated, tTaFinals('eliminated'))}
+                    tvNumber={tvAssignments[entry.playerId] ?? null}
+                    tvLabel={`${tCommon('tvNumber')} ${entry.player.nickname}`}
+                    timeValue={courseTimes[entry.playerId] || ""}
+                    timePlaceholder={tTaFinals('timePlaceholder')}
+                    isRetry={retryFlags[entry.playerId]}
+                    isEditingDisabled={false}
+                    retryLabel={tCommon('retry')}
+                    retryTitle={tTaFinals('retryPenalty')}
+                    timeInputProps={taTimeInputProps}
+                    onTvChange={handleTvChange}
+                    onTimeChange={handleTimeChange}
+                    onTimeBlur={handleTimeBlur}
+                    onRetryToggle={handleRetryToggle}
+                  />
                 ))}
               </div>
               {/* 配信に反映: push TV1→player1Name, TV2→player2Name to broadcast overlay */}

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -27,7 +27,7 @@
  * - 3-second auto-refresh for live tracking
  */
 
-import { memo, useState, useEffect, useCallback, use, useMemo } from "react";
+import { memo, useState, useEffect, useCallback, use, useMemo, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -296,6 +296,7 @@ export default function TimeAttackFinals({
   const [courseTimes, setCourseTimes] = useState<Record<string, string>>({});
   const [retryFlags, setRetryFlags] = useState<Record<string, boolean>>({});
   const [submitting, setSubmitting] = useState(false);
+  const retryFlagsRef = useRef<Record<string, boolean>>({});
   const [saveError, setSaveError] = useState<string | null>(null);
   const [startingRound, setStartingRound] = useState(false);
   const [cancellingRound, setCancellingRound] = useState(false);
@@ -399,6 +400,10 @@ export default function TimeAttackFinals({
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  useEffect(() => {
+    retryFlagsRef.current = retryFlags;
+  }, [retryFlags]);
 
   // Auto-refresh every 3 seconds, but pause when user is editing to prevent
   // resetting their input. This ensures a smooth data entry experience.
@@ -597,15 +602,14 @@ export default function TimeAttackFinals({
 
   /** Toggle retry penalty: sets time to 9:59.990 and marks isRetry flag */
   const handleRetryToggle = useCallback((playerId: string) => {
-    setRetryFlags((prev) => {
-      const isCurrentlyRetry = prev[playerId];
-      setIsEditing(true);
-      setCourseTimes((prevTimes) => ({
-        ...prevTimes,
-        [playerId]: isCurrentlyRetry ? "" : RETRY_PENALTY_DISPLAY,
-      }));
-      return { ...prev, [playerId]: !isCurrentlyRetry };
-    });
+    setIsEditing(true);
+    const isCurrentlyRetry = retryFlagsRef.current[playerId];
+    const nextIsRetry = !isCurrentlyRetry;
+    setRetryFlags((prev) => ({ ...prev, [playerId]: nextIsRetry }));
+    setCourseTimes((prevTimes) => ({
+      ...prevTimes,
+      [playerId]: nextIsRetry ? RETRY_PENALTY_DISPLAY : "",
+    }));
   }, []);
 
   const handleTvChange = useCallback((playerId: string, value: number | null) => {
@@ -961,7 +965,7 @@ export default function TimeAttackFinals({
                     timeValue={courseTimes[entry.playerId] || ""}
                     timePlaceholder={tTaFinals('timePlaceholder')}
                     isRetry={retryFlags[entry.playerId]}
-                    isEditingDisabled={false}
+                    isEditingDisabled={submitting}
                     retryLabel={tCommon('retry')}
                     retryTitle={tTaFinals('retryPenalty')}
                     timeInputProps={taTimeInputProps}

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -174,7 +174,7 @@ type TaFinalsTimeEntryRowProps = {
   onRetryToggle: (playerId: string) => void;
 };
 
-const TaFinalsTimeEntryRow = memo(function TaFinalsTimeEntryRow({
+export const TaFinalsTimeEntryRow = memo(function TaFinalsTimeEntryRow({
   playerId,
   playerName,
   livesLabel,

--- a/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
@@ -25,7 +25,7 @@
  * - Namespaces: participant, ta, common
  */
 
-import { useState, useEffect, useCallback, use, useMemo } from 'react';
+import { memo, useState, useEffect, useCallback, use, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSession } from 'next-auth/react';
 import { usePolling } from '@/lib/hooks/usePolling';
@@ -77,6 +77,46 @@ interface TAApiData {
   qualificationEditingLockedForPlayers?: boolean;
   taPlayerSelfEdit?: boolean;
 }
+
+type TaParticipantTimeInputRowProps = {
+  courseAbbr: string;
+  value: string;
+  placeholder: string;
+  disabled: boolean;
+  inputClassName: string;
+  timeInputProps: Record<string, unknown>;
+  onChange: (course: string, value: string) => void;
+  onBlur: (course: string) => void;
+};
+
+const TaParticipantTimeInputRow = memo(function TaParticipantTimeInputRow({
+  courseAbbr,
+  value,
+  placeholder,
+  disabled,
+  inputClassName,
+  timeInputProps,
+  onChange,
+  onBlur,
+}: TaParticipantTimeInputRowProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <Label className="w-12 text-xs font-mono">{courseAbbr}</Label>
+      <Input
+        type="text"
+        {...timeInputProps}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(courseAbbr, e.target.value)}
+        onBlur={() => onBlur(courseAbbr)}
+        disabled={disabled}
+        className={inputClassName}
+      />
+    </div>
+  );
+});
+
+TaParticipantTimeInputRow.displayName = 'TaParticipantTimeInputRow';
 
 /**
  * Convert display time string to milliseconds for preview calculation.
@@ -249,34 +289,40 @@ export default function TimeAttackParticipantPage({
   }, [playerId, entries]);
 
   /** Handle individual course time input change */
-  const handleTimeChange = (course: string, value: string) => {
+  const handleTimeChange = useCallback((course: string, value: string) => {
     setTimeInputs(prev => ({ ...prev, [course]: value }));
-  };
+  }, []);
 
   /** Auto-format time on blur — normalizes input to M:SS.mm */
-  const handleTimeBlur = (course: string) => {
-    const raw = timeInputs[course];
-    if (!raw || raw.trim() === "") return;
-    const formatted = autoFormatTime(raw);
-    if (formatted !== null && formatted !== raw) {
-      setTimeInputs(prev => ({ ...prev, [course]: formatted }));
-    }
-  };
+  const handleTimeBlur = useCallback((course: string) => {
+    setTimeInputs((prev) => {
+      const raw = prev[course];
+      if (!raw || raw.trim() === "") return prev;
+      const formatted = autoFormatTime(raw);
+      if (formatted !== null && formatted !== raw) {
+        return { ...prev, [course]: formatted };
+      }
+      return prev;
+    });
+  }, []);
 
   /** Handle partner course time input change */
-  const handlePartnerTimeChange = (course: string, value: string) => {
+  const handlePartnerTimeChange = useCallback((course: string, value: string) => {
     setPartnerTimeInputs(prev => ({ ...prev, [course]: value }));
-  };
+  }, []);
 
   /** Auto-format partner time on blur */
-  const handlePartnerTimeBlur = (course: string) => {
-    const raw = partnerTimeInputs[course];
-    if (!raw || raw.trim() === "") return;
-    const formatted = autoFormatTime(raw);
-    if (formatted !== null && formatted !== raw) {
-      setPartnerTimeInputs(prev => ({ ...prev, [course]: formatted }));
-    }
-  };
+  const handlePartnerTimeBlur = useCallback((course: string) => {
+    setPartnerTimeInputs((prev) => {
+      const raw = prev[course];
+      if (!raw || raw.trim() === "") return prev;
+      const formatted = autoFormatTime(raw);
+      if (formatted !== null && formatted !== raw) {
+        return { ...prev, [course]: formatted };
+      }
+      return prev;
+    });
+  }, []);
 
   /** Submit all entered times to the server */
   const handleSubmitTimes = async () => {
@@ -580,19 +626,17 @@ export default function TimeAttackParticipantPage({
                             </CardHeader>
                             <CardContent className="space-y-3">
                               {COURSE_INFO.filter((c) => c.cup === cup).map((course) => (
-                                <div key={course.abbr} className="flex items-center gap-2">
-                                  <Label className="w-12 text-xs font-mono">{course.abbr}</Label>
-                                  <Input
-                                    type="text"
-                                    {...taTimeInputProps}
-                                    placeholder={tTa('timePlaceholder')}
-                                    value={partnerTimeInputs[course.abbr] || ''}
-                                    onChange={(e) => handlePartnerTimeChange(course.abbr, e.target.value)}
-                                    onBlur={() => handlePartnerTimeBlur(course.abbr)}
-                                    disabled={frozenStages.includes("qualification") || qualificationEditingLocked}
-                                    className="font-mono text-sm"
-                                  />
-                                </div>
+                                <TaParticipantTimeInputRow
+                                  key={course.abbr}
+                                  courseAbbr={course.abbr}
+                                  value={partnerTimeInputs[course.abbr] || ''}
+                                  placeholder={tTa('timePlaceholder')}
+                                  onChange={handlePartnerTimeChange}
+                                  onBlur={handlePartnerTimeBlur}
+                                  disabled={frozenStages.includes("qualification") || qualificationEditingLocked}
+                                  inputClassName="font-mono text-sm"
+                                  timeInputProps={taTimeInputProps}
+                                />
                               ))}
                             </CardContent>
                           </Card>
@@ -677,19 +721,17 @@ export default function TimeAttackParticipantPage({
                             </CardHeader>
                             <CardContent className="space-y-3">
                               {COURSE_INFO.filter((c) => c.cup === cup).map((course) => (
-                                <div key={course.abbr} className="flex items-center gap-2">
-                                  <Label className="w-12 text-xs font-mono">{course.abbr}</Label>
-                                  <Input
-                                    type="text"
-                                    {...taTimeInputProps}
-                                    placeholder={tTa('timePlaceholder')}
-                                    value={timeInputs[course.abbr] || ''}
-                                    onChange={(e) => handleTimeChange(course.abbr, e.target.value)}
-                                    onBlur={() => handleTimeBlur(course.abbr)}
-                                    disabled={frozenStages.includes("qualification") || qualificationEditingLocked}
-                                    className="font-mono text-sm"
-                                  />
-                                </div>
+                                <TaParticipantTimeInputRow
+                                  key={course.abbr}
+                                  courseAbbr={course.abbr}
+                                  value={timeInputs[course.abbr] || ''}
+                                  placeholder={tTa('timePlaceholder')}
+                                  onChange={handleTimeChange}
+                                  onBlur={handleTimeBlur}
+                                  disabled={frozenStages.includes("qualification") || qualificationEditingLocked}
+                                  inputClassName="font-mono text-sm"
+                                  timeInputProps={taTimeInputProps}
+                                />
                               ))}
                             </CardContent>
                           </Card>

--- a/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
@@ -89,7 +89,7 @@ type TaParticipantTimeInputRowProps = {
   onBlur: (course: string) => void;
 };
 
-const TaParticipantTimeInputRow = memo(function TaParticipantTimeInputRow({
+export const TaParticipantTimeInputRow = memo(function TaParticipantTimeInputRow({
   courseAbbr,
   value,
   placeholder,

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -20,7 +20,7 @@
  * - Auto-refresh every 3 seconds for live tournament tracking
  */
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { memo, useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -89,6 +89,98 @@ export interface TAEliminationPhaseProps {
   description: string;
   targetSurvivors: number;
 }
+
+type TAEliminationPhaseRowProps = {
+  playerId: string;
+  playerName: string;
+  tvNumber: number | null;
+  tvLabel: string;
+  timeValue: string;
+  timePlaceholder: string;
+  isRetry: boolean;
+  isEditingDisabled: boolean;
+  retryLabel: string;
+  retryTitle: string;
+  timeInputProps: Record<string, unknown>;
+  onTvChange: (playerId: string, value: number | null) => void;
+  onTimeChange: (playerId: string, value: string) => void;
+  onTimeBlur: (playerId: string) => void;
+  onRetryToggle: (playerId: string) => void;
+};
+
+const TAEliminationPhaseRow = memo(function TAEliminationPhaseRow({
+  playerId,
+  playerName,
+  tvNumber,
+  tvLabel,
+  timeValue,
+  timePlaceholder,
+  isRetry,
+  isEditingDisabled,
+  retryLabel,
+  retryTitle,
+  timeInputProps,
+  onTvChange,
+  onTimeChange,
+  onTimeBlur,
+  onRetryToggle,
+}: TAEliminationPhaseRowProps) {
+  return (
+    <div
+      className={TA_FINALS_ROUND_ENTRY_ROW_CLASS}
+      data-testid="ta-finals-round-entry-row"
+    >
+      <div className={TA_FINALS_ROUND_PLAYER_LABEL_CLASS}>
+        <Label
+          className={TA_FINALS_ROUND_PLAYER_NAME_CLASS}
+          data-testid="ta-finals-round-player-name"
+        >
+          {playerName}
+        </Label>
+      </div>
+      <div
+        className={TA_FINALS_ROUND_CONTROLS_CLASS}
+        data-testid="ta-finals-round-controls"
+      >
+        <select
+          className="h-9 w-full rounded border bg-background px-2 text-center text-sm sm:h-8 sm:w-16 sm:shrink-0"
+          value={tvNumber ?? ""}
+          onChange={(e) =>
+            onTvChange(playerId, e.target.value ? parseInt(e.target.value) : null)
+          }
+          aria-label={tvLabel}
+        >
+          <option value="">-</option>
+          {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>TV{n}</option>)}
+        </select>
+        <Input
+          type="text"
+          {...timeInputProps}
+          placeholder={timePlaceholder}
+          value={timeValue}
+          onChange={(e) =>
+            onTimeChange(playerId, e.target.value)
+          }
+          onBlur={() => onTimeBlur(playerId)}
+          disabled={isRetry}
+          className={TA_FINALS_TIME_INPUT_CLASS}
+        />
+        {/* Retry penalty button: sets time to 9:59.990 */}
+        <Button
+          variant={isRetry ? "destructive" : "outline"}
+          size="sm"
+          onClick={() => onRetryToggle(playerId)}
+          title={retryTitle}
+          disabled={isEditingDisabled}
+        >
+          {retryLabel}
+        </Button>
+      </div>
+    </div>
+  );
+});
+
+TAEliminationPhaseRow.displayName = 'TAEliminationPhaseRow';
 
 /** TTEntry from the phases API */
 interface TTEntry {
@@ -455,40 +547,51 @@ export default function TAEliminationPhase({
   };
 
   /** Handle time input change for a specific player */
-  const handleTimeChange = (playerId: string, value: string) => {
+  const handleTvChange = useCallback((playerId: string, value: number | null) => {
+    setTvAssignments((prev) => ({
+      ...prev,
+      [playerId]: value,
+    }));
+    resetBroadcastStatus();
+  }, [resetBroadcastStatus]);
+
+  const handleTimeChange = useCallback((playerId: string, value: string) => {
     setIsEditing(true);
     setCourseTimes((prev) => ({ ...prev, [playerId]: value }));
     // Clear retry flag when manually entering a time
-    if (retryFlags[playerId]) {
-      setRetryFlags((prev) => ({ ...prev, [playerId]: false }));
-    }
-  };
+    setRetryFlags((prev) => {
+      if (!prev[playerId]) return prev;
+      return { ...prev, [playerId]: false };
+    });
+  }, []);
 
-  const handleTimeBlur = (playerId: string) => {
-    const raw = courseTimes[playerId];
-    if (!raw || raw.trim() === "") return;
-    const formatted = autoFormatTime(raw);
-    if (formatted !== null && formatted !== raw) {
-      setCourseTimes((prev) => ({ ...prev, [playerId]: formatted }));
-    }
-  };
+  const handleTimeBlur = useCallback((playerId: string) => {
+    setCourseTimes((prev) => {
+      const raw = prev[playerId];
+      if (!raw || raw.trim() === "") return prev;
+      const formatted = autoFormatTime(raw);
+      if (formatted !== null && formatted !== raw) {
+        return { ...prev, [playerId]: formatted };
+      }
+      return prev;
+    });
+  }, []);
 
   /**
    * Toggle retry penalty for a player.
    * Sets the time to 9:59.990 and marks the isRetry flag.
    */
-  const handleRetryToggle = (playerId: string) => {
+  const handleRetryToggle = useCallback((playerId: string) => {
     setIsEditing(true);
-    const isCurrentlyRetry = retryFlags[playerId];
-    setRetryFlags((prev) => ({ ...prev, [playerId]: !isCurrentlyRetry }));
-    if (!isCurrentlyRetry) {
-      // Set penalty time display
-      setCourseTimes((prev) => ({ ...prev, [playerId]: RETRY_PENALTY_DISPLAY }));
-    } else {
-      // Clear penalty time
-      setCourseTimes((prev) => ({ ...prev, [playerId]: "" }));
-    }
-  };
+    setRetryFlags((prev) => {
+      const isCurrentlyRetry = prev[playerId];
+      setCourseTimes((prevTimes) => ({
+        ...prevTimes,
+        [playerId]: isCurrentlyRetry ? "" : RETRY_PENALTY_DISPLAY,
+      }));
+      return { ...prev, [playerId]: !isCurrentlyRetry };
+    });
+  }, []);
 
   /**
    * Submit round results: sends player times to the API for elimination processing.
@@ -779,64 +882,24 @@ export default function TAEliminationPhase({
                   {tElim('timeInputHelp')}
                 </p>
                 {activeEntries.map((entry) => (
-                  <div
+                  <TAEliminationPhaseRow
                     key={entry.id}
-                    className={TA_FINALS_ROUND_ENTRY_ROW_CLASS}
-                    data-testid="ta-finals-round-entry-row"
-                  >
-                    <div className={TA_FINALS_ROUND_PLAYER_LABEL_CLASS}>
-                      <Label
-                        className={TA_FINALS_ROUND_PLAYER_NAME_CLASS}
-                        data-testid="ta-finals-round-player-name"
-                      >
-                        {entry.player.nickname}
-                      </Label>
-                    </div>
-                    <div
-                      className={TA_FINALS_ROUND_CONTROLS_CLASS}
-                      data-testid="ta-finals-round-controls"
-                    >
-                    {/* Per-player TV number selector: assign which screen this player uses */}
-                    <select
-                      className="h-9 w-full rounded border bg-background px-2 text-center text-sm sm:h-8 sm:w-16 sm:shrink-0"
-                      value={tvAssignments[entry.playerId] ?? ""}
-                      onChange={(e) => {
-                        setTvAssignments((prev) => ({
-                          ...prev,
-                          [entry.playerId]: e.target.value ? parseInt(e.target.value) : null,
-                        }));
-                        resetBroadcastStatus();
-                      }}
-                      aria-label={`${tCommon('tvNumber')} ${entry.player.nickname}`}
-                    >
-                      <option value="">-</option>
-                      {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>TV{n}</option>)}
-                    </select>
-                    <Input
-                      type="text"
-                      {...taTimeInputProps}
-                      placeholder={tElim('timePlaceholder')}
-                      value={courseTimes[entry.playerId] || ""}
-                      onChange={(e) =>
-                        handleTimeChange(entry.playerId, e.target.value)
-                      }
-                      onBlur={() => handleTimeBlur(entry.playerId)}
-                      disabled={retryFlags[entry.playerId]}
-                      className={TA_FINALS_TIME_INPUT_CLASS}
-                    />
-                    {/* Retry penalty button: sets time to 9:59.990 */}
-                    <Button
-                      variant={
-                        retryFlags[entry.playerId] ? "destructive" : "outline"
-                      }
-                      size="sm"
-                      onClick={() => handleRetryToggle(entry.playerId)}
-                      title={tElim('passPenalty')}
-                    >
-                      {tElim('pass')}
-                    </Button>
-                    </div>
-                  </div>
+                    playerId={entry.playerId}
+                    playerName={entry.player.nickname}
+                    tvNumber={tvAssignments[entry.playerId] ?? null}
+                    tvLabel={`${tCommon('tvNumber')} ${entry.player.nickname}`}
+                    timeValue={courseTimes[entry.playerId] || ""}
+                    timePlaceholder={tElim('timePlaceholder')}
+                    isRetry={retryFlags[entry.playerId]}
+                    isEditingDisabled={submitting}
+                    retryLabel={tElim('pass')}
+                    retryTitle={tElim('passPenalty')}
+                    timeInputProps={taTimeInputProps}
+                    onTvChange={handleTvChange}
+                    onTimeChange={handleTimeChange}
+                    onTimeBlur={handleTimeBlur}
+                    onRetryToggle={handleRetryToggle}
+                  />
                 ))}
               </div>
               {/* 配信に反映: push TV1→player1Name, TV2→player2Name to broadcast overlay */}

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -264,8 +264,12 @@ export default function TAEliminationPhase({
   // This ensures the auto-recovery check always reads the latest value.
   const currentRoundRef = useRef(currentRound);
   currentRoundRef.current = currentRound;
+  useEffect(() => {
+    retryFlagsRef.current = retryFlags;
+  }, [retryFlags]);
   const [courseTimes, setCourseTimes] = useState<Record<string, string>>({});
   const [retryFlags, setRetryFlags] = useState<Record<string, boolean>>({});
+  const retryFlagsRef = useRef<Record<string, boolean>>({});
   const [submitting, setSubmitting] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
@@ -583,14 +587,13 @@ export default function TAEliminationPhase({
    */
   const handleRetryToggle = useCallback((playerId: string) => {
     setIsEditing(true);
-    setRetryFlags((prev) => {
-      const isCurrentlyRetry = prev[playerId];
-      setCourseTimes((prevTimes) => ({
-        ...prevTimes,
-        [playerId]: isCurrentlyRetry ? "" : RETRY_PENALTY_DISPLAY,
-      }));
-      return { ...prev, [playerId]: !isCurrentlyRetry };
-    });
+    const isCurrentlyRetry = retryFlagsRef.current[playerId];
+    const nextIsRetry = !isCurrentlyRetry;
+    setRetryFlags((prev) => ({ ...prev, [playerId]: nextIsRetry }));
+    setCourseTimes((prevTimes) => ({
+      ...prevTimes,
+      [playerId]: nextIsRetry ? RETRY_PENALTY_DISPLAY : "",
+    }));
   }, []);
 
   /**

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -108,7 +108,7 @@ type TAEliminationPhaseRowProps = {
   onRetryToggle: (playerId: string) => void;
 };
 
-const TAEliminationPhaseRow = memo(function TAEliminationPhaseRow({
+export const TAEliminationPhaseRow = memo(function TAEliminationPhaseRow({
   playerId,
   playerName,
   tvNumber,

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -854,8 +854,12 @@ export function createFinalsHandlers(config: FinalsConfig) {
         const bOverride = b.qualification.rankOverride != null;
         if (aOverride !== bOverride) return aOverride ? -1 : 1;
         if (aOverride) {
+          // After the inequality guard above, `aOverride` and `bOverride` are both true
+          // only when both qualifications have non-null `rankOverride` values.
           const aRankOverride = a.qualification.rankOverride ?? Number.POSITIVE_INFINITY;
           const bRankOverride = b.qualification.rankOverride ?? Number.POSITIVE_INFINITY;
+          // `Number.POSITIVE_INFINITY` is defensive; nullish values here should not occur
+          // after the above guard, but this keeps ordering logic type-safe.
           if (aRankOverride !== bRankOverride) return aRankOverride - bRankOverride;
 
           // When manual overrides collide on the same rank value, prefer the


### PR DESCRIPTION
## Summary
- Exported TA row components used in TA finals, elimination, and participant pages for direct unit coverage.
- Added behavior tests for memoized row components:
  - Prop rendering
  - `isRetry` disable behavior for time input
  - `isEditingDisabled` disables retry button
  - callback argument verification for tv/time/blur/retry handlers.

## Issues
- Resolves #1926

## Validation
- Added focused component tests in `smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx`.
- Did not run local test suite in this pass.
