### PR TITLE
Add TA memoized row component unit tests

### DIFF
--- a/smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { TaFinalsTimeEntryRow } from '@/app/tournaments/[id]/ta/finals/page';
+import { TAEliminationPhaseRow } from '@/components/tournament/ta-elimination-phase';
+import { TaParticipantTimeInputRow } from '@/app/tournaments/[id]/ta/participant/page';
+
+const timeInputProps = {
+  inputMode: 'decimal',
+  autoComplete: 'off',
+} as const;
+
+describe('TaFinalsTimeEntryRow', () => {
+  it('renders props and calls callbacks with correct arguments', () => {
+    const onTvChange = jest.fn();
+    const onTimeChange = jest.fn();
+    const onTimeBlur = jest.fn();
+    const onRetryToggle = jest.fn();
+
+    render(
+      <TaFinalsTimeEntryRow
+        playerId="player-1"
+        playerName="Alice"
+        livesLabel="L3"
+        tvNumber={2}
+        tvLabel="TV number"
+        timeValue="1:23.45"
+        timePlaceholder="Time"
+        isRetry={true}
+        isEditingDisabled={false}
+        retryLabel="Retry"
+        retryTitle="Retry time"
+        timeInputProps={timeInputProps}
+        onTvChange={onTvChange}
+        onTimeChange={onTimeChange}
+        onTimeBlur={onTimeBlur}
+        onRetryToggle={onRetryToggle}
+      />
+    );
+
+    const tvSelect = screen.getByLabelText('TV number');
+    fireEvent.change(tvSelect, { target: { value: '3' } });
+    expect(onTvChange).toHaveBeenCalledWith('player-1', 3);
+
+    const timeInput = screen.getByPlaceholderText('Time');
+    fireEvent.change(timeInput, { target: { value: '1:10.00' } });
+    expect(onTimeChange).toHaveBeenCalledWith('player-1', '1:10.00');
+
+    fireEvent.blur(timeInput);
+    expect(onTimeBlur).toHaveBeenCalledWith('player-1');
+    expect(timeInput).toBeDisabled();
+
+    const retryButton = screen.getByRole('button', { name: 'Retry' });
+    fireEvent.click(retryButton);
+    expect(onRetryToggle).toHaveBeenCalledWith('player-1');
+  });
+
+  it('disables retry button when editing is disabled', () => {
+    render(
+      <TaFinalsTimeEntryRow
+        playerId="player-1"
+        playerName="Alice"
+        livesLabel="L3"
+        tvNumber={null}
+        tvLabel="TV number"
+        timeValue="1:23.45"
+        timePlaceholder="Time"
+        isRetry={false}
+        isEditingDisabled={true}
+        retryLabel="Retry"
+        retryTitle="Retry time"
+        timeInputProps={timeInputProps}
+        onTvChange={jest.fn()}
+        onTimeChange={jest.fn()}
+        onTimeBlur={jest.fn()}
+        onRetryToggle={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeDisabled();
+  });
+});
+
+describe('TAEliminationPhaseRow', () => {
+  it('renders props and calls callbacks with correct arguments', () => {
+    const onTvChange = jest.fn();
+    const onTimeChange = jest.fn();
+    const onTimeBlur = jest.fn();
+    const onRetryToggle = jest.fn();
+
+    render(
+      <TAEliminationPhaseRow
+        playerId="player-2"
+        playerName="Bob"
+        tvNumber={1}
+        tvLabel="TV number for phase"
+        timeValue="0:59.99"
+        timePlaceholder="Time"
+        isRetry={false}
+        isEditingDisabled={false}
+        retryLabel="Penalty"
+        retryTitle="Toggle penalty"
+        timeInputProps={timeInputProps}
+        onTvChange={onTvChange}
+        onTimeChange={onTimeChange}
+        onTimeBlur={onTimeBlur}
+        onRetryToggle={onRetryToggle}
+      />
+    );
+
+    const tvSelect = screen.getByLabelText('TV number for phase');
+    fireEvent.change(tvSelect, { target: { value: '4' } });
+    expect(onTvChange).toHaveBeenCalledWith('player-2', 4);
+
+    const timeInput = screen.getByPlaceholderText('Time');
+    fireEvent.change(timeInput, { target: { value: '0:58.12' } });
+    fireEvent.blur(timeInput);
+    expect(onTimeChange).toHaveBeenCalledWith('player-2', '0:58.12');
+    expect(onTimeBlur).toHaveBeenCalledWith('player-2');
+    expect(screen.getByRole('button', { name: 'Penalty' })).not.toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Penalty' }));
+    expect(onRetryToggle).toHaveBeenCalledWith('player-2');
+  });
+
+  it('disables retry button when editing is disabled', () => {
+    render(
+      <TAEliminationPhaseRow
+        playerId="player-2"
+        playerName="Bob"
+        tvNumber={null}
+        tvLabel="TV number for phase"
+        timeValue="0:59.99"
+        timePlaceholder="Time"
+        isRetry={false}
+        isEditingDisabled={true}
+        retryLabel="Penalty"
+        retryTitle="Toggle penalty"
+        timeInputProps={timeInputProps}
+        onTvChange={jest.fn()}
+        onTimeChange={jest.fn()}
+        onTimeBlur={jest.fn()}
+        onRetryToggle={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Penalty' })).toBeDisabled();
+  });
+});
+
+describe('TaParticipantTimeInputRow', () => {
+  it('renders props and calls callbacks with correct arguments', () => {
+    const onChange = jest.fn();
+    const onBlur = jest.fn();
+
+    render(
+      <TaParticipantTimeInputRow
+        courseAbbr="GV1"
+        value="1:23.45"
+        placeholder="GV1"
+        disabled={false}
+        inputClassName="test-class"
+        timeInputProps={timeInputProps}
+        onChange={onChange}
+        onBlur={onBlur}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('GV1');
+    fireEvent.change(input, { target: { value: '1:22.00' } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith('GV1', '1:22.00');
+    expect(onBlur).toHaveBeenCalledWith('GV1');
+    expect(input).not.toBeDisabled();
+  });
+
+  it('forwards disabled prop', () => {
+    render(
+      <TaParticipantTimeInputRow
+        courseAbbr="GV1"
+        value="1:23.45"
+        placeholder="GV1"
+        disabled={true}
+        inputClassName="test-class"
+        timeInputProps={timeInputProps}
+        onChange={jest.fn()}
+        onBlur={jest.fn()}
+      />
+    );
+
+    expect(screen.getByPlaceholderText('GV1')).toBeDisabled();
+  });
+});

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -174,7 +174,7 @@ type TaFinalsTimeEntryRowProps = {
   onRetryToggle: (playerId: string) => void;
 };
 
-const TaFinalsTimeEntryRow = memo(function TaFinalsTimeEntryRow({
+export const TaFinalsTimeEntryRow = memo(function TaFinalsTimeEntryRow({
   playerId,
   playerName,
   livesLabel,

--- a/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
@@ -89,7 +89,7 @@ type TaParticipantTimeInputRowProps = {
   onBlur: (course: string) => void;
 };
 
-const TaParticipantTimeInputRow = memo(function TaParticipantTimeInputRow({
+export const TaParticipantTimeInputRow = memo(function TaParticipantTimeInputRow({
   courseAbbr,
   value,
   placeholder,

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -90,6 +90,7 @@ export interface TAEliminationPhaseProps {
   targetSurvivors: number;
 }
 
+
 type TAEliminationPhaseRowProps = {
   playerId: string;
   playerName: string;
@@ -108,7 +109,7 @@ type TAEliminationPhaseRowProps = {
   onRetryToggle: (playerId: string) => void;
 };
 
-const TAEliminationPhaseRow = memo(function TAEliminationPhaseRow({
+export const TAEliminationPhaseRow = memo(function TAEliminationPhaseRow({
   playerId,
   playerName,
   tvNumber,


### PR DESCRIPTION
## Summary
- Export memoized TA row components for testability
  - `TaFinalsTimeEntryRow` in `smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx`
  - `TAEliminationPhaseRow` in `smkc-score-app/src/components/tournament/ta-elimination-phase.tsx`
  - `TaParticipantTimeInputRow` in `smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx`
- Add unit tests for callback wiring and disabled-state behavior
  - `smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx`

## Validation
- Added focused unit tests covering:
  - props rendering and callback arguments for each row component
  - disabled behavior for retry input and retry button
  - onTvChange/onTimeChange/onTimeBlur/onRetryToggle contracts

## Reference
- Issue: https://github.com/azumag/JSMKC/issues/1926
- No production data changes.
