### PR TITLE
test: detect page.getByRole lookup drift in setup-mode helper

### DIFF
--- a/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
@@ -50,6 +50,18 @@ describe('group setup E2E helper', () => {
       .toThrow('dialog.locator received unexpected value "section[data-new]". Expected one of: label, input[type="number"]');
   });
 
+  it('prints expected page role lookups when the Playwright fixture receives an unexpected role selector', () => {
+    expect(() =>
+      throwUnexpectedMockCall(
+        'page.getByRole lookup',
+        formatRoleLookup('button', 'Unexpected'),
+        EXPECTED_PAGE_ROLE_LOOKUPS,
+      ),
+    ).toThrow(
+      'page.getByRole lookup received unexpected value "role=button name=Unexpected". Expected one of: role=button name=Setup Groups|Edit Groups|グループ設定|グループ編集, role=dialog name=',
+    );
+  });
+
   it('skips clicking an already-selected disabled group-count button while saving seeded groups', async () => {
     const groupCountClick = jest.fn(async () => undefined);
     const saveClick = jest.fn(async () => undefined);


### PR DESCRIPTION
## Summary
- Harden group setup E2E helper test by asserting unexpected  selectors are surfaced with the expected lookup list.
- Add one regression case mirroring existing  guard to catch selector-name mismatch for role-based mock assertions.

## Validation
- Not run here per automation flow; this is a static assertion-focused test-only change.
- Existing test suite should exercise this path as part of  coverage.

## Issues
- fixes #1725