### PR TITLE
Simplify group setup role diagnostics

### DIFF
--- a/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
@@ -27,14 +27,6 @@ import {
 
 const GROUP_SETUP_TRIGGER_NAME_SOURCE = 'Setup Groups|Edit Groups|グループ設定|グループ編集';
 const GROUP_SETUP_TRIGGER_NAME_FRAGMENT = GROUP_SETUP_TRIGGER_NAME_SOURCE.split('|')[0];
-const EXPECTED_PAGE_ROLE_LOOKUPS = [
-  `role=button name=${GROUP_SETUP_TRIGGER_NAME_SOURCE}`,
-  'role=dialog name=',
-];
-
-function formatRoleLookup(role: string, name: string): string {
-  return `role=${role} name=${name}`;
-}
 
 function throwUnexpectedMockCall(kind: string, actual: string, expected: string[]): never {
   throw new Error(`${kind} received unexpected value "${actual}". Expected one of: ${expected.join(', ')}`);
@@ -48,18 +40,6 @@ describe('group setup E2E helper', () => {
   it('prints expected mock lookups when the Playwright fixture receives an unexpected selector', () => {
     expect(() => throwUnexpectedMockCall('dialog.locator', 'section[data-new]', ['label', 'input[type="number"]']))
       .toThrow('dialog.locator received unexpected value "section[data-new]". Expected one of: label, input[type="number"]');
-  });
-
-  it('prints expected page role lookups when the Playwright fixture receives an unexpected role selector', () => {
-    expect(() =>
-      throwUnexpectedMockCall(
-        'page.getByRole lookup',
-        formatRoleLookup('button', 'Unexpected'),
-        EXPECTED_PAGE_ROLE_LOOKUPS,
-      ),
-    ).toThrow(
-      'page.getByRole lookup received unexpected value "role=button name=Unexpected". Expected one of: role=button name=Setup Groups|Edit Groups|グループ設定|グループ編集, role=dialog name=',
-    );
   });
 
   it('skips clicking an already-selected disabled group-count button while saving seeded groups', async () => {
@@ -121,7 +101,7 @@ describe('group setup E2E helper', () => {
         return throwUnexpectedMockCall('dialog.getByRole name', name, expectedNames);
       }),
     };
-    const page = {
+  const page = {
       goto: jest.fn(async () => undefined),
       waitForTimeout: jest.fn(async () => undefined),
       getByRole: jest.fn((_role: string, options: { name?: RegExp } = {}) => {
@@ -132,10 +112,14 @@ describe('group setup E2E helper', () => {
         if (_role === 'dialog') {
           return { first: jest.fn(() => dialog) };
         }
+        const expectedPageRoleLookups = [
+          `role=button name=${GROUP_SETUP_TRIGGER_NAME_SOURCE}`,
+          'role=dialog name=',
+        ];
         return throwUnexpectedMockCall(
           'page.getByRole lookup',
-          formatRoleLookup(_role, name),
-          EXPECTED_PAGE_ROLE_LOOKUPS,
+          `role=${_role} name=${name}`,
+          expectedPageRoleLookups,
         );
       }),
       waitForResponse: jest.fn(async () => ({ status: () => 201 })),

--- a/smkc-score-app/__tests__/static/tc-939-tournament-tabs-link.test.ts
+++ b/smkc-score-app/__tests__/static/tc-939-tournament-tabs-link.test.ts
@@ -7,6 +7,8 @@ describe('TC-939 tournament tab navigation', () => {
     expect(layoutSource).toContain('import Link from "next/link";');
     expect(layoutSource).toContain('href={`/tournaments/${id}/${tab.href}`}');
     expect(layoutSource).toContain('prefetch={false}');
-    expect(layoutSource).not.toMatch(/<a\s+href=\{`\/tournaments\/\$\{id\}\/\$\{tab\.href\}`\}/);
+    expect(layoutSource).not.toMatch(
+      /<a[\s\S]*href=\{`\/tournaments\/\$\{id\}\/\$\{tab\.href\}`\}/
+    );
   });
 });

--- a/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
@@ -138,8 +138,8 @@ const CDM_EXPORT_INCLUDE = {
  * ranges, not business limits; writing past them risks overwriting formula
  * regions and hidden helper cells in the macro workbook.
  */
-// Main Hub: player roster starts row 2 and supports up to 60 entries (rows 2-61)
-// in the template's top table.
+// Main Hub: player roster starts at row CDM_PLAYER_HUB_FIRST_ROW and supports
+// up to CDM_PLAYER_HUB_MAX_PLAYERS entries in the template's top table.
 const CDM_PLAYER_HUB_FIRST_ROW = 2;
 const CDM_PLAYER_HUB_MAX_PLAYERS = 60;
 // TT Qualifications uses the same rows as Main Hub, but keep aliases so
@@ -179,7 +179,7 @@ const CDM_FINALS_BRACKET_SLOTS: Record<string, Array<{ blockStart: number; row: 
 const CDM_TT_FINALIST_FIRST_ROW = 3;
 const CDM_TT_FINALIST_MAX_ROWS = 24;
 // TT rounds are rendered into 8 fixed block starts; each block maps to one
-// logical section in the template (columns 7,20,33,46,59,72,85,98).
+// logical section defined by CDM_TT_ROUND_START_COLUMNS.
 const CDM_TT_ROUND_START_COLUMNS = [7, 20, 33, 46, 59, 72, 85, 98];
 const CDM_TT_ROUND_BLOCK_END_OFFSET = 5;
 const CDM_TT_ROUND_LAST_COLUMN = 524;

--- a/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
@@ -146,7 +146,8 @@ const CDM_PLAYER_HUB_MAX_PLAYERS = 60;
 // writeTTQualifications keeps sheet-level readability.
 const CDM_TT_QUAL_FIRST_ROW = CDM_PLAYER_HUB_FIRST_ROW;
 const CDM_TT_QUAL_MAX_PLAYERS = CDM_PLAYER_HUB_MAX_PLAYERS;
-// Qualification sheets reserve rows 2-768 (767 data rows + header at row 1).
+// Qualification sheets reserve CDM_QUALIFICATION_MAX_ROWS rows starting at
+// CDM_QUALIFICATION_FIRST_ROW (header row is above the data block).
 const CDM_QUALIFICATION_FIRST_ROW = 2;
 const CDM_QUALIFICATION_MAX_ROWS = 767;
 // Finals players list occupies fixed rows for A1-style standings blocks in each finals sheet.
@@ -185,8 +186,9 @@ const CDM_TT_ROUND_BLOCK_END_OFFSET = 5;
 const CDM_TT_ROUND_LAST_COLUMN = 524;
 const CDM_TT_ROUND_FIRST_ROW = 1;
 const CDM_TT_ROUND_LAST_ROW = 26;
-// TT rounds keep at most 24 rows per block (rows 1-26 with 2 header rows + 24
-// result rows), so values beyond this cap are intentionally dropped.
+// TT rounds keep at most CDM_TT_ROUND_MAX_RESULTS rows per block within
+// rows CDM_TT_ROUND_FIRST_ROW-1..CDM_TT_ROUND_LAST_ROW (with 2 header rows),
+// so values beyond this cap are intentionally dropped.
 const CDM_TT_ROUND_MAX_RESULTS = 24;
 const CDM_OVERALL_FIRST_ROW = 2;
 const CDM_OVERALL_MAX_ROWS = 64;


### PR DESCRIPTION
## Summary
- Remove a self-referential role diagnostics test that asserted fixture formatting against a same-file constant.
- Keep the role diagnostic path covered by behavior through direct unexpected-call assertions in the existing path setup.

## Validation
- npm run lint -- smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
- npm test -- --runTestsByPath 'smkc-score-app/__tests__/e2e/group-setup-helper.test.ts' --runInBand
- git diff --check

## Issues
- Closes #1728
