### PR TITLE
Fix page.getByRole lookup diagnostics in group setup helper

### DIFF
--- a/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
@@ -112,13 +112,14 @@ describe('group setup E2E helper', () => {
         if (_role === 'dialog') {
           return { first: jest.fn(() => dialog) };
         }
-        const expectedPageRoleLookups = [
+  const expectedPageRoleLookups = [
           `role=button name=${GROUP_SETUP_TRIGGER_NAME_SOURCE}`,
           'role=dialog name=',
         ];
+        const actualPageRoleLookup = `role=${_role} name=${name}`;
         return throwUnexpectedMockCall(
-          'page.getByRole lookup',
-          `role=${_role} name=${name}`,
+          'page.getByRole',
+          actualPageRoleLookup,
           expectedPageRoleLookups,
         );
       }),


### PR DESCRIPTION
## Summary
- Align page.getByRole mock expected lookup formatting with actual lookup text.
- Keep diagnostic formatting consistent with existing `page.getByRole` output strings.

Closes #1723
