### PR TITLE
Improve setupModePlayersViaUi mock diagnostics

### DIFF
--- a/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
@@ -29,7 +29,8 @@ const GROUP_SETUP_TRIGGER_NAME_SOURCE = 'Setup Groups|Edit Groups|グループ�
 const GROUP_SETUP_TRIGGER_NAME_FRAGMENT = GROUP_SETUP_TRIGGER_NAME_SOURCE.split('|')[0];
 
 function throwUnexpectedMockCall(kind: string, actual: string, expected: string[]): never {
-  throw new Error(`${kind} received unexpected value "${actual}". Expected one of: ${expected.join(', ')}`);
+  const quotedExpected = expected.map((value) => `'${value}'`).join(', ');
+  throw new Error(`${kind} received unexpected value "${actual}". Allowed values: [${quotedExpected}]`);
 }
 
 describe('group setup E2E helper', () => {
@@ -39,7 +40,7 @@ describe('group setup E2E helper', () => {
 
   it('prints expected mock lookups when the Playwright fixture receives an unexpected selector', () => {
     expect(() => throwUnexpectedMockCall('dialog.locator', 'section[data-new]', ['label', 'input[type="number"]']))
-      .toThrow('dialog.locator received unexpected value "section[data-new]". Expected one of: label, input[type="number"]');
+      .toThrow(`dialog.locator received unexpected value "section[data-new]". Allowed values: ['label', 'input[type=\"number\"]']`);
   });
 
   it('skips clicking an already-selected disabled group-count button while saving seeded groups', async () => {

--- a/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
@@ -112,13 +112,14 @@ describe('group setup E2E helper', () => {
         if (_role === 'dialog') {
           return { first: jest.fn(() => dialog) };
         }
-        const expectedPageRoleLookups = [
+  const expectedPageRoleLookups = [
           `role=button name=${GROUP_SETUP_TRIGGER_NAME_SOURCE}`,
           'role=dialog name=',
         ];
+        const actualPageRoleLookup = `role=${_role} name=${name}`;
         return throwUnexpectedMockCall(
-          'page.getByRole lookup',
-          `role=${_role} name=${name}`,
+          'page.getByRole',
+          actualPageRoleLookup,
           expectedPageRoleLookups,
         );
       }),


### PR DESCRIPTION
## Summary
- Improve Playwright mock failure diagnostics in group-setup-helper tests by formatting unexpected selector/role inputs with an explicit allowed list.

## Validation
- Added/updated unit test assertion in  for unexpected mock lookup message.

## Issues
- closes #1721