### PR TITLE
i18n sudden death labels on TA finals pages

### DIFF
--- a/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
@@ -29,7 +29,8 @@ const GROUP_SETUP_TRIGGER_NAME_SOURCE = 'Setup Groups|Edit Groups|グループ�
 const GROUP_SETUP_TRIGGER_NAME_FRAGMENT = GROUP_SETUP_TRIGGER_NAME_SOURCE.split('|')[0];
 
 function throwUnexpectedMockCall(kind: string, actual: string, expected: string[]): never {
-  throw new Error(`${kind} received unexpected value "${actual}". Expected one of: ${expected.join(', ')}`);
+  const quotedExpected = expected.map((value) => `'${value}'`).join(', ');
+  throw new Error(`${kind} received unexpected value "${actual}". Allowed values: [${quotedExpected}]`);
 }
 
 describe('group setup E2E helper', () => {
@@ -39,7 +40,7 @@ describe('group setup E2E helper', () => {
 
   it('prints expected mock lookups when the Playwright fixture receives an unexpected selector', () => {
     expect(() => throwUnexpectedMockCall('dialog.locator', 'section[data-new]', ['label', 'input[type="number"]']))
-      .toThrow('dialog.locator received unexpected value "section[data-new]". Expected one of: label, input[type="number"]');
+      .toThrow(`dialog.locator received unexpected value "section[data-new]". Allowed values: ['label', 'input[type=\"number\"]']`);
   });
 
   it('skips clicking an already-selected disabled group-count button while saving seeded groups', async () => {

--- a/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
@@ -112,13 +112,14 @@ describe('group setup E2E helper', () => {
         if (_role === 'dialog') {
           return { first: jest.fn(() => dialog) };
         }
-        const expectedPageRoleLookups = [
+  const expectedPageRoleLookups = [
           `role=button name=${GROUP_SETUP_TRIGGER_NAME_SOURCE}`,
           'role=dialog name=',
         ];
+        const actualPageRoleLookup = `role=${_role} name=${name}`;
         return throwUnexpectedMockCall(
-          'page.getByRole lookup',
-          `role=${_role} name=${name}`,
+          'page.getByRole',
+          actualPageRoleLookup,
           expectedPageRoleLookups,
         );
       }),

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -393,6 +393,19 @@ describe("TA Finals Phase Manager", () => {
   });
 
   describe("getNextPhase3ResetThreshold", () => {
+    it("uses the nearest configured lower threshold and falls back safely", () => {
+      expect(getNextPhase3ResetThreshold(16)).toBe(8);
+      expect(getNextPhase3ResetThreshold(15)).toBe(8);
+      expect(getNextPhase3ResetThreshold(11)).toBe(8);
+      expect(getNextPhase3ResetThreshold(8)).toBe(4);
+      expect(getNextPhase3ResetThreshold(7)).toBe(4);
+      expect(getNextPhase3ResetThreshold(4)).toBe(2);
+      expect(getNextPhase3ResetThreshold(3)).toBe(2);
+      expect(getNextPhase3ResetThreshold(2)).toBe(1);
+      expect(getNextPhase3ResetThreshold(1)).toBeNull();
+      expect(getNextPhase3ResetThreshold(0)).toBeNull();
+    });
+
     it("returns the highest configured reset threshold below activeCount", () => {
       expect(getNextPhase3ResetThreshold(9)).toBe(8);
       expect(getNextPhase3ResetThreshold(5)).toBe(4);

--- a/smkc-score-app/messages/en.json
+++ b/smkc-score-app/messages/en.json
@@ -791,7 +791,8 @@
     "suddenDeathTiebreak": "Sudden-death tiebreak",
     "suddenDeathRoundDesc": "Round {round}, tiebreak #{sequence}",
     "suddenDeathCourse": "Sudden-death course",
-    "submitSuddenDeath": "Submit sudden death"
+    "submitSuddenDeath": "Submit sudden death",
+    "suddenDeathRoundLabel": "Sudden death #{sequence}"
   },
   "revival": {
     "round1Title": "Loser's Revival Round 1",

--- a/smkc-score-app/messages/ja.json
+++ b/smkc-score-app/messages/ja.json
@@ -791,7 +791,8 @@
     "suddenDeathTiebreak": "サドンデスタイブレーク",
     "suddenDeathRoundDesc": "ラウンド {round}、タイブレーク #{sequence}",
     "suddenDeathCourse": "サドンデスコース",
-    "submitSuddenDeath": "サドンデス結果を送信"
+    "submitSuddenDeath": "サドンデス結果を送信",
+    "suddenDeathRoundLabel": "サドンデス #{sequence}"
   },
   "revival": {
     "round1Title": "敗者復活戦 ラウンド1",

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -261,6 +261,7 @@ export default function TimeAttackFinals({
   const { data: session } = useSession();
   /* i18n translation hooks for TA finals, finals, and common namespaces */
   const tTaFinals = useTranslations('taFinals');
+  const tTaSuddenDeath = useTranslations('taSuddenDeath');
   const tFinals = useTranslations('finals');
   const tCommon = useTranslations('common');
   // Input is a native element, so this does not skip rendering by reference equality.
@@ -1370,7 +1371,7 @@ export default function TimeAttackFinals({
                             {(round.suddenDeathRounds || []).map((sd) => (
                               <div key={sd.id} className="text-sm">
                                 <div className="flex justify-between">
-                                  <span className="font-medium">Sudden death #{sd.sequence}</span>
+                                  <span className="font-medium">{tTaSuddenDeath("suddenDeathRoundLabel", { sequence: sd.sequence })}</span>
                                   <Badge variant="outline" className="font-mono text-xs">{sd.course}</Badge>
                                 </div>
                                 {(sd.results || []).map((result) => (

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -229,6 +229,7 @@ export default function TAEliminationPhase({
   // i18n: 'taElimination' namespace for phase-specific strings,
   // 'common' namespace for shared UI labels (e.g., "Player")
   const tElim = useTranslations('taElimination');
+  const tTaSuddenDeath = useTranslations('taSuddenDeath');
   const tCommon = useTranslations('common');
   // Input is a native element, so this does not skip rendering by reference equality.
   // The memo keeps TA pages consistent and avoids rebuilding identical spread props during polling refreshes.
@@ -646,7 +647,7 @@ export default function TAEliminationPhase({
       }
 
       if (results.length < 2) {
-        setSaveError("Need at least 2 players to submit results");
+        setSaveError(tElim("needAtLeast2Players"));
         setSubmitting(false);
         return;
       }
@@ -1256,7 +1257,7 @@ export default function TAEliminationPhase({
                             {(round.suddenDeathRounds || []).map((sd) => (
                               <div key={sd.id} className="text-sm">
                                 <div className="flex justify-between">
-                                  <span className="font-medium">Sudden death #{sd.sequence}</span>
+                                  <span className="font-medium">{tTaSuddenDeath("suddenDeathRoundLabel", { sequence: sd.sequence })}</span>
                                   <Badge variant="outline" className="font-mono text-xs">{sd.course}</Badge>
                                 </div>
                                 {(sd.results || []).map((result) => (


### PR DESCRIPTION


- Fixes #822
- Sudden-death round row labels are now localized in TA elimination and TA finals.
- Added `taSuddenDeath.suddenDeathRoundLabel` to en/ja message catalogs.
- Replaced hard-coded "Need at least 2 players to submit results" with localized `needAtLeast2Players`.
