### PR TITLE
Use shared bracket tab constants in GP finals content tabs

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -847,7 +847,7 @@ export default function GrandPrixFinals({
             <TabsTrigger value={BRACKET_TABS.finals}>{tFinals('upperBracket')}</TabsTrigger>
             <TabsTrigger value={BRACKET_TABS.playoff}>{tFinals('playoffBracket')}</TabsTrigger>
           </TabsList>
-          <TabsContent value="finals">
+          <TabsContent value={BRACKET_TABS.finals}>
             <DoubleEliminationBracket
               matches={gpBracketMatches}
               bracketStructure={bracketStructure}
@@ -859,7 +859,7 @@ export default function GrandPrixFinals({
               onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
             />
           </TabsContent>
-          <TabsContent value="playoff">
+          <TabsContent value={BRACKET_TABS.playoff}>
             <PlayoffBracket
               playoffMatches={gpPlayoffBracketMatches}
               playoffStructure={playoffStructure}


### PR DESCRIPTION
## Summary
- Replace hard-coded `"finals"` and `"playoff"` values in GP finals `TabsContent` with shared `BRACKET_TABS` constants.
- Aligns tab `defaultValue`, trigger, and content values under one typed contract to prevent future drift.

## Issues
- Closes #1714

## Validation
- Change committed on `chore/fix-1714-gp-bracket-tab-values-clean` and pushed.
- CI checks are expected to run on this PR.