### PR TITLE
Fix group setup helper mock indentation

### DIFF
--- a/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
@@ -101,7 +101,7 @@ describe('group setup E2E helper', () => {
         return throwUnexpectedMockCall('dialog.getByRole name', name, expectedNames);
       }),
     };
-  const page = {
+    const page = {
       goto: jest.fn(async () => undefined),
       waitForTimeout: jest.fn(async () => undefined),
       getByRole: jest.fn((_role: string, options: { name?: RegExp } = {}) => {

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -847,7 +847,7 @@ export default function GrandPrixFinals({
             <TabsTrigger value={BRACKET_TABS.finals}>{tFinals('upperBracket')}</TabsTrigger>
             <TabsTrigger value={BRACKET_TABS.playoff}>{tFinals('playoffBracket')}</TabsTrigger>
           </TabsList>
-          <TabsContent value="finals">
+          <TabsContent value={BRACKET_TABS.finals}>
             <DoubleEliminationBracket
               matches={gpBracketMatches}
               bracketStructure={bracketStructure}
@@ -859,7 +859,7 @@ export default function GrandPrixFinals({
               onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
             />
           </TabsContent>
-          <TabsContent value="playoff">
+          <TabsContent value={BRACKET_TABS.playoff}>
             <PlayoffBracket
               playoffMatches={gpPlayoffBracketMatches}
               playoffStructure={playoffStructure}


### PR DESCRIPTION
## Summary
- Fix indentation alignment in group-setup E2E helper test mock setup to match surrounding block style.

## Validation
- Lint & Test: not run locally

Closes #1967
