### PR TITLE
test: loosen operation manual section number dependency

### DIFF
--- a/smkc-score-app/__tests__/docs/operation-tournament.test.ts
+++ b/smkc-score-app/__tests__/docs/operation-tournament.test.ts
@@ -6,7 +6,7 @@ describe('tournament operation manual', () => {
   const manual = fs.readFileSync(manualPath, 'utf8');
 
   it('documents the overall publicModes backfill procedure for existing tournaments', () => {
-    const sectionMatch = manual.match(/### 3\.4 既存大会で総合ランキングを公開する移行手順[\s\S]*?(?=\n---|\n## 4\.)/);
+    const sectionMatch = manual.match(/### .*既存大会で総合ランキングを公開する移行手順[\s\S]*?(?=\n---|\n## )/);
     expect(sectionMatch).not.toBeNull();
     const section = sectionMatch![0];
 

--- a/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
@@ -101,7 +101,7 @@ describe('group setup E2E helper', () => {
         return throwUnexpectedMockCall('dialog.getByRole name', name, expectedNames);
       }),
     };
-  const page = {
+    const page = {
       goto: jest.fn(async () => undefined),
       waitForTimeout: jest.fn(async () => undefined),
       getByRole: jest.fn((_role: string, options: { name?: RegExp } = {}) => {

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -847,7 +847,7 @@ export default function GrandPrixFinals({
             <TabsTrigger value={BRACKET_TABS.finals}>{tFinals('upperBracket')}</TabsTrigger>
             <TabsTrigger value={BRACKET_TABS.playoff}>{tFinals('playoffBracket')}</TabsTrigger>
           </TabsList>
-          <TabsContent value="finals">
+          <TabsContent value={BRACKET_TABS.finals}>
             <DoubleEliminationBracket
               matches={gpBracketMatches}
               bracketStructure={bracketStructure}
@@ -859,7 +859,7 @@ export default function GrandPrixFinals({
               onTvNumberChange={isAdmin ? handleBracketTvNumberChange : undefined}
             />
           </TabsContent>
-          <TabsContent value="playoff">
+          <TabsContent value={BRACKET_TABS.playoff}>
             <PlayoffBracket
               playoffMatches={gpPlayoffBracketMatches}
               playoffStructure={playoffStructure}


### PR DESCRIPTION
## Summary
- Remove heading-number dependency in operation-tournament docs test to prevent brittle failures when section numbering changes.

## Issues
- Closes #1752

## Validation
- Lint/Test + Claude review + Workers checks will be run by CI.
