### PR TITLE
fix layout tab links with prefetch false

### DIFF
--- a/smkc-score-app/src/app/layout.tsx
+++ b/smkc-score-app/src/app/layout.tsx
@@ -159,11 +159,12 @@ function NavLink({
   messageKey: string;
 }) {
   return (
-    <a
+    <Link
       href={href}
+      prefetch={false}
       className="inline-flex items-center px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
     >
       <NavLabelClient messageKey={messageKey} />
-    </a>
+    </Link>
   );
 }


### PR DESCRIPTION
## Summary
- Restore SPA-friendly navigation in root header tab links by using Next  for  entries in .
- Add  to preserve prefetch-disable behavior while avoiding full-page reload regressions.

## Issues
- Closes #939

## Validation
- Manual code review of changed JSX.
