### PR TITLE
Fix course cycle status panel comment in review followup

### DIFF
--- a/smkc-score-app/src/components/tournament/course-cycle-status-panel.tsx
+++ b/smkc-score-app/src/components/tournament/course-cycle-status-panel.tsx
@@ -23,7 +23,7 @@ export function CourseCycleStatusPanel({
   status,
   availableCoursesCount,
 }: CourseCycleStatusPanelProps) {
-  // availableCoursesCount comes from the server-backed course pool, not the cycle-status helper.
+  // availableCoursesCount is a separate prop because it comes from the server-backed course pool, not the cycle-status helper.
   return (
     <div className="border border-foreground/15 bg-muted/30 p-3 text-sm space-y-2">
       <div className="flex justify-between gap-3">


### PR DESCRIPTION
This PR addresses issue #1686 from review-followup.

Changes made:
- Rewrite the component comment in
  smkc-score-app/src/components/tournament/course-cycle-status-panel.tsx to a single explicit line per review guidance.

Notes:
- No behavior/runtime changes, comment-only formatting update.