### PR TITLE
fix: TA TV number parsing uses radix-10

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
@@ -5,6 +5,7 @@ import {
   TA_TIME_INPUT_BASE_PROPS,
   TA_TIME_INPUT_HELP_CLASS,
   getTaTimeInputProps,
+  parseTvNumberInput,
 } from "@/lib/ta/time-entry-layout";
 
 describe("TA time entry layout", () => {
@@ -45,5 +46,11 @@ describe("TA time entry layout", () => {
     expect(TA_FINALS_ROUND_PLAYER_NAME_CLASS.split(" ")).toEqual(
       expect.arrayContaining(["block", "truncate", "text-base", "sm:text-sm"]),
     );
+  });
+
+  it("parses TV number input with explicit radix", () => {
+    expect(parseTvNumberInput("3")).toBe(3);
+    expect(parseTvNumberInput("09")).toBe(9);
+    expect(parseTvNumberInput("")).toBeNull();
   });
 });

--- a/smkc-score-app/src/lib/ta/time-entry-layout.ts
+++ b/smkc-score-app/src/lib/ta/time-entry-layout.ts
@@ -17,6 +17,7 @@ export const TA_TIME_INPUT_HELP_CLASS =
   "rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-sm font-medium leading-relaxed text-foreground";
 
 export function parseTvNumberInput(value: string): number | null {
+  // Keep radix explicit for predictable decimal parsing of values like "09".
   return value ? parseInt(value, 10) : null;
 }
 

--- a/smkc-score-app/src/lib/ta/time-entry-layout.ts
+++ b/smkc-score-app/src/lib/ta/time-entry-layout.ts
@@ -16,6 +16,10 @@ export function getTaTimeInputProps(title: string) {
 export const TA_TIME_INPUT_HELP_CLASS =
   "rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-sm font-medium leading-relaxed text-foreground";
 
+export function parseTvNumberInput(value: string): number | null {
+  return value ? parseInt(value, 10) : null;
+}
+
 export const TA_FINALS_ROUND_ENTRY_ROW_CLASS =
   "rounded-md border bg-background/60 p-3 space-y-2 sm:flex sm:items-center sm:gap-2 sm:space-y-0 sm:border-0 sm:bg-transparent sm:p-0";
 


### PR DESCRIPTION
Closes #1983

## Summary
- Add parseTvNumberInput helper with parseInt(value, 10)
- Use helper in TaFinalsTimeEntryRow and TAEliminationPhaseRow
- Add unit tests for TV number parsing cases: '3' => 3, '09' => 9, '' => null

## Validation
- Unit tests updated: smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts