### PR TITLE
Use parseTvNumberInput in TA TV row handlers

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
@@ -5,6 +5,7 @@ import {
   TA_TIME_INPUT_BASE_PROPS,
   TA_TIME_INPUT_HELP_CLASS,
   getTaTimeInputProps,
+  parseTvNumberInput,
 } from "@/lib/ta/time-entry-layout";
 
 describe("TA time entry layout", () => {
@@ -45,5 +46,11 @@ describe("TA time entry layout", () => {
     expect(TA_FINALS_ROUND_PLAYER_NAME_CLASS.split(" ")).toEqual(
       expect.arrayContaining(["block", "truncate", "text-base", "sm:text-sm"]),
     );
+  });
+
+  it("parses TV number input with explicit radix", () => {
+    expect(parseTvNumberInput("3")).toBe(3);
+    expect(parseTvNumberInput("09")).toBe(9);
+    expect(parseTvNumberInput("")).toBeNull();
   });
 });

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -84,6 +84,7 @@ import {
   TA_FINALS_TIME_INPUT_CLASS,
   TA_TIME_INPUT_HELP_CLASS,
   getTaTimeInputProps,
+  parseTvNumberInput,
 } from "@/lib/ta/time-entry-layout";
 import { getCourseCycleStatus } from "@/lib/ta/course-cycle-status";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
@@ -217,7 +218,7 @@ export const TaFinalsTimeEntryRow = memo(function TaFinalsTimeEntryRow({
           className="h-9 w-full rounded border bg-background px-2 text-center text-sm sm:h-8 sm:w-16 sm:shrink-0"
           value={tvNumber ?? ""}
           onChange={(e) =>
-            onTvChange(playerId, e.target.value ? parseInt(e.target.value, 10) : null)
+            onTvChange(playerId, parseTvNumberInput(e.target.value))
           }
           aria-label={tvLabel}
         >

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -67,6 +67,7 @@ import {
   TA_FINALS_TIME_INPUT_CLASS,
   TA_TIME_INPUT_HELP_CLASS,
   getTaTimeInputProps,
+  parseTvNumberInput,
 } from "@/lib/ta/time-entry-layout";
 import { getCourseCycleStatus } from "@/lib/ta/course-cycle-status";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
@@ -147,7 +148,7 @@ export const TAEliminationPhaseRow = memo(function TAEliminationPhaseRow({
           className="h-9 w-full rounded border bg-background px-2 text-center text-sm sm:h-8 sm:w-16 sm:shrink-0"
           value={tvNumber ?? ""}
           onChange={(e) =>
-            onTvChange(playerId, e.target.value ? parseInt(e.target.value, 10) : null)
+            onTvChange(playerId, parseTvNumberInput(e.target.value))
           }
           aria-label={tvLabel}
         >

--- a/smkc-score-app/src/lib/ta/time-entry-layout.ts
+++ b/smkc-score-app/src/lib/ta/time-entry-layout.ts
@@ -17,6 +17,7 @@ export const TA_TIME_INPUT_HELP_CLASS =
   "rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-sm font-medium leading-relaxed text-foreground";
 
 export function parseTvNumberInput(value: string): number | null {
+  // Keep radix explicit for predictable decimal parsing of values like "09".
   return value ? parseInt(value, 10) : null;
 }
 

--- a/smkc-score-app/src/lib/ta/time-entry-layout.ts
+++ b/smkc-score-app/src/lib/ta/time-entry-layout.ts
@@ -16,6 +16,10 @@ export function getTaTimeInputProps(title: string) {
 export const TA_TIME_INPUT_HELP_CLASS =
   "rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-sm font-medium leading-relaxed text-foreground";
 
+export function parseTvNumberInput(value: string): number | null {
+  return value ? parseInt(value, 10) : null;
+}
+
 export const TA_FINALS_ROUND_ENTRY_ROW_CLASS =
   "rounded-md border bg-background/60 p-3 space-y-2 sm:flex sm:items-center sm:gap-2 sm:space-y-0 sm:border-0 sm:bg-transparent sm:p-0";
 


### PR DESCRIPTION
## Summary
- use parseTvNumberInput in TaFinalsTimeEntryRow and TAEliminationPhaseRow TV number select handlers
- keep TA TV number parsing behavior centralized with the helper introduced in prior review

## Issues: Closes #1988

## Validation
- npm test -- --runTestsByPath __tests__/lib/ta/time-entry-layout.test.ts __tests__/components/tournament/ta-time-entry-rows.test.tsx --runInBand
- npm run lint
- git diff --check origin/main..HEAD
