### PR TITLE
Add behavior-oriented BM_MR_MATCH_LEAN_SELECT contract test

### DIFF
--- a/smkc-score-app/__tests__/lib/prisma-selects.test.ts
+++ b/smkc-score-app/__tests__/lib/prisma-selects.test.ts
@@ -1,0 +1,23 @@
+import { BM_MR_MATCH_LEAN_SELECT } from '@/lib/prisma-selects';
+
+describe('prisma selects', () => {
+  it('BM_MR_MATCH_LEAN_SELECT is a strict boolean contract for shared match payload', () => {
+    const expectedFields = [
+      'id',
+      'tournamentId',
+      'player1Id',
+      'player2Id',
+      'score1',
+      'score2',
+      'rounds',
+      'completed',
+      'isBye',
+    ];
+
+    const selectedFields = Object.entries(BM_MR_MATCH_LEAN_SELECT);
+
+    expect(selectedFields.every(([, value]) => value === true)).toBe(true);
+    expect(Object.keys(BM_MR_MATCH_LEAN_SELECT)).toEqual(expect.arrayContaining(expectedFields));
+    expect(Object.keys(BM_MR_MATCH_LEAN_SELECT).length).toBeGreaterThanOrEqual(expectedFields.length);
+  });
+});


### PR DESCRIPTION
## Summary
- Add regression-focused unit test for BM_MR_MATCH_LEAN_SELECT contract.
- Replace fragile mirrored select-value testing approach by shape+boolean assertions.
- Rebase the PR branch onto current main after #2003.

## Issues
- Closes #1759

## Validation
- npm test -- __tests__/lib/prisma-selects.test.ts --runInBand
- npm run lint (passes with existing warnings)
- git diff --check
