### PR TITLE
Fix TA TV number parsing for nonnumeric input

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2905,6 +2905,17 @@
   3. `placeholder` が翻訳キー由来の `M:SS.mm` であることを確認する
 - **期待結果**: TAタイム入力欄の入力例ヒントとplaceholderは各画面のi18n文字列から描画される
 
+## TC-1987: TA TV番号入力 helper は非数値を null に正規化する
+- **URL**: n/a (helper contract)
+- **authRequired**: false
+- **背景**: issue #1987。`parseTvNumberInput` が `abc` のような非数値文字列を `NaN` として返すと、TA決勝・撃墜フェーズのTV番号更新で想定外の値が残る可能性がある。
+- **手順**:
+  1. `tc-ta.js` の helper contract ケースで `parseTvNumberInput('3')` と `parseTvNumberInput('09')` が10進数として解釈されることを確認する
+  2. `parseTvNumberInput('')` と `parseTvNumberInput('abc')` が `null` になることを確認する
+  3. 単体テストでも同じ境界値を固定し、TA行コンポーネント側は helper の重複単体テストを持たないことを確認する
+- **期待結果**: TAのTV番号 helper は空入力・非数値入力を保存可能な数値として扱わず、`null` に正規化する
+- **スクリプト**: tc-ta.js TC-1987 / time-entry-layout.test.ts / ta-time-entry-rows.test.tsx
+
 ## TC-896: TA決勝フェーズのモバイル管理画面でプレイヤー名が見える
 - **URL**: /tournaments/[temp-id]/ta/finals
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
@@ -6,7 +6,6 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { TaFinalsTimeEntryRow } from '@/app/tournaments/[id]/ta/finals/page';
 import { TAEliminationPhaseRow } from '@/components/tournament/ta-elimination-phase';
 import { TaParticipantTimeInputRow } from '@/app/tournaments/[id]/ta/participant/page';
-import { parseTvNumberInput } from '@/lib/ta/time-entry-layout';
 
 const timeInputProps = {
   inputMode: 'decimal',
@@ -127,12 +126,6 @@ describe('TAEliminationPhaseRow', () => {
     expect(screen.getByRole('button', { name: 'Penalty' })).not.toBeDisabled();
     fireEvent.click(screen.getByRole('button', { name: 'Penalty' }));
     expect(onRetryToggle).toHaveBeenCalledWith('player-2');
-  });
-
-  it('parses TV number input with explicit radix', () => {
-    expect(parseTvNumberInput('3')).toBe(3);
-    expect(parseTvNumberInput('09')).toBe(9);
-    expect(parseTvNumberInput('')).toBeNull();
   });
 
   it('disables retry button when editing is disabled', () => {

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -97,6 +97,20 @@ describe('E2E case drift coverage', () => {
     'tournament',
     'ta-sudden-death-panel.test.tsx',
   );
+  const taTimeEntryLayoutTest = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'lib',
+    'ta',
+    'time-entry-layout.test.ts',
+  );
+  const taTimeEntryRowsTest = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'components',
+    'tournament',
+    'ta-time-entry-rows.test.tsx',
+  );
   const qualificationFallbackTest = readRepoFile(
     'smkc-score-app',
     '__tests__',
@@ -1256,6 +1270,19 @@ describe('E2E case drift coverage', () => {
     expect(taSuddenDeathPanelTest).toContain("setSuddenDeathTime('player-1', '10000')");
     expect(taSuddenDeathPanelTest).toContain("handleSuddenDeathTimeBlur('player-1')");
     expect(taSuddenDeathPanelTest).toContain("toBe('1:00.00')");
+  });
+
+  it('documents TC-1987 as TA TV number helper non-numeric normalization coverage', () => {
+    const section = e2eCaseSection('TC-1987');
+
+    expect(section).toContain('issue #1987');
+    expect(section).toContain("parseTvNumberInput('abc')");
+    expect(section).toContain('time-entry-layout.test.ts');
+    expect(section).toContain('ta-time-entry-rows.test.tsx');
+    expect(tcTa).toContain("log('TC-1987'");
+    expect(tcTa).toContain("parseTvNumberInput('abc') === null");
+    expect(taTimeEntryLayoutTest).toContain('expect(parseTvNumberInput("abc")).toBeNull();');
+    expect(taTimeEntryRowsTest).not.toContain('parseTvNumberInput');
   });
 
   it('documents TC-534 as BM Top-24 unresolved winner warning coverage', () => {

--- a/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
@@ -52,5 +52,6 @@ describe("TA time entry layout", () => {
     expect(parseTvNumberInput("3")).toBe(3);
     expect(parseTvNumberInput("09")).toBe(9);
     expect(parseTvNumberInput("")).toBeNull();
+    expect(parseTvNumberInput("abc")).toBeNull();
   });
 });

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -26,6 +26,7 @@
  *   TC-896  TA finals mobile admin input rows keep player names visible.
  *   TC-897  TA time inputs request the mobile numeric keyboard.
  *   TC-913  TA time input hint/title/placeholder are localized.
+ *   TC-1987 TA TV number helper normalizes non-numeric input to null.
  *   TC-816  Started TA phase page does not flash a Start Phase button while
  *           phase status is still loading.
  *   TC-1032 Phase 3 revival race targets every zero-life candidate when a
@@ -68,6 +69,7 @@ const { createSharedE2eFixture, setupTaEntriesFromShared, ensurePlayerPassword }
 const { assertStackedCardBoxes } = require('./lib/layout-assertions');
 const { runSuite } = require('./lib/runner');
 const { orderTaEntriesForDeterministicResultSlots } = require('./lib/deterministic-order');
+const { parseTvNumberInput } = require('../src/lib/ta/time-entry-layout');
 
 const results = makeResults();
 const log = makeLog(results);
@@ -775,6 +777,22 @@ async function runTc896(adminPage) {
   } finally {
     await adminPage.setViewportSize({ width: 1280, height: 720 }).catch(() => {});
     if (setup) await setup.cleanup().catch(() => {});
+  }
+}
+
+/* ───────── TC-1987: TA TV helper rejects non-numeric values ───────── */
+async function runTc1987() {
+  try {
+    const decimal = parseTvNumberInput('3') === 3;
+    const leadingZero = parseTvNumberInput('09') === 9;
+    const empty = parseTvNumberInput('') === null;
+    const nonNumeric = parseTvNumberInput('abc') === null;
+    const ok = decimal && leadingZero && empty && nonNumeric;
+
+    log('TC-1987', ok ? 'PASS' : 'FAIL',
+      ok ? '' : `decimal=${decimal} leadingZero=${leadingZero} empty=${empty} nonNumeric=${nonNumeric}`);
+  } catch (err) {
+    log('TC-1987', 'FAIL', err instanceof Error ? err.message : 'TA TV helper contract failed');
   }
 }
 
@@ -1975,6 +1993,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-808A', fn: runTc808A },
       { name: 'TC-897', fn: runTc897 },
       { name: 'TC-913', fn: runTc913 },
+      { name: 'TC-1987', fn: runTc1987 },
       { name: 'TC-896', fn: runTc896 },
       { name: 'TC-805', fn: runTc805 },
       { name: 'TC-809', fn: runTc809 },
@@ -1999,7 +2018,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 
 module.exports = {
   runTc801, runTc802, runTc839, runTc804, runTc805, runTc806, runTc807, runTc808, runTc808A, runTc809, runTc810, runTc811,
-  runTc837, runTc840, runTc878, runTc896, runTc897, runTc913,
+  runTc837, runTc840, runTc878, runTc896, runTc897, runTc913, runTc1987,
   runTc812, runTc813, runTc814, runTc1032, runTc1033, runTc815, runTc816, runTc817, runTc1005,
   getSuite,
   results,

--- a/smkc-score-app/src/lib/ta/time-entry-layout.ts
+++ b/smkc-score-app/src/lib/ta/time-entry-layout.ts
@@ -18,7 +18,9 @@ export const TA_TIME_INPUT_HELP_CLASS =
 
 export function parseTvNumberInput(value: string): number | null {
   // Keep radix explicit for predictable decimal parsing of values like "09".
-  return value ? parseInt(value, 10) : null;
+  if (!value) return null;
+  const tvNumber = parseInt(value, 10);
+  return Number.isNaN(tvNumber) ? null : tvNumber;
 }
 
 export const TA_FINALS_ROUND_ENTRY_ROW_CLASS =


### PR DESCRIPTION
## Summary
- Add TC-1987 to the E2E scenario catalog and tc-ta helper contract coverage.
- Add unit/drift coverage for non-numeric TA TV-number parsing.
- Normalize non-numeric parseTvNumberInput values to null instead of NaN.


## Issues
- Closes #1987

## Validation
- `npm test -- --runTestsByPath __tests__/lib/ta/time-entry-layout.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npm test -- --runTestsByPath __tests__/components/tournament/ta-time-entry-rows.test.tsx`
- `node -e "require('ts-node/register/transpile-only'); const { runTc1987, results } = require('./e2e/tc-ta'); Promise.resolve(runTc1987()).then(() => { console.log(JSON.stringify(results)); const failed = results.filter(r => r.status !== 'PASS'); if (failed.length) process.exit(1); });"`
