### PR TITLE
Fix preview E2E browser cache setup

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -214,9 +214,10 @@
   6. public DNS fallback は `dig +short` の説明行や不正な IPv4/IPv6 風文字列を host resolver rules に採用しないことを確認する
   7. macOS で `/Applications/Google Chrome.app` が存在しても、runner が自動で `E2E_BROWSER_CHANNEL=chrome` を設定しないことを確認する
   8. `E2E_BROWSER_CHANNEL=chrome` または `E2E_EXECUTABLE_PATH=...` を明示した場合だけ、その指定が子プロセスへ渡ることを確認する
+  9. `npm run e2e:install-browser` と preview runner が同じ `PLAYWRIGHT_BROWSERS_PATH` を使い、`playwright` import 前に子プロセスへ渡ることを確認する
 - **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / Crashpad permission failure で停止しない
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
-- **補助検証**: `smkc-score-app/__tests__/e2e/run-preview.test.ts`
+- **補助検証**: `smkc-score-app/__tests__/e2e/run-preview.test.ts`, `smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts`
 
 ## TC-111: Preview D1 schema preflight
 - **URL**: n/a (runner command)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1045,6 +1045,7 @@ describe('E2E case drift coverage', () => {
 
   it.each([
     ['TC-109', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/run-preview.test.ts'],
+    ['TC-109', 'PLAYWRIGHT_BROWSERS_PATH', 'smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts'],
     ['TC-111', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts'],
     ['TC-726', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-finals-assigned-cups.test.ts'],
     ['TC-728', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-ranking.test.ts'],

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -38,6 +38,9 @@ describe('preview E2E runner', () => {
     delete process.env.E2E_PROFILE_DIR;
     delete process.env.E2E_BROWSER_CHANNEL;
     delete process.env.E2E_EXECUTABLE_PATH;
+    delete process.env.E2E_BROWSER_HOME;
+    delete process.env.PLAYWRIGHT_BROWSERS_PATH;
+    delete process.env.PLAYWRIGHT_SKIP_BROWSER_GC;
     lookupMock.mockReset();
     spawnSyncMock.mockReset();
     spawnSyncMock.mockReturnValue({ status: 1, stdout: '', stderr: '' });
@@ -53,6 +56,24 @@ describe('preview E2E runner', () => {
 
     expect(env.E2E_BASE_URL).toBe('https://preview.smkc.bluemoon.works');
     expect(env.E2E_PROFILE_DIR).toBe('/tmp/playwright-smkc-preview-profile');
+  });
+
+  it('passes the managed Playwright browser cache to the preview child process before import time', () => {
+    const env = runner.buildPreviewRuntimeEnv({
+      E2E_BROWSER_HOME: '/tmp/jsmkc-preview-browser-home',
+    });
+
+    expect(env.PLAYWRIGHT_BROWSERS_PATH).toBe('/tmp/jsmkc-preview-browser-home/ms-playwright');
+    expect(env.PLAYWRIGHT_SKIP_BROWSER_GC).toBe('1');
+  });
+
+  it('preserves a caller-provided Playwright browser cache for preview runs', () => {
+    const env = runner.buildPreviewRuntimeEnv({
+      E2E_BROWSER_HOME: '/tmp/jsmkc-preview-browser-home',
+      PLAYWRIGHT_BROWSERS_PATH: '/tmp/jsmkc-explicit-preview-browsers',
+    });
+
+    expect(env.PLAYWRIGHT_BROWSERS_PATH).toBe('/tmp/jsmkc-explicit-preview-browsers');
   });
 
   it('exposes npm run e2e:preview as the official all-suite preview alias', () => {

--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -31,6 +31,7 @@ describe('E2E browser launch helpers', () => {
 
   afterEach(() => {
     process.env = { ...originalEnv };
+    jest.dontMock('playwright');
   });
 
   it('defaults Playwright browsers to a writable temp path', () => {
@@ -40,23 +41,41 @@ describe('E2E browser launch helpers', () => {
     );
   });
 
-  it('does not mutate Playwright process env during module load', () => {
+  it('initializes Playwright cache env before importing Playwright', () => {
     process.env = {
       ...originalEnv,
       E2E_BROWSER_HOME: '/tmp/jsmkc-browser-home',
     };
     delete process.env.PLAYWRIGHT_BROWSERS_PATH;
     delete process.env.PLAYWRIGHT_SKIP_BROWSER_GC;
+    let capturedBrowsersPath: string | undefined;
+    let capturedSkipBrowserGc: string | undefined;
+
+    jest.doMock('playwright', () => {
+      capturedBrowsersPath = process.env.PLAYWRIGHT_BROWSERS_PATH;
+      capturedSkipBrowserGc = process.env.PLAYWRIGHT_SKIP_BROWSER_GC;
+      return {
+        chromium: {
+          launch: jest.fn(),
+          launchPersistentContext: jest.fn(),
+        },
+      };
+    });
 
     common = loadCommon();
 
-    expect(process.env.PLAYWRIGHT_BROWSERS_PATH).toBeUndefined();
-    expect(process.env.PLAYWRIGHT_SKIP_BROWSER_GC).toBeUndefined();
+    expect(capturedBrowsersPath).toBe('/tmp/jsmkc-browser-home/ms-playwright');
+    expect(capturedSkipBrowserGc).toBe('1');
+    expect(process.env.PLAYWRIGHT_BROWSERS_PATH).toBe('/tmp/jsmkc-browser-home/ms-playwright');
+    expect(process.env.PLAYWRIGHT_SKIP_BROWSER_GC).toBe('1');
     expect(common.resolvePlaywrightBrowsersPath()).toBe('/tmp/jsmkc-browser-home/ms-playwright');
   });
 
   it('respects caller-provided browser home and installs path env', () => {
     process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
+    delete process.env.PLAYWRIGHT_BROWSERS_PATH;
+    common = loadCommon();
+
     const env = common.createPlaywrightBrowserInstallEnv();
 
     expect(env.PLAYWRIGHT_BROWSERS_PATH).toBe('/tmp/jsmkc-browser-home/ms-playwright');
@@ -66,6 +85,7 @@ describe('E2E browser launch helpers', () => {
   it('uses explicit Playwright browsers path env when provided', () => {
     process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
     process.env.PLAYWRIGHT_BROWSERS_PATH = '/tmp/jsmkc-explicit-browsers';
+    common = loadCommon();
 
     const env = common.createPlaywrightBrowserInstallEnv();
 
@@ -75,6 +95,8 @@ describe('E2E browser launch helpers', () => {
 
   it('syncs Playwright browser cache into process.env during explicit runtime initialization', () => {
     process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
+    delete process.env.PLAYWRIGHT_BROWSERS_PATH;
+    common = loadCommon();
 
     const env = common.initializePlaywrightBrowserRuntimeEnv();
 
@@ -87,6 +109,8 @@ describe('E2E browser launch helpers', () => {
     process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
     process.env.E2E_EXECUTABLE_PATH = '/Applications/Chromium.app/Contents/MacOS/Chromium';
     process.env.E2E_BROWSER_CHANNEL = 'chrome';
+    delete process.env.PLAYWRIGHT_BROWSERS_PATH;
+    common = loadCommon();
 
     const config = common.getChromiumLaunchConfig();
 

--- a/smkc-score-app/e2e/install-browser.js
+++ b/smkc-score-app/e2e/install-browser.js
@@ -4,7 +4,7 @@ const { spawnSync } = require('child_process');
 const {
   createPlaywrightBrowserInstallEnv,
   resolvePlaywrightBrowsersPath,
-} = require('./lib/common');
+} = require('./lib/browser-env');
 
 function printUsage() {
   console.log([

--- a/smkc-score-app/e2e/lib/browser-env.js
+++ b/smkc-score-app/e2e/lib/browser-env.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const DEFAULT_E2E_BROWSER_HOME = path.join(os.tmpdir(), 'playwright-e2e-home');
+
+function resolveE2EBrowserHome() {
+  return process.env.E2E_BROWSER_HOME || DEFAULT_E2E_BROWSER_HOME;
+}
+
+function resolvePlaywrightBrowsersPath() {
+  return process.env.PLAYWRIGHT_BROWSERS_PATH || path.join(resolveE2EBrowserHome(), 'ms-playwright');
+}
+
+function createPlaywrightBrowserInstallEnv(env = process.env) {
+  const browserHome = env.E2E_BROWSER_HOME || DEFAULT_E2E_BROWSER_HOME;
+  const browsersPath = env.PLAYWRIGHT_BROWSERS_PATH || path.join(browserHome, 'ms-playwright');
+  fs.mkdirSync(browserHome, { recursive: true });
+  fs.mkdirSync(browsersPath, { recursive: true });
+  return {
+    ...env,
+    PLAYWRIGHT_BROWSERS_PATH: browsersPath,
+    /* Prevent Playwright from garbage-collecting the shared cache between
+     * separate automation runs that all rely on the same temp location. */
+    PLAYWRIGHT_SKIP_BROWSER_GC: env.PLAYWRIGHT_SKIP_BROWSER_GC || '1',
+  };
+}
+
+function initializePlaywrightBrowserRuntimeEnv() {
+  const env = createPlaywrightBrowserInstallEnv();
+  process.env.PLAYWRIGHT_BROWSERS_PATH = env.PLAYWRIGHT_BROWSERS_PATH;
+  process.env.PLAYWRIGHT_SKIP_BROWSER_GC = env.PLAYWRIGHT_SKIP_BROWSER_GC;
+  return env;
+}
+
+module.exports = {
+  createPlaywrightBrowserInstallEnv,
+  initializePlaywrightBrowserRuntimeEnv,
+  resolveE2EBrowserHome,
+  resolvePlaywrightBrowsersPath,
+};

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -12,8 +12,13 @@
  *   internally if setup throws partway through, so partial state never leaks.
  */
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
+const {
+  createPlaywrightBrowserInstallEnv,
+  initializePlaywrightBrowserRuntimeEnv,
+  resolveE2EBrowserHome,
+  resolvePlaywrightBrowsersPath,
+} = require('./browser-env');
 const {
   DEFAULT_E2E_BASE_URL,
   DEFAULT_E2E_PROFILE_DIR,
@@ -23,7 +28,6 @@ const {
 } = require('./env');
 const { assertGpCombinedStandingsHeaders } = require('./standings-assertions');
 
-const DEFAULT_E2E_BROWSER_HOME = path.join(os.tmpdir(), 'playwright-e2e-home');
 const LOCALE_COMMON_MESSAGES = [
   { locale: 'ja', messages: require('../../messages/ja.json').common },
   { locale: 'en', messages: require('../../messages/en.json').common },
@@ -42,6 +46,7 @@ const QUALIFICATION_POINTS_HEADER_LABELS = LOCALE_COMMON_MESSAGES
 const QUALIFICATION_POINTS_TOOLTIP_TITLES = LOCALE_COMMON_MESSAGES
   .map((entry) => getRequiredCommonMessage(entry, 'qualificationPointsTooltip'));
 
+initializePlaywrightBrowserRuntimeEnv();
 const { chromium } = require('playwright');
 
 const BASE = resolveE2EBaseUrl();
@@ -301,35 +306,6 @@ function getChromiumArgs() {
   }
 
   return args;
-}
-
-function resolveE2EBrowserHome() {
-  return process.env.E2E_BROWSER_HOME || DEFAULT_E2E_BROWSER_HOME;
-}
-
-function resolvePlaywrightBrowsersPath() {
-  return process.env.PLAYWRIGHT_BROWSERS_PATH || path.join(resolveE2EBrowserHome(), 'ms-playwright');
-}
-
-function createPlaywrightBrowserInstallEnv() {
-  const browserHome = resolveE2EBrowserHome();
-  const browsersPath = resolvePlaywrightBrowsersPath();
-  fs.mkdirSync(browserHome, { recursive: true });
-  fs.mkdirSync(browsersPath, { recursive: true });
-  return {
-    ...process.env,
-    PLAYWRIGHT_BROWSERS_PATH: browsersPath,
-    /* Prevent Playwright from garbage-collecting the shared cache between
-     * separate automation runs that all rely on the same temp location. */
-    PLAYWRIGHT_SKIP_BROWSER_GC: process.env.PLAYWRIGHT_SKIP_BROWSER_GC || '1',
-  };
-}
-
-function initializePlaywrightBrowserRuntimeEnv() {
-  const env = createPlaywrightBrowserInstallEnv();
-  process.env.PLAYWRIGHT_BROWSERS_PATH = env.PLAYWRIGHT_BROWSERS_PATH;
-  process.env.PLAYWRIGHT_SKIP_BROWSER_GC = env.PLAYWRIGHT_SKIP_BROWSER_GC;
-  return env;
 }
 
 /* ───────── Browser launch environment setup ───────── */

--- a/smkc-score-app/e2e/run-preview.js
+++ b/smkc-score-app/e2e/run-preview.js
@@ -11,6 +11,9 @@ const {
 const {
   assertPreviewD1Schema,
 } = require('./lib/preview-schema-preflight');
+const {
+  createPlaywrightBrowserInstallEnv,
+} = require('./lib/browser-env');
 
 function buildPreviewRuntimeEnv(env = process.env) {
   const runtimeEnv = {
@@ -19,7 +22,7 @@ function buildPreviewRuntimeEnv(env = process.env) {
     E2E_PROFILE_DIR: resolveE2EProfileDir(env),
   };
 
-  return runtimeEnv;
+  return createPlaywrightBrowserInstallEnv(runtimeEnv);
 }
 
 async function assertBaseUrlResolvable(baseUrl) {


### PR DESCRIPTION
## Summary
- Add TC-109 coverage for preview E2E using the same Playwright browser cache as e2e:install-browser.
- Move Playwright browser env setup into a lightweight helper that can run before importing playwright.
- Pass PLAYWRIGHT_BROWSERS_PATH into preview child processes and initialize common E2E helpers before chromium is required.

## Issues
- Closes #1995

## Validation
- npm test -- --runInBand __tests__/lib/e2e-browser-launch.test.ts __tests__/e2e/run-preview.test.ts __tests__/docs/e2e-cases-drift.test.ts
- node --check e2e/lib/browser-env.js && node --check e2e/lib/common.js && node --check e2e/run-preview.js && node --check e2e/install-browser.js
- npm run lint -- e2e/lib/browser-env.js e2e/lib/common.js e2e/run-preview.js e2e/install-browser.js __tests__/lib/e2e-browser-launch.test.ts __tests__/e2e/run-preview.test.ts __tests__/docs/e2e-cases-drift.test.ts (exit 0; e2e JS files are ignored by the current ESLint config and reported as warnings)
