### PR TITLE
Add TA finals TV number E2E coverage

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2917,6 +2917,18 @@
 - **期待結果**: TAのTV番号 helper は空入力・非数値入力を保存可能な数値として扱わず、`null` に正規化する
 - **スクリプト**: tc-ta.js TC-1987 / time-entry-layout.test.ts / ta-time-entry-rows.test.tsx
 
+## TC-1996: TA決勝 row のTV番号を送信 payload と履歴に保存する
+- **URL**: /tournaments/[temp-id]/ta/finals, /api/tournaments/[id]/ta/phases
+- **authRequired**: true (admin)
+- **背景**: issue #1996。TA決勝 row handler は `parseTvNumberInput(e.target.value)` でTV番号を数値化するが、UI row から submit payload、phase API の round 履歴までを通す E2E カバレッジがなかった。
+- **手順**:
+  1. 管理者で一時 TA fixture を作成し、Phase 3 へ昇格して `/ta/finals` でラウンドを開始する
+  2. 1人目の決勝 row で TV3 を選択し、もう1人は TV番号を未選択のままにする
+  3. ラウンド結果を送信し、`/api/tournaments/[id]/ta/phases` の submit payload で1人目の `tvNumber` が数値 `3`、2人目に `NaN` や不要な `tvNumber` が含まれないことを確認する
+  4. `GET /api/tournaments/[id]/ta/phases?phase=phase3` で保存済み round の results に `tvNumber: 3` と `tvNumber: null` が残ることを確認する
+- **期待結果**: TA決勝のTV番号選択は UI row から API payload へ数値として渡り、未選択行は不正値ではなく `null` として履歴に残る
+- **スクリプト**: tc-ta.js TC-1996 / e2e-cases-drift.test.ts / ta/phases route.test.ts
+
 ## TC-896: TA決勝フェーズのモバイル管理画面でプレイヤー名が見える
 - **URL**: /tournaments/[temp-id]/ta/finals
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
@@ -1221,6 +1221,31 @@ describe('POST /api/tournaments/[id]/ta/phases', () => {
     expect(NextResponse.json).toHaveBeenCalledWith({ success: true, data: { eliminated: [] } });
   });
 
+  it('should accept cleared phase3 result tvNumber values', async () => {
+    (submitRoundResults as jest.Mock).mockResolvedValue({ eliminated: [] });
+    const body = {
+      action: 'submit_results',
+      phase: 'phase3',
+      roundNumber: 1,
+      results: [
+        { playerId: 'claaaaaaaaaaaaaaaaaaaaaaaaaa', timeMs: 63000, tvNumber: 3 },
+        { playerId: 'clbbbbbbbbbbbbbbbbbbbbbbbbbb', timeMs: 65000, tvNumber: null },
+        { playerId: 'clcccccccccccccccccccccccccc', timeMs: 70000 },
+      ],
+    };
+
+    await phasesRoute.POST(createPostRequest(body), { params: mockParams });
+
+    expect(submitRoundResults).toHaveBeenCalledWith(
+      prisma,
+      expect.objectContaining({ tournamentId: 'tournament-1' }),
+      'phase3',
+      1,
+      body.results
+    );
+    expect(NextResponse.json).toHaveBeenCalledWith({ success: true, data: { eliminated: [] } });
+  });
+
   it('should reject submit_results with invalid tvNumber (out of range)', async () => {
     const body = {
       action: 'submit_results',

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -161,6 +161,7 @@ describe('E2E case drift coverage', () => {
     ['TC-1032', tcTa],
     ['TC-1033', tcTa],
     ['TC-808A', tcTa],
+    ['TC-1996', tcTa],
     ['TC-939', tcAll],
     ['TC-1010', tcBm],
     ['TC-TA-FLOW-24', tcTaFlow],
@@ -1284,6 +1285,21 @@ describe('E2E case drift coverage', () => {
     expect(tcTa).toContain("parseTvNumberInput('abc') === null");
     expect(taTimeEntryLayoutTest).toContain('expect(parseTvNumberInput("abc")).toBeNull();');
     expect(taTimeEntryRowsTest).not.toContain('parseTvNumberInput');
+  });
+
+  it('documents TC-1996 as TA finals row TV payload and persistence coverage', () => {
+    const section = e2eCaseSection('TC-1996');
+
+    expect(section).toContain('issue #1996');
+    expect(section).toContain('/ta/finals');
+    expect(section).toContain('submit payload');
+    expect(section).toContain('tvNumber: 3');
+    expect(section).toContain('tvNumber: null');
+    expect(section).toContain('ta/phases route.test.ts');
+    expect(tcTa).toContain("log('TC-1996'");
+    expect(tcTa).toContain("selectOption('3')");
+    expect(tcTa).toContain("capturedSubmitPayload");
+    expect(taPhasesRouteTest).toContain('should accept cleared phase3 result tvNumber values');
   });
 
   it('documents TC-534 as BM Top-24 unresolved winner warning coverage', () => {

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -27,6 +27,7 @@
  *   TC-897  TA time inputs request the mobile numeric keyboard.
  *   TC-913  TA time input hint/title/placeholder are localized.
  *   TC-1987 TA TV number helper normalizes non-numeric input to null.
+ *   TC-1996 TA finals row TV number persists from UI submit payload to history.
  *   TC-816  Started TA phase page does not flash a Start Phase button while
  *           phase status is still loading.
  *   TC-1032 Phase 3 revival race targets every zero-life candidate when a
@@ -793,6 +794,77 @@ async function runTc1987() {
       ok ? '' : `decimal=${decimal} leadingZero=${leadingZero} empty=${empty} nonNumeric=${nonNumeric}`);
   } catch (err) {
     log('TC-1987', 'FAIL', err instanceof Error ? err.message : 'TA TV helper contract failed');
+  }
+}
+
+/* ───────── TC-1996: TA finals row TV number persists through submit ───────── */
+async function runTc1996(adminPage) {
+  let setup = null;
+  let capturedSubmitPayload = null;
+  let routePattern = null;
+  try {
+    setup = await createIsolatedTaQualification(adminPage, 'Finals TV Number Payload', sharedTaPlayers(2), { seedTimes: false });
+    const { tournamentId } = setup;
+    const seeded = await seedTaQualificationRanks(adminPage, tournamentId, setup.entries, 1);
+    const promote = await apiPromoteTaPhase(adminPage, tournamentId, 'promote_phase3');
+    if (promote.s !== 200) throw new Error(`promote_phase3 failed (${promote.s})`);
+
+    await nav(adminPage, `/tournaments/${tournamentId}/ta/finals`);
+    const roundNumber = await uiPhaseStartRound(adminPage, tournamentId, 'phase3');
+    const activeEntries = (await apiFetchTaPhase(adminPage, tournamentId, 'phase3')).b?.data?.entries ?? [];
+    const [tvEntry, clearEntry] = activeEntries.filter((e) => !e.eliminated);
+    if (!tvEntry || !clearEntry) {
+      throw new Error(`expected two active phase3 entries, got ${activeEntries.length}`);
+    }
+
+    const tvRow = adminPage.locator('[data-testid="ta-finals-round-entry-row"]')
+      .filter({ hasText: tvEntry.player.nickname })
+      .first();
+    await tvRow.locator('select').selectOption('3');
+
+    routePattern = `**/api/tournaments/${tournamentId}/ta/phases`;
+    await adminPage.route(routePattern, async (route) => {
+      const request = route.request();
+      if (request.method() === 'POST') {
+        const body = request.postDataJSON();
+        if (body?.action === 'submit_results' && body?.phase === 'phase3') {
+          capturedSubmitPayload = body;
+        }
+      }
+      await route.continue();
+    });
+
+    const seededByPlayer = new Map(seeded.map((entry) => [entry.playerId, entry]));
+    await uiPhaseSubmitResults(adminPage, tournamentId, 'phase3', [
+      { playerId: tvEntry.playerId, nickname: tvEntry.player.nickname, timeMs: seededByPlayer.get(tvEntry.playerId)?.totalMs ?? 63000 },
+      { playerId: clearEntry.playerId, nickname: clearEntry.player.nickname, timeMs: seededByPlayer.get(clearEntry.playerId)?.totalMs ?? 65000 },
+    ]);
+    await adminPage.unroute(routePattern).catch(() => {});
+    routePattern = null;
+
+    const payloadResults = capturedSubmitPayload?.results ?? [];
+    const tvPayload = payloadResults.find((r) => r.playerId === tvEntry.playerId);
+    const clearPayload = payloadResults.find((r) => r.playerId === clearEntry.playerId);
+
+    const phaseAfterSubmit = (await apiFetchTaPhase(adminPage, tournamentId, 'phase3')).b?.data ?? {};
+    const submittedRound = (phaseAfterSubmit.rounds ?? []).find((round) => round.roundNumber === roundNumber);
+    const storedResults = submittedRound?.results ?? [];
+    const storedTv = storedResults.find((r) => r.playerId === tvEntry.playerId);
+    const storedClear = storedResults.find((r) => r.playerId === clearEntry.playerId);
+
+    const payloadOk = tvPayload?.tvNumber === 3 &&
+      clearPayload &&
+      !Object.prototype.hasOwnProperty.call(clearPayload, 'tvNumber') &&
+      !payloadResults.some((r) => Number.isNaN(r.tvNumber));
+    const storedOk = storedTv?.tvNumber === 3 && storedClear?.tvNumber === null;
+
+    log('TC-1996', payloadOk && storedOk ? 'PASS' : 'FAIL',
+      payloadOk && storedOk ? '' : `payload=${JSON.stringify(payloadResults)} stored=${JSON.stringify(storedResults)}`);
+  } catch (err) {
+    log('TC-1996', 'FAIL', err instanceof Error ? err.message : 'TA finals TV number persistence failed');
+  } finally {
+    if (routePattern) await adminPage.unroute(routePattern).catch(() => {});
+    if (setup) await setup.cleanup().catch(() => {});
   }
 }
 
@@ -1994,6 +2066,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-897', fn: runTc897 },
       { name: 'TC-913', fn: runTc913 },
       { name: 'TC-1987', fn: runTc1987 },
+      { name: 'TC-1996', fn: runTc1996 },
       { name: 'TC-896', fn: runTc896 },
       { name: 'TC-805', fn: runTc805 },
       { name: 'TC-809', fn: runTc809 },


### PR DESCRIPTION
## Summary
- Add TC-1996 to document TA finals row TV-number payload and history persistence.
- Register runnable tc-ta.js coverage that selects TV3 in `/ta/finals`, captures the submit payload, and verifies saved round results.
- Add drift/API route tests for the new scenario and cleared/null tvNumber handling.

## Issues
- Closes #1996

## Validation
- `node --check smkc-score-app/e2e/tc-ta.js`
- `npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts '__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts'` (docs suite matched)
- `npm test -- --runInBand --runTestsByPath '__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts'`
- `npx eslint e2e/tc-ta.js __tests__/docs/e2e-cases-drift.test.ts '__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts'` (E2E file ignored by existing pattern; no errors)
- `git diff --check`
