### PR TITLE
Clarify TA phase tvNumber test name

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts
@@ -1221,7 +1221,7 @@ describe('POST /api/tournaments/[id]/ta/phases', () => {
     expect(NextResponse.json).toHaveBeenCalledWith({ success: true, data: { eliminated: [] } });
   });
 
-  it('should accept cleared phase3 result tvNumber values', async () => {
+  it('should accept phase3 results with null or absent tvNumber', async () => {
     (submitRoundResults as jest.Mock).mockResolvedValue({ eliminated: [] });
     const body = {
       action: 'submit_results',

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1299,7 +1299,7 @@ describe('E2E case drift coverage', () => {
     expect(tcTa).toContain("log('TC-1996'");
     expect(tcTa).toContain("selectOption('3')");
     expect(tcTa).toContain("capturedSubmitPayload");
-    expect(taPhasesRouteTest).toContain('should accept cleared phase3 result tvNumber values');
+    expect(taPhasesRouteTest).toContain('should accept phase3 results with null or absent tvNumber');
   });
 
   it('documents TC-534 as BM Top-24 unresolved winner warning coverage', () => {


### PR DESCRIPTION
## Summary
- Rename the TC-1996 API route test to state that it covers `tvNumber: null` and absent `tvNumber` explicitly.
- Update the E2E drift guard anchor to match the clearer test name.

## Issues
- Closes #2001

## Validation
- `npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts`
- `npm test -- --runInBand --runTestsByPath '__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts'`
- `npx eslint __tests__/docs/e2e-cases-drift.test.ts '__tests__/app/api/tournaments/[id]/ta/phases/route.test.ts'`
- `git diff --check`
