### PR TITLE
Classify TC-109 helper coverage as runner command

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -214,10 +214,10 @@
   6. public DNS fallback は `dig +short` の説明行や不正な IPv4/IPv6 風文字列を host resolver rules に採用しないことを確認する
   7. macOS で `/Applications/Google Chrome.app` が存在しても、runner が自動で `E2E_BROWSER_CHANNEL=chrome` を設定しないことを確認する
   8. `E2E_BROWSER_CHANNEL=chrome` または `E2E_EXECUTABLE_PATH=...` を明示した場合だけ、その指定が子プロセスへ渡ることを確認する
-  9. `npm run e2e:install-browser` と preview runner が同じ `PLAYWRIGHT_BROWSERS_PATH` を使い、`playwright` import 前に子プロセスへ渡ることを確認する
+  9. `npm run e2e:install-browser` と preview runner が同じ `PLAYWRIGHT_BROWSERS_PATH` を使い、`playwright` import 前に子プロセスへ渡ることを補助検証で確認する
 - **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / Crashpad permission failure で停止しない
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
-- **補助検証**: `smkc-score-app/__tests__/e2e/run-preview.test.ts`, `smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts`
+- **補助検証**: `smkc-score-app/__tests__/e2e/run-preview.test.ts`, `smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts`（どちらも runner command 扱いで、URL 欄には環境変数名を入れない）
 
 ## TC-111: Preview D1 schema preflight
 - **URL**: n/a (runner command)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1046,7 +1046,7 @@ describe('E2E case drift coverage', () => {
 
   it.each([
     ['TC-109', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/run-preview.test.ts'],
-    ['TC-109', 'PLAYWRIGHT_BROWSERS_PATH', 'smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts'],
+    ['TC-109', 'n/a (runner command)', 'smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts'],
     ['TC-111', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts'],
     ['TC-726', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-finals-assigned-cups.test.ts'],
     ['TC-728', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-ranking.test.ts'],
@@ -1066,6 +1066,23 @@ describe('E2E case drift coverage', () => {
 
     expect(section).toContain(marker);
     expect(section).toContain(coverage);
+  });
+
+  it('keeps TC-109 helper coverage classified without environment variable names in the URL slot', () => {
+    const source = readRepoFile('smkc-score-app', '__tests__', 'docs', 'e2e-cases-drift.test.ts');
+    const classificationTable = sectionBetween(
+      source,
+      "it.each([\n    ['TC-109'",
+      '])(',
+    );
+    const tc109Rows = classificationTable.match(/\['TC-109',\s*'([^']+)',\s*'([^']+)'\]/g) ?? [];
+
+    expect(tc109Rows).toHaveLength(2);
+    expect(tc109Rows).toEqual([
+      "['TC-109', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/run-preview.test.ts']",
+      "['TC-109', 'n/a (runner command)', 'smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts']",
+    ]);
+    expect(tc109Rows.join('\n')).not.toContain('PLAYWRIGHT_BROWSERS_PATH');
   });
 
   it('keeps late static-only TC classifications ordered within their local block', () => {


### PR DESCRIPTION
## Summary
- Clarify TC-109 helper coverage in the E2E scenario doc as runner-command validation rather than a URL target.
- Replace the second TC-109 drift classification marker with `n/a (runner command)`.
- Add a regression guard so TC-109 helper rows cannot use environment variable names in the URL/marker slot again.

## Issues
Closes #1999

## Validation
- `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/run-preview.test.ts __tests__/lib/e2e-browser-launch.test.ts`
- `npx eslint __tests__/docs/e2e-cases-drift.test.ts`
- `git diff --check`
