### PR TITLE
Tighten BM/MR lean select contract test

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -994,6 +994,17 @@
 - **期待結果**: helper の module-level cache は読みやすい宣言順で初期化され、既存の E2E case section 取得挙動は変わらない
 - **スクリプト**: n/a (static/doc coverage) — `smkc-score-app/__tests__/helpers/e2e-cases.ts`, `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2006-2007: BM/MR match lean select — strict field contract
+- **URL**: n/a
+- **authRequired**: false
+- **背景**: issue #2006/#2007。`BM_MR_MATCH_LEAN_SELECT` は BM/MR 予選 match payload の共有 select 契約であり、余分なフィールド追加を `arrayContaining` や件数の下限だけで許容してはいけない。
+- **手順**:
+  1. `prisma-selects.test.ts` が期待 field list と `Object.keys(BM_MR_MATCH_LEAN_SELECT)` を exact match で比較することを確認する
+  2. 全 selected values が `true` であることを確認する
+  3. drift test が本 TC と unit coverage の対応を検証する
+- **期待結果**: BM/MR 共有 match payload は期待 field だけを select し、余分なフィールド追加時は unit/static coverage が失敗する
+- **スクリプト**: n/a (unit/static coverage) — `smkc-score-app/__tests__/lib/prisma-selects.test.ts`, `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-320: BM/MR/GP マッチリスト行レベルのスコア入力リンク非表示化 ✅ FIXED (PR #407)
 - **URL**: /tournaments/[temp-id]/bm, /mr, /gp → Matches タブ
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -153,6 +153,7 @@ describe('E2E case drift coverage', () => {
     ['TC-1451-1452', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-1454-1455', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-1457', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
+    ['TC-2006-2007', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/lib/prisma-selects.test.ts'],
     ['TC-1528', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/e2e/ta-phase-submit-helper.test.ts'],
     ['TC-1669', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts'],
     ['TC-1671', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts'],
@@ -1090,11 +1091,24 @@ describe('E2E case drift coverage', () => {
       "['TC-803', 'TC-318 でカバー済み'",
     );
 
-    const orderedTcs = ['TC-1451-1452', 'TC-1454-1455', 'TC-1457', 'TC-1528', 'TC-1669', 'TC-1671'];
+    const orderedTcs = ['TC-1451-1452', 'TC-1454-1455', 'TC-1457', 'TC-2006-2007', 'TC-1528', 'TC-1669', 'TC-1671'];
     const indexes = orderedTcs.map((tc) => block.indexOf(`['${tc}'`));
 
     expect(indexes.every((index) => index >= 0)).toBe(true);
     expect(indexes).toEqual([...indexes].sort((a, b) => a - b));
+  });
+
+  it('keeps TC-2006-2007 aligned with exact BM/MR lean select field coverage', () => {
+    const section = e2eCaseSection('TC-2006-2007');
+    const prismaSelectsTest = readRepoFile('smkc-score-app', '__tests__', 'lib', 'prisma-selects.test.ts');
+
+    expect(section).toContain('issue #2006/#2007');
+    expect(section).toContain('BM_MR_MATCH_LEAN_SELECT');
+    expect(section).toContain('exact match');
+    expect(section).toContain('smkc-score-app/__tests__/lib/prisma-selects.test.ts');
+    expect(prismaSelectsTest).toContain('Object.keys(BM_MR_MATCH_LEAN_SELECT)).toEqual(expectedFields)');
+    expect(prismaSelectsTest).not.toContain('expect.arrayContaining(expectedFields)');
+    expect(prismaSelectsTest).not.toContain('toBeGreaterThanOrEqual(expectedFields.length)');
   });
 
   it('keeps TC-1090-1091 aligned with overall-ranking static and unit coverage', () => {

--- a/smkc-score-app/__tests__/lib/prisma-selects.test.ts
+++ b/smkc-score-app/__tests__/lib/prisma-selects.test.ts
@@ -17,7 +17,6 @@ describe('prisma selects', () => {
     const selectedFields = Object.entries(BM_MR_MATCH_LEAN_SELECT);
 
     expect(selectedFields.every(([, value]) => value === true)).toBe(true);
-    expect(Object.keys(BM_MR_MATCH_LEAN_SELECT)).toEqual(expect.arrayContaining(expectedFields));
-    expect(Object.keys(BM_MR_MATCH_LEAN_SELECT).length).toBeGreaterThanOrEqual(expectedFields.length);
+    expect(Object.keys(BM_MR_MATCH_LEAN_SELECT)).toEqual(expectedFields);
   });
 });


### PR DESCRIPTION
## Summary
- Add TC-2006-2007 scenario coverage for the BM/MR lean select field contract.
- Add drift coverage that keeps the scenario tied to prisma-selects.test.ts.
- Change BM_MR_MATCH_LEAN_SELECT key assertions from arrayContaining/minimum length to exact field equality.

## Issues
- Closes #2006
- Closes #2007

## Validation
- npm test -- __tests__/lib/prisma-selects.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint (passes with existing warnings)
- git diff --check
