### PR TITLE
test: make TC-2006-2007 drift assertion format-robust

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1106,7 +1106,9 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('BM_MR_MATCH_LEAN_SELECT');
     expect(section).toContain('exact match');
     expect(section).toContain('smkc-score-app/__tests__/lib/prisma-selects.test.ts');
-    expect(prismaSelectsTest).toContain('Object.keys(BM_MR_MATCH_LEAN_SELECT)).toEqual(expectedFields)');
+    expect(prismaSelectsTest).toMatch(
+      /Object\.keys\s*\(\s*BM_MR_MATCH_LEAN_SELECT\s*\)\)\s*\.toEqual\s*\(\s*expectedFields\s*\)/,
+    );
     expect(prismaSelectsTest).not.toContain('expect.arrayContaining(expectedFields)');
     expect(prismaSelectsTest).not.toContain('toBeGreaterThanOrEqual(expectedFields.length)');
   });


### PR DESCRIPTION
## Summary
- Replace fragile string containment assertion in drift test with whitespace-tolerant regex matching
- Target case: TC-2006-2007 alignment against prisma-selects
- Scope: test stability improvement only; production code is unchanged

## Issues
- Closes #2009

## Validation
- `npm test -- __tests__/docs/e2e-cases-drift.test.ts --runInBand`
- `npx eslint __tests__/docs/e2e-cases-drift.test.ts`
- `git diff --check`
