### PR TITLE
test: simplify group setup role lookup guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2495,6 +2495,20 @@
   - 将来 selectable UI に戻す場合は guard 更新が必要になる
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts`
 
+## TC-1980-1982: BM/MR/GP グループ設定 — page.getByRole モックの期待値エイリアスを持たない
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #1980 / #1982。`group-setup-helper.test.ts` の `page.getByRole` モックで `EXPECTED_PAGE_ROLE_LOOKUPS` をローカル変数へ再代入すると、期待値の所在が増えてレビュー時にインデント崩れや不要な中間変数の指摘が再発する。
+- **手順**:
+  1. `group-setup-helper.test.ts` の `page.getByRole` unexpected branch を確認する
+  2. `throwUnexpectedMockCall('page.getByRole', roleLookup(_role, name), EXPECTED_PAGE_ROLE_LOOKUPS)` の形で直接渡していることを確認する
+  3. `const expectedPageRoleLookups` / `const actualPageRoleLookup` のローカルエイリアスが残っていないことを確認する
+- **期待結果**:
+  - `EXPECTED_PAGE_ROLE_LOOKUPS` が単一の期待値定義として使われる
+  - unexpected selector のエラーメッセージは既存の許可リストを維持する
+  - インデントだけを直す follow-up が再発しない
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/e2e/group-setup-helper.test.ts __tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-1009: 総合ランキング決勝順位 — 16人/Top-24 判定の matchNumber 閾値を明文化する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -118,6 +118,12 @@ describe('E2E case drift coverage', () => {
     'ui',
     'loading-skeleton.test.tsx',
   );
+  const groupSetupHelperTest = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'e2e',
+    'group-setup-helper.test.ts',
+  );
   const exportRoute = readRepoFile(
     'smkc-score-app',
     'src',
@@ -482,6 +488,7 @@ describe('E2E case drift coverage', () => {
     const followupSection = e2eCaseSection('TC-1678');
     const disabledButtonSection = e2eCaseSection('TC-1680');
     const outlineButtonSection = e2eCaseSection('TC-1682');
+    const helperAliasSection = e2eCaseSection('TC-1980-1982');
     const guard = readRepoFile(
       'smkc-score-app',
       '__tests__',
@@ -498,6 +505,13 @@ describe('E2E case drift coverage', () => {
     expect(disabledButtonSection).toContain('disabled');
     expect(outlineButtonSection).toContain('issue #1682');
     expect(outlineButtonSection).toContain('variant="outline"');
+    expect(helperAliasSection).toContain('issue #1980 / #1982');
+    expect(helperAliasSection).toContain('EXPECTED_PAGE_ROLE_LOOKUPS');
+    expect(groupSetupHelperTest).not.toContain('const expectedPageRoleLookups');
+    expect(groupSetupHelperTest).not.toContain('const actualPageRoleLookup');
+    expect(groupSetupHelperTest).toMatch(
+      /throwUnexpectedMockCall\(\s*'page\.getByRole',\s*roleLookup\(_role,\s*name\),\s*EXPECTED_PAGE_ROLE_LOOKUPS,\s*\)/,
+    );
     expect(guard).toContain("e2eCaseSection('TC-1007')");
     expect(guard).toContain("e2eCaseSection('TC-1678')");
     expect(guard).toContain("not.toContain('groupCount={groupCount}')");

--- a/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
@@ -126,16 +126,17 @@ describe('group setup E2E helper', () => {
         if (_role === 'dialog') {
           return { first: jest.fn(() => dialog) };
         }
-        const expectedPageRoleLookups = EXPECTED_PAGE_ROLE_LOOKUPS;
-        const actualPageRoleLookup = roleLookup(_role, name);
         return throwUnexpectedMockCall(
           'page.getByRole',
-          actualPageRoleLookup,
-          expectedPageRoleLookups,
+          roleLookup(_role, name),
+          EXPECTED_PAGE_ROLE_LOOKUPS,
         );
       }),
       waitForResponse: jest.fn(async () => ({ status: () => 201 })),
     };
+
+    expect(() => page.getByRole('link', { name: /Unknown/ }))
+      .toThrow(`page.getByRole received unexpected value "role=link name=Unknown". Allowed values: ['role=button name=Setup Groups|Edit Groups|グループ設定|グループ編集', 'role=dialog name=']`);
 
     await setupModePlayersViaUi(page, 'bm', 'tournament-1', [
       { name: 'Player 1', nickname: 'P1' },


### PR DESCRIPTION
## Summary
- Add TC-1980-1982 scenario coverage for the group setup helper mock contract
- Add drift coverage that prevents reintroducing page.getByRole local aliases
- Remove redundant expectedPageRoleLookups / actualPageRoleLookup locals and keep the unexpected selector error covered

## Issues
- Closes #1982
- Closes #1980
- Closes #1968
- Closes #1967
- Closes #1963
- Closes #1961
- Closes #1958
- Closes #1956
- Closes #1953
- Closes #1951
- Closes #1950
- Closes #1948

## Validation
- `npm test -- --runTestsByPath __tests__/e2e/group-setup-helper.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand`
- `npx eslint __tests__/e2e/group-setup-helper.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `git diff --check`
