### PR TITLE
test: relax group setup drift guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2509,6 +2509,20 @@
   - インデントだけを直す follow-up が再発しない
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/e2e/group-setup-helper.test.ts __tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2012: BM/MR/GP グループ設定 — TC-1980-1982 guard を空白依存にしない
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #2012。TC-1980-1982 の静的 guard が `throwUnexpectedMockCall(...)` 呼び出し全体を正規表現で読むと、正当な改行・フォーマット変更だけで false positive になる。
+- **手順**:
+  1. TC-1980-1982 のドリフト guard を確認する
+  2. `throwUnexpectedMockCall(` / `roleLookup(_role, name)` / `EXPECTED_PAGE_ROLE_LOOKUPS` の存在チェックで意図を確認する
+  3. 呼び出し全体の空白配置を固定する `toMatch` 正規表現が残っていないことを確認する
+- **期待結果**:
+  - ローカルエイリアス禁止の意図は維持される
+  - 正当なフォーマット変更では guard が落ちない
+  - TC-1980-1982 の回帰検知は `toContain` ベースで十分に保たれる
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-1009: 総合ランキング決勝順位 — 16人/Top-24 判定の matchNumber 閾値を明文化する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -489,6 +489,7 @@ describe('E2E case drift coverage', () => {
     const disabledButtonSection = e2eCaseSection('TC-1680');
     const outlineButtonSection = e2eCaseSection('TC-1682');
     const helperAliasSection = e2eCaseSection('TC-1980-1982');
+    const helperAliasGuardSection = e2eCaseSection('TC-2012');
     const guard = readRepoFile(
       'smkc-score-app',
       '__tests__',
@@ -507,11 +508,13 @@ describe('E2E case drift coverage', () => {
     expect(outlineButtonSection).toContain('variant="outline"');
     expect(helperAliasSection).toContain('issue #1980 / #1982');
     expect(helperAliasSection).toContain('EXPECTED_PAGE_ROLE_LOOKUPS');
+    expect(helperAliasGuardSection).toContain('issue #2012');
+    expect(helperAliasGuardSection).toContain('toContain');
     expect(groupSetupHelperTest).not.toContain('const expectedPageRoleLookups');
     expect(groupSetupHelperTest).not.toContain('const actualPageRoleLookup');
-    expect(groupSetupHelperTest).toMatch(
-      /throwUnexpectedMockCall\(\s*'page\.getByRole',\s*roleLookup\(_role,\s*name\),\s*EXPECTED_PAGE_ROLE_LOOKUPS,\s*\)/,
-    );
+    expect(groupSetupHelperTest).toContain('throwUnexpectedMockCall(');
+    expect(groupSetupHelperTest).toContain('roleLookup(_role, name)');
+    expect(groupSetupHelperTest).toContain('EXPECTED_PAGE_ROLE_LOOKUPS');
     expect(guard).toContain("e2eCaseSection('TC-1007')");
     expect(guard).toContain("e2eCaseSection('TC-1678')");
     expect(guard).toContain("not.toContain('groupCount={groupCount}')");


### PR DESCRIPTION
## Summary
- Add TC-2012 scenario coverage for the TC-1980-1982 drift guard contract
- Replace the whitespace-sensitive full-call regex with smaller toContain checks
- Preserve the local alias negative checks while allowing harmless formatter changes

## Issues
- Closes #2012

## Validation
- `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts --runInBand`
- `npx eslint __tests__/docs/e2e-cases-drift.test.ts`
- `git diff --check`
