### PR TITLE
test: require group setup guard call co-occurrence

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2520,8 +2520,22 @@
 - **期待結果**:
   - ローカルエイリアス禁止の意図は維持される
   - 正当なフォーマット変更では guard が落ちない
-  - TC-1980-1982 の回帰検知は `toContain` ベースで十分に保たれる
+  - TC-1980-1982 の回帰検知は AST helper で同一呼び出しを確認する
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts`
+
+## TC-2014: BM/MR/GP グループ設定 — unexpected branch guard の引数共出現を保証する
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #2014。TC-2012 で guard を `toContain` に分割した結果、`throwUnexpectedMockCall(` / `roleLookup(_role, name)` / `EXPECTED_PAGE_ROLE_LOOKUPS` が別々の箇所に散在してもテストが通る可能性が残った。
+- **手順**:
+  1. TC-1980-1982 の `page.getByRole` unexpected branch guard を確認する
+  2. TypeScript AST helper で `throwUnexpectedMockCall('page.getByRole', roleLookup(_role, name), EXPECTED_PAGE_ROLE_LOOKUPS)` が同一の `throwUnexpectedMockCall(...)` 呼び出しに揃っていることを確認する
+  3. helper 自体が、必要な引数が別呼び出しに分散した fixture を拒否することを確認する
+- **期待結果**:
+  - `page.getByRole` unexpected branch は `EXPECTED_PAGE_ROLE_LOOKUPS` を直接渡す
+  - 同一呼び出し内の共出現が崩れた場合は drift guard が落ちる
+  - 正当な改行・インデント変更では guard が落ちない
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/helpers/e2e-cases.test.ts`
 
 ## TC-1009: 総合ランキング決勝順位 — 16人/Top-24 判定の matchNumber 閾値を明文化する
 - **URL**: n/a (unit/static coverage)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1,5 +1,10 @@
 import * as gpFinalsValidatorExports from '../../e2e/lib/gp-finals-validators';
-import { e2eCaseSection, readRepoFile, sectionBetween } from '../helpers/e2e-cases';
+import {
+  callExpressionWithArguments,
+  e2eCaseSection,
+  readRepoFile,
+  sectionBetween,
+} from '../helpers/e2e-cases';
 
 function readE2eScript(script: string) {
   return readRepoFile('smkc-score-app', 'e2e', script);
@@ -490,6 +495,7 @@ describe('E2E case drift coverage', () => {
     const outlineButtonSection = e2eCaseSection('TC-1682');
     const helperAliasSection = e2eCaseSection('TC-1980-1982');
     const helperAliasGuardSection = e2eCaseSection('TC-2012');
+    const helperAliasCallGuardSection = e2eCaseSection('TC-2014');
     const guard = readRepoFile(
       'smkc-score-app',
       '__tests__',
@@ -509,12 +515,16 @@ describe('E2E case drift coverage', () => {
     expect(helperAliasSection).toContain('issue #1980 / #1982');
     expect(helperAliasSection).toContain('EXPECTED_PAGE_ROLE_LOOKUPS');
     expect(helperAliasGuardSection).toContain('issue #2012');
-    expect(helperAliasGuardSection).toContain('toContain');
+    expect(helperAliasGuardSection).toContain('空白依存');
+    expect(helperAliasCallGuardSection).toContain('issue #2014');
+    expect(helperAliasCallGuardSection).toContain('同一の `throwUnexpectedMockCall(...)` 呼び出し');
     expect(groupSetupHelperTest).not.toContain('const expectedPageRoleLookups');
     expect(groupSetupHelperTest).not.toContain('const actualPageRoleLookup');
-    expect(groupSetupHelperTest).toContain('throwUnexpectedMockCall(');
-    expect(groupSetupHelperTest).toContain('roleLookup(_role, name)');
-    expect(groupSetupHelperTest).toContain('EXPECTED_PAGE_ROLE_LOOKUPS');
+    expect(callExpressionWithArguments(groupSetupHelperTest, 'throwUnexpectedMockCall', [
+      "'page.getByRole'",
+      'roleLookup(_role, name)',
+      'EXPECTED_PAGE_ROLE_LOOKUPS',
+    ])).toContain('EXPECTED_PAGE_ROLE_LOOKUPS');
     expect(guard).toContain("e2eCaseSection('TC-1007')");
     expect(guard).toContain("e2eCaseSection('TC-1678')");
     expect(guard).toContain("not.toContain('groupCount={groupCount}')");

--- a/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
@@ -1,0 +1,31 @@
+import { callExpressionWithArguments } from './e2e-cases';
+
+describe('E2E case helpers', () => {
+  it('finds required arguments on the same call expression', () => {
+    const source = `
+      throwUnexpectedMockCall('page.getByRole', roleLookup(_role, name), EXPECTED_PAGE_ROLE_LOOKUPS);
+      throwUnexpectedMockCall('dialog.locator', selector, EXPECTED_SELECTORS);
+    `;
+
+    expect(callExpressionWithArguments(source, 'throwUnexpectedMockCall', [
+      "'page.getByRole'",
+      'roleLookup(_role, name)',
+      'EXPECTED_PAGE_ROLE_LOOKUPS',
+    ])).toContain('roleLookup(_role, name)');
+  });
+
+  it('rejects required arguments split across different calls', () => {
+    const source = `
+      throwUnexpectedMockCall('page.getByRole', roleLookup(_role, name), EXPECTED_SELECTORS);
+      throwUnexpectedMockCall('dialog.locator', selector, EXPECTED_PAGE_ROLE_LOOKUPS);
+    `;
+
+    expect(() => callExpressionWithArguments(source, 'throwUnexpectedMockCall', [
+      "'page.getByRole'",
+      'roleLookup(_role, name)',
+      'EXPECTED_PAGE_ROLE_LOOKUPS',
+    ])).toThrow(
+      "call expression not found: throwUnexpectedMockCall('page.getByRole', roleLookup(_role, name), EXPECTED_PAGE_ROLE_LOOKUPS)",
+    );
+  });
+});

--- a/smkc-score-app/__tests__/helpers/e2e-cases.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.ts
@@ -53,6 +53,52 @@ export function e2eCaseSection(tc: string, source = e2eCases) {
   return source.slice(start, end);
 }
 
+export function callExpressionWithArguments(
+  source: string,
+  functionName: string,
+  requiredArgumentTexts: string[],
+) {
+  const sourceFile = ts.createSourceFile(
+    'source.tsx',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+  let matchedCall: ts.CallExpression | null = null;
+
+  function isTargetCall(node: ts.CallExpression) {
+    if (!ts.isIdentifier(node.expression) || node.expression.text !== functionName) {
+      return false;
+    }
+
+    const argumentTexts = node.arguments.map((argument) => argument.getText(sourceFile));
+    return requiredArgumentTexts.every((requiredText) => argumentTexts.includes(requiredText));
+  }
+
+  function visit(node: ts.Node) {
+    if (matchedCall) return;
+
+    if (ts.isCallExpression(node) && isTargetCall(node)) {
+      matchedCall = node;
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  if (!matchedCall) {
+    throw new Error(
+      `call expression not found: ${functionName}(${requiredArgumentTexts.join(', ')})`,
+    );
+  }
+
+  return matchedCall.getText(sourceFile);
+}
+
 export function functionReturnObjectLiteral(source: string, functionName: string) {
   const sourceFile = ts.createSourceFile(
     'source.tsx',


### PR DESCRIPTION
Summary
- Add TC-2014 scenario coverage for the group setup unexpected-branch drift guard.
- Replace split string-presence checks with a TypeScript AST helper that verifies the required arguments occur on the same throwUnexpectedMockCall(...) call.
- Add helper unit coverage proving split arguments across different calls are rejected.

Issues: Closes #2014

Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/helpers/e2e-cases.test.ts --runInBand
- npx eslint __tests__/docs/e2e-cases-drift.test.ts __tests__/helpers/e2e-cases.ts __tests__/helpers/e2e-cases.test.ts
- npm run lint
- git diff --check
