### PR TITLE
Refine BM_MR_MATCH_LEAN_SELECT test contract

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -994,15 +994,15 @@
 - **期待結果**: helper の module-level cache は読みやすい宣言順で初期化され、既存の E2E case section 取得挙動は変わらない
 - **スクリプト**: n/a (static/doc coverage) — `smkc-score-app/__tests__/helpers/e2e-cases.ts`, `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
 
-## TC-2006-2007: BM/MR match lean select — strict field contract
+## TC-2006-2007: BM/MR match lean select — shallow boolean payload contract
 - **URL**: n/a
 - **authRequired**: false
-- **背景**: issue #2006/#2007。`BM_MR_MATCH_LEAN_SELECT` は BM/MR 予選 match payload の共有 select 契約であり、余分なフィールド追加を `arrayContaining` や件数の下限だけで許容してはいけない。
+- **背景**: issue #2006/#2007。`BM_MR_MATCH_LEAN_SELECT` は BM/MR 予選 match payload の共有 select 契約であり、必須 field set は `satisfies` 型契約で守り、unit test では Prisma select として shallow な `true` 値だけを持つことを確認する。
 - **手順**:
-  1. `prisma-selects.test.ts` が期待 field list と `Object.keys(BM_MR_MATCH_LEAN_SELECT)` を exact match で比較することを確認する
-  2. 全 selected values が `true` であることを確認する
+  1. `prisma-selects.test.ts` が `Object.entries(BM_MR_MATCH_LEAN_SELECT)` から selected entries を検証することを確認する
+  2. selected entries が空でなく、各 entry が空でない key と `true` 値だけを持つことを確認する
   3. drift test が本 TC と unit coverage の対応を検証する
-- **期待結果**: BM/MR 共有 match payload は期待 field だけを select し、余分なフィールド追加時は unit/static coverage が失敗する
+- **期待結果**: BM/MR 共有 match payload は shallow な boolean select として維持され、必須 field set の増減は `satisfies` 型契約で検出する
 - **スクリプト**: n/a (unit/static coverage) — `smkc-score-app/__tests__/lib/prisma-selects.test.ts`, `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
 
 ## TC-320: BM/MR/GP マッチリスト行レベルのスコア入力リンク非表示化 ✅ FIXED (PR #407)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1125,19 +1125,19 @@ describe('E2E case drift coverage', () => {
     expect(indexes).toEqual([...indexes].sort((a, b) => a - b));
   });
 
-  it('keeps TC-2006-2007 aligned with exact BM/MR lean select field coverage', () => {
+  it('keeps TC-2006-2007 aligned with shallow BM/MR lean select payload coverage', () => {
     const section = e2eCaseSection('TC-2006-2007');
     const prismaSelectsTest = readRepoFile('smkc-score-app', '__tests__', 'lib', 'prisma-selects.test.ts');
 
     expect(section).toContain('issue #2006/#2007');
     expect(section).toContain('BM_MR_MATCH_LEAN_SELECT');
-    expect(section).toContain('exact match');
+    expect(section).toContain('shallow');
     expect(section).toContain('smkc-score-app/__tests__/lib/prisma-selects.test.ts');
-    expect(prismaSelectsTest).toMatch(
-      /Object\.keys\s*\(\s*BM_MR_MATCH_LEAN_SELECT\s*\)\)\s*\.toEqual\s*\(\s*expectedFields\s*\)/,
-    );
-    expect(prismaSelectsTest).not.toContain('expect.arrayContaining(expectedFields)');
-    expect(prismaSelectsTest).not.toContain('toBeGreaterThanOrEqual(expectedFields.length)');
+    expect(prismaSelectsTest).toContain('Object.entries(BM_MR_MATCH_LEAN_SELECT)');
+    expect(prismaSelectsTest).toContain('selectedFields.length');
+    expect(prismaSelectsTest).toContain('key.length > 0 && value === true');
+    expect(prismaSelectsTest).not.toContain('const expectedFields');
+    expect(prismaSelectsTest).not.toContain('Object.keys(BM_MR_MATCH_LEAN_SELECT)');
   });
 
   it('keeps TC-1090-1091 aligned with overall-ranking static and unit coverage', () => {

--- a/smkc-score-app/__tests__/lib/prisma-selects.test.ts
+++ b/smkc-score-app/__tests__/lib/prisma-selects.test.ts
@@ -1,22 +1,10 @@
 import { BM_MR_MATCH_LEAN_SELECT } from '@/lib/prisma-selects';
 
 describe('prisma selects', () => {
-  it('BM_MR_MATCH_LEAN_SELECT is a strict boolean contract for shared match payload', () => {
-    const expectedFields = [
-      'id',
-      'tournamentId',
-      'player1Id',
-      'player2Id',
-      'score1',
-      'score2',
-      'rounds',
-      'completed',
-      'isBye',
-    ];
-
+  it('BM_MR_MATCH_LEAN_SELECT selects a shallow boolean payload for match queries', () => {
     const selectedFields = Object.entries(BM_MR_MATCH_LEAN_SELECT);
 
-    expect(selectedFields.every(([, value]) => value === true)).toBe(true);
-    expect(Object.keys(BM_MR_MATCH_LEAN_SELECT)).toEqual(expectedFields);
+    expect(selectedFields.length).toBeGreaterThan(0);
+    expect(selectedFields.every(([key, value]) => key.length > 0 && value === true)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Removed the mirrored expected field list from the BM_MR_MATCH_LEAN_SELECT unit test.
- Kept regression coverage focused on the shallow Prisma select payload contract.
- Updated TC-2006-2007 and its drift guard to match the new shallow boolean payload coverage.

## Issues
Closes #1759

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/prisma-selects.test.ts
- npm run lint (passes with existing warnings)
