### PR TITLE
Clarify BM_MR select contract intent

### DIFF
--- a/smkc-score-app/src/lib/prisma-selects.ts
+++ b/smkc-score-app/src/lib/prisma-selects.ts
@@ -56,10 +56,9 @@ type BmMrMatchLeanSelectRequiredField =
  * field set. Route tests verify BM/MR both pass this shared object into Prisma;
  * this type contract prevents accidental removal of fields that the shared PUT
  * response and qualification recalculation path read immediately after update.
- * The broad `Record<string, true>` half keeps future additions in this shared
- * object constrained to plain `true` scalar selects; it prevents accidental
- * `field: false` or nested-object selects from bypassing the intent of this
- * lean payload contract.
+ * The `Record<BmMrMatchLeanSelectRequiredField, true>` part is the contract
+ * for required fields; `Record<string, true>` additionally constrains all
+ * entries to explicit `true` scalar-select values.
  */
 export const BM_MR_MATCH_LEAN_SELECT = {
   id: true,


### PR DESCRIPTION
## Summary
- Clarify the comment for BM_MR_MATCH_LEAN_SELECT to document the split role of `Record<BmMrMatchLeanSelectRequiredField, true>` and `Record<string, true>`.
- No behavioral changes.

## Issues
- #1761

## Validation
- Not run (comment-only change).
