### PR TITLE
Fix preview E2E Crashpad launch isolation

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -213,8 +213,9 @@
   5. public DNS fallback は IPv4 A レコードがない host でも IPv6 AAAA レコードを解決できることを確認する
   6. public DNS fallback は `dig +short` の説明行や不正な IPv4/IPv6 風文字列を host resolver rules に採用しないことを確認する
   7. macOS で `/Applications/Google Chrome.app` が存在しても、runner が自動で `E2E_BROWSER_CHANNEL=chrome` を設定しないことを確認する
-  8. `E2E_BROWSER_CHANNEL=chrome` または `E2E_EXECUTABLE_PATH=...` を明示した場合だけ、その指定が子プロセスへ渡ることを確認する
-  9. `npm run e2e:install-browser` と preview runner が同じ `PLAYWRIGHT_BROWSERS_PATH` を使い、`playwright` import 前に子プロセスへ渡ることを補助検証で確認する
+  8. browser launch config が Crashpad を自動テスト向けに無効化し、crash dump path を writable な E2E browser home 配下へ固定することを確認する
+  9. `E2E_BROWSER_CHANNEL=chrome` または `E2E_EXECUTABLE_PATH=...` を明示した場合だけ、その指定が子プロセスへ渡ることを確認する
+  10. `npm run e2e:install-browser` と preview runner が同じ `PLAYWRIGHT_BROWSERS_PATH` を使い、`playwright` import 前に子プロセスへ渡ることを補助検証で確認する
 - **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / Crashpad permission failure で停止しない
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
 - **補助検証**: `smkc-score-app/__tests__/e2e/run-preview.test.ts`, `smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts`（どちらも runner command 扱いで、URL 欄には環境変数名を入れない）

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
 import packageJson from '../../package.json';
 
 const lookupMock = jest.fn();
@@ -118,6 +120,15 @@ describe('preview E2E runner', () => {
     if (platform) {
       Object.defineProperty(process, 'platform', platform);
     }
+  });
+
+  it('documents Crashpad launch isolation as part of TC-109 startup coverage', () => {
+    const e2eCases = fs.readFileSync(path.join(__dirname, '..', '..', '..', 'E2E_TEST_CASES.md'), 'utf8');
+    const section = e2eCases.split('## TC-109:')[1]?.split('\n## ')[0] ?? '';
+
+    expect(section).toContain('Crashpad');
+    expect(section).toContain('crash dump path');
+    expect(section).toContain('writable');
   });
 
   it('preserves caller-provided browser channel override', () => {

--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -136,4 +136,15 @@ describe('E2E browser launch helpers', () => {
 
     expect(config.args).toContain('--host-resolver-rules=MAP preview.smkc.bluemoon.works 104.21.41.48');
   });
+
+  it('disables Crashpad for automated preview launches and keeps dumps in browser home', () => {
+    process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
+    common = loadCommon();
+
+    const config = common.getChromiumLaunchConfig();
+
+    expect(config.args).toContain('--disable-crashpad-for-testing');
+    expect(config.args).toContain('--disable-breakpad');
+    expect(config.args).toContain('--crash-dumps-dir=/tmp/jsmkc-browser-home/Crashpad');
+  });
 });

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -281,9 +281,14 @@ function snakeDraft28(playerIds) {
  * player-login browsers, and cleanup.
  */
 function getChromiumArgs() {
+  const crashDumpsDir = path.join(resolveE2EBrowserHome(), 'Crashpad');
+  fs.mkdirSync(crashDumpsDir, { recursive: true });
   const args = [
     '--disable-crash-reporter',
     '--disable-crashpad',
+    '--disable-crashpad-for-testing',
+    '--disable-breakpad',
+    `--crash-dumps-dir=${crashDumpsDir}`,
     '--disable-dev-shm-usage',
     '--disable-gpu',
     '--disable-background-timer-throttling',


### PR DESCRIPTION
## Summary
- Added TC-109 coverage for Crashpad launch isolation in preview E2E startup.
- Pass Chromium automated-testing Crashpad disable flags and keep crash dumps under the writable E2E browser home.
- Added focused runner/browser launch tests for the Crashpad isolation contract.

## Issues
Closes #1148

## Validation
- npm test -- --runTestsByPath __tests__/e2e/run-preview.test.ts __tests__/lib/e2e-browser-launch.test.ts
- npm run lint (passes with existing warnings)
