### PR TITLE
Fix Crashpad launch config side effects

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -214,8 +214,9 @@
   6. public DNS fallback は `dig +short` の説明行や不正な IPv4/IPv6 風文字列を host resolver rules に採用しないことを確認する
   7. macOS で `/Applications/Google Chrome.app` が存在しても、runner が自動で `E2E_BROWSER_CHANNEL=chrome` を設定しないことを確認する
   8. browser launch config が Crashpad を自動テスト向けに無効化し、crash dump path を writable な E2E browser home 配下へ固定することを確認する
-  9. `E2E_BROWSER_CHANNEL=chrome` または `E2E_EXECUTABLE_PATH=...` を明示した場合だけ、その指定が子プロセスへ渡ることを確認する
-  10. `npm run e2e:install-browser` と preview runner が同じ `PLAYWRIGHT_BROWSERS_PATH` を使い、`playwright` import 前に子プロセスへ渡ることを補助検証で確認する
+  9. Chromium 引数生成はディレクトリ作成などの I/O を行わず、launch config 作成時に必要な browser home / cache / Crashpad ディレクトリを準備することを確認する
+  10. `E2E_BROWSER_CHANNEL=chrome` または `E2E_EXECUTABLE_PATH=...` を明示した場合だけ、その指定が子プロセスへ渡ることを確認する
+  11. `npm run e2e:install-browser` と preview runner が同じ `PLAYWRIGHT_BROWSERS_PATH` を使い、`playwright` import 前に子プロセスへ渡ることを補助検証で確認する
 - **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / Crashpad permission failure で停止しない
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
 - **補助検証**: `smkc-score-app/__tests__/e2e/run-preview.test.ts`, `smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts`（どちらも runner command 扱いで、URL 欄には環境変数名を入れない）

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -1,6 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
-import fs from 'fs';
-import path from 'path';
 import packageJson from '../../package.json';
 
 const lookupMock = jest.fn();
@@ -18,6 +16,7 @@ jest.mock('child_process', () => ({
 }));
 
 type PreviewRunner = typeof import('../../e2e/run-preview');
+type E2ECommon = typeof import('../../e2e/lib/common');
 
 function loadRunner() {
   let loaded: PreviewRunner | undefined;
@@ -26,6 +25,16 @@ function loadRunner() {
     loaded = require('../../e2e/run-preview') as PreviewRunner;
   });
   if (!loaded) throw new Error('Failed to load preview runner');
+  return loaded;
+}
+
+function loadCommon() {
+  let loaded: E2ECommon | undefined;
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    loaded = require('../../e2e/lib/common') as E2ECommon;
+  });
+  if (!loaded) throw new Error('Failed to load e2e common helpers');
   return loaded;
 }
 
@@ -122,13 +131,17 @@ describe('preview E2E runner', () => {
     }
   });
 
-  it('documents Crashpad launch isolation as part of TC-109 startup coverage', () => {
-    const e2eCases = fs.readFileSync(path.join(__dirname, '..', '..', '..', 'E2E_TEST_CASES.md'), 'utf8');
-    const section = e2eCases.split('## TC-109:')[1]?.split('\n## ')[0] ?? '';
+  it('keeps Crashpad launch isolation in the executable launch helper contract', () => {
+    process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-preview-browser-home';
 
-    expect(section).toContain('Crashpad');
-    expect(section).toContain('crash dump path');
-    expect(section).toContain('writable');
+    const config = loadCommon().getChromiumLaunchConfig();
+
+    expect(config.env.HOME).toBe('/tmp/jsmkc-preview-browser-home');
+    expect(config.env.XDG_CONFIG_HOME).toBe('/tmp/jsmkc-preview-browser-home/.config');
+    expect(config.env.XDG_CACHE_HOME).toBe('/tmp/jsmkc-preview-browser-home/.cache');
+    expect(config.args).toContain('--disable-crashpad-for-testing');
+    expect(config.args).toContain('--disable-breakpad');
+    expect(config.args).toContain('--crash-dumps-dir=/tmp/jsmkc-preview-browser-home/Crashpad');
   });
 
   it('preserves caller-provided browser channel override', () => {

--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
@@ -31,6 +32,7 @@ describe('E2E browser launch helpers', () => {
 
   afterEach(() => {
     process.env = { ...originalEnv };
+    jest.restoreAllMocks();
     jest.dontMock('playwright');
   });
 
@@ -146,5 +148,29 @@ describe('E2E browser launch helpers', () => {
     expect(config.args).toContain('--disable-crashpad-for-testing');
     expect(config.args).toContain('--disable-breakpad');
     expect(config.args).toContain('--crash-dumps-dir=/tmp/jsmkc-browser-home/Crashpad');
+  });
+
+  it('keeps Chromium argument generation free of filesystem side effects', () => {
+    process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
+    common = loadCommon();
+    const mkdirSyncSpy = jest.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined);
+
+    const args = common.getChromiumArgs();
+
+    expect(args).toContain('--crash-dumps-dir=/tmp/jsmkc-browser-home/Crashpad');
+    expect(mkdirSyncSpy).not.toHaveBeenCalled();
+  });
+
+  it('prepares Crashpad under the browser home when creating the launch config', () => {
+    process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-browser-home';
+    common = loadCommon();
+    const mkdirSyncSpy = jest.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined);
+
+    common.getChromiumLaunchConfig();
+
+    expect(mkdirSyncSpy).toHaveBeenCalledWith('/tmp/jsmkc-browser-home', { recursive: true });
+    expect(mkdirSyncSpy).toHaveBeenCalledWith('/tmp/jsmkc-browser-home/.config', { recursive: true });
+    expect(mkdirSyncSpy).toHaveBeenCalledWith('/tmp/jsmkc-browser-home/.cache', { recursive: true });
+    expect(mkdirSyncSpy).toHaveBeenCalledWith('/tmp/jsmkc-browser-home/Crashpad', { recursive: true });
   });
 });

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -280,9 +280,12 @@ function snakeDraft28(playerIds) {
  * call so the behaviour is uniform across tc-all, individual mode suites,
  * player-login browsers, and cleanup.
  */
+function resolveCrashDumpsDir(baseHome = resolveE2EBrowserHome()) {
+  return path.join(baseHome, 'Crashpad');
+}
+
 function getChromiumArgs() {
-  const crashDumpsDir = path.join(resolveE2EBrowserHome(), 'Crashpad');
-  fs.mkdirSync(crashDumpsDir, { recursive: true });
+  const crashDumpsDir = resolveCrashDumpsDir();
   const args = [
     '--disable-crash-reporter',
     '--disable-crashpad',
@@ -323,7 +326,8 @@ function createBrowserLaunchEnv() {
   const baseHome = resolveE2EBrowserHome();
   const configHome = path.join(baseHome, '.config');
   const cacheHome = path.join(baseHome, '.cache');
-  for (const dir of [baseHome, configHome, cacheHome]) {
+  const crashDumpsDir = resolveCrashDumpsDir(baseHome);
+  for (const dir of [baseHome, configHome, cacheHome, crashDumpsDir]) {
     fs.mkdirSync(dir, { recursive: true });
   }
   return {


### PR DESCRIPTION
Summary
- Move Crashpad directory preparation out of getChromiumArgs() and into launch config environment setup.
- Replace the fragile TC-109 docs-string assertion with executable launch-helper coverage.
- Add TC-109 scenario coverage for side-effect-free Chromium argument generation and launch-time directory preparation.
- Fix the TA elimination retryFlagsRef declaration/sync order that was breaking Cloudflare builds.

Issues: Closes #2026, Closes #2027, Closes #1922

Validation
- npm test -- --runTestsByPath __tests__/lib/e2e-browser-launch.test.ts __tests__/e2e/run-preview.test.ts
- npm run lint
- npx eslint src/components/tournament/ta-elimination-phase.tsx
- npm run build:cf
