### PR TITLE
Fix TA retry flag ref sync order

### DIFF
--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -267,12 +267,10 @@ export default function TAEliminationPhase({
   // This ensures the auto-recovery check always reads the latest value.
   const currentRoundRef = useRef(currentRound);
   currentRoundRef.current = currentRound;
-  useEffect(() => {
-    retryFlagsRef.current = retryFlags;
-  }, [retryFlags]);
   const [courseTimes, setCourseTimes] = useState<Record<string, string>>({});
   const [retryFlags, setRetryFlags] = useState<Record<string, boolean>>({});
   const retryFlagsRef = useRef<Record<string, boolean>>({});
+  retryFlagsRef.current = retryFlags;
   const [submitting, setSubmitting] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 


### PR DESCRIPTION
Summary
- Remove the retryFlagsRef useEffect that referenced retryFlags before declaration.
- Sync retryFlagsRef during render, matching currentRoundRef and eliminating the Cloudflare build type error.

Issues: Closes #1922

Validation
- npx eslint src/components/tournament/ta-elimination-phase.tsx
- npm run build:cf
