### PR TITLE
Mock run-preview Crashpad mkdir calls

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -217,6 +217,7 @@
   9. Chromium 引数生成はディレクトリ作成などの I/O を行わず、launch config 作成時に必要な browser home / cache / Crashpad ディレクトリを準備することを確認する
   10. `E2E_BROWSER_CHANNEL=chrome` または `E2E_EXECUTABLE_PATH=...` を明示した場合だけ、その指定が子プロセスへ渡ることを確認する
   11. `npm run e2e:install-browser` と preview runner が同じ `PLAYWRIGHT_BROWSERS_PATH` を使い、`playwright` import 前に子プロセスへ渡ることを補助検証で確認する
+  12. run-preview 側の Crashpad launch helper 補助テストは `fs.mkdirSync` をモックし、実際の `/tmp` 配下へテスト副作用を残さないことを確認する
 - **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / Crashpad permission failure で停止しない
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
 - **補助検証**: `smkc-score-app/__tests__/e2e/run-preview.test.ts`, `smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts`（どちらも runner command 扱いで、URL 欄には環境変数名を入れない）

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1101,6 +1101,8 @@ describe('E2E case drift coverage', () => {
 
   it('keeps TC-109 helper coverage classified without environment variable names in the URL slot', () => {
     const tc109Rows = tc109ClassifiedRows.filter(([tc]) => tc === 'TC-109');
+    const section = e2eCaseSection('TC-109');
+    const runPreviewTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'run-preview.test.ts');
 
     expect(tc109Rows).toHaveLength(2);
     expect(tc109Rows).toEqual([
@@ -1108,6 +1110,10 @@ describe('E2E case drift coverage', () => {
       ['TC-109', 'n/a (runner command)', 'smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts'],
     ]);
     expect(tc109Rows.map((entry) => entry.join(',')).join('\n')).not.toContain('PLAYWRIGHT_BROWSERS_PATH');
+    expect(section).toContain('fs.mkdirSync');
+    expect(section).toContain('実際の `/tmp` 配下へテスト副作用を残さない');
+    expect(runPreviewTest).toContain("jest.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined)");
+    expect(runPreviewTest).toContain('expect(mkdirSyncSpy).toHaveBeenCalledWith');
   });
 
   it('keeps late static-only TC classifications ordered within their local block', () => {

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import fs from 'fs';
 import packageJson from '../../package.json';
 
 const lookupMock = jest.fn();
@@ -60,6 +61,7 @@ describe('preview E2E runner', () => {
 
   afterEach(() => {
     process.env = { ...originalEnv };
+    jest.restoreAllMocks();
   });
 
   it('builds preview runtime env with default preview target', () => {
@@ -133,6 +135,7 @@ describe('preview E2E runner', () => {
 
   it('keeps Crashpad launch isolation in the executable launch helper contract', () => {
     process.env.E2E_BROWSER_HOME = '/tmp/jsmkc-preview-browser-home';
+    const mkdirSyncSpy = jest.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined);
 
     const config = loadCommon().getChromiumLaunchConfig();
 
@@ -142,6 +145,10 @@ describe('preview E2E runner', () => {
     expect(config.args).toContain('--disable-crashpad-for-testing');
     expect(config.args).toContain('--disable-breakpad');
     expect(config.args).toContain('--crash-dumps-dir=/tmp/jsmkc-preview-browser-home/Crashpad');
+    expect(mkdirSyncSpy).toHaveBeenCalledWith('/tmp/jsmkc-preview-browser-home', { recursive: true });
+    expect(mkdirSyncSpy).toHaveBeenCalledWith('/tmp/jsmkc-preview-browser-home/.config', { recursive: true });
+    expect(mkdirSyncSpy).toHaveBeenCalledWith('/tmp/jsmkc-preview-browser-home/.cache', { recursive: true });
+    expect(mkdirSyncSpy).toHaveBeenCalledWith('/tmp/jsmkc-preview-browser-home/Crashpad', { recursive: true });
   });
 
   it('preserves caller-provided browser channel override', () => {


### PR DESCRIPTION
Summary
- Document TC-109 coverage for run-preview Crashpad helper tests avoiding real filesystem side effects
- Mock fs.mkdirSync in run-preview's Crashpad launch isolation test and assert the expected directory preparation calls
- Add drift coverage that keeps the TC-109 scenario, run-preview helper test, and mkdirSync mock aligned

Issues: Closes #2029

Validation
- npm test -- --runTestsByPath __tests__/e2e/run-preview.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint
