### PR TITLE
Stabilize TC-109 drift guard anchors

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -248,6 +248,18 @@
 - **期待結果**: TC-109 の文書連携は維持され、補助テスト内の安全なリネームや整形では drift guard が壊れない
 - **スクリプト**: `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2041: TC-109 drift guard の境界は専用アンカーで固定する
+- **URL**: n/a (static/doc coverage)
+- **authRequired**: false
+- **背景**: issue #2041/#2039。TC-2034 の drift guard は `e2e-cases-drift.test.ts` 自身の一部を検査するが、`it(...)` 名を `sectionBetween()` の境界に使うと、テスト名リネームや並び替えで不要に壊れやすい。
+- **手順**:
+  1. TC-109 helper coverage の検査ブロックが `TC-2041-TC109-DRIFT-GUARD-START/END` の専用コメントアンカーで囲まれていることを確認する
+  2. TC-2034 drift guard が `sectionBetween()` の境界に `it(...)` 名ではなく専用コメントアンカーを使うことを確認する
+  3. `sectionBetween()` helper が専用アンカー間の本文を返し、欠落した end marker では失敗することを補助検証で確認する
+- **期待結果**: TC-109 の drift guard はテスト名の安全なリネームや近接テストの並び替えに依存しない
+- **スクリプト**: `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
+- **補助検証**: `smkc-score-app/__tests__/helpers/e2e-cases.test.ts`
+
 ## TC-110: Preview 管理者ログイン補助スクリプトの要素待機
 - **URL**: /auth/signin
 - **authRequired**: false (ログイン準備)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -166,6 +166,7 @@ describe('E2E case drift coverage', () => {
     ['TC-1457', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-2006-2007', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/lib/prisma-selects.test.ts'],
     ['TC-2034', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts'],
+    ['TC-2041', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts'],
     ['TC-1528', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/e2e/ta-phase-submit-helper.test.ts'],
     ['TC-1669', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts'],
     ['TC-1671', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts'],
@@ -1140,6 +1141,7 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain(coverage);
   });
 
+  // [TC-2041-TC109-DRIFT-GUARD-START]
   it('keeps TC-109 helper coverage classified without environment variable names in the URL slot', () => {
     const tc109Rows = tc109ClassifiedRows.filter(([tc]) => tc === 'TC-109');
     const section = e2eCaseSection('TC-109');
@@ -1153,14 +1155,15 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('fs.mkdirSync');
     expect(section).toContain('実際の `/tmp` 配下へテスト副作用を残さない');
   });
+  // [TC-2041-TC109-DRIFT-GUARD-END]
 
   it('keeps TC-109 drift guard focused on docs instead of helper implementation strings', () => {
     const section = e2eCaseSection('TC-2034');
     const driftTestSource = readRepoFile('smkc-score-app', '__tests__', 'docs', 'e2e-cases-drift.test.ts');
     const tc109DriftBlock = sectionBetween(
       driftTestSource,
-      "it('keeps TC-109 helper coverage classified without environment variable names in the URL slot'",
-      "it('keeps TC-109 drift guard focused on docs instead of helper implementation strings'",
+      '// [TC-2041-TC109-DRIFT-GUARD-START]',
+      '// [TC-2041-TC109-DRIFT-GUARD-END]',
     );
 
     expect(section).toContain('TC-109');
@@ -1168,6 +1171,23 @@ describe('E2E case drift coverage', () => {
     expect(tc109DriftBlock).toContain("e2eCaseSection('TC-109')");
     expect(tc109DriftBlock).not.toContain("readRepoFile('smkc-score-app', '__tests__', 'e2e', 'run-preview.test.ts')");
     expect(tc109DriftBlock).not.toContain('toHaveBeenCalledWith');
+  });
+
+  it('keeps TC-2041 aligned with explicit TC-109 drift guard anchors', () => {
+    const section = e2eCaseSection('TC-2041');
+    const driftTestSource = readRepoFile('smkc-score-app', '__tests__', 'docs', 'e2e-cases-drift.test.ts');
+    const anchoredBlock = sectionBetween(
+      driftTestSource,
+      '// [TC-2041-TC109-DRIFT-GUARD-START]',
+      '// [TC-2041-TC109-DRIFT-GUARD-END]',
+    );
+
+    expect(section).toContain('issue #2041/#2039');
+    expect(section).toContain('TC-2041-TC109-DRIFT-GUARD-START/END');
+    expect(section).toContain('__tests__/helpers/e2e-cases.test.ts');
+    expect(anchoredBlock).toContain("e2eCaseSection('TC-109')");
+    expect(anchoredBlock).toContain('fs.mkdirSync');
+    expect(anchoredBlock).not.toContain("it('keeps TC-109 drift guard focused on docs instead of helper implementation strings'");
   });
 
   it('keeps late static-only TC classifications ordered within their local block', () => {

--- a/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
@@ -1,6 +1,45 @@
-import { callExpressionWithArguments, sectionAfterBlockComment } from './e2e-cases';
+import {
+  callExpressionWithArguments,
+  sectionAfterBlockComment,
+  sectionBetween,
+} from './e2e-cases';
 
 describe('E2E case helpers', () => {
+  it('extracts sections using explicit comment anchors', () => {
+    const source = `
+      // [TC-2041-TC109-DRIFT-GUARD-START]
+      it('can be renamed safely', () => {
+        expect(true).toBe(true);
+      });
+      // [TC-2041-TC109-DRIFT-GUARD-END]
+      it('neighboring test can move', () => {});
+    `;
+
+    const section = sectionBetween(
+      source,
+      '// [TC-2041-TC109-DRIFT-GUARD-START]',
+      '// [TC-2041-TC109-DRIFT-GUARD-END]',
+    );
+
+    expect(section).toContain("it('can be renamed safely'");
+    expect(section).not.toContain('neighboring test can move');
+  });
+
+  it('fails when an explicit comment anchor end marker is missing', () => {
+    const source = `
+      // [TC-2041-TC109-DRIFT-GUARD-START]
+      it('can be renamed safely', () => {});
+    `;
+
+    expect(() => sectionBetween(
+      source,
+      '// [TC-2041-TC109-DRIFT-GUARD-START]',
+      '// [TC-2041-TC109-DRIFT-GUARD-END]',
+    )).toThrow(
+      'section end marker not found after "// [TC-2041-TC109-DRIFT-GUARD-START]": "// [TC-2041-TC109-DRIFT-GUARD-END]"',
+    );
+  });
+
   it('finds required arguments on the same call expression', () => {
     const source = `
       throwUnexpectedMockCall('page.getByRole', roleLookup(_role, name), EXPECTED_PAGE_ROLE_LOOKUPS);


### PR DESCRIPTION
## Summary
- Add TC-2041 to document the TC-109 drift guard anchor contract
- Replace TC-2034 `sectionBetween()` test-name boundaries with explicit TC-2041 comment anchors
- Add helper coverage for anchored `sectionBetween()` extraction and missing end marker failure

## Issues
Closes #2041
Closes #2039

## Validation
- `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/helpers/e2e-cases.test.ts`
- `npm run lint` (passes with existing warnings)
