### PR TITLE
chore: rename TC-109 drift guard anchors

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -253,7 +253,7 @@
 - **authRequired**: false
 - **背景**: issue #2041/#2039。TC-2034 の drift guard は `e2e-cases-drift.test.ts` 自身の一部を検査するが、`it(...)` 名を `sectionBetween()` の境界に使うと、テスト名リネームや並び替えで不要に壊れやすい。
 - **手順**:
-  1. TC-109 helper coverage の検査ブロックが `TC-2041-TC109-DRIFT-GUARD-START/END` の専用コメントアンカーで囲まれていることを確認する
+  1. TC-109 helper coverage の検査ブロックが `TC109-HELPER-COVERAGE-DRIFT-GUARD-START/END` の専用コメントアンカーで囲まれていることを確認する
   2. TC-2034 drift guard が `sectionBetween()` の境界に `it(...)` 名ではなく専用コメントアンカーを使うことを確認する
   3. `sectionBetween()` helper が専用アンカー間の本文を返し、欠落した end marker では失敗することを補助検証で確認する
 - **期待結果**: TC-109 の drift guard はテスト名の安全なリネームや近接テストの並び替えに依存しない

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1141,7 +1141,7 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain(coverage);
   });
 
-  // [TC-2041-TC109-DRIFT-GUARD-START]
+  // [TC109-HELPER-COVERAGE-DRIFT-GUARD-START]
   it('keeps TC-109 helper coverage classified without environment variable names in the URL slot', () => {
     const tc109Rows = tc109ClassifiedRows.filter(([tc]) => tc === 'TC-109');
     const section = e2eCaseSection('TC-109');
@@ -1155,15 +1155,15 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('fs.mkdirSync');
     expect(section).toContain('実際の `/tmp` 配下へテスト副作用を残さない');
   });
-  // [TC-2041-TC109-DRIFT-GUARD-END]
+  // [TC109-HELPER-COVERAGE-DRIFT-GUARD-END]
 
   it('keeps TC-109 drift guard focused on docs instead of helper implementation strings', () => {
     const section = e2eCaseSection('TC-2034');
     const driftTestSource = readRepoFile('smkc-score-app', '__tests__', 'docs', 'e2e-cases-drift.test.ts');
     const tc109DriftBlock = sectionBetween(
       driftTestSource,
-      '// [TC-2041-TC109-DRIFT-GUARD-START]',
-      '// [TC-2041-TC109-DRIFT-GUARD-END]',
+      '// [TC109-HELPER-COVERAGE-DRIFT-GUARD-START]',
+      '// [TC109-HELPER-COVERAGE-DRIFT-GUARD-END]',
     );
 
     expect(section).toContain('TC-109');
@@ -1178,12 +1178,12 @@ describe('E2E case drift coverage', () => {
     const driftTestSource = readRepoFile('smkc-score-app', '__tests__', 'docs', 'e2e-cases-drift.test.ts');
     const anchoredBlock = sectionBetween(
       driftTestSource,
-      '// [TC-2041-TC109-DRIFT-GUARD-START]',
-      '// [TC-2041-TC109-DRIFT-GUARD-END]',
+      '// [TC109-HELPER-COVERAGE-DRIFT-GUARD-START]',
+      '// [TC109-HELPER-COVERAGE-DRIFT-GUARD-END]',
     );
 
     expect(section).toContain('issue #2041/#2039');
-    expect(section).toContain('TC-2041-TC109-DRIFT-GUARD-START/END');
+    expect(section).toContain('TC109-HELPER-COVERAGE-DRIFT-GUARD-START/END');
     expect(section).toContain('__tests__/helpers/e2e-cases.test.ts');
     expect(anchoredBlock).toContain("e2eCaseSection('TC-109')");
     expect(anchoredBlock).toContain('fs.mkdirSync');

--- a/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
@@ -7,18 +7,18 @@ import {
 describe('E2E case helpers', () => {
   it('extracts sections using explicit comment anchors', () => {
     const source = `
-      // [TC-2041-TC109-DRIFT-GUARD-START]
+      // [TC109-HELPER-COVERAGE-DRIFT-GUARD-START]
       it('can be renamed safely', () => {
         expect(true).toBe(true);
       });
-      // [TC-2041-TC109-DRIFT-GUARD-END]
+      // [TC109-HELPER-COVERAGE-DRIFT-GUARD-END]
       it('neighboring test can move', () => {});
     `;
 
     const section = sectionBetween(
       source,
-      '// [TC-2041-TC109-DRIFT-GUARD-START]',
-      '// [TC-2041-TC109-DRIFT-GUARD-END]',
+      '// [TC109-HELPER-COVERAGE-DRIFT-GUARD-START]',
+      '// [TC109-HELPER-COVERAGE-DRIFT-GUARD-END]',
     );
 
     expect(section).toContain("it('can be renamed safely'");
@@ -27,16 +27,16 @@ describe('E2E case helpers', () => {
 
   it('fails when an explicit comment anchor end marker is missing', () => {
     const source = `
-      // [TC-2041-TC109-DRIFT-GUARD-START]
+      // [TC109-HELPER-COVERAGE-DRIFT-GUARD-START]
       it('can be renamed safely', () => {});
     `;
 
     expect(() => sectionBetween(
       source,
-      '// [TC-2041-TC109-DRIFT-GUARD-START]',
-      '// [TC-2041-TC109-DRIFT-GUARD-END]',
+      '// [TC109-HELPER-COVERAGE-DRIFT-GUARD-START]',
+      '// [TC109-HELPER-COVERAGE-DRIFT-GUARD-END]',
     )).toThrow(
-      'section end marker not found after "// [TC-2041-TC109-DRIFT-GUARD-START]": "// [TC-2041-TC109-DRIFT-GUARD-END]"',
+      'section end marker not found after "// [TC109-HELPER-COVERAGE-DRIFT-GUARD-START]": "// [TC109-HELPER-COVERAGE-DRIFT-GUARD-END]"',
     );
   });
 


### PR DESCRIPTION
## Summary
- Rename TC-2041-specific drift guard comment anchors to a generic issue-independent identifier (`TC109-HELPER-COVERAGE-DRIFT-GUARD-START/END`).
- Update the E2E scenario catalog plus helper and drift-test expectations to match the generic TC-109 anchor names.

## Issues
Closes #2051

## Validation
- `npm test -- __tests__/docs/e2e-cases-drift.test.ts __tests__/helpers/e2e-cases.test.ts`
- GitHub CI: `gh pr checks 2052`
