### PR TITLE
test: clarify sectionAfterBlockComment boundary wording

### DIFF
--- a/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
@@ -68,7 +68,7 @@ describe('E2E case helpers', () => {
     );
   });
 
-  it('extracts code after a block comment without requiring a comment boundary marker', () => {
+  it('extracts code after a block comment using a code boundary instead of a comment end-marker', () => {
     const source = `
       /**
        * Keep these reads sequential.


### PR DESCRIPTION
## Summary
- Fix ambiguous test description in e2e helper test to match actual boundary logic.
- Update wording so the helper still requires the comment start marker while using a code boundary instead of a comment end-marker.

## Issues: Closes #2048

## Validation
- npm test -- --runTestsByPath __tests__/helpers/e2e-cases.test.ts
- npm run lint -- __tests__/helpers/e2e-cases.test.ts