### PR TITLE
test: add sectionBetween start marker missing guard

### DIFF
--- a/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
@@ -40,6 +40,21 @@ describe('E2E case helpers', () => {
     );
   });
 
+  it('fails when an explicit comment anchor start marker is missing', () => {
+    const source = `
+      it('orphan test', () => {});
+      // [TC-2041-TC109-DRIFT-GUARD-END]
+    `;
+
+    expect(() =>
+      sectionBetween(
+        source,
+        '// [TC-2041-TC109-DRIFT-GUARD-START]',
+        '// [TC-2041-TC109-DRIFT-GUARD-END]',
+      ),
+    ).toThrow('section start marker not found: "// [TC-2041-TC109-DRIFT-GUARD-START]"');
+  });
+
   it('finds required arguments on the same call expression', () => {
     const source = `
       throwUnexpectedMockCall('page.getByRole', roleLookup(_role, name), EXPECTED_PAGE_ROLE_LOOKUPS);


### PR DESCRIPTION
## Summary\n- Add unit test coverage for sectionBetween when explicit start marker is missing\n- Assert exact throw message and address review-followup issue #2050\n\n## Issues\n- Closes #2050\n\n## Validation\n- Not run locally in this run\n