### PR TITLE
Fix sectionBetween whitespace terminal handling

### DIFF
--- a/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
@@ -88,6 +88,23 @@ describe('E2E case helpers', () => {
     );
   });
 
+  it('treats whitespace-only terminal sections as empty', () => {
+    const source = `// [TC-2058-WHITESPACE-TERMINAL-START]
+   
+`;
+
+    expect(() =>
+      sectionBetween(
+        source,
+        '// [TC-2058-WHITESPACE-TERMINAL-START]',
+        '// [TC-2058-WHITESPACE-TERMINAL-END]',
+        { allowTerminal: true },
+      ),
+    ).toThrow(
+      'terminal section for marker "// [TC-2058-WHITESPACE-TERMINAL-START]" has no content',
+    );
+  });
+
   it('finds required arguments on the same call expression', () => {
     const source = `
       throwUnexpectedMockCall('page.getByRole', roleLookup(_role, name), EXPECTED_PAGE_ROLE_LOOKUPS);

--- a/smkc-score-app/__tests__/helpers/e2e-cases.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.ts
@@ -30,7 +30,8 @@ export function sectionBetween(
   }
 
   if (sectionEndCandidate === -1) {
-    if (source.length <= sectionStart + startMarker.length) {
+    const terminalSection = source.slice(sectionStart + startMarker.length);
+    if (terminalSection.trim().length === 0) {
       throw new Error(`terminal section for marker "${startMarker}" has no content`);
     }
     return source.slice(sectionStart);


### PR DESCRIPTION
## Summary
- Treat terminal sections as empty in `sectionBetween` when only whitespace follows `startMarker` under `allowTerminal`.
- Add regression coverage for whitespace-only terminal section behavior.

## Issue
- Closes #2058

## Validation
- Unit test added in `smkc-score-app/__tests__/helpers/e2e-cases.test.ts`
- Code change in `smkc-score-app/__tests__/helpers/e2e-cases.ts`
