### PR TITLE
Add tab-only terminal whitespace coverage for sectionBetween

### DIFF
--- a/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
@@ -103,6 +103,21 @@ describe('E2E case helpers', () => {
     );
   });
 
+  it('fails when an allowed terminal section has only tab content', () => {
+    const source = '// [TC-2058-TAB-WHITESPACE-TERMINAL-SECTION-START]\n\t\n\t';
+
+    expect(() =>
+      sectionBetween(
+        source,
+        '// [TC-2058-TAB-WHITESPACE-TERMINAL-SECTION-START]',
+        '// [TC-2058-TAB-WHITESPACE-TERMINAL-SECTION-END]',
+        { allowTerminal: true },
+      ),
+    ).toThrow(
+      'terminal section for marker "// [TC-2058-TAB-WHITESPACE-TERMINAL-SECTION-START]" has no content',
+    );
+  });
+
   it('finds required arguments on the same call expression', () => {
     const source = `
       throwUnexpectedMockCall('page.getByRole', roleLookup(_role, name), EXPECTED_PAGE_ROLE_LOOKUPS);


### PR DESCRIPTION
## Summary
- Add regression coverage for `sectionBetween` terminal section handling when terminal content is only tabs.
- Reassert that `allowTerminal: true` treats whitespace-only terminal content as empty and throws.

## Issue
- Closes #2058

## Validation
- Updated `smkc-score-app/__tests__/helpers/e2e-cases.test.ts`.
