### PR TITLE
Split TA memoization test describe blocks

### DIFF
--- a/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
+++ b/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
@@ -54,7 +54,9 @@ describe('TA time input props memoization', () => {
     expect(source).toContain('Input is a native element, so this does not skip rendering by reference equality.');
     expect(source).toContain('avoids rebuilding identical spread props during polling refreshes.');
   });
+});
 
+describe('TA row component memo wrapping', () => {
   it.each(memoizedRowTargets)(
     'memoizes row component props in $label',
     ({ path, componentName }) => {


### PR DESCRIPTION
## Summary
- Split TA time input memoization coverage into separate concern-specific describe blocks.
- Keep existing assertions unchanged while separating prop memoization checks from React.memo row-wrapper checks.

## Issues
- Closes #2065

## Validation
- npm test -- --runTestsByPath __tests__/static/ta-time-input-props-usememo.test.ts
- npm run lint (passes with existing warnings)