### PR TITLE
test: clarify TA memo wrapper test title

### DIFF
--- a/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
+++ b/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
@@ -58,7 +58,7 @@ describe('TA time input props memoization', () => {
 
 describe('TA row component memo wrapping', () => {
   it.each(memoizedRowTargets)(
-    'memoizes row component props in $label',
+    'wraps row component with React.memo in $label',
     ({ path, componentName }) => {
       const source = readRepoFile('smkc-score-app', ...path);
       const memoDeclaration = new RegExp(


### PR DESCRIPTION
## Summary
- Rename the TA row memo wrapper static test case so it describes React.memo wrapping instead of props memoization.
- Keep the existing row wrapper assertions unchanged.

## Issues
- Closes #2064

## Validation
- npm test -- --runTestsByPath __tests__/static/ta-time-input-props-usememo.test.ts
- npm run lint (passes with existing warnings)