### PR TITLE
Resolve review follow-up #2062

### DIFF
--- a/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.test.ts
@@ -104,17 +104,17 @@ describe('E2E case helpers', () => {
   });
 
   it('fails when an allowed terminal section has only tab content', () => {
-    const source = '// [TC-2058-TAB-WHITESPACE-TERMINAL-SECTION-START]\n\t\n\t';
+    const source = '// [TAB-WHITESPACE-TERMINAL-SECTION-START]\n\t\n\t';
 
     expect(() =>
       sectionBetween(
         source,
-        '// [TC-2058-TAB-WHITESPACE-TERMINAL-SECTION-START]',
-        '// [TC-2058-TAB-WHITESPACE-TERMINAL-SECTION-END]',
+        '// [TAB-WHITESPACE-TERMINAL-SECTION-START]',
+        '// [TAB-WHITESPACE-TERMINAL-SECTION-END]',
         { allowTerminal: true },
       ),
     ).toThrow(
-      'terminal section for marker "// [TC-2058-TAB-WHITESPACE-TERMINAL-SECTION-START]" has no content',
+      'terminal section for marker "// [TAB-WHITESPACE-TERMINAL-SECTION-START]" has no content',
     );
   });
 


### PR DESCRIPTION
## Summary
- Rename `TC-2058-TAB-WHITESPACE-TERMINAL-SECTION` markers in sectionBetween tab-whitespace regression test to descriptive names without issue IDs.

## Issues
- Closes #2062

## Validation
- `npm test -- __tests__/helpers/e2e-cases.test.ts`
- GitHub Actions `Lint & Test` passed for CI and Claude Code Review.
