### PR TITLE
Cover auth error and vitals routes

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -76,6 +76,30 @@
   4. フォーム要素が正しく存在するか
 - **期待結果**: サインインページが正常に表示される
 
+## TC-2070A: 認証エラーページの安全な表示と復帰導線
+- **URL**: /auth/error?error=CredentialsSignin, /auth/error?error=NotWhitelisted
+- **authRequired**: false
+- **背景**: issue #2070。NextAuth のエラー遷移先 `/auth/error` は、認証失敗理由を安全な文言で表示し、再ログインとトップページへの復帰導線を提供する必要がある。`/auth/signin` だけではこの実ページを確認できない。
+- **手順**:
+  1. `/auth/error?error=CredentialsSignin` にアクセスする
+  2. 認証エラー見出し、資格情報エラーの文言、`/auth/signin` と `/` へのリンクを確認する
+  3. `/auth/error?error=NotWhitelisted` にアクセスする
+  4. 管理者未登録の安全な説明文と復帰導線を確認する
+- **期待結果**: エラー詳細はユーザー向けの安全な文言で表示され、再ログインとトップページへのリンクが常に存在する
+- **スクリプト**: tc-all.js TC-2070A
+
+## TC-2070B: Web Vitals ingestion は通常設定で 204 を返しページ表示を壊さない
+- **URL**: /api/internal/vitals, /
+- **authRequired**: false
+- **背景**: issue #2070。`WebVitalsReporter` は root layout に常時マウントされるが、通常環境では `PERF_LOG !== '1'` のため `/api/internal/vitals` が副作用なしに 204 を返すことを preview で確認する。`PERF_LOG=1` のログ内容は環境依存なので単体テストで補助する。
+- **手順**:
+  1. ブラウザコンテキストから `/api/internal/vitals` に最小 payload を POST する
+  2. 通常 preview 設定で 204 が返ることを確認する
+  3. トップページに遷移し、Web Vitals reporter のマウントでページロードが壊れないことを確認する
+- **期待結果**: 通常設定では vitals endpoint は 204 を返し、トップページは JS エラーなしに表示される
+- **スクリプト**: tc-all.js TC-2070B
+- **補助検証**: `smkc-score-app/__tests__/app/api/internal/vitals/route.test.ts`
+
 ## TC-008: Overall Ranking ページの表示
 - **URL**: /tournaments/[id]/overall-ranking
 - **authRequired**: false

--- a/smkc-score-app/__tests__/app/api/internal/vitals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/internal/vitals/route.test.ts
@@ -1,0 +1,85 @@
+const mockInfo = jest.fn();
+
+jest.mock('@/lib/logger', () => ({
+  createLogger: jest.fn(() => ({
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: mockInfo,
+    debug: jest.fn(),
+  })),
+}));
+
+async function loadRoute(perfLog: string | undefined) {
+  jest.resetModules();
+  mockInfo.mockClear();
+  if (perfLog === undefined) {
+    delete process.env.PERF_LOG;
+  } else {
+    process.env.PERF_LOG = perfLog;
+  }
+  return import('@/app/api/internal/vitals/route');
+}
+
+describe('POST /api/internal/vitals', () => {
+  const originalPerfLog = process.env.PERF_LOG;
+
+  afterEach(() => {
+    if (originalPerfLog === undefined) {
+      delete process.env.PERF_LOG;
+    } else {
+      process.env.PERF_LOG = originalPerfLog;
+    }
+  });
+
+  it('returns 204 without parsing or logging when PERF_LOG is disabled', async () => {
+    const { POST } = await loadRoute(undefined);
+
+    const response = await POST(new Request('http://localhost/api/internal/vitals', {
+      method: 'POST',
+      body: 'not json',
+    }));
+
+    expect(response.status).toBe(204);
+    expect(mockInfo).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid json when PERF_LOG is enabled', async () => {
+    const { POST } = await loadRoute('1');
+
+    const response = await POST(new Request('http://localhost/api/internal/vitals', {
+      method: 'POST',
+      body: 'not json',
+    }));
+
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toBe('invalid json');
+    expect(mockInfo).not.toHaveBeenCalled();
+  });
+
+  it('logs sanitized metric fields and returns 204 when PERF_LOG is enabled', async () => {
+    const { POST } = await loadRoute('1');
+
+    const response = await POST(new Request('http://localhost/api/internal/vitals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: 'metric-1',
+        name: 'LCP',
+        value: 123.4,
+        rating: 'good',
+        navigationType: 'reload',
+        path: '/tournaments',
+        ignored: 'not logged',
+      }),
+    }));
+
+    expect(response.status).toBe(204);
+    expect(mockInfo).toHaveBeenCalledWith('vital', {
+      name: 'LCP',
+      value: 123.4,
+      rating: 'good',
+      path: '/tournaments',
+      navigationType: 'reload',
+    });
+  });
+});

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -195,6 +195,8 @@ describe('E2E case drift coverage', () => {
     ['TC-808A', tcTa],
     ['TC-1996', tcTa],
     ['TC-939', tcAll],
+    ['TC-2070A', tcAll],
+    ['TC-2070B', tcAll],
     ['TC-1010', tcBm],
     ['TC-TA-FLOW-24', tcTaFlow],
   ])('keeps %s documented and registered in its runnable E2E script', (tc, scriptSource) => {

--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -44,4 +44,15 @@ describe('tc-all focused suite registration', () => {
     expect(source).toContain('// TC-401/402 は上の共有4モード大会と総合ランキング検証に再利用。');
     expect(source).not.toContain('Legacy lightweight full-workflow and GP dialog UI checks were retired.');
   });
+
+  it('registers auth error and web vitals preview checks for TC-2070', () => {
+    expect(source).toContain("log('TC-2070A'");
+    expect(source).toContain('/auth/error?error=');
+    expect(source).toContain('CredentialsSignin');
+    expect(source).toContain('NotWhitelisted');
+
+    expect(source).toContain("log('TC-2070B'");
+    expect(source).toContain('/api/internal/vitals');
+    expect(source).toContain('vitalsStatus === 204');
+  });
 });

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -384,6 +384,36 @@ async function main() {
   const hasPlayerTab = t.includes('Player') || t.includes('プレイヤー');
   log('TC-007', hasPlayerTab ? 'PASS' : 'FAIL');
 
+  // TC-2070A: auth error page renders safe copy and recovery links
+  let tc2070A = true;
+  for (const { code, expected } of [
+    { code: 'CredentialsSignin', expected: ['Invalid nickname or password', 'ニックネームまたはパスワード'] },
+    { code: 'NotWhitelisted', expected: ['not registered as an administrator', '管理者として登録されていません'] },
+  ]) {
+    await nav(page, `/auth/error?error=${code}`);
+    t = await vis(page);
+    const hasSafeCopy = expected.some((text) => t.includes(text));
+    const hasRecoveryLinks =
+      await page.locator('a[href="/auth/signin"]').count() > 0 &&
+      await page.locator('a[href="/"]').count() > 0;
+    if (!hasSafeCopy || !hasRecoveryLinks) tc2070A = false;
+  }
+  log('TC-2070A', tc2070A ? 'PASS' : 'FAIL');
+
+  // TC-2070B: web vitals endpoint is preview-safe with PERF_LOG disabled
+  const vitalsStatus = await page.evaluate(async () => {
+    const response = await fetch('/api/internal/vitals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: 'tc-2070', name: 'LCP', value: 1, rating: 'good', path: '/' }),
+    });
+    return response.status;
+  }).catch(() => 0);
+  await nav(page, '/');
+  t = await vis(page);
+  log('TC-2070B', vitalsStatus === 204 && t.includes('SMKC') ? 'PASS' : 'FAIL',
+    vitalsStatus === 204 ? '' : `vitals status=${vitalsStatus}`);
+
   // TC-008
   await nav(page, `/tournaments/${TID}/overall-ranking`);
   t = await vis(page);


### PR DESCRIPTION
## Summary
- Add TC-2070A/TC-2070B E2E scenario coverage for auth error pages and Web Vitals ingestion.
- Register the new tc-all checks and document them in drift coverage.
- Add unit coverage for `/api/internal/vitals` PERF_LOG off/on behavior.

## Issues
Closes #2070

## Validation
- `npm test -- __tests__/app/api/internal/vitals/route.test.ts __tests__/e2e/tc-all-registration.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npm run lint` (exit 0; existing warnings only)
