### PR TITLE
Fix TC-1996 phase round times

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -3027,7 +3027,7 @@
 - **手順**:
   1. 管理者で一時 TA fixture を作成し、Phase 3 へ昇格して `/ta/finals` でラウンドを開始する
   2. 1人目の決勝 row で TV3 を選択し、もう1人は TV番号を未選択のままにする
-  3. ラウンド結果を送信し、`/api/tournaments/[id]/ta/phases` の submit payload で1人目の `tvNumber` が数値 `3`、2人目に `NaN` や不要な `tvNumber` が含まれないことを確認する
+  3. 資格合計ではなく Phase 3 用の単走ラウンドタイムでラウンド結果を送信し、`/api/tournaments/[id]/ta/phases` の submit payload で1人目の `tvNumber` が数値 `3`、2人目に `NaN` や不要な `tvNumber` が含まれないことを確認する
   4. `GET /api/tournaments/[id]/ta/phases?phase=phase3` で保存済み round の results に `tvNumber: 3` と `tvNumber: null` が残ることを確認する
 - **期待結果**: TA決勝のTV番号選択は UI row から API payload へ数値として渡り、未選択行は不正値ではなく `null` として履歴に残る
 - **スクリプト**: tc-ta.js TC-1996 / e2e-cases-drift.test.ts / ta/phases route.test.ts

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1477,12 +1477,15 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #1996');
     expect(section).toContain('/ta/finals');
     expect(section).toContain('submit payload');
+    expect(section).toContain('単走ラウンドタイム');
     expect(section).toContain('tvNumber: 3');
     expect(section).toContain('tvNumber: null');
     expect(section).toContain('ta/phases route.test.ts');
     expect(tcTa).toContain("log('TC-1996'");
     expect(tcTa).toContain("selectOption('3')");
     expect(tcTa).toContain("capturedSubmitPayload");
+    expect(tcTa).toContain('makeTaPhaseRoundTimeMs(tvEntry)');
+    expect(tcTa).not.toContain('seededByPlayer.get(tvEntry.playerId)?.totalMs');
     expect(taPhasesRouteTest).toContain('should accept phase3 results with null or absent tvNumber');
   });
 

--- a/smkc-score-app/__tests__/e2e/ta-phase-submit-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/ta-phase-submit-helper.test.ts
@@ -31,9 +31,23 @@ describe('TA E2E phase round submission helper', () => {
     };
 
     expect(Object.keys(__testHooks).sort()).toEqual([
+      'makeTaPhaseRoundTimeMs',
       'submitTaPhaseRoundByApi',
       'submitTaPhaseRoundWithCourseByApi',
     ]);
+  });
+
+  it('builds per-round TA phase times instead of qualification totals', async () => {
+    const { __testHooks } = await import('../../e2e/tc-ta.js') as {
+      __testHooks: {
+        makeTaPhaseRoundTimeMs: (entry: { rank?: number } | null, fallbackRank?: number) => number;
+      };
+    };
+
+    expect(__testHooks.makeTaPhaseRoundTimeMs({ rank: 1 })).toBe(60200);
+    expect(__testHooks.makeTaPhaseRoundTimeMs({ rank: 12 })).toBe(62400);
+    expect(__testHooks.makeTaPhaseRoundTimeMs({})).toBe(64000);
+    expect(__testHooks.makeTaPhaseRoundTimeMs(null, 3)).toBe(60600);
   });
 
   it('keeps automatic-course phase submissions on the shared start/submit helper', async () => {

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -75,6 +75,7 @@ const { parseTvNumberInput } = require('../src/lib/ta/time-entry-layout');
 const results = makeResults();
 const log = makeLog(results);
 let sharedFixture = null;
+const TA_PHASE_ROUND_BASE_TIME_MS = 60000;
 /* Shared TA qualification state. Populated once in beforeAll via
  * setupTaEntriesFromShared so TC-801/802/804/805 do not each re-clear and
  * re-seed 28 players × 20 courses (≈140s per call). Subsequent phase-promoting
@@ -185,10 +186,15 @@ async function apiUpdateTaLives(adminPage, tournamentId, entryId, livesDelta) {
   }, [`/api/tournaments/${tournamentId}/ta`, { entryId, action: 'update_lives', livesDelta }]);
 }
 
+function makeTaPhaseRoundTimeMs(entry, fallbackRank = 20) {
+  const rank = Number.isFinite(entry?.rank) ? entry.rank : fallbackRank;
+  return TA_PHASE_ROUND_BASE_TIME_MS + rank * 200;
+}
+
 async function submitTaPhaseRoundByApi(adminPage, tournamentId, phase, activeEntries) {
   const results = activeEntries.map((e) => ({
     playerId: e.playerId,
-    timeMs: 60000 + (e.rank || 20) * 200,
+    timeMs: makeTaPhaseRoundTimeMs(e),
   }));
   const submission = await submitTaPhaseRound(adminPage, tournamentId, phase, undefined, results);
   return submission.data;
@@ -805,7 +811,7 @@ async function runTc1996(adminPage) {
   try {
     setup = await createIsolatedTaQualification(adminPage, 'Finals TV Number Payload', sharedTaPlayers(2), { seedTimes: false });
     const { tournamentId } = setup;
-    const seeded = await seedTaQualificationRanks(adminPage, tournamentId, setup.entries, 1);
+    await seedTaQualificationRanks(adminPage, tournamentId, setup.entries, 1);
     const promote = await apiPromoteTaPhase(adminPage, tournamentId, 'promote_phase3');
     if (promote.s !== 200) throw new Error(`promote_phase3 failed (${promote.s})`);
 
@@ -834,10 +840,9 @@ async function runTc1996(adminPage) {
       await route.continue();
     });
 
-    const seededByPlayer = new Map(seeded.map((entry) => [entry.playerId, entry]));
     await uiPhaseSubmitResults(adminPage, tournamentId, 'phase3', [
-      { playerId: tvEntry.playerId, nickname: tvEntry.player.nickname, timeMs: seededByPlayer.get(tvEntry.playerId)?.totalMs ?? 63000 },
-      { playerId: clearEntry.playerId, nickname: clearEntry.player.nickname, timeMs: seededByPlayer.get(clearEntry.playerId)?.totalMs ?? 65000 },
+      { playerId: tvEntry.playerId, nickname: tvEntry.player.nickname, timeMs: makeTaPhaseRoundTimeMs(tvEntry) },
+      { playerId: clearEntry.playerId, nickname: clearEntry.player.nickname, timeMs: makeTaPhaseRoundTimeMs(clearEntry) },
     ]);
     await adminPage.unroute(routePattern).catch(() => {});
     routePattern = null;
@@ -2096,6 +2101,7 @@ module.exports = {
   getSuite,
   results,
   __testHooks: {
+    makeTaPhaseRoundTimeMs,
     submitTaPhaseRoundByApi,
     submitTaPhaseRoundWithCourseByApi,
   },


### PR DESCRIPTION
## Summary
- document TC-1996 as submitting Phase 3 per-round times, not TA qualification totals
- add a shared TA E2E helper for bounded phase-round times and use it in TC-1996
- add Jest coverage so the helper and TC-1996 contract cannot drift back to qualification totals

## Issues
Closes #2077

## Validation
- `npm test -- --runTestsByPath __tests__/e2e/ta-phase-submit-helper.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npm run lint` (passes with existing warnings)
- `E2E_TESTS=TC-1996 npm run e2e:preview:ta` (blocked before browser launch by existing Preview D1 schema preflight failure from #2071)
