### PR TITLE
Fix TC-357 qualification loading headings

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -973,12 +973,12 @@
 
 ## TC-357: Suspense fallback — 4モード予選ページの見出しが即時描画される
 - **authRequired**: true (admin)
-- **背景**: RSC streaming / PPR の待機中でも E2E セレクタと利用者の初期表示が安定するよう、BM/MR/GP/TA の qualification fallback はモード名見出しを先に描画する必要がある。
+- **背景**: RSC streaming / PPR の待機中、および RSC fallback 解決後に client polling data が hydrate されるまでの間も E2E セレクタと利用者の初期表示が安定するよう、BM/MR/GP/TA の qualification fallback/client loading state はモード名見出しを先に描画する必要がある。
 - **手順**:
   1. 共有トーナメント ID を使って BM/MR/GP/TA の各予選ページへ順に遷移し、`domcontentloaded` 直後に確認する
   2. 各ページで `h1` を即時確認する
-  3. BM は `バトルモード` または `Battle Mode`、MR は `マッチレース` または `Match Race`、GP は `グランプリ` または `Grand Prix`、TA は `タイムアタック` または `Time Attack` を含む見出しがあることを確認する
-- **期待結果**: 4モードすべてで fallback 期間中もモード名見出しが存在し、遅いデータ取得でも見出しセレクタが安定する
+  3. BM は `バトルモード` または `Battle Mode`、MR は `マッチレース` または `Match Race`、GP は `グランプリ` または `Grand Prix`、TA は `タイムアタック` / `Time Attack` / `Time Trial` のいずれかを含む見出しがあることを確認する
+- **期待結果**: 4モードすべてで fallback/client loading 期間中もモード名見出しが存在し、遅いデータ取得でも見出しセレクタが安定する
 - **スクリプト**: tc-all.js TC-357
 
 ## TC-401: 全モードトーナメント — TA/BM/MR/GP の予選データが正しく存在する

--- a/smkc-score-app/__tests__/components/ui/loading-skeleton.test.tsx
+++ b/smkc-score-app/__tests__/components/ui/loading-skeleton.test.tsx
@@ -4,7 +4,10 @@
 
 import { render, screen } from '@testing-library/react';
 
-import { QualificationFallback } from '@/components/ui/loading-skeleton';
+import {
+  QualificationClientLoadingState,
+  QualificationFallback,
+} from '@/components/ui/loading-skeleton';
 
 describe('QualificationFallback', () => {
   it('renders the supplied mode title as a level-one heading', () => {
@@ -23,5 +26,13 @@ describe('QualificationFallback', () => {
     render(<QualificationFallback title="" />);
 
     expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+  });
+});
+
+describe('QualificationClientLoadingState', () => {
+  it('keeps the supplied mode title as a level-one heading during client loading', () => {
+    render(<QualificationClientLoadingState title="バトルモード" />);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'バトルモード' })).toBeInTheDocument();
   });
 });

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -263,7 +263,7 @@ describe('E2E case drift coverage', () => {
     expect(tc356Block).not.toContain('document.querySelector("div.overflow-x-auto")');
   });
 
-  it('keeps TC-357 checking exact mode-title h1 fallback headings', () => {
+  it('keeps TC-357 checking exact mode-title h1 fallback and client loading headings', () => {
     const section = e2eCaseSection('TC-357');
     const tc357Block = sectionBetween(tcAll, '// TC-357:', '// TC-104:');
 
@@ -272,9 +272,11 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('`バトルモード` または `Battle Mode`');
     expect(section).toContain('`マッチレース` または `Match Race`');
     expect(section).toContain('`グランプリ` または `Grand Prix`');
-    expect(section).toContain('`タイムアタック` または `Time Attack`');
+    expect(section).toContain('`タイムアタック` / `Time Attack` / `Time Trial`');
     expect(qualificationFallbackTest).toContain('QualificationFallback');
+    expect(qualificationFallbackTest).toContain('QualificationClientLoadingState');
     expectHeadingRoleOptions(qualificationFallbackTest, 'getByRole', [/name:\s*["']グランプリ["']/]);
+    expect(qualificationFallbackTest).toContain("name: 'バトルモード'");
     expectHeadingRoleOptions(qualificationFallbackTest, 'queryByRole', []);
     expect(qualificationFallbackTest).toContain('title=""');
     expect(tc357Block).toContain("waitUntil: 'domcontentloaded'");
@@ -285,7 +287,7 @@ describe('E2E case drift coverage', () => {
     expect(tc357Block).toContain("bm: ['バトルモード', 'Battle Mode']");
     expect(tc357Block).toContain("mr: ['マッチレース', 'Match Race']");
     expect(tc357Block).toContain("gp: ['グランプリ', 'Grand Prix']");
-    expect(tc357Block).toContain("ta: ['タイムアタック', 'Time Attack']");
+    expect(tc357Block).toContain("ta: ['タイムアタック', 'Time Attack', 'Time Trial']");
   });
 
   it('documents TC-816A as CDM finals native bracket coordinate coverage', () => {

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -4273,11 +4273,11 @@ async function main() {
     }
   }
 
-  // TC-357: PPR mode page fallback renders a mode-title h1 immediately (before streaming)
-  // Verifies that the QualificationFallback Suspense skeleton includes the
-  // exact mode title in an h1, not just any heading on the page, so regressions
-  // in the fallback title prop are detected even on slow D1 fetches
-  // (issue #809). Tests the static shell by checking HTTP response HTML.
+  // TC-357: PPR mode page fallback/client loading renders a mode-title h1 immediately.
+  // Verifies that both the QualificationFallback Suspense skeleton and the
+  // client-side first-load skeleton keep the mode title in an h1, not just any
+  // heading on the page, so regressions in the initial shell are detected even
+  // on slow D1 fetches (issue #2075).
   if (TID) {
     const modes357 = ['bm', 'mr', 'gp', 'ta'];
     const results357 = [];
@@ -4292,7 +4292,7 @@ async function main() {
           bm: ['バトルモード', 'Battle Mode'],
           mr: ['マッチレース', 'Match Race'],
           gp: ['グランプリ', 'Grand Prix'],
-          ta: ['タイムアタック', 'Time Attack'],
+          ta: ['タイムアタック', 'Time Attack', 'Time Trial'],
         };
         const hasExpectedTitle = await page.evaluate((titles) => {
           const headings = Array.from(document.querySelectorAll('h1'));

--- a/smkc-score-app/src/app/tournaments/[id]/bm/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/bm/page-client.tsx
@@ -77,7 +77,7 @@ import { usePolling } from "@/lib/hooks/usePolling";
 import type { QualInitialData } from "@/lib/api-factories/qual-initial-data";
 import { useQualificationActions } from "@/lib/hooks/useQualificationActions";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
-import { CardSkeleton } from "@/components/ui/loading-skeleton";
+import { QualificationClientLoadingState } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
 import { parseManualScore } from "@/lib/parse-manual-score";
 import {
@@ -434,18 +434,7 @@ export default function BattleModePageClient({
 
   /* Loading skeleton shown only on first visit (no cached data yet) */
   if (!pollData) {
-    return (
-      <div className="space-y-6">
-        <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4">
-          <div className="space-y-3">
-            <div className="h-9 w-32 bg-muted animate-pulse rounded" />
-            <div className="h-5 w-48 bg-muted animate-pulse rounded" />
-          </div>
-          <div className="h-10 w-24 bg-muted animate-pulse rounded" />
-        </div>
-        <CardSkeleton />
-      </div>
-    );
+    return <QualificationClientLoadingState title={t('title')} titleSkeletonClassName="w-48" />;
   }
 
   return (

--- a/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/page-client.tsx
@@ -80,7 +80,7 @@ import { usePolling } from "@/lib/hooks/usePolling";
 import type { QualInitialData } from "@/lib/api-factories/qual-initial-data";
 import { useQualificationActions } from "@/lib/hooks/useQualificationActions";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
-import { CardSkeleton } from "@/components/ui/loading-skeleton";
+import { QualificationClientLoadingState } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
 import {
   canCreateFinalsFromQualification,
@@ -589,18 +589,7 @@ export default function GrandPrixPageClient({
 
   /* Loading skeleton shown only on first visit (no cached data yet) */
   if (!pollData) {
-    return (
-      <div className="space-y-6">
-        <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4">
-          <div className="space-y-3">
-            <div className="h-9 w-32 bg-muted animate-pulse rounded" />
-            <div className="h-5 w-48 bg-muted animate-pulse rounded" />
-          </div>
-          <div className="h-10 w-24 bg-muted animate-pulse rounded" />
-        </div>
-        <CardSkeleton />
-      </div>
-    );
+    return <QualificationClientLoadingState title={t('title')} titleSkeletonClassName="w-48" />;
   }
 
   return (

--- a/smkc-score-app/src/app/tournaments/[id]/mr/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/mr/page-client.tsx
@@ -75,7 +75,7 @@ import { usePolling } from "@/lib/hooks/usePolling";
 import type { QualInitialData } from "@/lib/api-factories/qual-initial-data";
 import { useQualificationActions } from "@/lib/hooks/useQualificationActions";
 import { UpdateIndicator } from "@/components/ui/update-indicator";
-import { CardSkeleton } from "@/components/ui/loading-skeleton";
+import { QualificationClientLoadingState } from "@/components/ui/loading-skeleton";
 import { createLogger } from "@/lib/client-logger";
 import {
   canCreateFinalsFromQualification,
@@ -482,18 +482,7 @@ export default function MatchRacePageClient({
 
   /* Loading skeleton shown only on first visit (no cached data yet) */
   if (!pollData) {
-    return (
-      <div className="space-y-6">
-        <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4">
-          <div className="space-y-3">
-            <div className="h-9 w-32 bg-muted animate-pulse rounded" />
-            <div className="h-5 w-48 bg-muted animate-pulse rounded" />
-          </div>
-          <div className="h-10 w-24 bg-muted animate-pulse rounded" />
-        </div>
-        <CardSkeleton />
-      </div>
-    );
+    return <QualificationClientLoadingState title={t('title')} titleSkeletonClassName="w-48" />;
   }
 
   return (

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
@@ -73,7 +73,7 @@ import { autoFormatTime, generateRandomTimeString, msToDisplayTime, timeToMs } f
 import { usePolling } from "@/lib/hooks/usePolling";
 import { useBroadcastReflect } from "@/lib/hooks/use-broadcast-reflect";
 import type { TaInitialData } from "@/lib/ta/initial-data";
-import { CardSkeleton } from "@/components/ui/loading-skeleton";
+import { QualificationClientLoadingState } from "@/components/ui/loading-skeleton";
 import { Dice5, ChevronDown, ChevronRight, Eye, Lock, Unlock } from "lucide-react";
 import { toast } from "sonner";
 import { createLogger } from "@/lib/client-logger";
@@ -681,17 +681,7 @@ export default function TimeAttackPageClient({
 
   // === Loading State (only on first visit with no cached data) ===
   if (!pollData) {
-    return (
-      <div className="space-y-6">
-        <div className="flex justify-between items-center">
-          <div className="space-y-3">
-            <div className="h-9 w-24 bg-muted animate-pulse rounded" />
-            <div className="h-5 w-48 bg-muted animate-pulse rounded" />
-          </div>
-        </div>
-        <CardSkeleton />
-      </div>
-    );
+    return <QualificationClientLoadingState title={t('title')} titleSkeletonClassName="w-48" />;
   }
 
   // === Error State ===

--- a/smkc-score-app/src/components/ui/loading-skeleton.tsx
+++ b/smkc-score-app/src/components/ui/loading-skeleton.tsx
@@ -153,3 +153,27 @@ export function QualificationFallback({ title }: { title?: string } = {}) {
     </div>
   );
 }
+
+/** Client-side first-load skeleton for BM/MR/GP/TA qualification pages.
+ * Keeps the mode h1 mounted after the RSC fallback resolves but before polling
+ * data hydrates, so immediate E2E heading checks do not race the client shell. */
+export function QualificationClientLoadingState({
+  title,
+  titleSkeletonClassName = "w-32",
+}: {
+  title: string;
+  titleSkeletonClassName?: string;
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4">
+        <div className="space-y-3">
+          <h1 className="text-2xl font-semibold">{title}</h1>
+          <Skeleton className={cn("h-5", titleSkeletonClassName)} />
+        </div>
+        <Skeleton className="h-10 w-24" />
+      </div>
+      <CardSkeleton />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Keep BM/MR/GP/TA qualification mode headings mounted during client first-load skeletons
- Update TC-357 coverage and drift guards for fallback/client loading heading contract
- Add component coverage for the shared qualification client loading state

## Issues
Closes #2075

## Validation
- npm test -- __tests__/components/ui/loading-skeleton.test.tsx __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npx eslint __tests__/components/ui/loading-skeleton.test.tsx __tests__/docs/e2e-cases-drift.test.ts 'src/app/tournaments/[id]/bm/page-client.tsx' 'src/app/tournaments/[id]/mr/page-client.tsx' 'src/app/tournaments/[id]/gp/page-client.tsx' 'src/app/tournaments/[id]/ta/page-client.tsx' src/components/ui/loading-skeleton.tsx --max-warnings=0

Note: full `npm run lint -- --max-warnings=0` still fails on 42 pre-existing warnings outside this change.
