### PR TITLE
Fix TC-816A CDM finals fixture setup

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -754,11 +754,12 @@
 - **URL**: /api/tournaments/[id]/export?format=cdm
 - **背景**: issue #816。CDM Finals シートは dense table ではなく固定 bracket レイアウトなので、match を順番に詰めると Barrage / Top 16 / Upper / Lower / GF / Reset の位置がずれる。
 - **手順**:
-  1. playoff、winners、losers、grand final、reset の各 round を含む CDM export fixture を作る
-  2. BM/MR/GP Finals の round が `CDM_FINALS_BRACKET_SLOTS` の block/row 座標へ配置されることを確認する
-  3. GP Finals の cupResults summary が移動先の bracket slot に残ることを確認する
+  1. 共有大会の BM/MR/GP finals state を確認し、slot-mappable finals match がない mode は top 24 の finals を生成して CDM export fixture を準備する
+  2. 生成後も finals match がない mode は、mode 別 match count と round 一覧を診断ログに出して失敗する
+  3. BM/MR/GP Finals の round が `CDM_FINALS_BRACKET_SLOTS` の block/row 座標へ配置されることを確認する
+  4. GP Finals の cupResults summary が移動先の bracket slot に残ることを確認する
 - **期待結果**: finals match は CDM 2025 テンプレートの native bracket coordinates に配置され、GP の cup/points 補足情報も失われない
-- **スクリプト**: `tc-all.js TC-816A`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+- **スクリプト**: `tc-all.js TC-816A`, `__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
 
 ## TC-1877A: CDM export — grand_final_reset の正規化で到達不能条件を残さない
 - **URL**: /api/tournaments/[id]/export?format=cdm

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -309,7 +309,13 @@ describe('E2E case drift coverage', () => {
     expect(tcAll).toContain('cdmE2eGpCupResultsSummary');
     expect(tcAll).toContain('gpCupResultsChecked');
     expect(tcAll).toContain('checkedByMode');
+    expect(tcAll).toContain('ensureCdmE2eFinalsFixture');
+    expect(tcAll).toContain('apiGenerateBmFinals(page, tournamentId, 24)');
+    expect(tcAll).toContain('apiGenerateMrFinals(page, tournamentId, 24)');
+    expect(tcAll).toContain('cdmE2eFinalsReadinessSummary');
     expect(tcAll).toContain('slot.blockStart + 5');
+    expect(section).toContain('mode 別 match count と round 一覧');
+    expect(section).toContain('__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts');
     expect(exportRouteTest).toContain('should place CDM finals matches in native bracket coordinates');
     expect(exportRouteTest).toContain('sheet.Y7.v');
     expect(exportRouteTest).toContain('sheet.BA47.v');

--- a/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
@@ -1,0 +1,52 @@
+import {
+  cdmE2eFinalsMatches,
+  cdmE2eFinalsReadinessDetails,
+  cdmE2eFinalsReadinessSummary,
+} from '../../e2e/tc-all';
+
+describe('TC-816A CDM finals fixture readiness', () => {
+  it('counts slot-mappable playoff and finals matches by mode', () => {
+    const readiness = cdmE2eFinalsReadinessDetails([
+      {
+        mode: 'BM',
+        state: {
+          playoffMatches: [{ round: 'playoff_r1', bracketPosition: 'P1' }],
+          matches: [{ round: 'winners_r1', bracketPosition: 'W1' }],
+        },
+      },
+      { mode: 'MR', state: { playoffMatches: [], matches: [] } },
+      {
+        mode: 'GP',
+        state: {
+          matches: [
+            { round: 'gf', bracketPosition: 'GF' },
+            { round: 'ignored_round', bracketPosition: 'table-only' },
+          ],
+        },
+      },
+    ]);
+
+    expect(readiness).toEqual([
+      { mode: 'BM', count: 2, rounds: ['playoff_r1', 'winners_r1'] },
+      { mode: 'MR', count: 0, rounds: [] },
+      { mode: 'GP', count: 1, rounds: ['grand_final'] },
+    ]);
+  });
+
+  it('prints actionable per-mode readiness diagnostics', () => {
+    expect(cdmE2eFinalsReadinessSummary([
+      { mode: 'BM', count: 2, rounds: ['playoff_r1', 'winners_r1'] },
+      { mode: 'MR', count: 0, rounds: [] },
+    ])).toBe('BM=2 rounds=playoff_r1/winners_r1; MR=0 rounds=<none>');
+  });
+
+  it('keeps reset and grand final matches mappable for workbook checks', () => {
+    expect(cdmE2eFinalsMatches({
+      matches: [
+        { round: 'grand_final_reset', bracketPosition: 'Reset' },
+        { round: 'gf', bracketPosition: 'GF' },
+        { round: 'not_exported', bracketPosition: 'table-only' },
+      ],
+    })).toHaveLength(2);
+  });
+});

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -35,6 +35,8 @@ const {
   setupModePlayersViaUi,
   makeTaTimesForRank,
   apiPutAllGpQualScores,
+  apiGenerateBmFinals,
+  apiGenerateMrFinals,
   apiGenerateGpFinals,
   apiFetchBmFinalsState,
   apiFetchMrFinalsState,
@@ -115,6 +117,44 @@ function cdmE2eFinalsMatches(state) {
     ...(state?.playoffMatches || []),
     ...(state?.matches || []),
   ].filter((match) => cdmE2eSlotRound(match));
+}
+
+function cdmE2eFinalsReadinessDetails(modeStates) {
+  return modeStates.map(({ mode, state }) => {
+    const matches = cdmE2eFinalsMatches(state);
+    const rounds = [...new Set(matches.map((match) => cdmE2eSlotRound(match)).filter(Boolean))];
+    return { mode, count: matches.length, rounds };
+  });
+}
+
+function cdmE2eFinalsReadinessSummary(readinessDetails) {
+  return readinessDetails
+    .map(({ mode, count, rounds }) => `${mode}=${count} rounds=${rounds.length > 0 ? rounds.join('/') : '<none>'}`)
+    .join('; ');
+}
+
+async function ensureCdmE2eFinalsFixture(page, tournamentId) {
+  const fetchModeStates = async () => ([
+    { mode: 'BM', sheetName: 'BM Finals', state: await apiFetchBmFinalsState(page, tournamentId) },
+    { mode: 'MR', sheetName: 'MR Finals', state: await apiFetchMrFinalsState(page, tournamentId) },
+    { mode: 'GP', sheetName: 'GP Finals', state: await apiFetchGpFinalsState(page, tournamentId) },
+  ]);
+
+  let modeStates = await fetchModeStates();
+  let readinessDetails = cdmE2eFinalsReadinessDetails(modeStates);
+  const missingModes = new Set(readinessDetails.filter(({ count }) => count === 0).map(({ mode }) => mode));
+
+  if (missingModes.size > 0) {
+    const generators = [];
+    if (missingModes.has('BM')) generators.push(apiGenerateBmFinals(page, tournamentId, 24));
+    if (missingModes.has('MR')) generators.push(apiGenerateMrFinals(page, tournamentId, 24));
+    if (missingModes.has('GP')) generators.push(apiGenerateGpFinals(page, tournamentId, 24));
+    await Promise.all(generators);
+    modeStates = await fetchModeStates();
+    readinessDetails = cdmE2eFinalsReadinessDetails(modeStates);
+  }
+
+  return { modeStates, readinessDetails };
 }
 
 function cdmE2eGpCupResultsSummary(match) {
@@ -3293,30 +3333,22 @@ async function main() {
     const exportTid = sharedFixture?.tournamentId ?? TID;
     if (exportTid) {
       try {
-        const [bmState, mrState, gpState, exportResp] = await Promise.all([
-          apiFetchBmFinalsState(page, exportTid),
-          apiFetchMrFinalsState(page, exportTid),
-          apiFetchGpFinalsState(page, exportTid),
-          page.evaluate(async (url) => {
-            const response = await fetch(url, { credentials: 'same-origin' });
-            const buffer = await response.arrayBuffer();
-            return {
-              status: response.status,
-              bytes: Array.from(new Uint8Array(buffer)),
-              contentType: response.headers.get('content-type') || '',
-            };
-          }, `${BASE}/api/tournaments/${exportTid}/export?format=cdm`),
-        ]);
+        const { modeStates, readinessDetails } = await ensureCdmE2eFinalsFixture(page, exportTid);
+        const readinessSummary = cdmE2eFinalsReadinessSummary(readinessDetails);
+        const exportResp = await page.evaluate(async (url) => {
+          const response = await fetch(url, { credentials: 'same-origin' });
+          const buffer = await response.arrayBuffer();
+          return {
+            status: response.status,
+            bytes: Array.from(new Uint8Array(buffer)),
+            contentType: response.headers.get('content-type') || '',
+          };
+        }, `${BASE}/api/tournaments/${exportTid}/export?format=cdm`);
 
         if (exportResp.status !== 200) {
           log('TC-816A', 'FAIL', `CDM export HTTP ${exportResp.status}`);
         } else {
           const workbook = XLSX.read(Buffer.from(exportResp.bytes), { type: 'buffer' });
-          const modeStates = [
-            { mode: 'BM', sheetName: 'BM Finals', state: bmState },
-            { mode: 'MR', sheetName: 'MR Finals', state: mrState },
-            { mode: 'GP', sheetName: 'GP Finals', state: gpState },
-          ];
           const failures = [];
           let checked = 0;
           let gpCupResultsChecked = false;
@@ -3356,8 +3388,8 @@ async function main() {
 
           log('TC-816A',
             checked > 0 && missingModes.length === 0 && failures.length === 0 ? 'PASS' : 'FAIL',
-            checked === 0 ? 'No finals matches available for CDM coordinate verification'
-            : missingModes.length > 0 ? `No finals matches checked for modes: ${missingModes.join(', ')}`
+            checked === 0 ? `No finals matches available for CDM coordinate verification (${readinessSummary})`
+            : missingModes.length > 0 ? `No finals matches checked for modes: ${missingModes.join(', ')} (${readinessSummary})`
             : failures.length > 0 ? failures.slice(0, 3).join('; ')
             : !gpCupResultsChecked ? 'GP cupResults not available; skipped summary-cell check'
             : '');
@@ -4405,4 +4437,7 @@ if (require.main === module) {
 
 module.exports = {
   pageFetchJson,
+  cdmE2eFinalsMatches,
+  cdmE2eFinalsReadinessDetails,
+  cdmE2eFinalsReadinessSummary,
 };


### PR DESCRIPTION
Summary
- Ensure TC-816A generates missing BM/MR/GP finals before reading the CDM workbook.
- Add per-mode finals readiness diagnostics and focused coverage for slot-mappable finals state.
- Update the E2E scenario drift guard to document the fixture setup contract.

Issues: Closes #2073

Validation
- npm test -- __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/tc-816a-cdm-finals-fixture.test.ts --runInBand
- npm test -- __tests__/lib/broadcast-input.test.ts --runInBand
- npx eslint --no-warn-ignored __tests__/e2e/tc-816a-cdm-finals-fixture.test.ts __tests__/docs/e2e-cases-drift.test.ts
- node -c e2e/tc-all.js
- git diff --check