### PR TITLE
chore: export cdm e2e finals fixture helper

### DIFF
--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -4440,4 +4440,5 @@ module.exports = {
   cdmE2eFinalsMatches,
   cdmE2eFinalsReadinessDetails,
   cdmE2eFinalsReadinessSummary,
+  ensureCdmE2eFinalsFixture,
 };


### PR DESCRIPTION
## Summary
- Add `ensureCdmE2eFinalsFixture` to the CommonJS exports in `smkc-score-app/e2e/tc-all.js`.
- Allow future focused tests to import the CDM finals fixture helper without changing runtime behavior.

## Issues
Closes #2101

## Validation
- GitHub CI: `Lint & Test` passed on PR #2102
- Cloudflare Workers build passed on PR #2102
