### PR TITLE
Fix preview D1 preflight diagnostics

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -256,7 +256,9 @@
   3. 必須カラムが欠落している場合はブラウザを起動せず、`npm run db:migrations:apply:preview` を促すエラーで停止することを確認する
   4. Wrangler の auth token 取得失敗や log file 書き込み失敗は schema 欠落として扱わず、`wrangler login` / `CLOUDFLARE_API_TOKEN` と `WRANGLER_LOG_PATH` の確認を促すことを確認する
   5. runner が `WRANGLER_LOG_PATH` 未指定時に writable な一時ログパスを渡し、`~/Library/Preferences/.wrangler/logs` 権限で停止しないことを確認する
-  6. `GPMatch.assignedCups` と `GPMatch.suddenDeathWinnerId` が wrangler-format migration にも存在することを確認する
+  6. Wrangler が stderr/stdout なしで一時的に exit 1 を返した場合は1回だけ再試行し、再失敗時も schema drift と断定せず command/status/stdout/stderr の診断を出すことを確認する
+  7. schema drift と明確に判定できる stderr または必須カラム欠落時のみ `npm run db:migrations:apply:preview` を促すことを確認する
+  8. `GPMatch.assignedCups` と `GPMatch.suddenDeathWinnerId` が wrangler-format migration にも存在することを確認する
 - **期待結果**: preview D1 schema drift は TC 本体の 500 ではなく、起動前 preflight の明示エラーとして検出される
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
 - **補助検証**: `smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts`

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -141,15 +141,61 @@ describe('preview schema preflight', () => {
     );
   });
 
-  it('fails with migration guidance when wrangler cannot run the check', () => {
+  it('fails with migration guidance when wrangler reports a clear schema error', () => {
     const preflight = loadPreflight();
     spawnSyncMock.mockReturnValue({
       status: 1,
       stdout: '',
-      stderr: 'No migrations to apply',
+      stderr: 'SQLITE_ERROR: no such column: suddenDeathWinnerId',
     });
 
     expect(() => preflight.assertPreviewD1Schema({})).toThrow(/db:migrations:apply:preview/);
+  });
+
+  it('retries empty Wrangler status 1 once and keeps migration guidance out of transient diagnostics', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: '',
+      stderr: '',
+    });
+
+    let message = '';
+    try {
+      preflight.assertPreviewD1Schema({});
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+    expect(message).toMatch(/Wrangler exited non-zero before preview D1 schema could be verified/);
+    expect(message).toMatch(/Command: wrangler d1 execute DB --remote --env preview --json --command/);
+    expect(message).toMatch(/Command exited 1/);
+    expect(message).toMatch(/stderr: \(empty\)/);
+    expect(message).toMatch(/stdout: \(empty\)/);
+    expect(message).not.toMatch(/db:migrations:apply:preview/);
+  });
+
+  it('preserves non-schema Wrangler stderr without classifying it as migration drift', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: 'Checking preview database...',
+      stderr: 'Network connection reset by peer',
+    });
+
+    let message = '';
+    try {
+      preflight.assertPreviewD1Schema({});
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    expect(message).toMatch(/Wrangler exited non-zero before preview D1 schema could be verified/);
+    expect(message).toMatch(/stderr: Network connection reset by peer/);
+    expect(message).toMatch(/stdout: Checking preview database/);
+    expect(message).not.toMatch(/db:migrations:apply:preview/);
   });
 
   it('does not classify generic wrangler login help text as an auth failure', () => {

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -9,6 +9,7 @@ const REQUIRED_PREVIEW_COLUMNS = [
 ];
 const WRANGLER_TIMEOUT_MS = 30_000;
 const DEFAULT_WRANGLER_LOG_PATH = path.join(os.tmpdir(), 'jsmkc-wrangler-preflight.log');
+const WRANGLER_TRANSIENT_STATUS_RETRIES = 1;
 
 function buildPreviewSchemaCheckSql(columns = REQUIRED_PREVIEW_COLUMNS) {
   return columns
@@ -80,8 +81,46 @@ function isWranglerAuthOrLogFailure(stderr) {
   ].some((pattern) => pattern.test(stderr));
 }
 
+function isWranglerSchemaFailure(stderr) {
+  return [
+    /no such (table|column)/i,
+    /SQLITE_ERROR/i,
+    /migration/i,
+    /schema/i,
+  ].some((pattern) => pattern.test(stderr));
+}
+
+function boundedOutput(value, maxLength = 800) {
+  const text = String(value || '').trim();
+  if (!text) return '(empty)';
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength)}...`;
+}
+
 function formatPreflightError(lines) {
   return lines.filter(Boolean).join('\n');
+}
+
+function runWranglerSchemaCheck(sql, wranglerEnv) {
+  const args = ['d1', 'execute', 'DB', '--remote', '--env', 'preview', '--json', '--command', sql];
+  let result;
+
+  for (let attempt = 0; attempt <= WRANGLER_TRANSIENT_STATUS_RETRIES; attempt += 1) {
+    result = spawnSync('wrangler', args, {
+      encoding: 'utf8',
+      cwd: process.cwd(),
+      env: wranglerEnv,
+      timeout: WRANGLER_TIMEOUT_MS,
+    });
+
+    const stderr = String(result.stderr || '').trim();
+    const stdout = String(result.stdout || '').trim();
+    if (result.status === 0 || result.error || stderr || stdout || attempt === WRANGLER_TRANSIENT_STATUS_RETRIES) {
+      return { result, args };
+    }
+  }
+
+  return { result, args };
 }
 
 function assertPreviewD1Schema(env = process.env) {
@@ -89,11 +128,7 @@ function assertPreviewD1Schema(env = process.env) {
 
   const sql = buildPreviewSchemaCheckSql();
   const wranglerEnv = buildWranglerEnv(env);
-  const result = spawnSync(
-    'wrangler',
-    ['d1', 'execute', 'DB', '--remote', '--env', 'preview', '--json', '--command', sql],
-    { encoding: 'utf8', cwd: process.cwd(), env: wranglerEnv, timeout: WRANGLER_TIMEOUT_MS },
-  );
+  const { result, args } = runWranglerSchemaCheck(sql, wranglerEnv);
 
   if (result.error?.code === 'ETIMEDOUT') {
     throw new Error(
@@ -130,10 +165,14 @@ function assertPreviewD1Schema(env = process.env) {
 
     throw new Error(
       formatPreflightError([
-        'Preview D1 schema preflight failed before launching the browser.',
+        'Wrangler exited non-zero before preview D1 schema could be verified.',
         `Command exited ${result.status}.`,
-        stderr ? `stderr: ${stderr}` : '',
-        'Run npm run db:migrations:apply:preview, then retry npm run e2e:preview.',
+        `Command: wrangler ${args.join(' ')}`,
+        `stderr: ${boundedOutput(result.stderr)}`,
+        `stdout: ${boundedOutput(result.stdout)}`,
+        isWranglerSchemaFailure(stderr)
+          ? 'Run npm run db:migrations:apply:preview, then retry npm run e2e:preview.'
+          : 'Wrangler returned a generic nonzero status; check the command output above, then retry npm run e2e:preview.',
       ]),
     );
   }
@@ -159,7 +198,9 @@ module.exports = {
   buildWranglerEnv,
   buildPreviewSchemaCheckSql,
   DEFAULT_WRANGLER_LOG_PATH,
+  isWranglerSchemaFailure,
   isWranglerAuthOrLogFailure,
   parsePresentColumns,
+  WRANGLER_TRANSIENT_STATUS_RETRIES,
   WRANGLER_TIMEOUT_MS,
 };


### PR DESCRIPTION
## Summary
- Add TC-111 scenario coverage for transient Wrangler preview D1 preflight failures.
- Retry one empty-output Wrangler status 1 before failing, and include command/status/stdout/stderr diagnostics on generic nonzero exits.
- Keep migration guidance limited to confirmed missing columns or clear schema/migration errors.

## Issues
Closes #2071

## Validation
- `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npm run lint` (exit 0; existing warnings only)
