### PR TITLE
Fix TA preview suite timeout

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -100,6 +100,18 @@
 - **スクリプト**: tc-all.js TC-2070B
 - **補助検証**: `smkc-score-app/__tests__/app/api/internal/vitals/route.test.ts`
 
+## TC-2078: TA preview suite は 35分 soft timeout で中断しない
+- **URL**: n/a (runner configuration / preview suite)
+- **authRequired**: true (admin profile for full preview run)
+- **背景**: issue #2078。TA suite は 29ケースを持ち、共有28人fixture、isolated tournament、phase-chain coverage を維持するため preview では 35分上限を超えることがある。通常の `npm run e2e:preview:all` / `npm run e2e:preview:ta` で `[TA] suite timed out after 35m` を出して残りケースを soft abort しないよう、TA suite は明示的な実行時間上限を持つ。
+- **手順**:
+  1. `tc-ta.js` の suite 設定を読み込む
+  2. TA suite が 29ケースを維持していることを確認する
+  3. TA suite 固有の timeout が 35分より長く、`TC-1005` まで実行対象に残ることを確認する
+  4. runner の `E2E_SUITE_TIMEOUT_MS` override が TA 固有 timeout より優先されることを確認する
+- **期待結果**: TA preview suite は通常設定で 75分上限を使い、phase-chain/isolated fixture coverage を削らずに `TC-1005` まで実行できる
+- **スクリプト**: `npm run e2e:preview:ta` / `npm test -- --runTestsByPath __tests__/e2e/ta-suite-timeout.test.ts __tests__/lib/e2e-runner-timeout.test.ts`
+
 ## TC-008: Overall Ranking ページの表示
 - **URL**: /tournaments/[id]/overall-ranking
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -961,6 +961,25 @@ describe('E2E case drift coverage', () => {
     expect(helperTest).toContain('secondEntries');
   });
 
+  it('keeps TC-2078 aligned with TA suite timeout coverage', () => {
+    const section = e2eCaseSection('TC-2078');
+    const tcTaTimeoutTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'ta-suite-timeout.test.ts');
+    const runnerTimeoutTest = readRepoFile('smkc-score-app', '__tests__', 'lib', 'e2e-runner-timeout.test.ts');
+
+    expect(section).toContain('issue #2078');
+    expect(section).toContain('75分上限');
+    expect(section).toContain('29ケース');
+    expect(section).toContain('TC-1005');
+    expect(section).toContain('E2E_SUITE_TIMEOUT_MS');
+    expect(section).toContain('__tests__/e2e/ta-suite-timeout.test.ts');
+    expect(section).toContain('__tests__/lib/e2e-runner-timeout.test.ts');
+    expect(tcTaTimeoutTest).toContain('TA_SUITE_TIMEOUT_MS');
+    expect(tcTaTimeoutTest).toContain('75 * 60 * 1000');
+    expect(tcTaTimeoutTest).toContain('TC-1005');
+    expect(runnerTimeoutTest).toContain('resolveSuiteTimeoutMs');
+    expect(runnerTimeoutTest).toContain('E2E_SUITE_TIMEOUT_MS');
+  });
+
   it('keeps TC-2055 aligned with the sectionBetween allowTerminal contract', () => {
     const section = e2eCaseSection('TC-2055');
     const helper = readRepoFile('smkc-score-app', '__tests__', 'helpers', 'e2e-cases.ts');

--- a/smkc-score-app/__tests__/e2e/ta-suite-timeout.test.ts
+++ b/smkc-score-app/__tests__/e2e/ta-suite-timeout.test.ts
@@ -1,0 +1,19 @@
+describe('TC-2078 TA E2E suite timeout contract', () => {
+  it('runs the full TA suite with an explicit preview-sized timeout', async () => {
+    const taSuite = await import('../../e2e/tc-ta.js') as {
+      TA_SUITE_TIMEOUT_MS: number;
+      getSuite: () => {
+        suiteTimeoutMs?: number;
+        tests: Array<{ name: string }>;
+      };
+    };
+
+    const suite = taSuite.getSuite();
+
+    expect(taSuite.TA_SUITE_TIMEOUT_MS).toBe(75 * 60 * 1000);
+    expect(suite.suiteTimeoutMs).toBe(taSuite.TA_SUITE_TIMEOUT_MS);
+    expect(suite.suiteTimeoutMs).toBeGreaterThan(35 * 60 * 1000);
+    expect(suite.tests.map((test) => test.name)).toContain('TC-1005');
+    expect(suite.tests).toHaveLength(29);
+  });
+});

--- a/smkc-score-app/__tests__/lib/e2e-runner-timeout.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-runner-timeout.test.ts
@@ -1,0 +1,30 @@
+describe('E2E runner suite timeout resolution', () => {
+  const originalTimeout = process.env.E2E_SUITE_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (originalTimeout === undefined) {
+      delete process.env.E2E_SUITE_TIMEOUT_MS;
+    } else {
+      process.env.E2E_SUITE_TIMEOUT_MS = originalTimeout;
+    }
+    jest.resetModules();
+  });
+
+  it('uses a suite-specific timeout when no environment override is set', async () => {
+    delete process.env.E2E_SUITE_TIMEOUT_MS;
+    const runner = await import('../../e2e/lib/runner.js') as {
+      resolveSuiteTimeoutMs: (explicitTimeoutMs?: number | null) => number;
+    };
+
+    expect(runner.resolveSuiteTimeoutMs(75 * 60 * 1000)).toBe(75 * 60 * 1000);
+  });
+
+  it('keeps E2E_SUITE_TIMEOUT_MS as the highest-priority override', async () => {
+    process.env.E2E_SUITE_TIMEOUT_MS = String(42 * 60 * 1000);
+    const runner = await import('../../e2e/lib/runner.js') as {
+      resolveSuiteTimeoutMs: (explicitTimeoutMs?: number | null) => number;
+    };
+
+    expect(runner.resolveSuiteTimeoutMs(75 * 60 * 1000)).toBe(42 * 60 * 1000);
+  });
+});

--- a/smkc-score-app/e2e/lib/runner.js
+++ b/smkc-score-app/e2e/lib/runner.js
@@ -19,6 +19,10 @@ function envMs(name, fallback) {
   return Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
+function resolveSuiteTimeoutMs(explicitTimeoutMs = null) {
+  return envMs('E2E_SUITE_TIMEOUT_MS', explicitTimeoutMs || DEFAULT_SUITE_TIMEOUT_MS);
+}
+
 function formatDuration(ms) {
   if (ms < 1000) return `${ms}ms`;
   const seconds = Math.round(ms / 1000);
@@ -154,11 +158,12 @@ async function runSuiteInBrowser({
   results,
   log,
   tests,
+  suiteTimeoutMs: explicitSuiteTimeoutMs = null,
   beforeAll = null,
   afterAll = null,
 }) {
   if (!page) throw new Error('runSuiteInBrowser requires an open page');
-  const suiteTimeoutMs = envMs('E2E_SUITE_TIMEOUT_MS', DEFAULT_SUITE_TIMEOUT_MS);
+  const suiteTimeoutMs = resolveSuiteTimeoutMs(explicitSuiteTimeoutMs);
   /* In-process composition: a single 28-player finals "first" test (e.g.
    * TC-604, TC-503, TC-703) consumes ~40 min just to UI-seed 182 matches
    * before any assertion runs. The standalone runSuite path inherited the
@@ -231,8 +236,16 @@ async function runSuiteInBrowser({
   return { failed: forcedFailure || summary.failed > 0, summary };
 }
 
-async function runSuite({ suiteName, results, log, tests, beforeAll = null, afterAll = null }) {
-  const suiteTimeoutMs = envMs('E2E_SUITE_TIMEOUT_MS', DEFAULT_SUITE_TIMEOUT_MS);
+async function runSuite({
+  suiteName,
+  results,
+  log,
+  tests,
+  suiteTimeoutMs: explicitSuiteTimeoutMs = null,
+  beforeAll = null,
+  afterAll = null,
+}) {
+  const suiteTimeoutMs = resolveSuiteTimeoutMs(explicitSuiteTimeoutMs);
   let browser = null;
   let page = null;
 
@@ -284,6 +297,7 @@ module.exports = {
   envMs,
   exitAfterCleanup,
   formatDuration,
+  resolveSuiteTimeoutMs,
   runSuite,
   runSuiteInBrowser,
   summarizeResults,

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -76,6 +76,7 @@ const results = makeResults();
 const log = makeLog(results);
 let sharedFixture = null;
 const TA_PHASE_ROUND_BASE_TIME_MS = 60000;
+const TA_SUITE_TIMEOUT_MS = 75 * 60 * 1000;
 /* Shared TA qualification state. Populated once in beforeAll via
  * setupTaEntriesFromShared so TC-801/802/804/805 do not each re-clear and
  * re-seed 28 players × 20 courses (≈140s per call). Subsequent phase-promoting
@@ -2026,6 +2027,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
   const ownsFixture = !externalFixture;
   return {
     suiteName: 'TA',
+    suiteTimeoutMs: TA_SUITE_TIMEOUT_MS,
     results,
     log,
     beforeAll: async (adminPage) => {
@@ -2098,6 +2100,7 @@ module.exports = {
   runTc801, runTc802, runTc839, runTc804, runTc805, runTc806, runTc807, runTc808, runTc808A, runTc809, runTc810, runTc811,
   runTc837, runTc840, runTc878, runTc896, runTc897, runTc913, runTc1987,
   runTc812, runTc813, runTc814, runTc1032, runTc1033, runTc815, runTc816, runTc817, runTc1005,
+  TA_SUITE_TIMEOUT_MS,
   getSuite,
   results,
   __testHooks: {


### PR DESCRIPTION
Summary
- Add TC-2078 scenario coverage for TA preview suite timeout behavior.
- Allow E2E suites to declare an explicit suite timeout while preserving E2E_SUITE_TIMEOUT_MS override.
- Give the TA suite a 75 minute timeout and add Jest coverage for the TA contract plus runner timeout resolution.

Issues: Closes #2078

Validation
- npm test -- --runTestsByPath __tests__/e2e/ta-suite-timeout.test.ts __tests__/lib/e2e-runner-timeout.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npx eslint --no-warn-ignored e2e/lib/runner.js e2e/tc-ta.js __tests__/e2e/ta-suite-timeout.test.ts __tests__/lib/e2e-runner-timeout.test.ts __tests__/docs/e2e-cases-drift.test.ts
- git diff --check
- node -c smkc-score-app/e2e/lib/runner.js && node -c smkc-score-app/e2e/tc-ta.js
