### PR TITLE
docs: document TA repeat-avoidance rationale

### DIFF
--- a/smkc-score-app/src/lib/ta/course-selection.ts
+++ b/smkc-score-app/src/lib/ta/course-selection.ts
@@ -173,5 +173,9 @@ export async function selectRandomCourse(
     );
   }
 
+  // Keep regular rounds aligned with the previous-change behavior: avoid repeating
+  // the immediate previous course when alternatives exist, so selection stays
+  // predictable and avoids accidental back-to-back repeats under normal play as well
+  // as in sudden-death sequences.
   return selectRandomAvailableCourse(playedCourses, playedCourses[playedCourses.length - 1]);
 }


### PR DESCRIPTION
## Summary
- Document `selectRandomCourse` repeat-avoidance intent for normal TA rounds.
- Keep the existing `selectRandomAvailableCourse` behavior unchanged while clarifying why immediate repeats are avoided when alternatives exist.

## Issues
Closes #823

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts --runInBand
- ./node_modules/.bin/eslint --no-warn-ignored src/lib/ta/course-selection.ts __tests__/docs/e2e-cases-drift.test.ts
- git diff --check main...HEAD