### PR TITLE
test: cover TC-939 reload-only failure

### DIFF
--- a/smkc-score-app/__tests__/lib/tc939-reporting.test.ts
+++ b/smkc-score-app/__tests__/lib/tc939-reporting.test.ts
@@ -33,6 +33,23 @@ describe('describeTc939TabNavigation', () => {
     });
   });
 
+  it('reports reload-only failure without className issues', async () => {
+    const { describeTc939TabNavigation } = await import('../../e2e/lib/tc939-reporting.js') as {
+      describeTc939TabNavigation: (input: {
+        spaMarker: unknown;
+        cleanClasses: boolean;
+      }) => { status: 'PASS' | 'FAIL'; detail: string };
+    };
+
+    expect(describeTc939TabNavigation({
+      spaMarker: 'reload-only',
+      cleanClasses: true,
+    })).toEqual({
+      status: 'FAIL',
+      detail: 'Tab click caused a full document reload',
+    });
+  });
+
   it('reports a className-only failure without a reload message', async () => {
     const { describeTc939TabNavigation } = await import('../../e2e/lib/tc939-reporting.js') as {
       describeTc939TabNavigation: (input: {


### PR DESCRIPTION
## Summary
- Add the missing TC-939 reload-only unit test case
- Confirm reload-only failures report the reload message without a className message

## Issues
Closes #2128

## Validation
- npm test -- --runTestsByPath __tests__/lib/tc939-reporting.test.ts
