### PR TITLE
Clarify GP TC-831/TC-832 order rationale

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -249,12 +249,12 @@ describe('E2E case drift coverage', () => {
 
   it('documents why GP TC-831 stays before TC-832 in the suite order', () => {
     // Regex intent:
-    // - (?:\\n\\s*//[^\\n]*)* allows the rationale comment to wrap across lines.
+    // - [\\s\\S]*? allows the rationale comment to wrap across lines.
     // - \\s* allows formatting drift in spaces and newlines between the comment and array entries.
     // - ['"] accepts either quote style around TC labels in the runner list.
-    // Allow whitespace/quote formatting drift while requiring comment -> TC-831 -> TC-832 adjacency.
+    // Allow multiline comment formatting drift while requiring comment -> TC-831 -> TC-832 adjacency.
     expect(tcGp).toMatch(
-      /\/\/\s*TC-831 stays before TC-832[^\n]*(?:\n\s*\/\/[^\n]*)*\n\s*\{\s*name:\s*['"]TC-831['"]\s*,\s*fn:\s*runTc831\s*\}\s*,\s*\n\s*\{\s*name:\s*['"]TC-832['"]\s*,\s*fn:\s*runTc832\s*\}/,
+      /\/\/\s*TC-831 stays before TC-832[\s\S]*?\n\s*\{\s*name:\s*['"]TC-831['"]\s*,\s*fn:\s*runTc831\s*\}\s*,\s*\n\s*\{\s*name:\s*['"]TC-832['"]\s*,\s*fn:\s*runTc832\s*\}/,
     );
   });
 

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -1837,7 +1837,8 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-712', fn: runTc712 },
       { name: 'TC-719', fn: runTc719 },
       { name: 'TC-720', fn: runTc720 },
-      // TC-831 stays before TC-832 so GP suite logs remain readable in numeric TC order.
+      // TC-831 stays before TC-832 so GP suite logs show numeric progression, keeping the
+      // CI review order easy to scan when one of them fails.
       { name: 'TC-831', fn: runTc831 },
       { name: 'TC-832', fn: runTc832 },
       { name: 'TC-721', fn: runTc721 },


### PR DESCRIPTION
## Summary
- Clarifies the TC-831/TC-832 GP suite ordering rationale inline in `tc-gp.js`.
- Keeps the drift test tolerant of wrapped rationale comments while preserving the TC-831 -> TC-832 adjacency guard.

## Issues
Closes #1774

## Validation
- `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts`
- `npx eslint e2e/tc-gp.js __tests__/docs/e2e-cases-drift.test.ts` (exit 0; `e2e/tc-gp.js` is ignored by existing ESLint ignore pattern)
