### PR TITLE
Clarify phase3 fallback survivor logic

### DIFF
--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -73,12 +73,13 @@ export const PHASE_CONFIG = {
 } as const;
 
 export function getNextPhase3ResetThreshold(activeCount: number): number | null {
+  const minimumPhase3Survivors = PHASE_CONFIG.phase3.survivorsNeeded;
   const thresholds = [...PHASE_CONFIG.phase3.lifeResetThresholds]
     .filter((threshold) => threshold < activeCount)
     .sort((a, b) => b - a);
   // When no configured reset threshold remains below activeCount, fallback to one survivor.
   // This makes the elimination limit activeCount - 1 and protects the last remaining player.
-  return thresholds[0] ?? (activeCount > 1 ? 1 : null);
+  return thresholds[0] ?? (activeCount > minimumPhase3Survivors ? minimumPhase3Survivors : null);
 }
 
 function getPhase3EliminationLimit(activeCount: number): number {


### PR DESCRIPTION
## Summary
- Clarifies the phase3 fallback survivor threshold by naming the survivor guard used when configured reset thresholds no longer apply.
- Addresses Claude's DRY follow-up by sourcing the value from `PHASE_CONFIG.phase3.survivorsNeeded` instead of duplicating `1` locally.

## Issues
Closes #917

## Validation
- `npm test -- --runTestsByPath __tests__/lib/ta/finals-phase-manager.test.ts --runInBand`
- `npm run lint -- src/lib/ta/finals-phase-manager.ts __tests__/lib/ta/finals-phase-manager.test.ts`
