### PR TITLE
test: harden TC-831 drift fixture guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2602,6 +2602,21 @@
   - 正当な改行・インデント変更では guard が落ちない
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/helpers/e2e-cases.test.ts`
 
+## TC-2139: GP E2E drift guard — TC-831/TC-832 負 fixture をコメント文面固定にしない
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #2139。TC-831/TC-832 の順序 rationale を守る負テストで、fixture 注入がコメント全文の完全一致に依存すると、コメントの typo 修正だけで注入が空振りし、原因の分かりにくい失敗になる。
+- **手順**:
+  1. `e2e-cases-drift.test.ts` の TC-831/TC-832 rationale guard を確認する
+  2. 負 fixture 生成が rationale の完全一致文字列ではなく、既存の adjacency 正規表現を使っていることを確認する
+  3. fixture 注入後に `weakenedFixture !== tcGp` を確認し、注入空振りを早期に検出する
+  4. `group-setup-helper.test.ts` が suite spec 経由で TC-831 と TC-832 の隣接順を検証する
+- **期待結果**:
+  - コメント文面だけの安全な変更では負 fixture 注入が壊れない
+  - rationale と TC-831/TC-832 の間に non-comment code が入ると drift guard が落ちる
+  - fixture 注入が空振りした場合は専用アサーションで原因が分かる
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/group-setup-helper.test.ts`
+
 ## TC-1009: 総合ランキング決勝順位 — 16人/Top-24 判定の matchNumber 閾値を明文化する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -262,15 +262,26 @@ describe('E2E case drift coverage', () => {
 
   it('rejects non-comment code between the GP TC-831 rationale and suite entry', () => {
     const weakenedFixture = tcGp.replace(
-      /\/\/ TC-831 stays before TC-832 so GP suite logs show numeric progression, keeping the\n\s*\/\/ CI review order easy to scan when one of them fails.\n/,
+      gpTc831Tc832OrderRationale,
       [
         '// TC-831 stays before TC-832 so GP suite logs show numeric progression, keeping the',
         '// CI review order easy to scan when one of them fails.',
         "      { name: 'TC-999', fn: runTc999 },",
+        "      { name: 'TC-831', fn: runTc831 },",
+        "      { name: 'TC-832', fn: runTc832 },",
       ].join('\n') + '\n',
     );
 
+    expect(weakenedFixture).not.toBe(tcGp);
     expect(weakenedFixture).not.toMatch(gpTc831Tc832OrderRationale);
+  });
+
+  it('keeps TC-2139 documented with the TC-831 fixture-injection guard', () => {
+    const section = e2eCaseSection('TC-2139');
+
+    expect(section).toContain('fixture 注入が空振りした場合');
+    expect(section).toContain('group-setup-helper.test.ts');
+    expect(section).toContain('__tests__/docs/e2e-cases-drift.test.ts');
   });
 
   it('keeps TC-830 aligned with runtime unit and bracket component coverage', () => {

--- a/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
+++ b/smkc-score-app/__tests__/e2e/group-setup-helper.test.ts
@@ -172,6 +172,13 @@ describe('group setup E2E helper', () => {
     expect(tc831Index).toBeLessThan(tc832Index);
   });
 
+  it('keeps GP TC-831 and TC-832 adjacent through suite specs', () => {
+    const gpTestNames = getGpSuite().tests.map((testCase: { name: string }) => testCase.name);
+    const tc831Index = gpTestNames.indexOf('TC-831');
+
+    expect(gpTestNames.slice(tc831Index, tc831Index + 2)).toEqual(['TC-831', 'TC-832']);
+  });
+
   it('checks finals target-win helpers by behavior', () => {
     expect(bmFinalsTargetWinsForMatch({ round: 'winners_r1' })).toBe(5);
     expect(bmFinalsTargetWinsForMatch({ round: 'losers_r3' })).toBe(7);


### PR DESCRIPTION
## Summary
- Adds TC-2139 to the E2E scenario catalog for the GP TC-831/TC-832 drift guard fixture-injection behavior.
- Reuses the existing TC-831/TC-832 adjacency regex when building the negative fixture, then asserts the injection actually changed the fixture before checking rejection.
- Adds suite-spec coverage that TC-831 and TC-832 remain adjacent without relying on source-string scans.

## Issues
Closes #2139

## Validation
- `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/group-setup-helper.test.ts --runInBand`
- `npm run lint -- __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/group-setup-helper.test.ts`
- `git diff --check`
