### PR TITLE
test: remove finals route dead helper

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2602,6 +2602,20 @@
   - 正当な改行・インデント変更では guard が落ちない
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/helpers/e2e-cases.test.ts`
 
+## TC-2136: finals-route.test.ts — 未使用 qualification helper を残さない
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #2136。`__tests__/lib/api-factories/finals-route.test.ts` の `_createMockQualification` は PR #2134 後に参照元がなくなった dead helper で、将来使うかもしれない前提で残すと実際の fixture contract とずれたテスト補助コードが残る。
+- **手順**:
+  1. `finals-route.test.ts` の共有 helper 群を確認する
+  2. 実際に使われる `createMockMatch` と各 describe 内の `createMockQualifications` は残す
+  3. 未使用の `_createMockQualification` が存在しないことを静的ガードで確認する
+- **期待結果**:
+  - finals route factory のテストから未使用 helper が削除されている
+  - 使われている match/qualification fixture helper は維持される
+  - `_createMockQualification` が戻った場合は TC-2136 guard が失敗する
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-2136-finals-route-dead-helper.test.ts __tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-2139: GP E2E drift guard — TC-831/TC-832 負 fixture をコメント文面固定にしない
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -284,6 +284,14 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('__tests__/docs/e2e-cases-drift.test.ts');
   });
 
+  it('keeps TC-2136 documented with the finals-route dead-helper guard', () => {
+    const section = e2eCaseSection('TC-2136');
+
+    expect(section).toContain('_createMockQualification');
+    expect(section).toContain('finals-route.test.ts');
+    expect(section).toContain('__tests__/static/tc-2136-finals-route-dead-helper.test.ts');
+  });
+
   it('keeps TC-830 aligned with runtime unit and bracket component coverage', () => {
     const section = e2eCaseSection('TC-830');
     const pageWiringTest = readRepoFile('smkc-score-app', '__tests__', 'app', 'tournaments', 'gp-finals-page-wiring.test.tsx');

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -90,18 +90,6 @@ describe('Finals Route Factory', () => {
     ...overrides,
   });
 
-  const _createMockQualification = (overrides = {}) => ({
-    id: 'qual-1',
-    playerId: 'player-1',
-    group: 'A',
-    score: 3,
-    wins: 2,
-    losses: 0,
-    points: 6,
-    player: { id: 'player-1', name: 'Player 1' },
-    ...overrides,
-  });
-
   const expectNoBmMatchWrites = () => {
     const matchModel = prisma.bMMatch as any;
     for (const method of ['create', 'createMany', 'deleteMany', 'update', 'updateMany']) {

--- a/smkc-score-app/__tests__/static/tc-2136-finals-route-dead-helper.test.ts
+++ b/smkc-score-app/__tests__/static/tc-2136-finals-route-dead-helper.test.ts
@@ -1,0 +1,17 @@
+import { readRepoFile } from '../helpers/e2e-cases';
+
+describe('TC-2136 finals route test helper cleanup', () => {
+  const source = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'lib',
+    'api-factories',
+    'finals-route.test.ts',
+  );
+
+  it('does not keep the unused qualification helper in finals-route.test.ts', () => {
+    expect(source).toContain('const createMockMatch =');
+    expect(source).toContain('const createMockQualifications =');
+    expect(source).not.toContain('_createMockQualification');
+  });
+});


### PR DESCRIPTION
## Summary
- Remove the unused `_createMockQualification` helper from `finals-route.test.ts`.
- Add TC-2136 to the E2E case catalog and drift coverage.
- Add a static guard so the dead helper does not return.

## Issues
Closes #2136

## Validation
- npm test -- --runTestsByPath __tests__/static/tc-2136-finals-route-dead-helper.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm test -- --runTestsByPath __tests__/lib/api-factories/finals-route.test.ts --runInBand
- git diff --check
