### PR TITLE
test: harden GP TC-831/TC-832 order rationale scope

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -247,6 +247,8 @@ describe('E2E case drift coverage', () => {
     expect(scriptSource).toContain(`log('${tc}'`);
   });
 
+  const gpSuiteDefinition = sectionBetween(tcGp, '    tests: [', '    ],\n};\n');
+
   const gpTc831Tc832OrderRationale =
     /\/\/\s*TC-831 stays before TC-832[^\n]*(?:\n\s*\/\/[^\n]*)*\n\s*\{\s*name:\s*['"]TC-831['"]\s*,\s*fn:\s*runTc831\s*\}\s*,\s*\n\s*\{\s*name:\s*['"]TC-832['"]\s*,\s*fn:\s*runTc832\s*\}/;
 
@@ -261,7 +263,7 @@ describe('E2E case drift coverage', () => {
   });
 
   it('rejects non-comment code between the GP TC-831 rationale and suite entry', () => {
-    const weakenedFixture = tcGp.replace(
+    const weakenedFixture = gpSuiteDefinition.replace(
       gpTc831Tc832OrderRationale,
       [
         '// TC-831 stays before TC-832 so GP suite logs show numeric progression, keeping the',
@@ -272,7 +274,7 @@ describe('E2E case drift coverage', () => {
       ].join('\n') + '\n',
     );
 
-    expect(weakenedFixture).not.toBe(tcGp);
+    expect(weakenedFixture).not.toBe(gpSuiteDefinition);
     expect(weakenedFixture).not.toMatch(gpTc831Tc832OrderRationale);
   });
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -247,7 +247,7 @@ describe('E2E case drift coverage', () => {
     expect(scriptSource).toContain(`log('${tc}'`);
   });
 
-  const gpSuiteDefinition = sectionBetween(tcGp, '    tests: [', '    ],\n};\n');
+  const gpSuiteDefinition = sectionBetween(tcGp, '    tests: [', '    ],');
 
   const gpTc831Tc832OrderRationale =
     /\/\/\s*TC-831 stays before TC-832[^\n]*(?:\n\s*\/\/[^\n]*)*\n\s*\{\s*name:\s*['"]TC-831['"]\s*,\s*fn:\s*runTc831\s*\}\s*,\s*\n\s*\{\s*name:\s*['"]TC-832['"]\s*,\s*fn:\s*runTc832\s*\}/;

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1867,11 +1867,11 @@ describe('Finals Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const _response = await PUT(request, {
+      const response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
-      const json = await _response.json();
+      const json = await response.json();
       expect(json.data.winnerId).toBe('player-1');
       expect(json.data.loserId).toBe('player-2');
     });
@@ -1899,11 +1899,11 @@ describe('Finals Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const _response = await PUT(request, {
+      const response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
-      const json = await _response.json();
+      const json = await response.json();
       expect(json.data.winnerId).toBe('player-2');
       expect(json.data.loserId).toBe('player-1');
     });
@@ -1928,7 +1928,7 @@ describe('Finals Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const _response = await PUT(request, {
+      const response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
@@ -1961,7 +1961,7 @@ describe('Finals Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const _response = await PUT(request, {
+      const response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
@@ -1995,11 +1995,11 @@ describe('Finals Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify({ matchId: 'match-1', score1: 3, score2: 1 }),
       });
-      const _response = await PUT(request, {
+      const response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
-      expect(_response.status).toBe(200);
+      expect(response.status).toBe(200);
       expect((prisma.bMMatch as any).count).toHaveBeenCalledWith({
         where: { tournamentId: 'tournament-123', stage: 'finals' },
       });
@@ -2032,7 +2032,7 @@ describe('Finals Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const _response = await PUT(request, {
+      const response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
@@ -2151,7 +2151,7 @@ describe('Finals Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const _response = await PUT(request, {
+      const response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
@@ -2183,7 +2183,7 @@ describe('Finals Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const _response = await PUT(request, {
+      const response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -2032,7 +2032,7 @@ describe('Finals Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const response = await PUT(request, {
+      const _response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
@@ -2151,7 +2151,7 @@ describe('Finals Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const response = await PUT(request, {
+      const _response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
@@ -2183,7 +2183,7 @@ describe('Finals Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const response = await PUT(request, {
+      const _response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -222,7 +222,7 @@ describe('Qualification Route Factory', () => {
         method: 'POST',
         body: JSON.stringify({ players: createMockPlayers() }),
       });
-      const _response = await POST(request, {
+      const response = await POST(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
@@ -1416,7 +1416,7 @@ describe('Qualification Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const _response = await PUT(request, {
+      const response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
@@ -1482,7 +1482,7 @@ describe('Qualification Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const _response = await PUT(request, {
+      const response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
@@ -1493,7 +1493,7 @@ describe('Qualification Route Factory', () => {
 
     it('should update both players qualification records', async () => {
       const requestBody = createMockRequestBody();
-      const mockMatch = { id: 'match-123', player1Id: 'player-1', player2Id: 'player-2' };
+      const _mockMatch = { id: 'match-123', player1Id: 'player-1', player2Id: 'player-2' };
 
       (prisma.bMMatch as any).findMany.mockResolvedValue([]);
       (prisma.bMQualification as any).updateMany.mockResolvedValue({ count: 1 });

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -41,7 +41,6 @@ import {
 } from '@/lib/api-factories/qualification-route';
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { NextRequest } from 'next/server';
-import { EventTypeConfig } from '@/lib/event-types/types';
 import { COURSES, CUPS } from '@/lib/constants';
 
 // Mock dependencies
@@ -223,7 +222,7 @@ describe('Qualification Route Factory', () => {
         method: 'POST',
         body: JSON.stringify({ players: createMockPlayers() }),
       });
-      const response = await POST(request, {
+      const _response = await POST(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
@@ -1417,7 +1416,7 @@ describe('Qualification Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const response = await PUT(request, {
+      const _response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
@@ -1463,9 +1462,9 @@ describe('Qualification Route Factory', () => {
 
     it('should aggregate player stats via config.aggregatePlayerStats', async () => {
       const requestBody = createMockRequestBody();
-      const mockMatch = { id: 'match-123', player1Id: 'player-1', player2Id: 'player-2' };
-      const mockPlayer1Matches = [mockMatch];
-      const mockPlayer2Matches = [mockMatch];
+      const _mockMatch = { id: 'match-123', player1Id: 'player-1', player2Id: 'player-2' };
+      const mockPlayer1Matches = [_mockMatch];
+      const mockPlayer2Matches = [_mockMatch];
 
       (prisma.bMMatch as any).findMany
         .mockResolvedValueOnce(mockPlayer1Matches)
@@ -1483,7 +1482,7 @@ describe('Qualification Route Factory', () => {
         method: 'PUT',
         body: JSON.stringify(requestBody),
       });
-      const response = await PUT(request, {
+      const _response = await PUT(request, {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 

--- a/smkc-score-app/__tests__/lib/debug/score-generators.test.ts
+++ b/smkc-score-app/__tests__/lib/debug/score-generators.test.ts
@@ -17,7 +17,6 @@ import {
   TOTAL_MR_RACES,
   TOTAL_GP_RACES,
   TOTAL_COURSES,
-  getDriverPoints,
 } from '@/lib/constants';
 import { timeToMs } from '@/lib/ta/time-utils';
 

--- a/smkc-score-app/__tests__/lib/tournament/double-elimination.test.ts
+++ b/smkc-score-app/__tests__/lib/tournament/double-elimination.test.ts
@@ -13,7 +13,7 @@
  *   - Initial win counts (both zero), BM and MR match types
  *   - Large player counts (32 players) and minimal (2 players)
  */
-import { generateDoubleEliminationBracket, type MatchNode, type BracketPlayer } from '@/lib/tournament/double-elimination';
+import { generateDoubleEliminationBracket, type BracketPlayer } from '@/lib/tournament/double-elimination';
 
 describe('Double Elimination Bracket Functions', () => {
   describe('generateDoubleEliminationBracket', () => {

--- a/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/bm/match/[matchId]/report/route.ts
@@ -19,7 +19,7 @@
  */
 
 import { NextRequest } from "next/server";
-import { PLAYER_PUBLIC_SELECT, PLAYER_AUTH_SELECT } from '@/lib/prisma-selects';
+import { PLAYER_AUTH_SELECT } from '@/lib/prisma-selects';
 
 import {
   createErrorResponse,

--- a/smkc-score-app/src/app/players/page.tsx
+++ b/smkc-score-app/src/app/players/page.tsx
@@ -34,9 +34,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
-  CardTitle,
 } from "@/components/ui/card";
 import {
   Table,


### PR DESCRIPTION
## Summary\n- Scope the GP suite order guard in e2e drift tests to the suite block only, preventing accidental matches outside suite definition.\n- This strengthens #1776 so order rationale and adjacency checks remain robust against future script refactors.\n\n## Issue\n- Closes #1776\n