### PR TITLE
test: clarify qualification mock match fixture

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2631,6 +2631,20 @@
   - fixture 注入が空振りした場合は専用アサーションで原因が分かる
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/group-setup-helper.test.ts`
 
+## TC-2145: qualification-route.test.ts — 参照される mock match に未使用変数風の名前を使わない
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #2145。`__tests__/lib/api-factories/qualification-route.test.ts` の `should aggregate player stats` で参照される fixture が `_mockMatch` と命名され、未使用変数の慣習と衝突してレビュー時に誤読されやすい。
+- **手順**:
+  1. `qualification-route.test.ts` の player stats aggregation fixture を確認する
+  2. `mockPlayer1Matches` / `mockPlayer2Matches` が `mockMatch` を参照していることを確認する
+  3. `_mockMatch` が qualification route factory テストに残っていないことを静的ガードで確認する
+- **期待結果**:
+  - 参照される match fixture は `mockMatch` として読める
+  - 未使用変数を示す `_mockMatch` が戻った場合は TC-2145 guard が失敗する
+  - E2E scenario と guard test が同じ対象ファイルを指す
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-2145-qualification-route-mock-match-name.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/api-factories/qualification-route.test.ts`
+
 ## TC-1009: 総合ランキング決勝順位 — 16人/Top-24 判定の matchNumber 閾値を明文化する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -294,6 +294,14 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('__tests__/static/tc-2136-finals-route-dead-helper.test.ts');
   });
 
+  it('keeps TC-2145 documented with the qualification-route mock-match naming guard', () => {
+    const section = e2eCaseSection('TC-2145');
+
+    expect(section).toContain('_mockMatch');
+    expect(section).toContain('qualification-route.test.ts');
+    expect(section).toContain('__tests__/static/tc-2145-qualification-route-mock-match-name.test.ts');
+  });
+
   it('keeps TC-830 aligned with runtime unit and bracket component coverage', () => {
     const section = e2eCaseSection('TC-830');
     const pageWiringTest = readRepoFile('smkc-score-app', '__tests__', 'app', 'tournaments', 'gp-finals-page-wiring.test.tsx');

--- a/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/qualification-route.test.ts
@@ -562,6 +562,7 @@ describe('Qualification Route Factory', () => {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
+      expect(response.status).toBe(201);
       expect(mockCreateAuditLog).toHaveBeenCalledWith({
         userId: 'user-1',
         ipAddress: '192.168.1.1',
@@ -1462,9 +1463,9 @@ describe('Qualification Route Factory', () => {
 
     it('should aggregate player stats via config.aggregatePlayerStats', async () => {
       const requestBody = createMockRequestBody();
-      const _mockMatch = { id: 'match-123', player1Id: 'player-1', player2Id: 'player-2' };
-      const mockPlayer1Matches = [_mockMatch];
-      const mockPlayer2Matches = [_mockMatch];
+      const mockMatch = { id: 'match-123', player1Id: 'player-1', player2Id: 'player-2' };
+      const mockPlayer1Matches = [mockMatch];
+      const mockPlayer2Matches = [mockMatch];
 
       (prisma.bMMatch as any).findMany
         .mockResolvedValueOnce(mockPlayer1Matches)
@@ -1486,6 +1487,7 @@ describe('Qualification Route Factory', () => {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
+      expect(response.status).toBe(200);
       expect(config.aggregatePlayerStats).toHaveBeenCalledTimes(2);
       expect(config.aggregatePlayerStats).toHaveBeenCalledWith(mockPlayer1Matches, 'player-1', config.calculateMatchResult);
       expect(config.aggregatePlayerStats).toHaveBeenCalledWith(mockPlayer2Matches, 'player-2', config.calculateMatchResult);
@@ -1493,7 +1495,6 @@ describe('Qualification Route Factory', () => {
 
     it('should update both players qualification records', async () => {
       const requestBody = createMockRequestBody();
-      const _mockMatch = { id: 'match-123', player1Id: 'player-1', player2Id: 'player-2' };
 
       (prisma.bMMatch as any).findMany.mockResolvedValue([]);
       (prisma.bMQualification as any).updateMany.mockResolvedValue({ count: 1 });
@@ -1513,6 +1514,7 @@ describe('Qualification Route Factory', () => {
         params: Promise.resolve({ id: 'tournament-123' }),
       });
 
+      expect(response.status).toBe(200);
       expect((prisma as any).$executeRawUnsafe).toHaveBeenCalledTimes(1);
       const [, payload, tournamentId] = (prisma as any).$executeRawUnsafe.mock.calls[0];
       expect(tournamentId).toBe('tournament-123');

--- a/smkc-score-app/__tests__/static/tc-2145-qualification-route-mock-match-name.test.ts
+++ b/smkc-score-app/__tests__/static/tc-2145-qualification-route-mock-match-name.test.ts
@@ -1,0 +1,18 @@
+import { readRepoFile } from '../helpers/e2e-cases';
+
+describe('TC-2145 qualification route mock match naming', () => {
+  const source = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'lib',
+    'api-factories',
+    'qualification-route.test.ts',
+  );
+
+  it('does not use unused-variable-style names for referenced mock matches', () => {
+    expect(source).toContain('const mockMatch =');
+    expect(source).toContain('const mockPlayer1Matches = [mockMatch];');
+    expect(source).toContain('const mockPlayer2Matches = [mockMatch];');
+    expect(source).not.toContain('_mockMatch');
+  });
+});


### PR DESCRIPTION
Summary
- Rename the referenced qualification-route match fixture from `_mockMatch` to `mockMatch`.
- Remove the unused `_mockMatch` declaration in the adjacent qualification record test.
- Add TC-2145 E2E scenario documentation plus doc/static drift guards.

Issues: Closes #2145

Validation
- npm test -- --runTestsByPath __tests__/static/tc-2145-qualification-route-mock-match-name.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/api-factories/qualification-route.test.ts --runInBand
- npm run lint -- __tests__/static/tc-2145-qualification-route-mock-match-name.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/api-factories/qualification-route.test.ts
- git diff --check
