### PR TITLE
refactor: inline GP finals cup fallback to shared helper

### DIFF
--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -426,12 +426,8 @@ export default function GrandPrixFinals({
     return COURSE_INFO.filter((c) => c.cup === cup).map((c) => c.abbr);
   };
 
-  const nextCupName = (index: number, preferred?: string, assignedCups?: string[]) => {
-    return getCupForFormIndex(index, assignedCups, CUPS, preferred);
-  };
-
   const makeBlankCupForm = (index: number, preferred?: string, assignedCups?: string[]): CupScoreForm => {
-    const cup = nextCupName(index, preferred, assignedCups);
+    const cup = getCupForFormIndex(index, assignedCups, CUPS, preferred);
     return {
       cup,
       races: getCupCourses(cup).map((course) => ({ course, position1: null, position2: null })),

--- a/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/gp/finals/page.tsx
@@ -528,7 +528,7 @@ export default function GrandPrixFinals({
     }
     const savedForms = match.cupResults && match.cupResults.length > 0
       ? match.cupResults.map((result, index) => {
-          const resultCup = result.cup || nextCupName(index, cup, match.assignedCups);
+          const resultCup = result.cup || getCupForFormIndex(index, match.assignedCups, CUPS, cup);
           return {
             cup: resultCup,
             races: result.races && result.races.length === TOTAL_GP_RACES


### PR DESCRIPTION
Summary
- Remove the redundant `nextCupName` wrapper in the GP finals page.
- Call `getCupForFormIndex` directly with shared `CUPS` for blank forms and result fallback.
- Rebase the branch so this PR only contains the #833 change set.

Issues: Closes #833

Validation
- npm test -- --runTestsByPath __tests__/lib/gp-finals-score-form.test.ts __tests__/app/tournaments/gp-finals-page-wiring.test.tsx --runInBand
- npm run lint -- src/app/tournaments/[id]/gp/finals/page.tsx __tests__/lib/gp-finals-score-form.test.ts __tests__/app/tournaments/gp-finals-page-wiring.test.tsx
- git diff --check
