### PR TITLE
test: stabilize TC-2145 static mock match guards

### DIFF
--- a/smkc-score-app/__tests__/static/tc-2145-qualification-route-mock-match-name.test.ts
+++ b/smkc-score-app/__tests__/static/tc-2145-qualification-route-mock-match-name.test.ts
@@ -11,8 +11,8 @@ describe('TC-2145 qualification route mock match naming', () => {
 
   it('does not use unused-variable-style names for referenced mock matches', () => {
     expect(source).toContain('const mockMatch =');
-    expect(source).toContain('const mockPlayer1Matches = [mockMatch];');
-    expect(source).toContain('const mockPlayer2Matches = [mockMatch];');
+    expect(source).toMatch(/const\s+mockPlayer1Matches\s*=\s*\[mockMatch\]/);
+    expect(source).toMatch(/const\s+mockPlayer2Matches\s*=\s*\[mockMatch\]/);
     expect(source).not.toContain('_mockMatch');
   });
 });


### PR DESCRIPTION
## Summary
- Use regex-based static assertions for TC-2145 mock match array declarations so the guard survives formatter-only spacing or line-break changes.

## Issues
Closes #2148

## Validation
- npm test -- --runTestsByPath __tests__/static/tc-2145-qualification-route-mock-match-name.test.ts --runInBand
- npx eslint __tests__/static/tc-2145-qualification-route-mock-match-name.test.ts
- git diff --check main...HEAD