### PR TITLE
Fix runner suite timeout fallback

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -109,7 +109,8 @@
   2. TA suite が 29ケースを維持していることを確認する
   3. TA suite 固有の timeout が 35分より長く、`TC-1005` まで実行対象に残ることを確認する
   4. runner の `E2E_SUITE_TIMEOUT_MS` override が TA 固有 timeout より優先されることを確認する
-- **期待結果**: TA preview suite は通常設定で 75分上限を使い、phase-chain/isolated fixture coverage を削らずに `TC-1005` まで実行できる
+  5. runner の明示 timeout fallback は `null` / `undefined` のときだけ既定値を使い、`0` を `DEFAULT_SUITE_TIMEOUT_MS` に置き換えないことを確認する
+- **期待結果**: TA preview suite は通常設定で 75分上限を使い、phase-chain/isolated fixture coverage を削らずに `TC-1005` まで実行できる。issue #2111 の nullish fallback 契約により、将来の明示的な falsy timeout 値も OR fallback で失われない
 - **スクリプト**: `npm run e2e:preview:ta` / `npm test -- --runTestsByPath __tests__/e2e/ta-suite-timeout.test.ts __tests__/lib/e2e-runner-timeout.test.ts`
 
 ## TC-008: Overall Ranking ページの表示

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1023,6 +1023,8 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('29ケース');
     expect(section).toContain('TC-1005');
     expect(section).toContain('E2E_SUITE_TIMEOUT_MS');
+    expect(section).toContain('issue #2111');
+    expect(section).toContain('nullish fallback');
     expect(section).toContain('__tests__/e2e/ta-suite-timeout.test.ts');
     expect(section).toContain('__tests__/lib/e2e-runner-timeout.test.ts');
     expect(tcTaTimeoutTest).toContain('TA_SUITE_TIMEOUT_MS');
@@ -1030,6 +1032,7 @@ describe('E2E case drift coverage', () => {
     expect(tcTaTimeoutTest).toContain('TC-1005');
     expect(runnerTimeoutTest).toContain('resolveSuiteTimeoutMs');
     expect(runnerTimeoutTest).toContain('E2E_SUITE_TIMEOUT_MS');
+    expect(runnerTimeoutTest).toContain('preserves explicit zero');
   });
 
   it('keeps TC-2055 aligned with the sectionBetween allowTerminal contract', () => {

--- a/smkc-score-app/__tests__/lib/e2e-runner-timeout.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-runner-timeout.test.ts
@@ -27,4 +27,13 @@ describe('E2E runner suite timeout resolution', () => {
 
     expect(runner.resolveSuiteTimeoutMs(75 * 60 * 1000)).toBe(42 * 60 * 1000);
   });
+
+  it('preserves explicit zero instead of falling back to the default timeout', async () => {
+    delete process.env.E2E_SUITE_TIMEOUT_MS;
+    const runner = await import('../../e2e/lib/runner.js') as {
+      resolveSuiteTimeoutMs: (explicitTimeoutMs?: number | null) => number;
+    };
+
+    expect(runner.resolveSuiteTimeoutMs(0)).toBe(0);
+  });
 });

--- a/smkc-score-app/e2e/lib/runner.js
+++ b/smkc-score-app/e2e/lib/runner.js
@@ -20,7 +20,7 @@ function envMs(name, fallback) {
 }
 
 function resolveSuiteTimeoutMs(explicitTimeoutMs = null) {
-  return envMs('E2E_SUITE_TIMEOUT_MS', explicitTimeoutMs || DEFAULT_SUITE_TIMEOUT_MS);
+  return envMs('E2E_SUITE_TIMEOUT_MS', explicitTimeoutMs ?? DEFAULT_SUITE_TIMEOUT_MS);
 }
 
 function formatDuration(ms) {


### PR DESCRIPTION
## Summary
- Document TC-2078/issue #2111 runner timeout fallback expectations in the E2E scenario list
- Add drift coverage tying the scenario to the runner timeout tests
- Preserve explicit `0` in `resolveSuiteTimeoutMs` by switching the fallback from `||` to `??`

## Issues
Closes #2111

## Validation
- `npm test -- --runTestsByPath __tests__/lib/e2e-runner-timeout.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npm run lint`
- `npm run build:cf`
