### PR TITLE
Refine TC-2136 static guard focus

### DIFF
--- a/smkc-score-app/__tests__/static/tc-2136-finals-route-dead-helper.test.ts
+++ b/smkc-score-app/__tests__/static/tc-2136-finals-route-dead-helper.test.ts
@@ -8,23 +8,11 @@ describe('TC-2136 finals route test helper cleanup', () => {
     'api-factories',
     'finals-route.test.ts',
   );
-  const guardSource = readRepoFile(
-    'smkc-score-app',
-    '__tests__',
-    'static',
-    'tc-2136-finals-route-dead-helper.test.ts',
-  );
-
   it('has removed the unused _createMockQualification helper from finals-route.test.ts', () => {
+    // Keep static checks focused on structural behavior; wording changes
+    // are not stability guarantees for regression prevention.
     expect(source).toContain('const createMockMatch =');
     expect(source).toContain('const createMockQualifications =');
     expect(source).not.toContain('_createMockQualification');
-  });
-
-  it('uses positive wording for the dead-helper guard description', () => {
-    expect(guardSource).toContain(
-      "it('has removed the unused _createMockQualification helper from finals-route.test.ts'",
-    );
-    expect(guardSource).not.toContain(["it('does not", ' keep'].join(''));
   });
 });


### PR DESCRIPTION
## Summary
- Remove the wording-based assertion from the TC-2136 finals helper static test.
- Keep the structural dead-helper guard and document why wording checks are intentionally avoided.

## Issues
Closes #2152

## Validation
- npm test -- --runTestsByPath __tests__/static/tc-2136-finals-route-dead-helper.test.ts
- npm run lint
- npm run build:cf