### PR TITLE
test: remove TC-2156 style-only drift coverage

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2671,20 +2671,6 @@
   - `_createMockQualification` が戻った場合は TC-2136 guard が引き続き失敗する
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-2136-finals-route-dead-helper.test.ts __tests__/docs/e2e-cases-drift.test.ts`
 
-## TC-2156: tc-2136 static guard — 構造チェックコメントを1行に保つ
-- **URL**: n/a (unit/static coverage)
-- **authRequired**: false
-- **背景**: issue #2156。TC-2136 の static guard では、コメントが2行に分かれて CLAUDE.md の短い1行コメント方針から外れていた。コメントの意図は「文言ではなく構造を固定する」だけなので、1行に圧縮しても guard の読みやすさを保てる。
-- **手順**:
-  1. `tc-2136-finals-route-dead-helper.test.ts` の `_createMockQualification` guard を確認する
-  2. guard 直前のコメントが構造チェックの意図を1行で説明していることを確認する
-  3. 同じ static guard が `createMockMatch` / `createMockQualifications` の維持と `_createMockQualification` 不在を引き続き検証する
-- **期待結果**:
-  - TC-2136 guard の補足コメントは `Keep static checks structural` を含む1行で読める
-  - コメント変更後も dead helper の再導入を検知する static guard は維持される
-  - E2E scenario と drift guard が issue #2156 のコメント方針を追跡する
-- **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-2136-finals-route-dead-helper.test.ts __tests__/docs/e2e-cases-drift.test.ts`
-
 ## TC-1009: 総合ランキング決勝順位 — 16人/Top-24 判定の matchNumber 閾値を明文化する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -310,22 +310,6 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('__tests__/static/tc-2136-finals-route-dead-helper.test.ts');
   });
 
-  it('keeps TC-2156 documented with the one-line TC-2136 static guard comment', () => {
-    const section = e2eCaseSection('TC-2156');
-    const guardTest = readRepoFile(
-      'smkc-score-app',
-      '__tests__',
-      'static',
-      'tc-2136-finals-route-dead-helper.test.ts',
-    );
-
-    expect(section).toContain('issue #2156');
-    expect(section).toContain('Keep static checks structural');
-    expect(section).toContain('__tests__/static/tc-2136-finals-route-dead-helper.test.ts');
-    expect(guardTest).toContain('// Keep static checks structural; wording changes are not stability guarantees.');
-    expect(guardTest).not.toContain('wording changes\n    // are not stability guarantees');
-  });
-
   it('keeps TC-2161 documented with non-blocking Wrangler auth preflight coverage', () => {
     const section = e2eCaseSection('TC-2161');
     const preflight = readE2eLib('preview-schema-preflight.js');


### PR DESCRIPTION
Summary
- Remove the TC-2156 E2E scenario because it only tracks comment formatting policy already covered by CLAUDE/lint guidance.
- Remove the matching e2e-cases-drift test block, including the brittle hard-coded comment text assertion.

Issues: Closes #2159, Closes #2158

Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts
- npm run lint (passes with existing warnings)