### PR TITLE
Resolve overall publicModes compatibility for existing tournaments

### DIFF
--- a/smkc-score-app/migrations/0037_add_overall_to_existing_tournaments.sql
+++ b/smkc-score-app/migrations/0037_add_overall_to_existing_tournaments.sql
@@ -2,13 +2,13 @@ UPDATE Tournament
 SET publicModes = json_insert(
   publicModes,
   '$[#]',
-  '"overall"'
+  'overall'
 )
 WHERE
   status IN ('active', 'completed')
   AND deletedAt IS NULL
   AND NOT EXISTS (
-    SELECT 1
-    FROM json_each(publicModes)
-    WHERE value = 'overall'
+      SELECT 1
+      FROM json_each(publicModes)
+      WHERE value = 'overall'
   );

--- a/smkc-score-app/migrations/0037_add_overall_to_existing_tournaments.sql
+++ b/smkc-score-app/migrations/0037_add_overall_to_existing_tournaments.sql
@@ -1,0 +1,14 @@
+UPDATE Tournament
+SET publicModes = json_insert(
+  publicModes,
+  '$[#]',
+  '"overall"'
+)
+WHERE
+  status IN ('active', 'completed')
+  AND deletedAt IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM json_each(publicModes)
+    WHERE value = 'overall'
+  );

--- a/smkc-score-app/prisma/migrations/0018_add_overall_to_existing_tournaments/migration.sql
+++ b/smkc-score-app/prisma/migrations/0018_add_overall_to_existing_tournaments/migration.sql
@@ -2,7 +2,7 @@ UPDATE "Tournament"
 SET "publicModes" = json_insert(
   "publicModes",
   '$[#]',
-  '"overall"'
+  'overall'
 )
 WHERE
   "status" IN ('active', 'completed')

--- a/smkc-score-app/prisma/migrations/0018_add_overall_to_existing_tournaments/migration.sql
+++ b/smkc-score-app/prisma/migrations/0018_add_overall_to_existing_tournaments/migration.sql
@@ -1,0 +1,14 @@
+UPDATE "Tournament"
+SET "publicModes" = json_insert(
+  "publicModes",
+  '$[#]',
+  '"overall"'
+)
+WHERE
+  "status" IN ('active', 'completed')
+  AND "deletedAt" IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM json_each("publicModes")
+    WHERE value = 'overall'
+  );


### PR DESCRIPTION
## Summary
- Added migrations for existing active/completed tournaments to append `overall` to `publicModes` when missing.
- Added both Prisma and D1 migration paths so local and deploy migrations stay aligned.

## Issues
Closes #987

## Validation
- npm run lint
- npm test -- --runTestsByPath __tests__/lib/public-modes.test.ts
- gh pr checks 2164 --watch --interval 10
