### PR TITLE
Allow preview E2E past Wrangler auth preflight

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -113,6 +113,17 @@
 - **期待結果**: TA preview suite は通常設定で 75分上限を使い、phase-chain/isolated fixture coverage を削らずに `TC-1005` まで実行できる。issue #2111 の nullish fallback 契約により、将来の明示的な falsy timeout 値も OR fallback で失われない
 - **スクリプト**: `npm run e2e:preview:ta` / `npm test -- --runTestsByPath __tests__/e2e/ta-suite-timeout.test.ts __tests__/lib/e2e-runner-timeout.test.ts`
 
+## TC-2161: Preview D1 schema preflight は Wrangler 認証失敗だけで E2E 本体を止めない
+- **URL**: n/a (runner configuration / preview suite)
+- **authRequired**: true (Cloudflare D1 token is optional unless strict preflight is requested)
+- **背景**: issue #2161。Preview D1 schema preflight は schema drift を早期検出するために `wrangler d1 execute --remote --env preview --json` を実行するが、automation 環境で Wrangler refresh token が 401 になった場合は remote schema drift が確認できていない。認証/ログ初期化だけの失敗は E2E ブラウザ起動を妨げず、strict 確認が必要な環境だけ `E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1` で hard fail に戻せる必要がある。
+- **手順**:
+  1. Wrangler が `Failed to fetch auth token: 401 Unauthorized` を返す preflight を模擬する
+  2. 通常の `npm run e2e:preview:all` 相当では警告を出して preflight を通過することを確認する
+  3. `E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1` 指定時は同じ auth/log failure がブラウザ起動前に失敗することを確認する
+- **期待結果**: 認証/ログ初期化だけの失敗は通常 preview E2E を本体開始前に止めず、schema missing / SQLite error / timeout / strict preflight は従来どおり診断つきで失敗する
+- **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
+
 ## TC-008: Overall Ranking ページの表示
 - **URL**: /tournaments/[id]/overall-ranking
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -326,6 +326,19 @@ describe('E2E case drift coverage', () => {
     expect(guardTest).not.toContain('wording changes\n    // are not stability guarantees');
   });
 
+  it('keeps TC-2161 documented with non-blocking Wrangler auth preflight coverage', () => {
+    const section = e2eCaseSection('TC-2161');
+    const preflight = readE2eLib('preview-schema-preflight.js');
+    const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');
+
+    expect(section).toContain('issue #2161');
+    expect(section).toContain('E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1');
+    expect(section).toContain('__tests__/e2e/preview-schema-preflight.test.ts');
+    expect(preflight).toContain('shouldFailOnWranglerAuthOrLogFailure');
+    expect(preflight).toContain('console.warn(message)');
+    expect(preflightTest).toContain('continues preview startup on Wrangler auth and log setup failures by default');
+  });
+
   it('keeps TC-830 aligned with runtime unit and bracket component coverage', () => {
     const section = e2eCaseSection('TC-830');
     const pageWiringTest = readRepoFile('smkc-score-app', '__tests__', 'app', 'tournaments', 'gp-finals-page-wiring.test.tsx');

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { afterEach, describe, expect, it, jest, beforeEach } from '@jest/globals';
 import { readFileSync } from 'fs';
 import path from 'path';
 
@@ -23,6 +23,11 @@ function loadPreflight() {
 describe('preview schema preflight', () => {
   beforeEach(() => {
     spawnSyncMock.mockReset();
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('checks the columns that previously drifted on preview D1', () => {
@@ -205,7 +210,7 @@ describe('preview schema preflight', () => {
     expect(preflight.isWranglerAuthOrLogFailure('Failed to fetch auth token: 400 Bad Request')).toBe(true);
   });
 
-  it('separates Wrangler auth and log setup failures from schema migration guidance', () => {
+  it('continues preview startup on Wrangler auth and log setup failures by default', () => {
     const preflight = loadPreflight();
     spawnSyncMock.mockReturnValue({
       status: 1,
@@ -216,20 +221,40 @@ describe('preview schema preflight', () => {
       ].join('\n'),
     });
 
-    let message = '';
-    try {
-      preflight.assertPreviewD1Schema({});
-    } catch (error) {
-      message = error instanceof Error ? error.message : String(error);
-    }
+    expect(() => preflight.assertPreviewD1Schema({})).not.toThrow();
 
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    const message = String((console.warn as jest.Mock).mock.calls[0]?.[0] ?? '');
     expect(message).toMatch(/Wrangler auth\/log setup failed/);
+    expect(message).toMatch(/E2E run will continue/);
     expect(message).toMatch(/WRANGLER_LOG_PATH/);
     expect(message).not.toMatch(/db:migrations:apply:preview/);
     expect(message.split('\n')).toEqual(expect.arrayContaining([
       expect.stringMatching(/Command exited 1/),
       expect.stringMatching(/WRANGLER_LOG_PATH=/),
     ]));
+  });
+
+  it('can require Wrangler auth and log failures to block preview startup', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: '',
+      stderr: 'Failed to fetch auth token: 401 Unauthorized',
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({ E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT: '1' })).toThrow(
+      /Wrangler auth\/log setup failed/,
+    );
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('keeps TC-2161 documented as non-blocking auth preflight coverage', () => {
+    const section = readFileSync(path.join(process.cwd(), '..', 'E2E_TEST_CASES.md'), 'utf8');
+
+    expect(section).toContain('TC-2161');
+    expect(section).toContain('E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1');
+    expect(section).toContain('__tests__/e2e/preview-schema-preflight.test.ts');
   });
 
   it('fails with timeout guidance when wrangler hangs', () => {

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -101,6 +101,21 @@ function formatPreflightError(lines) {
   return lines.filter(Boolean).join('\n');
 }
 
+function shouldFailOnWranglerAuthOrLogFailure(env = process.env) {
+  return env.E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT === '1';
+}
+
+function buildWranglerAuthOrLogFailureMessage(status, stderr, wranglerEnv) {
+  return formatPreflightError([
+    'Preview D1 schema preflight could not verify the remote database because Wrangler auth/log setup failed.',
+    `Command exited ${status}.`,
+    stderr ? `stderr: ${stderr}` : '',
+    `WRANGLER_LOG_PATH=${wranglerEnv.WRANGLER_LOG_PATH}`,
+    'The preview E2E run will continue because this is an environment credential/setup problem, not confirmed schema drift.',
+    'Set CLOUDFLARE_API_TOKEN with D1 read access or refresh wrangler login, then rerun with E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1 to make this failure block browser launch.',
+  ]);
+}
+
 function runWranglerSchemaCheck(sql, wranglerEnv) {
   const args = ['d1', 'execute', 'DB', '--remote', '--env', 'preview', '--json', '--command', sql];
   let result;
@@ -152,15 +167,13 @@ function assertPreviewD1Schema(env = process.env) {
   if (result.status !== 0) {
     const stderr = String(result.stderr || '').trim();
     if (isWranglerAuthOrLogFailure(stderr)) {
-      throw new Error(
-        formatPreflightError([
-          'Preview D1 schema preflight failed before launching the browser because Wrangler auth/log setup failed.',
-          `Command exited ${result.status}.`,
-          stderr ? `stderr: ${stderr}` : '',
-          `WRANGLER_LOG_PATH=${wranglerEnv.WRANGLER_LOG_PATH}`,
-          'Refresh Wrangler auth with wrangler login or CLOUDFLARE_API_TOKEN, ensure WRANGLER_LOG_PATH is writable, then retry npm run e2e:preview.',
-        ]),
-      );
+      const message = buildWranglerAuthOrLogFailureMessage(result.status, stderr, wranglerEnv);
+      if (shouldFailOnWranglerAuthOrLogFailure(env)) {
+        throw new Error(message);
+      }
+
+      console.warn(message);
+      return;
     }
 
     throw new Error(
@@ -198,9 +211,11 @@ module.exports = {
   buildWranglerEnv,
   buildPreviewSchemaCheckSql,
   DEFAULT_WRANGLER_LOG_PATH,
+  buildWranglerAuthOrLogFailureMessage,
   isWranglerSchemaFailure,
   isWranglerAuthOrLogFailure,
   parsePresentColumns,
+  shouldFailOnWranglerAuthOrLogFailure,
   WRANGLER_TRANSIENT_STATUS_RETRIES,
   WRANGLER_TIMEOUT_MS,
 };


### PR DESCRIPTION
## Summary
- Add TC-2161 to document preview D1 preflight behavior when Wrangler auth/log setup fails.
- Let preview E2E continue past Wrangler auth/log setup failures by default because they do not confirm schema drift.
- Keep strict blocking behavior available through `E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1`, while preserving hard failures for real schema errors and timeouts.

## Issues
Closes #2161

## Validation
- npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint (passes with existing warnings)
- HOME=/private/tmp/jsmkc-wrangler-home npm run build:cf
