### PR TITLE
Keep preview preflight helpers private

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -121,7 +121,8 @@
   1. Wrangler が `Failed to fetch auth token: 401 Unauthorized` を返す preflight を模擬する
   2. 通常の `npm run e2e:preview:all` 相当では警告を出して preflight を通過することを確認する
   3. `E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1` 指定時は同じ auth/log failure がブラウザ起動前に失敗することを確認する
-- **期待結果**: 認証/ログ初期化だけの失敗は通常 preview E2E を本体開始前に止めず、schema missing / SQLite error / timeout / strict preflight は従来どおり診断つきで失敗する
+  4. auth/log failure の message/strict 判定 helper は public export せず、private helper のまま runner 経由で検証することを確認する
+- **期待結果**: 認証/ログ初期化だけの失敗は通常 preview E2E を本体開始前に止めず、schema missing / SQLite error / timeout / strict preflight は従来どおり診断つきで失敗する。TC-2161 の E2E scenario 文字列確認は `preview-schema-preflight.test.ts` 側に集約し、drift test は preview preflight 実装と補助テストの対応だけを監視する
 - **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
 
 ## TC-008: Overall Ranking ページの表示

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -310,17 +310,16 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('__tests__/static/tc-2136-finals-route-dead-helper.test.ts');
   });
 
-  it('keeps TC-2161 documented with non-blocking Wrangler auth preflight coverage', () => {
-    const section = e2eCaseSection('TC-2161');
+  it('keeps TC-2161 aligned with preview preflight implementation coverage', () => {
     const preflight = readE2eLib('preview-schema-preflight.js');
     const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');
 
-    expect(section).toContain('issue #2161');
-    expect(section).toContain('E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1');
-    expect(section).toContain('__tests__/e2e/preview-schema-preflight.test.ts');
     expect(preflight).toContain('shouldFailOnWranglerAuthOrLogFailure');
+    expect(preflight).toContain('buildWranglerAuthOrLogFailureMessage');
     expect(preflight).toContain('console.warn(message)');
     expect(preflightTest).toContain('continues preview startup on Wrangler auth and log setup failures by default');
+    expect(preflightTest).toContain('keeps TC-2161 documented as non-blocking auth preflight coverage');
+    expect(preflightTest).toContain('keeps Wrangler auth/log message helpers private to the preflight runner');
   });
 
   it('keeps TC-830 aligned with runtime unit and bracket component coverage', () => {

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -249,12 +249,20 @@ describe('preview schema preflight', () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 
+  it('keeps Wrangler auth/log message helpers private to the preflight runner', () => {
+    const preflight = loadPreflight();
+
+    expect(preflight).not.toHaveProperty('buildWranglerAuthOrLogFailureMessage');
+    expect(preflight).not.toHaveProperty('shouldFailOnWranglerAuthOrLogFailure');
+  });
+
   it('keeps TC-2161 documented as non-blocking auth preflight coverage', () => {
     const section = readFileSync(path.join(process.cwd(), '..', 'E2E_TEST_CASES.md'), 'utf8');
 
     expect(section).toContain('TC-2161');
     expect(section).toContain('E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1');
     expect(section).toContain('__tests__/e2e/preview-schema-preflight.test.ts');
+    expect(section).toContain('private helper');
   });
 
   it('fails with timeout guidance when wrangler hangs', () => {

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -211,11 +211,9 @@ module.exports = {
   buildWranglerEnv,
   buildPreviewSchemaCheckSql,
   DEFAULT_WRANGLER_LOG_PATH,
-  buildWranglerAuthOrLogFailureMessage,
   isWranglerSchemaFailure,
   isWranglerAuthOrLogFailure,
   parsePresentColumns,
-  shouldFailOnWranglerAuthOrLogFailure,
   WRANGLER_TRANSIENT_STATUS_RETRIES,
   WRANGLER_TIMEOUT_MS,
 };


### PR DESCRIPTION
## Summary
- Keep Wrangler auth/log message helpers private to the preview schema preflight runner.
- Move TC-2161 drift coverage away from duplicating E2E scenario text and keep scenario text checks in the focused preflight test.

## Issues
Closes #2166
Closes #2167

## Validation
- npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint
- HOME=/private/tmp/jsmkc-wrangler-home npm run build:cf
