### PR TITLE
Remove unreachable Wrangler preflight return

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -125,6 +125,17 @@
 - **期待結果**: 認証/ログ初期化だけの失敗は通常 preview E2E を本体開始前に止めず、schema missing / SQLite error / timeout / strict preflight は従来どおり診断つきで失敗する。TC-2161 の E2E scenario 文字列確認は `preview-schema-preflight.test.ts` 側に集約し、drift test は preview preflight 実装と補助テストの対応だけを監視する
 - **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
 
+## TC-2104: Preview D1 schema preflight の Wrangler retry loop は unreachable fallback return を持たない
+- **URL**: n/a (runner configuration / preview suite)
+- **authRequired**: true (Cloudflare D1 token is optional unless strict preflight is requested)
+- **背景**: issue #2104。`runWranglerSchemaCheck` は `WRANGLER_TRANSIENT_STATUS_RETRIES` まで retry し、最終 attempt では loop 内で必ず `{ result, args }` を返す。loop 後に同じ return を残すと unreachable dead code になり、retry 終了条件の意図が読み取りにくくなる。
+- **手順**:
+  1. Wrangler が空の status 1 を返し続ける preflight を模擬する
+  2. `runWranglerSchemaCheck` が `WRANGLER_TRANSIENT_STATUS_RETRIES + 1` 回だけ実行して最終 attempt の結果を返すことを確認する
+  3. `preview-schema-preflight.js` の `runWranglerSchemaCheck` 節に loop 後の `return { result, args };` が残っていないことを補助テストで確認する
+- **期待結果**: retry loop の最終 attempt が唯一の fallback return となり、到達不能な loop 後 return を持たずに preview preflight の診断挙動を維持する
+- **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
+
 ## TC-008: Overall Ranking ページの表示
 - **URL**: /tournaments/[id]/overall-ranking
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -347,6 +347,18 @@ describe('E2E case drift coverage', () => {
     expect(overlayPhaseTest).not.toContain('returns First to 5 for MR bracket finals');
   });
 
+  it('keeps TC-2104 aligned with preview preflight retry-loop coverage', () => {
+    const section = e2eCaseSection('TC-2104');
+    const preflight = readE2eLib('preview-schema-preflight.js');
+    const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');
+
+    expect(section).toContain('unreachable fallback return');
+    expect(section).toContain('WRANGLER_TRANSIENT_STATUS_RETRIES + 1');
+    expect(preflight).toContain('attempt === WRANGLER_TRANSIENT_STATUS_RETRIES');
+    expect(preflightTest).toContain('keeps runWranglerSchemaCheck free of a loop-after fallback return');
+    expect(preflightTest).toContain('keeps TC-2104 documented as unreachable retry fallback coverage');
+  });
+
   it('keeps TC-830 aligned with runtime unit and bracket component coverage', () => {
     const section = e2eCaseSection('TC-830');
     const pageWiringTest = readRepoFile('smkc-score-app', '__tests__', 'app', 'tournaments', 'gp-finals-page-wiring.test.tsx');

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -265,6 +265,26 @@ describe('preview schema preflight', () => {
     expect(section).toContain('private helper');
   });
 
+  it('keeps TC-2104 documented as unreachable retry fallback coverage', () => {
+    const section = readFileSync(path.join(process.cwd(), '..', 'E2E_TEST_CASES.md'), 'utf8');
+
+    expect(section).toContain('TC-2104');
+    expect(section).toContain('unreachable fallback return');
+    expect(section).toContain('WRANGLER_TRANSIENT_STATUS_RETRIES + 1');
+  });
+
+  it('keeps runWranglerSchemaCheck free of a loop-after fallback return', () => {
+    const source = readFileSync(path.join(process.cwd(), 'e2e/lib/preview-schema-preflight.js'), 'utf8');
+    const functionStart = source.indexOf('function runWranglerSchemaCheck');
+    const assertStart = source.indexOf('function assertPreviewD1Schema', functionStart);
+    const section = source.slice(functionStart, assertStart);
+
+    expect(functionStart).toBeGreaterThanOrEqual(0);
+    expect(assertStart).toBeGreaterThan(functionStart);
+    expect(section).toContain('attempt === WRANGLER_TRANSIENT_STATUS_RETRIES');
+    expect(section).not.toMatch(/}\s*return \{ result, args \};\s*}$/);
+  });
+
   it('fails with timeout guidance when wrangler hangs', () => {
     const preflight = loadPreflight();
     spawnSyncMock.mockReturnValue({

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -134,8 +134,6 @@ function runWranglerSchemaCheck(sql, wranglerEnv) {
       return { result, args };
     }
   }
-
-  return { result, args };
 }
 
 function assertPreviewD1Schema(env = process.env) {


### PR DESCRIPTION
## Summary
- Added TC-2104 E2E scenario coverage for the Wrangler retry-loop fallback contract.
- Added preview preflight and docs drift tests to keep the retry loop free of an unreachable loop-after return.
- Removed the unreachable fallback return after runWranglerSchemaCheck's retry loop.

## Issues
Closes #2104

## Validation
- npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint
