### PR TITLE
Narrow preview schema drift detection

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -293,7 +293,7 @@
   4. Wrangler の auth token 取得失敗や log file 書き込み失敗は schema 欠落として扱わず、`wrangler login` / `CLOUDFLARE_API_TOKEN` と `WRANGLER_LOG_PATH` の確認を促すことを確認する
   5. runner が `WRANGLER_LOG_PATH` 未指定時に writable な一時ログパスを渡し、`~/Library/Preferences/.wrangler/logs` 権限で停止しないことを確認する
   6. Wrangler が stderr/stdout なしで一時的に exit 1 を返した場合は1回だけ再試行し、再失敗時も schema drift と断定せず command/status/stdout/stderr の診断を出すことを確認する
-  7. schema drift と明確に判定できる stderr または必須カラム欠落時のみ `npm run db:migrations:apply:preview` を促すことを確認する
+  7. schema drift と明確に判定できる stderr または必須カラム欠落時のみ `npm run db:migrations:apply:preview` を促し、`Network error when connecting to schema registry`、`Unexpected schema`、`applying migration` のような汎用的な schema/migration 文言だけでは migration guidance を出さないことを確認する
   8. `GPMatch.assignedCups` と `GPMatch.suddenDeathWinnerId` が wrangler-format migration にも存在することを確認する
 - **期待結果**: preview D1 schema drift は TC 本体の 500 ではなく、起動前 preflight の明示エラーとして検出される
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1556,12 +1556,18 @@ describe('E2E case drift coverage', () => {
 
   it('keeps TC-111 aligned with the preview D1 columns that fail GP finals before browser launch', () => {
     const section = e2eCaseSection('TC-111');
+    const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');
 
     expect(section).toContain('Tournament.publicModes');
     expect(section).toContain('GPMatch.assignedCups');
     expect(section).toContain('GPMatch.suddenDeathWinnerId');
     expect(section).toContain('WRANGLER_LOG_PATH');
     expect(section).toContain('wrangler login');
+    expect(section).toContain('汎用的な schema/migration 文言だけでは');
+    expect(section).toContain('Network error when connecting to schema registry');
+    expect(section).toContain('Unexpected schema');
+    expect(preflightTest).toContain('classifies only concrete Wrangler schema drift stderr as migration guidance');
+    expect(preflightTest).toContain('keeps generic schema or migration stderr out of migration guidance');
   });
 
   it('documents TC-825 as a full Prisma migration JSON type guard for D1', () => {

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -157,6 +157,37 @@ describe('preview schema preflight', () => {
     expect(() => preflight.assertPreviewD1Schema({})).toThrow(/db:migrations:apply:preview/);
   });
 
+  it('classifies only concrete Wrangler schema drift stderr as migration guidance', () => {
+    const preflight = loadPreflight();
+
+    expect(preflight.isWranglerSchemaFailure('SQLITE_ERROR: no such table: GPMatch')).toBe(true);
+    expect(preflight.isWranglerSchemaFailure('SQLITE_ERROR: no such column: suddenDeathWinnerId')).toBe(true);
+    expect(preflight.isWranglerSchemaFailure('Preview D1 schema drift detected for Tournament.publicModes')).toBe(true);
+    expect(preflight.isWranglerSchemaFailure('pending D1 migration detected on preview')).toBe(true);
+    expect(preflight.isWranglerSchemaFailure('Network error when connecting to schema registry')).toBe(false);
+    expect(preflight.isWranglerSchemaFailure('Unexpected schema returned by registry')).toBe(false);
+    expect(preflight.isWranglerSchemaFailure('applying migration 0035_gp_finals_assigned_cups')).toBe(false);
+  });
+
+  it('keeps generic schema or migration stderr out of migration guidance', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: 'Checking preview database...',
+      stderr: 'Network error when connecting to schema registry while applying migration metadata',
+    });
+
+    let message = '';
+    try {
+      preflight.assertPreviewD1Schema({});
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toMatch(/Wrangler returned a generic nonzero status/);
+    expect(message).not.toMatch(/db:migrations:apply:preview/);
+  });
+
   it('retries empty Wrangler status 1 once and keeps migration guidance out of transient diagnostics', () => {
     const preflight = loadPreflight();
     spawnSyncMock.mockReturnValue({
@@ -283,6 +314,15 @@ describe('preview schema preflight', () => {
     expect(assertStart).toBeGreaterThan(functionStart);
     expect(section).toContain('attempt === WRANGLER_TRANSIENT_STATUS_RETRIES');
     expect(section).not.toMatch(/}\s*return \{ result, args \};\s*}$/);
+  });
+
+  it('keeps TC-111 documented as narrow schema drift classification coverage', () => {
+    const section = readFileSync(path.join(process.cwd(), '..', 'E2E_TEST_CASES.md'), 'utf8');
+
+    expect(section).toContain('TC-111');
+    expect(section).toContain('汎用的な schema/migration 文言だけでは');
+    expect(section).toContain('Network error when connecting to schema registry');
+    expect(section).toContain('Unexpected schema');
   });
 
   it('fails with timeout guidance when wrangler hangs', () => {

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -84,9 +84,12 @@ function isWranglerAuthOrLogFailure(stderr) {
 function isWranglerSchemaFailure(stderr) {
   return [
     /no such (table|column)/i,
-    /SQLITE_ERROR/i,
-    /migration/i,
-    /schema/i,
+    /SQLITE_ERROR:.*(?:no such (?:table|column)|missing (?:table|column)|unknown (?:table|column))/i,
+    /schema\s+drift/i,
+    /pending\s+(?:d1\s+)?migration/i,
+    /missing\s+(?:d1\s+)?migration/i,
+    /table .* not found/i,
+    /column .* not found/i,
   ].some((pattern) => pattern.test(stderr));
 }
 


### PR DESCRIPTION
## Summary
- Narrowed preview schema preflight stderr classification so generic `schema` or `migration` wording no longer triggers D1 migration guidance.
- Added direct coverage for true schema drift patterns and false-positive stderr examples from #2105.
- Updated TC-111 E2E scenario and drift guard coverage for the narrower classification contract.

## Issues
Closes #2105

## Validation
- npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint
- HOME=/tmp/jsmkc-wrangler-home XDG_CONFIG_HOME=/tmp/jsmkc-wrangler-config WRANGLER_LOG_PATH=/tmp/jsmkc-wrangler.log npm run build:cf
