### PR TITLE
Fix MR report auth ordering

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1822,6 +1822,18 @@
 - **期待結果**: MR participant で過去報告を確認でき、確定済みスコアを参加者自身が修正できる
 - **スクリプト**: `tc-mr.js TC-1083`
 
+## TC-2108: MR report route は scoresConfirmed より先に認可する
+- **URL**: /api/tournaments/[temp-id]/mr/match/[match-id]/report
+- **authRequired**: true (player/admin)
+- **背景**: issue #2108。MR report POST が `scoresConfirmed` を認可前に返すと、未認証ユーザーが matchId を知っているだけで確定状態を 400 vs 401/403 の差から推測できる。
+- **手順**:
+  1. 管理者セッションで MR 予選2名マッチを作成する
+  2. dual-report mismatch を作り、管理者 PUT で `scoresConfirmed=true` にする
+  3. Cookie を送らない fetch で同じ report URL に POST する
+  4. API route 単体テストで `checkScoreReportAuth` が `scoresConfirmed` validation より先に実行されることを確認する
+- **期待結果**: 未認証 POST は確定済み状態を示す 400 ではなく 401/403 になり、認可済み participant のみ `Scores have already been confirmed` を受け取る
+- **スクリプト**: `tc-mr.js TC-2108`
+
 ## TC-1082: BM/MR participant スコア入力ロジック共通化
 - **URL**: /tournaments/[temp-id]/bm/participant, /tournaments/[temp-id]/mr/participant
 - **authRequired**: true (player)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
@@ -206,7 +206,48 @@ describe('MR Score Report API Route - /api/tournaments/[id]/mr/match/[matchId]/r
         'Scores have already been confirmed for this match',
         'scoresConfirmed',
       );
-      expect(checkScoreReportAuth).not.toHaveBeenCalled();
+      expect(checkScoreReportAuth).toHaveBeenCalledWith(
+        request,
+        't1',
+        1,
+        mockMatch,
+      );
+      expect(prisma.mRMatch.update).not.toHaveBeenCalled();
+    });
+
+    it('should return auth failure before scoresConfirmed for unauthorized users', async () => {
+      const mockMatch = {
+        id: 'm1',
+        tournamentId: 't1',
+        version: 3,
+        completed: true,
+        scoresConfirmed: true,
+        player1Id: 'p1',
+        player2Id: 'p2',
+        player1: { id: 'p1', userId: 'u1' },
+        player2: { id: 'p2', userId: 'u2' },
+      };
+
+      (checkScoreReportAuth as jest.Mock).mockResolvedValue(false);
+      (prisma.mRMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/match/m1/report', {
+        reportingPlayer: 1,
+        score1: 2,
+        score2: 2,
+      });
+      const params = Promise.resolve({ id: 't1', matchId: 'm1' });
+      const result = await POST(request, { params });
+
+      expect(result).toEqual({
+        data: { error: 'Unauthorized: Not authorized for this match' },
+        status: 401,
+      });
+      expect(handleAuthError).toHaveBeenCalledWith('Unauthorized: Not authorized for this match');
+      expect(handleValidationError).not.toHaveBeenCalledWith(
+        'Scores have already been confirmed for this match',
+        'scoresConfirmed',
+      );
       expect(prisma.mRMatch.update).not.toHaveBeenCalled();
     });
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1533,6 +1533,24 @@ describe('E2E case drift coverage', () => {
     expect(mrReportRouteTest).toContain('should reject participant reports after admin scoresConfirmed');
   });
 
+  it('documents TC-2108 as MR report auth-before-scoresConfirmed coverage', () => {
+    const section = e2eCaseSection('TC-2108');
+    const tc2108 = sectionBetween(tcMr, 'async function runTc2108', '/* ───────── TC-620');
+    const authCheckIndex = mrReportRoute.indexOf('checkScoreReportAuth(request, tournamentId, reportingPlayer, match)');
+    const scoresConfirmedIndex = mrReportRoute.indexOf('match.scoresConfirmed');
+
+    expect(section).toContain('issue #2108');
+    expect(section).toContain('Cookie を送らない fetch');
+    expect(section).toContain('401/403');
+    expect(section).toContain('tc-mr.js TC-2108');
+    expect(tc2108).toContain("log('TC-2108'");
+    expect(tc2108).toContain("credentials: 'omit'");
+    expect(tc2108).toContain('leakedConfirmedState');
+    expect(authCheckIndex).toBeGreaterThanOrEqual(0);
+    expect(scoresConfirmedIndex).toBeGreaterThan(authCheckIndex);
+    expect(mrReportRouteTest).toContain('should return auth failure before scoresConfirmed for unauthorized users');
+  });
+
   it('documents TC-821A as shared TA sudden-death UI and logic coverage', () => {
     const section = e2eCaseSection('TC-821A');
 

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -24,6 +24,7 @@
  *  TC-612  GP race position validation (no-tie + double-game-over)
  *  TC-820  MR match/[matchId] page view-only
  *  TC-822  MR scoresConfirmed blocks later participant reports
+ *  TC-2108 MR report route auth-checks before scoresConfirmed
  *  TC-1079 MR qualification course assignment rejects invalid roundNumber before fallback
  *  TC-617  MR finals same-courses-per-round enforcement (PR #585 normalizer)
  *  TC-618  MR finals admin manual total-score override (PR #585 manual form)
@@ -1554,6 +1555,73 @@ async function runTc822(adminPage) {
   }
 }
 
+/* ───────── TC-2108: MR report auth before scoresConfirmed ─────────
+ * Once a match is scoresConfirmed, unauthenticated report POSTs must still
+ * fail as auth errors instead of revealing the confirmed state. */
+async function runTc2108(adminPage) {
+  try {
+    const { tournamentId, match } = await prepareSharedMrPair(adminPage, { dualReport: true });
+    const reportUrl = `/api/tournaments/${tournamentId}/mr/match/${match.id}/report`;
+
+    await adminPage.evaluate(async ([url, body]) => {
+      await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }, [reportUrl, { reportingPlayer: 1, score1: 3, score2: 1 }]);
+
+    await adminPage.evaluate(async ([url, body]) => {
+      await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }, [reportUrl, { reportingPlayer: 2, score1: 1, score2: 3 }]);
+
+    const afterMismatch = await apiFetchMr(adminPage, tournamentId);
+    const pendingMatch = (afterMismatch.matches || []).find((m) => m.id === match.id);
+    if (!pendingMatch) throw new Error('TC-2108 match missing after mismatch');
+
+    const confirmRes = await adminPage.evaluate(async ([url, body]) => {
+      const r = await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status };
+    }, [`/api/tournaments/${tournamentId}/mr/match/${match.id}`, {
+      score1: 3,
+      score2: 1,
+      completed: true,
+      scoresConfirmed: true,
+      version: pendingMatch.version,
+    }]);
+
+    const unauthReport = await adminPage.evaluate(async ([url, body]) => {
+      const r = await fetch(url, {
+        method: 'POST',
+        credentials: 'omit',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [reportUrl, { reportingPlayer: 1, score1: 2, score2: 2 }]);
+
+    const unauthorized = unauthReport.s === 401 || unauthReport.s === 403;
+    const leakedConfirmedState = unauthReport.s === 400
+      && JSON.stringify(unauthReport.b).includes('scoresConfirmed');
+
+    log('TC-2108', confirmRes.s === 200 && unauthorized && !leakedConfirmedState ? 'PASS' : 'FAIL',
+      confirmRes.s !== 200 ? `Admin confirmation failed (${confirmRes.s})`
+      : !unauthorized ? `Unauthenticated report returned ${unauthReport.s} instead of 401/403`
+      : leakedConfirmedState ? 'Unauthenticated report leaked scoresConfirmed validation'
+      : '');
+  } catch (err) {
+    log('TC-2108', 'FAIL', err instanceof Error ? err.message : 'MR TC-2108 auth order failed');
+  }
+}
+
 /* ───────── TC-620: MR qualification tie resolution ─────────
  * Mirrors TC-324 (BM) and TC-713 (GP) — creates 3 players, sets up MR
  * qualification, and forces every non-BYE match to a 2-2 draw so every
@@ -1814,6 +1882,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-612', fn: runTc612 },
       { name: 'TC-611', fn: runTc611 },
       { name: 'TC-822', fn: runTc822 },
+      { name: 'TC-2108', fn: runTc2108 },
       { name: 'TC-620', fn: runTc620 },
       { name: 'TC-617', fn: runTc617 },
       { name: 'TC-618', fn: runTc618 },

--- a/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/mr/match/[matchId]/report/route.ts
@@ -110,10 +110,6 @@ export async function POST(
       return handleValidationError("Match not found", "matchId");
     }
 
-    if (match.scoresConfirmed) {
-      return handleValidationError("Scores have already been confirmed for this match", "scoresConfirmed");
-    }
-
     /* Validate required fields before auth to fail fast on malformed requests */
     if (reportingPlayer !== 1 && reportingPlayer !== 2) {
       return handleValidationError("reportingPlayer must be 1 or 2", "reportingPlayer");
@@ -127,6 +123,10 @@ export async function POST(
     const isAuthorized = await checkScoreReportAuth(request, tournamentId, reportingPlayer, match);
     if (!isAuthorized) {
       return handleAuthError('Unauthorized: Not authorized for this match');
+    }
+
+    if (match.scoresConfirmed) {
+      return handleValidationError("Scores have already been confirmed for this match", "scoresConfirmed");
     }
 
     /*


### PR DESCRIPTION
## Summary
- Move MR report `scoresConfirmed` validation after `checkScoreReportAuth` so unauthenticated callers cannot infer confirmed match state.
- Add TC-2108 scenario coverage, E2E drift assertions, and focused route unit coverage for the auth-before-confirmed ordering.

## Issues
Closes #2108

## Validation
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts' '__tests__/docs/e2e-cases-drift.test.ts'`
- `npm run lint` (exit 0; existing warnings only)
- `npm run build:cf`
- `E2E_TESTS=TC-2108 npm run e2e:mr` attempted after `npm run e2e:install-browser`, but local Chromium launch is blocked by macOS Crashpad permission errors before tests start.
