### PR TITLE
Guard CDM Main Hub exactly-60 boundary

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -788,6 +788,17 @@
 - **期待結果**: finals match は CDM 2025 テンプレートの native bracket coordinates に配置され、GP の cup/points 補足情報も失われない
 - **スクリプト**: `tc-all.js TC-816A`, `__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2088: CDM export — Main Hub は60人ちょうどで B62 を空のままにする
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #2088。Main Hub の player rows は B2 から B61 までの60行に限定される。60人ちょうどの境界テストでは、最終行 B61 への書き込みだけでなく、範囲外の B62 が作成されないことも明示的に確認する必要がある。
+- **手順**:
+  1. CDM export fixture に TT entries を60人だけ用意する
+  2. `GET /api/tournaments/:id/export?format=cdm` を実行する
+  3. Main Hub の `B2` が1人目、`B61`/`C61` が60人目の name/nickname で埋まることを確認する
+  4. Main Hub の `B62` が `undefined` のままであることを確認する
+- **期待結果**: 60人ちょうどでは Main Hub の有効範囲だけが書き込まれ、61行目相当の `B62` は生成されない
+- **スクリプト**: `__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`
+
 ## TC-1877A: CDM export — grand_final_reset の正規化で到達不能条件を残さない
 - **URL**: /api/tournaments/[id]/export?format=cdm
 - **背景**: issue #1877。`grand_final_reset` は native slot table で先に解決されるため、同じ round 文字列を後段の別条件に残すと読み手に誤解を与える。

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -361,6 +361,7 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       expect(workbook.Sheets["Main Hub"].B2.v).toBe('Name 01');
       expect(workbook.Sheets["Main Hub"].B61.v).toBe('Name 60');
       expect(workbook.Sheets["Main Hub"].C61.v).toBe('Player 60');
+      expect(workbook.Sheets["Main Hub"].B62).toBeUndefined();
     });
 
     it('should cap Main Hub player rows at 60 when more players are provided', async () => {

--- a/smkc-score-app/__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts
@@ -1,0 +1,31 @@
+import { e2eCaseSection, readRepoFile } from '../helpers/e2e-cases';
+
+describe('TC-2088 CDM Main Hub boundary coverage', () => {
+  it('documents the exactly-60 Main Hub boundary scenario', () => {
+    const section = e2eCaseSection('TC-2088');
+
+    expect(section).toContain('issue #2088');
+    expect(section).toContain('B61');
+    expect(section).toContain('B62');
+    expect(section).toContain('undefined');
+    expect(section).toContain('__tests__/app/api/tournaments/[id]/export/route.test.ts');
+  });
+
+  it('keeps the unit test asserting B62 stays unwritten at exactly 60 players', () => {
+    const routeTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'app',
+      'api',
+      'tournaments',
+      '[id]',
+      'export',
+      'route.test.ts',
+    );
+
+    expect(routeTest).toContain('should write the Main Hub player rows for exactly 60 players');
+    expect(routeTest).toContain('Array.from({ length: 60 }');
+    expect(routeTest).toContain('workbook.Sheets["Main Hub"].B61.v');
+    expect(routeTest).toContain('workbook.Sheets["Main Hub"].B62).toBeUndefined()');
+  });
+});


### PR DESCRIPTION
Summary
- Add TC-2088 to document the CDM Main Hub exactly-60 player boundary.
- Add static E2E coverage that ties TC-2088 to the export route unit test.
- Assert the CDM Main Hub exactly-60 route test leaves B62 undefined.

Issues: Closes #2088

Validation
- npm test -- --runTestsByPath __tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts '__tests__/app/api/tournaments/[id]/export/route.test.ts'
- npm test
- npm run lint
- npm run build:cf
