### PR TITLE
Guard CDM export row caps

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -799,6 +799,26 @@
 - **期待結果**: 60人ちょうどでは Main Hub の有効範囲だけが書き込まれ、61行目相当の `B62` は生成されない
 - **スクリプト**: `__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`
 
+## TC-2089A: CDM export — Main Hub の 60行上限で row 62 を保護する
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #2089/#2092/#2093。CDM Main Hub は 60人分の固定テンプレート領域だけを書き換えるため、61人以上のデータが来ても row 62 の既存セルを上書きしてはならない。
+- **手順**:
+  1. `Main Hub` の B62〜L62 に stale sentinel 値を持つ CDM workbook fixture を用意する
+  2. 61件の TT entries を持つ tournament を CDM export する
+  3. B61/C61 には60人目が出力され、B62〜L62 の sentinel がすべて残ることを確認する
+- **期待結果**: Main Hub は 60人目までを書き込み、row 62 以降のテンプレートセルを保持する
+- **スクリプト**: `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+
+## TC-2180A: CDM export — TT Qualifications の 60行上限で row 62 を保護する
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #2180。TT Qualifications も Main Hub と同じ 60行固定テンプレート領域を使うため、61件目の qualification entry で row 62 のテンプレートセルを上書きしてはならない。
+- **手順**:
+  1. `TT Qualifications` の E62〜Z62 に stale sentinel 値を持つ CDM workbook fixture を用意する
+  2. 61件の TT qualification entries を持つ tournament を CDM export する
+  3. E61/F61 には60人目が出力され、E62〜Z62 の sentinel がすべて残ることを確認する
+- **期待結果**: TT Qualifications は 60件目までを書き込み、row 62 以降のテンプレートセルを保持する
+- **スクリプト**: `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-1877A: CDM export — grand_final_reset の正規化で到達不能条件を残さない
 - **URL**: /api/tournaments/[id]/export?format=cdm
 - **背景**: issue #1877。`grand_final_reset` は native slot table で先に解決されるため、同じ round 文字列を後段の別条件に残すと読み手に誤解を与える。

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -371,14 +371,14 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
             B62: { v: 'KEEP-OUT-OF-BOUNDS' },
             C62: { v: 'KEEP-OUT-OF-BOUNDS' },
             D62: { v: 'KEEP-OUT-OF-BOUNDS' },
-            E62: { v: 'KEEP-OUT-BOUNDS' },
-            F62: { v: 'KEEP-OUT-BOUNDS' },
-            G62: { v: 'KEEP-OUT-BOUNDS' },
-            H62: { v: 'KEEP-OUT-BOUNDS' },
-            I62: { v: 'KEEP-OUT-BOUNDS' },
-            J62: { v: 'KEEP-OUT-BOUNDS' },
-            K62: { v: 'KEEP-OUT-BOUNDS' },
-            L62: { v: 'KEEP-OUT-BOUNDS' },
+            E62: { v: 'KEEP-OUT-OF-BOUNDS' },
+            F62: { v: 'KEEP-OUT-OF-BOUNDS' },
+            G62: { v: 'KEEP-OUT-OF-BOUNDS' },
+            H62: { v: 'KEEP-OUT-OF-BOUNDS' },
+            I62: { v: 'KEEP-OUT-OF-BOUNDS' },
+            J62: { v: 'KEEP-OUT-OF-BOUNDS' },
+            K62: { v: 'KEEP-OUT-OF-BOUNDS' },
+            L62: { v: 'KEEP-OUT-OF-BOUNDS' },
           },
           "TT Qualifications": {},
           "BM Qualifications": {},
@@ -436,12 +436,87 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
       expect(workbook.Sheets["Main Hub"].B2.v).toBe('Name 01');
       expect(workbook.Sheets["Main Hub"].B61.v).toBe('Name 60');
-      expect(workbook.Sheets["Main Hub"].B62).toEqual({
-        v: 'KEEP-OUT-OF-BOUNDS',
+      for (const col of ["B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"]) {
+        expect(workbook.Sheets["Main Hub"][`${col}62`]).toEqual({
+          v: 'KEEP-OUT-OF-BOUNDS',
+        });
+      }
+    });
+
+    it('should cap TT Qualifications rows at 60 when more entries are provided', async () => {
+      const ttBoundaryColumns = [
+        "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O",
+        "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
+      ];
+      const staleWorkbook = {
+        Sheets: {
+          "Main Hub": {},
+          "TT Qualifications": Object.fromEntries(
+            ttBoundaryColumns.map((col) => [`${col}62`, { v: `KEEP-TT-${col}62` }]),
+          ),
+          "BM Qualifications": {},
+          "MR Qualifications": {},
+          "GP Qualifications": {},
+          "BM Finals": {},
+          "MR Finals": {},
+          "GP Finals": {},
+          "TT Finals": {},
+          "Overall Ranking": {},
+        },
+        Workbook: {},
+      };
+      (XLSX.read as jest.Mock).mockImplementationOnce(() => staleWorkbook as any);
+
+      const makePlayer = (index: number) => {
+        const n = String(index + 1).padStart(2, "0");
+        return {
+          playerId: `p${index + 1}`,
+          player: { id: `p${index + 1}`, name: `Name ${n}`, nickname: `Player ${n}` },
+          stage: 'qualification',
+          seeding: index + 1,
+          lives: 3,
+          eliminated: false,
+          times: {},
+          totalTime: 12000 + index,
+        };
+      };
+
+      const mockTournament = {
+        id: 't1',
+        name: 'CDM TT Qualification Cap',
+        date: new Date('2024-01-15'),
+        status: 'completed',
+        bmQualifications: [],
+        mrQualifications: [],
+        gpQualifications: [],
+        bmMatches: [],
+        mrMatches: [],
+        gpMatches: [],
+        ttEntries: Array.from({ length: 61 }, (_value, index) => makePlayer(index)),
+        ttPhaseRounds: [],
+        playerScores: [],
+      };
+
+      (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
       });
-      expect(workbook.Sheets["Main Hub"].C62).toEqual({
-        v: 'KEEP-OUT-OF-BOUNDS',
-      });
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
+      const params = Promise.resolve({ id: 't1' });
+      await GET(request, { params });
+
+      const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
+      expect(workbook.Sheets["TT Qualifications"].E2.v).toBe(1);
+      expect(workbook.Sheets["TT Qualifications"].F2.v).toBe('Player 01');
+      expect(workbook.Sheets["TT Qualifications"].E61.v).toBe(60);
+      expect(workbook.Sheets["TT Qualifications"].F61.v).toBe('Player 60');
+      for (const col of ttBoundaryColumns) {
+        expect(workbook.Sheets["TT Qualifications"][`${col}62`]).toEqual({
+          v: `KEEP-TT-${col}62`,
+        });
+      }
     });
 
     it('should use the first fallback CDM finals slot only for unknown rounds', async () => {

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -433,6 +433,28 @@ describe('E2E case drift coverage', () => {
     expect(exportRouteTest).toContain('workbook.Sheets["GP Finals"].AR19.v');
   });
 
+  it('documents CDM export row-cap coverage for Main Hub and TT Qualifications', () => {
+    const mainHubSection = e2eCaseSection('TC-2089A');
+    const ttQualificationsSection = e2eCaseSection('TC-2180A');
+
+    expect(mainHubSection).toContain('issue #2089/#2092/#2093');
+    expect(mainHubSection).toContain('B62〜L62');
+    expect(mainHubSection).toContain('B61/C61');
+    expect(mainHubSection).toContain('__tests__/app/api/tournaments/[id]/export/route.test.ts');
+    expect(ttQualificationsSection).toContain('issue #2180');
+    expect(ttQualificationsSection).toContain('E62〜Z62');
+    expect(ttQualificationsSection).toContain('E61/F61');
+    expect(ttQualificationsSection).toContain('__tests__/app/api/tournaments/[id]/export/route.test.ts');
+    expect(exportRoute).toContain('const CDM_PLAYER_HUB_ROW_SPAN = 60');
+    expect(exportRoute).toContain('const CDM_TT_QUAL_MAX_PLAYERS = CDM_PLAYER_HUB_MAX_PLAYERS');
+    expect(exportRouteTest).toContain('should cap Main Hub player rows at 60 when more players are provided');
+    expect(exportRouteTest).toContain('should cap TT Qualifications rows at 60 when more entries are provided');
+    expect(exportRouteTest).toContain('KEEP-OUT-OF-BOUNDS');
+    expect(exportRouteTest).not.toContain('KEEP-OUT-BOUNDS');
+    expect(exportRouteTest).toContain('ttBoundaryColumns');
+    expect(exportRouteTest).toContain('KEEP-TT-${col}62');
+  });
+
   it('documents TC-808A as TA TV3/TV4 broadcast warning coverage', () => {
     const section = e2eCaseSection('TC-808A');
 


### PR DESCRIPTION
## Summary
- add TC-2089A and TC-2180A E2E scenario coverage for CDM export row-cap boundaries
- expand Main Hub row-62 assertions from B/C to B-L and fix the stale sentinel typo
- add TT Qualifications row-62 stale-cell coverage for E-Z when 61 entries are exported

## Issues
Closes #2089
Closes #2092
Closes #2093
Closes #2180

## Validation
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/export/route.test.ts' __tests__/docs/e2e-cases-drift.test.ts
- npm test
- npm run lint
- npm run build:cf
