### PR TITLE
Harden CDM E2E finals readiness

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -825,6 +825,34 @@
 - **期待結果**: cupResults 検証は補助チェックになり、BM/MR/GP 座標検証が通れば TC-816A は PASS できる
 - **スクリプト**: `tc-all.js TC-816A`, `__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2098A: CDM export — finals readiness state を並列取得する
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #2098。TC-816A の fixture readiness は BM/MR/GP finals state をすべて必要とするため、逐次 `await` にすると D1/API 待ちがモード数ぶん積み上がる。
+- **手順**:
+  1. `ensureCdmE2eFinalsFixture` が BM/MR/GP finals state を `Promise.all` で取得することを確認する
+  2. unit test で BM の fetch promise を保留しても MR/GP fetch が即時開始されることを確認する
+- **期待結果**: readiness state の初回取得・再取得はモード間で並列に開始される
+- **スクリプト**: `tc-all.js TC-816A`, `__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+
+## TC-2099A: CDM export — finals readiness round 計算で slotRound を再計算しない
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #2099/#2100。`cdmE2eFinalsMatches` が slot-mappable match だけを扱う前提で、readiness details が `cdmE2eSlotRound` を再呼び出ししてから `.filter(Boolean)` するのは冗長で意図が読みにくい。
+- **手順**:
+  1. slot-mappable match と `slotRound` を共有する helper があることを確認する
+  2. `cdmE2eFinalsReadinessDetails` が共有済み `slotRound` から rounds を作り、`.filter(Boolean)` を使わないことを確認する
+- **期待結果**: readiness details は slot 判定を一度だけ行い、rounds は truthy な `slotRound` だけから組み立てられる
+- **スクリプト**: `tc-all.js TC-816A`, `__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+
+## TC-2182A: CDM export — finals fixture 生成失敗を mode 別 status で報告する
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #2182。TC-816A が不足モードの finals を自動生成するとき、POST の HTTP status/body を無視すると、後続の「match がない」診断だけでは失敗原因が追いにくい。
+- **手順**:
+  1. 不足モードの BM/MR/GP finals generation 結果を mode 名つきで検査する
+  2. 200/201 以外の status では `CDM finals fixture generation failed` と mode/status/body を含むエラーを出す
+  3. unit test で BM generation が 500 を返す場合の診断を確認する
+- **期待結果**: fixture 生成APIの失敗は、workbook検証前に mode 別の具体的な HTTP status として報告される
+- **スクリプト**: `tc-all.js TC-816A`, `__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-817B: CDM export — CSV では CDM 専用 include を取得しない
 - **URL**: /api/tournaments/[id]/export
 - **背景**: issue #817。CSV 出力は MR/GP qualification seed、TT phase rounds、overall playerScores を使用しないため、CDM 専用 include を無条件に付けると不要な JOIN が増える。

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -35,6 +35,12 @@ describe('E2E case drift coverage', () => {
   const gpFinalsValidators = readE2eLib('gp-finals-validators.js');
   const bmFinalsPage = readRepoFile('smkc-score-app', 'src', 'app', 'tournaments', '[id]', 'bm', 'finals', 'page.tsx');
   const tc1073Lr2Slots = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'tc-1073-16p-lr2-slots.test.ts');
+  const cdmFinalsFixtureTest = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'e2e',
+    'tc-816a-cdm-finals-fixture.test.ts',
+  );
   const prismaMigrationsTest = readRepoFile('smkc-score-app', '__tests__', 'docs', 'prisma-migrations.test.ts');
   const taPhasesRouteTest = readRepoFile(
     'smkc-score-app',
@@ -413,8 +419,8 @@ describe('E2E case drift coverage', () => {
     expect(tcAll).toContain('gpCupResultsChecked');
     expect(tcAll).toContain('checkedByMode');
     expect(tcAll).toContain('ensureCdmE2eFinalsFixture');
-    expect(tcAll).toContain('apiGenerateBmFinals(page, tournamentId, 24)');
-    expect(tcAll).toContain('apiGenerateMrFinals(page, tournamentId, 24)');
+    expect(tcAll).toContain("if (missingModes.has('BM')) generators.push({ mode: 'BM'");
+    expect(tcAll).toContain("if (missingModes.has('MR')) generators.push({ mode: 'MR'");
     expect(tcAll).toContain('cdmE2eFinalsReadinessSummary');
     expect(tcAll).toContain('slot.blockStart + 5');
     expect(section).toContain('mode 別 match count と round 一覧');
@@ -487,6 +493,30 @@ describe('E2E case drift coverage', () => {
     expect(tcAll).toContain('GP cupResults not available; skipped summary-cell check');
     expect(tcAll).toContain('checked > 0 && missingModes.length === 0 && failures.length === 0');
     expect(tcAll).not.toContain('missingModes.length === 0 && gpCupResultsChecked && failures.length === 0');
+  });
+
+  it('documents CDM E2E finals readiness parallel fetch and generator diagnostics', () => {
+    const parallelSection = e2eCaseSection('TC-2098A');
+    const roundSection = e2eCaseSection('TC-2099A');
+    const generatorSection = e2eCaseSection('TC-2182A');
+
+    expect(parallelSection).toContain('issue #2098');
+    expect(parallelSection).toContain('Promise.all');
+    expect(parallelSection).toContain('BM の fetch promise を保留しても MR/GP fetch が即時開始');
+    expect(roundSection).toContain('issue #2099/#2100');
+    expect(roundSection).toContain('.filter(Boolean)');
+    expect(generatorSection).toContain('issue #2182');
+    expect(generatorSection).toContain('CDM finals fixture generation failed');
+    expect(tcAll).toContain('async function fetchCdmE2eModeStates');
+    expect(tcAll).toContain('const [bmState, mrState, gpState] = await Promise.all([');
+    expect(tcAll).not.toContain("state: await apiFetchBmFinalsState(page, tournamentId)");
+    expect(tcAll).toContain('function cdmE2eFinalsSlotMatches');
+    expect(tcAll).toContain('slotMatches.map(({ slotRound }) => slotRound)');
+    expect(tcAll).not.toContain('matches.map((match) => cdmE2eSlotRound(match)).filter(Boolean)');
+    expect(tcAll).toContain('function assertCdmE2eGeneratorResults');
+    expect(tcAll).toContain('CDM finals fixture generation failed');
+    expect(cdmFinalsFixtureTest).toContain('fetches mode readiness states in parallel');
+    expect(cdmFinalsFixtureTest).toContain('reports failed finals generator status');
   });
 
   it('documents TC-817B as CSV/CDM export include split coverage', () => {

--- a/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
@@ -2,6 +2,7 @@ import {
   cdmE2eFinalsMatches,
   cdmE2eFinalsReadinessDetails,
   cdmE2eFinalsReadinessSummary,
+  ensureCdmE2eFinalsFixture,
 } from '../../e2e/tc-all';
 
 describe('TC-816A CDM finals fixture readiness', () => {
@@ -48,5 +49,63 @@ describe('TC-816A CDM finals fixture readiness', () => {
         { round: 'not_exported', bracketPosition: 'table-only' },
       ],
     })).toHaveLength(2);
+  });
+
+  it('fetches mode readiness states in parallel before checking missing modes', async () => {
+    const state = { matches: [{ round: 'winners_r1', bracketPosition: 'winners_r1' }] };
+    const starts: string[] = [];
+    let releaseBm: (value: typeof state) => void = () => {};
+    const bmPromise = new Promise<typeof state>((resolve) => {
+      releaseBm = resolve;
+    });
+    const api = {
+      fetchBmFinalsState: jest.fn(() => {
+        starts.push('BM');
+        return bmPromise;
+      }),
+      fetchMrFinalsState: jest.fn(() => {
+        starts.push('MR');
+        return Promise.resolve(state);
+      }),
+      fetchGpFinalsState: jest.fn(() => {
+        starts.push('GP');
+        return Promise.resolve(state);
+      }),
+      generateBmFinals: jest.fn(),
+      generateMrFinals: jest.fn(),
+      generateGpFinals: jest.fn(),
+    };
+
+    const readinessPromise = ensureCdmE2eFinalsFixture({} as never, 't1', api);
+    await Promise.resolve();
+
+    expect(starts).toEqual(['BM', 'MR', 'GP']);
+    releaseBm(state);
+    await expect(readinessPromise).resolves.toMatchObject({
+      readinessDetails: [
+        { mode: 'BM', count: 1 },
+        { mode: 'MR', count: 1 },
+        { mode: 'GP', count: 1 },
+      ],
+    });
+    expect(api.generateBmFinals).not.toHaveBeenCalled();
+    expect(api.generateMrFinals).not.toHaveBeenCalled();
+    expect(api.generateGpFinals).not.toHaveBeenCalled();
+  });
+
+  it('reports failed finals generator status before returning missing-match diagnostics', async () => {
+    const emptyState = { playoffMatches: [], matches: [] };
+    const api = {
+      fetchBmFinalsState: jest.fn(() => Promise.resolve(emptyState)),
+      fetchMrFinalsState: jest.fn(() => Promise.resolve(emptyState)),
+      fetchGpFinalsState: jest.fn(() => Promise.resolve(emptyState)),
+      generateBmFinals: jest.fn(() => Promise.resolve({ s: 500, b: { error: 'BM exploded' } })),
+      generateMrFinals: jest.fn(() => Promise.resolve({ s: 201, b: {} })),
+      generateGpFinals: jest.fn(() => Promise.resolve({ s: 200, b: {} })),
+    };
+
+    await expect(ensureCdmE2eFinalsFixture({} as never, 't1', api)).rejects.toThrow(
+      'CDM finals fixture generation failed: BM HTTP 500: BM exploded',
+    );
   });
 });

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -113,18 +113,33 @@ function cdmE2eCell(col, row) {
   return XLSX.utils.encode_cell({ c: col - 1, r: row - 1 });
 }
 
-function cdmE2eFinalsMatches(state) {
+const cdmE2eFinalsApi = {
+  fetchBmFinalsState: apiFetchBmFinalsState,
+  fetchMrFinalsState: apiFetchMrFinalsState,
+  fetchGpFinalsState: apiFetchGpFinalsState,
+  generateBmFinals: apiGenerateBmFinals,
+  generateMrFinals: apiGenerateMrFinals,
+  generateGpFinals: apiGenerateGpFinals,
+};
+
+function cdmE2eFinalsSlotMatches(state) {
   return [
     ...(state?.playoffMatches || []),
     ...(state?.matches || []),
-  ].filter((match) => cdmE2eSlotRound(match));
+  ]
+    .map((match) => ({ match, slotRound: cdmE2eSlotRound(match) }))
+    .filter(({ slotRound }) => slotRound);
+}
+
+function cdmE2eFinalsMatches(state) {
+  return cdmE2eFinalsSlotMatches(state).map(({ match }) => match);
 }
 
 function cdmE2eFinalsReadinessDetails(modeStates) {
   return modeStates.map(({ mode, state }) => {
-    const matches = cdmE2eFinalsMatches(state);
-    const rounds = [...new Set(matches.map((match) => cdmE2eSlotRound(match)).filter(Boolean))];
-    return { mode, count: matches.length, rounds };
+    const slotMatches = cdmE2eFinalsSlotMatches(state);
+    const rounds = [...new Set(slotMatches.map(({ slotRound }) => slotRound))];
+    return { mode, count: slotMatches.length, rounds };
   });
 }
 
@@ -134,24 +149,59 @@ function cdmE2eFinalsReadinessSummary(readinessDetails) {
     .join('; ');
 }
 
-async function ensureCdmE2eFinalsFixture(page, tournamentId) {
-  const fetchModeStates = async () => ([
-    { mode: 'BM', sheetName: 'BM Finals', state: await apiFetchBmFinalsState(page, tournamentId) },
-    { mode: 'MR', sheetName: 'MR Finals', state: await apiFetchMrFinalsState(page, tournamentId) },
-    { mode: 'GP', sheetName: 'GP Finals', state: await apiFetchGpFinalsState(page, tournamentId) },
+async function fetchCdmE2eModeStates(page, tournamentId, api = cdmE2eFinalsApi) {
+  const [bmState, mrState, gpState] = await Promise.all([
+    api.fetchBmFinalsState(page, tournamentId),
+    api.fetchMrFinalsState(page, tournamentId),
+    api.fetchGpFinalsState(page, tournamentId),
   ]);
 
-  let modeStates = await fetchModeStates();
+  return [
+    { mode: 'BM', sheetName: 'BM Finals', state: bmState },
+    { mode: 'MR', sheetName: 'MR Finals', state: mrState },
+    { mode: 'GP', sheetName: 'GP Finals', state: gpState },
+  ];
+}
+
+function cdmE2eGenerationResultDetail(result) {
+  const status = result?.s ?? 'unknown';
+  const body = result?.b;
+  const message = typeof body?.error === 'string' ? body.error
+    : typeof body?.message === 'string' ? body.message
+    : JSON.stringify(body ?? {});
+  return `HTTP ${status}${message && message !== '{}' ? `: ${message}` : ''}`;
+}
+
+function assertCdmE2eGeneratorResults(results) {
+  const failures = results.filter(({ result }) => ![200, 201].includes(result?.s));
+  if (failures.length === 0) return;
+
+  throw new Error(`CDM finals fixture generation failed: ${
+    failures.map(({ mode, result }) => `${mode} ${cdmE2eGenerationResultDetail(result)}`).join('; ')
+  }`);
+}
+
+async function generateCdmE2eMissingFinals(page, tournamentId, missingModes, api = cdmE2eFinalsApi) {
+  const generators = [];
+  if (missingModes.has('BM')) generators.push({ mode: 'BM', promise: api.generateBmFinals(page, tournamentId, 24) });
+  if (missingModes.has('MR')) generators.push({ mode: 'MR', promise: api.generateMrFinals(page, tournamentId, 24) });
+  if (missingModes.has('GP')) generators.push({ mode: 'GP', promise: api.generateGpFinals(page, tournamentId, 24) });
+
+  const results = await Promise.all(
+    generators.map(async ({ mode, promise }) => ({ mode, result: await promise })),
+  );
+  assertCdmE2eGeneratorResults(results);
+  return results;
+}
+
+async function ensureCdmE2eFinalsFixture(page, tournamentId, api = cdmE2eFinalsApi) {
+  let modeStates = await fetchCdmE2eModeStates(page, tournamentId, api);
   let readinessDetails = cdmE2eFinalsReadinessDetails(modeStates);
   const missingModes = new Set(readinessDetails.filter(({ count }) => count === 0).map(({ mode }) => mode));
 
   if (missingModes.size > 0) {
-    const generators = [];
-    if (missingModes.has('BM')) generators.push(apiGenerateBmFinals(page, tournamentId, 24));
-    if (missingModes.has('MR')) generators.push(apiGenerateMrFinals(page, tournamentId, 24));
-    if (missingModes.has('GP')) generators.push(apiGenerateGpFinals(page, tournamentId, 24));
-    await Promise.all(generators);
-    modeStates = await fetchModeStates();
+    await generateCdmE2eMissingFinals(page, tournamentId, missingModes, api);
+    modeStates = await fetchCdmE2eModeStates(page, tournamentId, api);
     readinessDetails = cdmE2eFinalsReadinessDetails(modeStates);
   }
 
@@ -4449,5 +4499,7 @@ module.exports = {
   cdmE2eFinalsMatches,
   cdmE2eFinalsReadinessDetails,
   cdmE2eFinalsReadinessSummary,
+  fetchCdmE2eModeStates,
+  generateCdmE2eMissingFinals,
   ensureCdmE2eFinalsFixture,
 };


### PR DESCRIPTION
## Summary
- fetch BM/MR/GP CDM finals readiness state in parallel for TC-816A
- share slot-round extraction so readiness details do not recompute or filter redundant values
- report failed finals fixture generation by mode with HTTP status/body before workbook diagnostics

## Issues
Closes #2098
Closes #2099
Closes #2100
Closes #2182

## Validation
- npm test -- --runTestsByPath __tests__/e2e/tc-816a-cdm-finals-fixture.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm test
- npm run lint
- npm run build:cf
