### PR TITLE
Limit CDM fixture helper exports

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -853,6 +853,16 @@
 - **期待結果**: fixture 生成APIの失敗は、workbook検証前に mode 別の具体的な HTTP status として報告される
 - **スクリプト**: `tc-all.js TC-816A`, `__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2187A: CDM export — TC-816A fixture helper の公開 API を最小化する
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #2187。`fetchCdmE2eModeStates` と `generateCdmE2eMissingFinals` は `ensureCdmE2eFinalsFixture` の内部処理であり、直接 import するテストがない状態で `tc-all.js` の公開 API に出すと不要な依存先になる。
+- **手順**:
+  1. TC-816A が `ensureCdmE2eFinalsFixture` 経由で readiness fetch と不足 finals generation を検証することを確認する
+  2. unit test で `tc-all.js` の module exports に `fetchCdmE2eModeStates` / `generateCdmE2eMissingFinals` が含まれないことを確認する
+  3. `ensureCdmE2eFinalsFixture` は引き続き公開され、TC-816A の fixture 検証から利用できることを確認する
+- **期待結果**: E2E helper の公開面は実際に外部テストが使う API に限定され、内部 helper への不要な直接依存を防げる
+- **スクリプト**: `tc-all.js TC-816A`, `__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-817B: CDM export — CSV では CDM 専用 include を取得しない
 - **URL**: /api/tournaments/[id]/export
 - **背景**: issue #817。CSV 出力は MR/GP qualification seed、TT phase rounds、overall playerScores を使用しないため、CDM 専用 include を無条件に付けると不要な JOIN が増える。

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -499,6 +499,7 @@ describe('E2E case drift coverage', () => {
     const parallelSection = e2eCaseSection('TC-2098A');
     const roundSection = e2eCaseSection('TC-2099A');
     const generatorSection = e2eCaseSection('TC-2182A');
+    const publicApiSection = e2eCaseSection('TC-2187A');
 
     expect(parallelSection).toContain('issue #2098');
     expect(parallelSection).toContain('Promise.all');
@@ -507,6 +508,8 @@ describe('E2E case drift coverage', () => {
     expect(roundSection).toContain('.filter(Boolean)');
     expect(generatorSection).toContain('issue #2182');
     expect(generatorSection).toContain('CDM finals fixture generation failed');
+    expect(publicApiSection).toContain('issue #2187');
+    expect(publicApiSection).toContain('公開 API を最小化');
     expect(tcAll).toContain('async function fetchCdmE2eModeStates');
     expect(tcAll).toContain('const [bmState, mrState, gpState] = await Promise.all([');
     expect(tcAll).not.toContain("state: await apiFetchBmFinalsState(page, tournamentId)");
@@ -515,8 +518,13 @@ describe('E2E case drift coverage', () => {
     expect(tcAll).not.toContain('matches.map((match) => cdmE2eSlotRound(match)).filter(Boolean)');
     expect(tcAll).toContain('function assertCdmE2eGeneratorResults');
     expect(tcAll).toContain('CDM finals fixture generation failed');
+    const tcAllExports = sectionBetween(tcAll, 'module.exports = {', '};');
+    expect(tcAllExports).not.toContain('fetchCdmE2eModeStates');
+    expect(tcAllExports).not.toContain('generateCdmE2eMissingFinals');
+    expect(tcAllExports).toContain('ensureCdmE2eFinalsFixture');
     expect(cdmFinalsFixtureTest).toContain('fetches mode readiness states in parallel');
     expect(cdmFinalsFixtureTest).toContain('reports failed finals generator status');
+    expect(cdmFinalsFixtureTest).toContain('keeps internal fixture helpers out of the tc-all public test API');
   });
 
   it('documents TC-817B as CSV/CDM export include split coverage', () => {

--- a/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
@@ -4,6 +4,7 @@ import {
   cdmE2eFinalsReadinessSummary,
   ensureCdmE2eFinalsFixture,
 } from '../../e2e/tc-all';
+import * as tcAllExports from '../../e2e/tc-all';
 
 describe('TC-816A CDM finals fixture readiness', () => {
   it('counts slot-mappable playoff and finals matches by mode', () => {
@@ -107,5 +108,11 @@ describe('TC-816A CDM finals fixture readiness', () => {
     await expect(ensureCdmE2eFinalsFixture({} as never, 't1', api)).rejects.toThrow(
       'CDM finals fixture generation failed: BM HTTP 500: BM exploded',
     );
+  });
+
+  it('keeps internal fixture helpers out of the tc-all public test API', () => {
+    expect(tcAllExports).not.toHaveProperty('fetchCdmE2eModeStates');
+    expect(tcAllExports).not.toHaveProperty('generateCdmE2eMissingFinals');
+    expect(tcAllExports).toHaveProperty('ensureCdmE2eFinalsFixture');
   });
 });

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -4499,7 +4499,5 @@ module.exports = {
   cdmE2eFinalsMatches,
   cdmE2eFinalsReadinessDetails,
   cdmE2eFinalsReadinessSummary,
-  fetchCdmE2eModeStates,
-  generateCdmE2eMissingFinals,
   ensureCdmE2eFinalsFixture,
 };


### PR DESCRIPTION
## Summary
- Add TC-2187A coverage for keeping TC-816A fixture helper exports minimal
- Remove unused `fetchCdmE2eModeStates` and `generateCdmE2eMissingFinals` exports from `tc-all.js`
- Add Jest/drift assertions that the internal helpers stay private while `ensureCdmE2eFinalsFixture` remains public

## Issues
Closes #2187

## Validation
- `npm test -- --runTestsByPath __tests__/e2e/tc-816a-cdm-finals-fixture.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npm test`
- `npm run lint`
- `npm run build:cf`
