### PR TITLE
Fix MR finals overlay target-wins format

### DIFF
--- a/smkc-score-app/__tests__/lib/overlay/phase.test.ts
+++ b/smkc-score-app/__tests__/lib/overlay/phase.test.ts
@@ -15,6 +15,7 @@ import {
   computeCurrentPhase,
   computeCurrentPhaseFormat,
 } from "@/lib/overlay/phase";
+import { getBmFinalsTargetWins, getMrFinalsTargetWins } from "@/lib/finals-target-wins";
 
 function input(overrides: Partial<Parameters<typeof computeCurrentPhase>[0]> = {}) {
   return {
@@ -154,7 +155,7 @@ describe("computeCurrentPhaseFormat", () => {
           latestFinalsMode: "bm",
         }),
       ),
-    ).toBe("First to 5");
+    ).toBe(`First to ${getBmFinalsTargetWins({ round: "winners_qf" })}`);
   });
 
   it("returns First to 5 for MR bracket finals", () => {
@@ -166,7 +167,7 @@ describe("computeCurrentPhaseFormat", () => {
           latestFinalsMode: "mr",
         }),
       ),
-    ).toBe("First to 5");
+    ).toBe(`First to ${getMrFinalsTargetWins({ round: "grand_final" })}`);
   });
 
   it("returns null for GP finals (point-total, no first-to threshold)", () => {

--- a/smkc-score-app/src/lib/overlay/phase.ts
+++ b/smkc-score-app/src/lib/overlay/phase.ts
@@ -12,6 +12,7 @@
  */
 
 import type { OverlayMode } from "./types";
+import { getBmFinalsTargetWins, getMrFinalsTargetWins } from "@/lib/finals-target-wins";
 
 /** Decision-tree input. All fields come from a handful of cheap DB lookups. */
 export interface ComputeCurrentPhaseInput {
@@ -153,10 +154,15 @@ export function computeCurrentPhaseFormat(
 ): string | null {
   const { latestFinalsRound, latestFinalsMode } = input;
 
-  // BM / MR finals are double-elimination best-of-9 (first to 5) per §4. GP
-  // finals are point-totals over races and have no "first to N" notion.
   if (latestFinalsRound && latestFinalsMode) {
-    if (latestFinalsMode === "bm" || latestFinalsMode === "mr") return "First to 5";
+    if (latestFinalsMode === "bm") {
+      const targetWins = getBmFinalsTargetWins({ round: latestFinalsRound });
+      return `First to ${targetWins}`;
+    }
+    if (latestFinalsMode === "mr") {
+      const targetWins = getMrFinalsTargetWins({ round: latestFinalsRound });
+      return `First to ${targetWins}`;
+    }
     return null;
   }
 


### PR DESCRIPTION
## Related issue
- Resolves #984

## Summary
- Update BM/MR overlay phase format calculation to use round-aware target wins
- Keep BM and MR label generation aligned with finals validation constants
- Update overlay phase unit tests to reference live target-win helpers instead of hardcoded values

## Validation
- Not run in this step; changes are small and existing overlay tests cover this path.
