### PR TITLE
Split getNextPhase3ResetThreshold tests into happy/fallback cases

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -393,30 +393,20 @@ describe("TA Finals Phase Manager", () => {
   });
 
   describe("getNextPhase3ResetThreshold", () => {
-    it("uses the nearest configured lower threshold and falls back safely", () => {
+    it("uses the highest configured threshold when activeCount allows one", () => {
       expect(getNextPhase3ResetThreshold(16)).toBe(8);
       expect(getNextPhase3ResetThreshold(15)).toBe(8);
       expect(getNextPhase3ResetThreshold(11)).toBe(8);
+      expect(getNextPhase3ResetThreshold(9)).toBe(8);
       expect(getNextPhase3ResetThreshold(8)).toBe(4);
       expect(getNextPhase3ResetThreshold(7)).toBe(4);
-      expect(getNextPhase3ResetThreshold(4)).toBe(2);
-      expect(getNextPhase3ResetThreshold(3)).toBe(2);
-      expect(getNextPhase3ResetThreshold(2)).toBe(1);
-      expect(getNextPhase3ResetThreshold(1)).toBeNull();
-      expect(getNextPhase3ResetThreshold(0)).toBeNull();
-    });
-
-    it("returns the highest configured reset threshold below activeCount", () => {
-      expect(getNextPhase3ResetThreshold(9)).toBe(8);
       expect(getNextPhase3ResetThreshold(5)).toBe(4);
+      expect(getNextPhase3ResetThreshold(4)).toBe(2);
       expect(getNextPhase3ResetThreshold(3)).toBe(2);
     });
 
     it("falls back to activeCount-1 when no configured threshold remains", () => {
       expect(getNextPhase3ResetThreshold(2)).toBe(1);
-    });
-
-    it("returns null when the active player count is one or fewer", () => {
       expect(getNextPhase3ResetThreshold(1)).toBeNull();
       expect(getNextPhase3ResetThreshold(0)).toBeNull();
     });


### PR DESCRIPTION
## Summary
- Split getNextPhase3ResetThreshold expectations into happy-path and fallback cases.
- Clarify test intent for configured thresholds versus fallback behavior.

## Issues
Closes #1793

## Validation
- CI Lint & Test passed
- Claude Code Review Lint & Test passed
- Wait for Cloudflare Workers Build passed
- Workers Builds: smkc passed
