### PR TITLE
Cover preview schema failure patterns

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -125,6 +125,18 @@
 - **期待結果**: 認証/ログ初期化だけの失敗は通常 preview E2E を本体開始前に止めず、schema missing / SQLite error / timeout / strict preflight は従来どおり診断つきで失敗する。TC-2161 の E2E scenario 文字列確認は `preview-schema-preflight.test.ts` 側に集約し、drift test は preview preflight 実装と補助テストの対応だけを監視する
 - **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
 
+## TC-2207: Preview D1 schema preflight は Wrangler schema drift 表記の追加パターンを migration guidance に分類する
+- **URL**: n/a (runner configuration / preview suite)
+- **authRequired**: true (Cloudflare D1 token is optional unless strict preflight is requested)
+- **背景**: issue #2207。`isWranglerSchemaFailure` は Wrangler/D1 が返す SQLite missing/unknown table-column、missing D1 migration、`table not found`、`column not found` 表記を schema drift として migration guidance に流すが、代表 stderr の positive coverage が不足していた。
+- **手順**:
+  1. `SQLITE_ERROR: missing table: GPMatch` を schema drift と判定することを確認する
+  2. `missing D1 migration detected on preview` を schema drift と判定することを確認する
+  3. `GPMatch table not found` と `suddenDeathWinnerId column not found` を schema drift と判定することを確認する
+  4. network / generic schema registry / migration apply progress の stderr は migration guidance に分類しないことを確認する
+- **期待結果**: preview E2E は実際の D1 schema drift 表記を migration guidance として早期失敗させる一方、接続や進行ログを schema drift と誤分類しない
+- **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
+
 ## TC-2104: Preview D1 schema preflight の Wrangler retry loop は unreachable fallback return を持たない
 - **URL**: n/a (runner configuration / preview suite)
 - **authRequired**: true (Cloudflare D1 token is optional unless strict preflight is requested)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -357,6 +357,21 @@ describe('E2E case drift coverage', () => {
     expect(preflightTest).toContain('keeps Wrangler auth/log message helpers private to the preflight runner');
   });
 
+  it('keeps TC-2207 aligned with preview schema failure pattern coverage', () => {
+    const section = e2eCaseSection('TC-2207');
+    const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');
+
+    expect(section).toContain('issue #2207');
+    expect(section).toContain('SQLITE_ERROR: missing table: GPMatch');
+    expect(section).toContain('missing D1 migration detected on preview');
+    expect(section).toContain('GPMatch table not found');
+    expect(section).toContain('suddenDeathWinnerId column not found');
+    expect(preflightTest).toContain("SQLITE_ERROR: missing table: GPMatch");
+    expect(preflightTest).toContain("missing D1 migration detected on preview");
+    expect(preflightTest).toContain("GPMatch table not found");
+    expect(preflightTest).toContain("suddenDeathWinnerId column not found");
+  });
+
   it('keeps TC-2195 aligned with the MR grand-final phase format test wording', () => {
     const section = e2eCaseSection('TC-2195');
 

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -162,8 +162,13 @@ describe('preview schema preflight', () => {
 
     expect(preflight.isWranglerSchemaFailure('SQLITE_ERROR: no such table: GPMatch')).toBe(true);
     expect(preflight.isWranglerSchemaFailure('SQLITE_ERROR: no such column: suddenDeathWinnerId')).toBe(true);
+    expect(preflight.isWranglerSchemaFailure('SQLITE_ERROR: missing table: GPMatch')).toBe(true);
+    expect(preflight.isWranglerSchemaFailure('SQLITE_ERROR: unknown column: suddenDeathWinnerId')).toBe(true);
     expect(preflight.isWranglerSchemaFailure('Preview D1 schema drift detected for Tournament.publicModes')).toBe(true);
     expect(preflight.isWranglerSchemaFailure('pending D1 migration detected on preview')).toBe(true);
+    expect(preflight.isWranglerSchemaFailure('missing D1 migration detected on preview')).toBe(true);
+    expect(preflight.isWranglerSchemaFailure('GPMatch table not found')).toBe(true);
+    expect(preflight.isWranglerSchemaFailure('suddenDeathWinnerId column not found')).toBe(true);
     expect(preflight.isWranglerSchemaFailure('Network error when connecting to schema registry')).toBe(false);
     expect(preflight.isWranglerSchemaFailure('Unexpected schema returned by registry')).toBe(false);
     expect(preflight.isWranglerSchemaFailure('applying migration 0035_gp_finals_assigned_cups')).toBe(false);

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -88,8 +88,8 @@ function isWranglerSchemaFailure(stderr) {
     /schema\s+drift/i,
     /pending\s+(?:d1\s+)?migration/i,
     /missing\s+(?:d1\s+)?migration/i,
-    /table .* not found/i,
-    /column .* not found/i,
+    /(?:table .+|[\w.]+ table) not found/i,
+    /(?:column .+|[\w.]+ column) not found/i,
   ].some((pattern) => pattern.test(stderr));
 }
 


### PR DESCRIPTION
Summary
- Add TC-2207 E2E scenario coverage for preview D1 schema preflight stderr patterns.
- Cover missing/unknown SQLite table-column, missing D1 migration, and name-first table/column not-found messages.
- Tighten `isWranglerSchemaFailure` so name-first table/column not-found stderr reaches migration guidance.

Issues: Closes #2207

Validation
- npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint
- npm test
- npm run build:cf
