### PR TITLE
Classify TC-2104 as structural coverage

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -140,6 +140,7 @@
 ## TC-2104: Preview D1 schema preflight の Wrangler retry loop は unreachable fallback return を持たない
 - **URL**: n/a (runner configuration / preview suite)
 - **authRequired**: true (Cloudflare D1 token is optional unless strict preflight is requested)
+- **分類**: Unit/Structural Tests (preview E2E startup guard)
 - **背景**: issue #2104。`runWranglerSchemaCheck` は `WRANGLER_TRANSIENT_STATUS_RETRIES` まで retry し、最終 attempt では loop 内で必ず `{ result, args }` を返す。loop 後に同じ return を残すと unreachable dead code になり、retry 終了条件の意図が読み取りにくくなる。
 - **手順**:
   1. Wrangler が空の status 1 を返し続ける preflight を模擬する

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -389,9 +389,12 @@ describe('E2E case drift coverage', () => {
     const preflight = readE2eLib('preview-schema-preflight.js');
     const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');
 
+    expect(section).toContain('Unit/Structural Tests');
+    expect(section).toContain('preview E2E startup guard');
     expect(section).toContain('unreachable fallback return');
     expect(section).toContain('WRANGLER_TRANSIENT_STATUS_RETRIES + 1');
     expect(preflight).toContain('attempt === WRANGLER_TRANSIENT_STATUS_RETRIES');
+    expect(preflightTest).toContain('documents TC-2104 as structural preview startup coverage');
     expect(preflightTest).toContain('keeps runWranglerSchemaCheck free of a loop-after fallback return');
     expect(preflightTest).toContain('keeps TC-2104 documented as unreachable retry fallback coverage');
   });

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -309,6 +309,13 @@ describe('preview schema preflight', () => {
     expect(section).toContain('WRANGLER_TRANSIENT_STATUS_RETRIES + 1');
   });
 
+  it('documents TC-2104 as structural preview startup coverage', () => {
+    const section = readFileSync(path.join(process.cwd(), '..', 'E2E_TEST_CASES.md'), 'utf8');
+
+    expect(section).toContain('Unit/Structural Tests');
+    expect(section).toContain('preview E2E startup guard');
+  });
+
   it('keeps runWranglerSchemaCheck free of a loop-after fallback return', () => {
     const source = readFileSync(path.join(process.cwd(), 'e2e/lib/preview-schema-preflight.js'), 'utf8');
     const functionStart = source.indexOf('function runWranglerSchemaCheck');


### PR DESCRIPTION
## Summary
- Classify TC-2104 as Unit/Structural Tests coverage in E2E_TEST_CASES.md.
- Add drift coverage so TC-2104 keeps that classification and preview startup guard wording.
- Add focused preview preflight test coverage for the structural classification.

## Issues
Closes #2203

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/preview-schema-preflight.test.ts
- npm run lint
- npm test
- npm run build:cf
