### PR TITLE
Centralize TC-2104 classification coverage

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -149,6 +149,17 @@
 - **期待結果**: retry loop の最終 attempt が唯一の fallback return となり、到達不能な loop 後 return を持たずに preview preflight の診断挙動を維持する
 - **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
 
+## TC-2214: TC-2104 の structural classification assertion は docs drift test に集約する
+- **URL**: n/a (test ownership / docs drift guard)
+- **authRequired**: false
+- **背景**: issue #2214。TC-2104 の `Unit/Structural Tests (preview E2E startup guard)` 分類アサーションが `e2e-cases-drift.test.ts` と `preview-schema-preflight.test.ts` に重複すると、分類文言の変更時に複数箇所を同期する必要がある。
+- **手順**:
+  1. `e2e-cases-drift.test.ts` が TC-2104 の分類文言と preview startup guard 目的を検証することを確認する
+  2. `preview-schema-preflight.test.ts` は Wrangler retry / unreachable fallback の実装寄り coverage だけを持つことを確認する
+  3. preflight test 側に TC-2104 分類文言の重複アサーションが残っていないことを確認する
+- **期待結果**: TC-2104 の分類文言 ownership は docs drift test に一本化され、preview preflight test は runner behavior と structural source guard に集中する
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/preview-schema-preflight.test.ts`
+
 ## TC-008: Overall Ranking ページの表示
 - **URL**: /tournaments/[id]/overall-ranking
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -394,9 +394,21 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('unreachable fallback return');
     expect(section).toContain('WRANGLER_TRANSIENT_STATUS_RETRIES + 1');
     expect(preflight).toContain('attempt === WRANGLER_TRANSIENT_STATUS_RETRIES');
-    expect(preflightTest).toContain('documents TC-2104 as structural preview startup coverage');
     expect(preflightTest).toContain('keeps runWranglerSchemaCheck free of a loop-after fallback return');
     expect(preflightTest).toContain('keeps TC-2104 documented as unreachable retry fallback coverage');
+    expect(preflightTest).not.toContain('documents TC-2104 as structural preview startup coverage');
+  });
+
+  it('keeps TC-2214 aligned with TC-2104 classification assertion ownership', () => {
+    const section = e2eCaseSection('TC-2214');
+    const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');
+
+    expect(section).toContain('issue #2214');
+    expect(section).toContain('e2e-cases-drift.test.ts');
+    expect(section).toContain('preview-schema-preflight.test.ts');
+    expect(section).toContain('TC-2104');
+    expect(preflightTest).not.toContain('Unit/Structural Tests');
+    expect(preflightTest).not.toContain('preview E2E startup guard');
   });
 
   it('keeps TC-2118 documented with the shared tournament-tab hydration guard', () => {

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -309,13 +309,6 @@ describe('preview schema preflight', () => {
     expect(section).toContain('WRANGLER_TRANSIENT_STATUS_RETRIES + 1');
   });
 
-  it('documents TC-2104 as structural preview startup coverage', () => {
-    const section = readFileSync(path.join(process.cwd(), '..', 'E2E_TEST_CASES.md'), 'utf8');
-
-    expect(section).toContain('Unit/Structural Tests');
-    expect(section).toContain('preview E2E startup guard');
-  });
-
   it('keeps runWranglerSchemaCheck free of a loop-after fallback return', () => {
     const source = readFileSync(path.join(process.cwd(), 'e2e/lib/preview-schema-preflight.js'), 'utf8');
     const functionStart = source.indexOf('function runWranglerSchemaCheck');


### PR DESCRIPTION
## Summary
- Add TC-2214 to document the TC-2104 classification assertion ownership.
- Keep TC-2104 classification checks in the docs drift test and remove the duplicate preflight test assertion.
- Add a drift guard that fails if the preflight test reintroduces the classification wording checks.

## Issues
Closes #2214

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/e2e/preview-schema-preflight.test.ts
- npm run lint
- npm test
- npm run build:cf
