### PR TITLE
Harden preview schema source-structure guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -137,6 +137,17 @@
 - **期待結果**: preview E2E は実際の D1 schema drift 表記を migration guidance として早期失敗させる一方、接続や進行ログを schema drift と誤分類しない
 - **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
 
+## TC-2202: Preview D1 schema preflight の source-structure test は marker 欠落と multiline fallback return を検出する
+- **URL**: n/a (runner configuration / preview suite)
+- **authRequired**: false
+- **背景**: issue #2202。`runWranglerSchemaCheck` の structural test は `assertPreviewD1Schema` marker が欠落した場合に `slice(..., -1)` で誤った範囲を検査せず、loop 後 fallback return の検出も multiline source に合わせて明示する必要がある。
+- **手順**:
+  1. `runWranglerSchemaCheck` と `assertPreviewD1Schema` の source marker が両方存在することを先に確認する
+  2. marker 欠落 fixture では source section 抽出が失敗することを確認する
+  3. loop 後の `return { result, args };` を multiline fixture で検出できることを確認する
+- **期待結果**: preview preflight の structural test は marker 欠落を即座に失敗させ、到達不能な loop 後 fallback return が改行を含む形で再導入されても検出する
+- **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-2104: Preview D1 schema preflight の Wrangler retry loop は unreachable fallback return を持たない
 - **URL**: n/a (runner configuration / preview suite)
 - **authRequired**: true (Cloudflare D1 token is optional unless strict preflight is requested)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -372,6 +372,19 @@ describe('E2E case drift coverage', () => {
     expect(preflightTest).toContain("suddenDeathWinnerId column not found");
   });
 
+  it('keeps TC-2202 aligned with preview preflight source-structure coverage', () => {
+    const section = e2eCaseSection('TC-2202');
+    const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');
+
+    expect(section).toContain('issue #2202');
+    expect(section).toContain('marker 欠落');
+    expect(section).toContain('multiline fallback return');
+    expect(preflightTest).toContain('runWranglerSchemaCheckSection');
+    expect(preflightTest).toContain('loopAfterFallbackReturnPattern');
+    expect(preflightTest).toContain('fails the runWranglerSchemaCheck section guard before slicing when markers drift');
+    expect(preflightTest).toContain('detects multiline loop-after fallback returns in the preflight source section');
+  });
+
   it('keeps TC-2195 aligned with the MR grand-final phase format test wording', () => {
     const section = e2eCaseSection('TC-2195');
 

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -20,6 +20,18 @@ function loadPreflight() {
   return loaded;
 }
 
+const loopAfterFallbackReturnPattern = /}\s*\n\s*return\s+\{\s*result,\s*args\s*\};\s*\n\s*}\s*$/;
+
+function runWranglerSchemaCheckSection(source: string) {
+  const functionStart = source.indexOf('function runWranglerSchemaCheck');
+  expect(functionStart).toBeGreaterThanOrEqual(0);
+
+  const assertStart = source.indexOf('function assertPreviewD1Schema', functionStart);
+  expect(assertStart).toBeGreaterThan(functionStart);
+
+  return source.slice(functionStart, assertStart);
+}
+
 describe('preview schema preflight', () => {
   beforeEach(() => {
     spawnSyncMock.mockReset();
@@ -311,14 +323,42 @@ describe('preview schema preflight', () => {
 
   it('keeps runWranglerSchemaCheck free of a loop-after fallback return', () => {
     const source = readFileSync(path.join(process.cwd(), 'e2e/lib/preview-schema-preflight.js'), 'utf8');
-    const functionStart = source.indexOf('function runWranglerSchemaCheck');
-    const assertStart = source.indexOf('function assertPreviewD1Schema', functionStart);
-    const section = source.slice(functionStart, assertStart);
+    const section = runWranglerSchemaCheckSection(source);
 
-    expect(functionStart).toBeGreaterThanOrEqual(0);
-    expect(assertStart).toBeGreaterThan(functionStart);
     expect(section).toContain('attempt === WRANGLER_TRANSIENT_STATUS_RETRIES');
-    expect(section).not.toMatch(/}\s*return \{ result, args \};\s*}$/);
+    expect(section).not.toMatch(loopAfterFallbackReturnPattern);
+  });
+
+  it('keeps TC-2202 documented as source-structure guard coverage', () => {
+    const section = readFileSync(path.join(process.cwd(), '..', 'E2E_TEST_CASES.md'), 'utf8');
+
+    expect(section).toContain('TC-2202');
+    expect(section).toContain('issue #2202');
+    expect(section).toContain('slice(..., -1)');
+    expect(section).toContain('multiline fixture');
+  });
+
+  it('fails the runWranglerSchemaCheck section guard before slicing when markers drift', () => {
+    const source = [
+      'function runWranglerSchemaCheck() {',
+      '  return { result, args };',
+      '}',
+    ].join('\n');
+
+    expect(() => runWranglerSchemaCheckSection(source)).toThrow();
+  });
+
+  it('detects multiline loop-after fallback returns in the preflight source section', () => {
+    const section = [
+      'function runWranglerSchemaCheck() {',
+      '  for (let attempt = 0; attempt <= WRANGLER_TRANSIENT_STATUS_RETRIES; attempt += 1) {',
+      '    if (attempt === WRANGLER_TRANSIENT_STATUS_RETRIES) return { result, args };',
+      '  }',
+      '  return { result, args };',
+      '}',
+    ].join('\n');
+
+    expect(section).toMatch(loopAfterFallbackReturnPattern);
   });
 
   it('keeps TC-111 documented as narrow schema drift classification coverage', () => {


### PR DESCRIPTION
Summary
- Add TC-2202 E2E scenario coverage for preview schema preflight source-structure guards.
- Fail the structural test before slicing when `assertPreviewD1Schema` marker lookup drifts.
- Use an explicit multiline fallback-return regex fixture to catch loop-after `return { result, args };` regressions.

Issues: Closes #2202

Validation
- npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint
- npm test -- --runInBand
- npm run build:cf
