### PR TITLE
Resolve review-followup #2223: require latestFinalsMode in phase input

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-2200-overlay-phase-input.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-2200-overlay-phase-input.test.ts
@@ -9,8 +9,12 @@ type ExpectTrue<T extends true> = T;
 type LatestFinalsStageIsRequired = ExpectTrue<
   IsRequired<ComputeCurrentPhaseInput, 'latestFinalsStage'>
 >;
+type LatestFinalsModeIsRequired = ExpectTrue<
+  IsRequired<ComputeCurrentPhaseInput, 'latestFinalsMode'>
+>;
 
 void (null as unknown as LatestFinalsStageIsRequired);
+void (null as unknown as LatestFinalsModeIsRequired);
 
 describe('TC-2200 overlay phase input shape', () => {
   it('requires callers to pass null when no latest finals stage exists', () => {

--- a/smkc-score-app/src/lib/overlay/phase.ts
+++ b/smkc-score-app/src/lib/overlay/phase.ts
@@ -45,7 +45,7 @@ export interface ComputeCurrentPhaseInput {
    * up the matching format ("First to 5" etc.) in `computeCurrentPhaseFormat`.
    * Null when there is no finals match yet, or when the latest match has no mode.
    */
-  latestFinalsMode?: OverlayMode | null;
+  latestFinalsMode: OverlayMode | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Align ComputeCurrentPhaseInput latestFinalsMode with latestFinalsStage as required nullable.
- Add explicit type-shape assertion for latestFinalsMode in tc-2200.

## Issues
- closes #2223

## Validation
- Not run locally in this turn; CI will validate.
