### PR TITLE
Handle sudden-death tie winner in finals playoff resolution

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1699,6 +1699,43 @@ describe('Finals Route Factory', () => {
       });
     });
 
+    it('GET Top-24 preview resolves a tied playoff winner from suddenDeathWinnerId', async () => {
+      (prisma.bMQualification as any).findMany.mockResolvedValue(createMockQualifications(24));
+      const playoffRows = [
+        { id: 'p-r2-5', matchNumber: 5, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 5, suddenDeathWinnerId: 'player-8', player1Id: 'player-19', player2Id: 'player-8', player1: { id: 'player-19' }, player2: { id: 'player-8' } },
+        { id: 'p-r2-6', matchNumber: 6, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-6', player2Id: 'player-21', player1: { id: 'player-6' }, player2: { id: 'player-21' } },
+        { id: 'p-r2-7', matchNumber: 7, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-7', player2Id: 'player-20', player1: { id: 'player-7' }, player2: { id: 'player-20' } },
+        { id: 'p-r2-8', matchNumber: 8, round: 'playoff_r2', stage: 'playoff', completed: true, score1: 5, score2: 0, player1Id: 'player-18', player2Id: 'player-9', player1: { id: 'player-18' }, player2: { id: 'player-9' } },
+      ];
+      (prisma.bMMatch as any).findMany.mockImplementation((args: any) => {
+        if (args?.where?.stage === 'playoff') return Promise.resolve(playoffRows);
+        return Promise.resolve([]);
+      });
+      (prisma.bMMatch as any).count.mockResolvedValue(0);
+
+      const config = createMockConfig({ getStyle: 'grouped' });
+      const { GET } = createFinalsHandlers(config);
+
+      const response = await GET(new NextRequest('http://localhost:3000'), {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(200);
+      const json = await response.json();
+      const seededPlayers = json.data.seededPlayers ?? [];
+      const playoffSeed = seededPlayers.find((player: { seed: number }) => player.seed === 16);
+      expect(playoffSeed).toEqual(expect.objectContaining({
+        seed: 16,
+        playerId: 'player-8',
+      }));
+      expect(mockLogger.warn).not.toHaveBeenCalledWith('Top-24 playoff winner could not be resolved', {
+        tournamentId: 'tournament-123',
+        eventTypeCode: 'bm',
+        matchNumber: 5,
+        advancesToUpperSeed: 16,
+      });
+    });
+
     it('logs and falls back when Top-24 preview construction fails', async () => {
       const previewError = Object.assign(new Error('SELECT * FROM SecretTable WHERE token = hidden'), {
         name: 'PrismaClientKnownRequestError',

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -393,30 +393,20 @@ describe("TA Finals Phase Manager", () => {
   });
 
   describe("getNextPhase3ResetThreshold", () => {
-    it("uses the nearest configured lower threshold and falls back safely", () => {
+    it("uses the highest configured threshold when activeCount allows one", () => {
       expect(getNextPhase3ResetThreshold(16)).toBe(8);
       expect(getNextPhase3ResetThreshold(15)).toBe(8);
       expect(getNextPhase3ResetThreshold(11)).toBe(8);
+      expect(getNextPhase3ResetThreshold(9)).toBe(8);
       expect(getNextPhase3ResetThreshold(8)).toBe(4);
       expect(getNextPhase3ResetThreshold(7)).toBe(4);
-      expect(getNextPhase3ResetThreshold(4)).toBe(2);
-      expect(getNextPhase3ResetThreshold(3)).toBe(2);
-      expect(getNextPhase3ResetThreshold(2)).toBe(1);
-      expect(getNextPhase3ResetThreshold(1)).toBeNull();
-      expect(getNextPhase3ResetThreshold(0)).toBeNull();
-    });
-
-    it("returns the highest configured reset threshold below activeCount", () => {
-      expect(getNextPhase3ResetThreshold(9)).toBe(8);
       expect(getNextPhase3ResetThreshold(5)).toBe(4);
+      expect(getNextPhase3ResetThreshold(4)).toBe(2);
       expect(getNextPhase3ResetThreshold(3)).toBe(2);
     });
 
     it("falls back to activeCount-1 when no configured threshold remains", () => {
       expect(getNextPhase3ResetThreshold(2)).toBe(1);
-    });
-
-    it("returns null when the active player count is one or fewer", () => {
       expect(getNextPhase3ResetThreshold(1)).toBeNull();
       expect(getNextPhase3ResetThreshold(0)).toBeNull();
     });

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -694,6 +694,23 @@ export function createFinalsHandlers(config: FinalsConfig) {
   ): { winnerId: string; winnerPlayer: PublicFinalsPlayer } | null {
     const score1 = Number(match[config.putScoreFields.dbField1]);
     const score2 = Number(match[config.putScoreFields.dbField2]);
+    if (score1 === score2 && typeof match.suddenDeathWinnerId === 'string') {
+      const suddenDeathWinnerId = match.suddenDeathWinnerId;
+      if (suddenDeathWinnerId.length === 0) {
+        return null;
+      }
+
+      const suddenDeathWinnerPlayer = match.player1Id === suddenDeathWinnerId ? match.player1 : match.player2;
+      if (!isPublicFinalsPlayer(suddenDeathWinnerPlayer)) {
+        return null;
+      }
+
+      return {
+        winnerId: suddenDeathWinnerId,
+        winnerPlayer: suddenDeathWinnerPlayer,
+      };
+    }
+
     if (!Number.isFinite(score1) || !Number.isFinite(score2) || score1 === score2) {
       return null;
     }


### PR DESCRIPTION
## Summary
- `getCompletedMatchWinner` in `smkc-score-app/src/lib/api-factories/finals-route.ts` now falls back to `suddenDeathWinnerId` when playoff scores are tied.
- Added regression test coverage for Top-24 preview winner resolution from sudden-death metadata.

## Issues
Closes #830

## Validation
- Added unit test case in `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts`.
