### PR TITLE
Extract BM/MR shared match update select

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
@@ -38,11 +38,12 @@ jest.mock('@/lib/qualification-confirmed-check', () => ({
 }));
 
 import prisma from '@/lib/prisma';
-import { BM_MR_MATCH_LEAN_SELECT, PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
+import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { auth } from '@/lib/auth';
 import { createLogger } from '@/lib/logger';
 import { GET, POST, PUT } from '@/app/api/tournaments/[id]/bm/route';
 import { configureNextResponseMock } from '../../../../../helpers/next-response-mock';
+import { EXPECTED_MATCH_UPDATE_SELECT } from '../../../../../helpers/expected-match-update-select';
 
 const requestUtilsMock = jest.requireMock('@/lib/request-utils') as { getServerSideIdentifier: jest.Mock };
 const _sanitizeMock = jest.requireMock('@/lib/sanitize') as { sanitizeInput: jest.Mock };
@@ -426,7 +427,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       expect(prisma.bMMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: null, completed: true },
-        select: BM_MR_MATCH_LEAN_SELECT,
+        select: EXPECTED_MATCH_UPDATE_SELECT,
       });
       expect(prisma.$executeRawUnsafe).toHaveBeenCalledTimes(1);
     });
@@ -456,7 +457,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       expect(prisma.bMMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 2, score2: 2, rounds: null, completed: true },
-        select: BM_MR_MATCH_LEAN_SELECT,
+        select: EXPECTED_MATCH_UPDATE_SELECT,
       });
     });
 
@@ -493,7 +494,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       expect(prisma.bMMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: [1, 2, 3, 4], completed: true },
-        select: BM_MR_MATCH_LEAN_SELECT,
+        select: EXPECTED_MATCH_UPDATE_SELECT,
       });
     });
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
@@ -33,11 +33,12 @@ jest.mock('@/lib/qualification-confirmed-check', () => ({
 }));
 
 import prisma from '@/lib/prisma';
-import { BM_MR_MATCH_LEAN_SELECT, PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
+import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { auth } from '@/lib/auth';
 import { createLogger } from '@/lib/logger';
 import { GET, POST, PUT } from '@/app/api/tournaments/[id]/mr/route';
 import { configureNextResponseMock } from '../../../../../helpers/next-response-mock';
+import { EXPECTED_MATCH_UPDATE_SELECT } from '../../../../../helpers/expected-match-update-select';
 
 const _rateLimitMock = jest.requireMock('@/lib/rate-limit') as { getServerSideIdentifier: jest.Mock };
 const sanitizeMock = jest.requireMock('@/lib/sanitize') as { sanitizeInput: jest.Mock };
@@ -350,7 +351,7 @@ describe('MR API Route - /api/tournaments/[id]/mr', () => {
       expect(prisma.mRMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: null, completed: true },
-        select: BM_MR_MATCH_LEAN_SELECT,
+        select: EXPECTED_MATCH_UPDATE_SELECT,
       });
       expect(prisma.$executeRawUnsafe).toHaveBeenCalledTimes(1);
     });
@@ -403,7 +404,7 @@ describe('MR API Route - /api/tournaments/[id]/mr', () => {
       expect(prisma.mRMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: validRounds, completed: true },
-        select: BM_MR_MATCH_LEAN_SELECT,
+        select: EXPECTED_MATCH_UPDATE_SELECT,
       });
     });
 

--- a/smkc-score-app/__tests__/helpers/expected-match-update-select.ts
+++ b/smkc-score-app/__tests__/helpers/expected-match-update-select.ts
@@ -1,0 +1,4 @@
+import { BM_MR_MATCH_LEAN_SELECT } from '@/lib/prisma-selects';
+
+export const EXPECTED_MATCH_UPDATE_SELECT = BM_MR_MATCH_LEAN_SELECT;
+

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -393,30 +393,20 @@ describe("TA Finals Phase Manager", () => {
   });
 
   describe("getNextPhase3ResetThreshold", () => {
-    it("uses the nearest configured lower threshold and falls back safely", () => {
+    it("uses the highest configured threshold when activeCount allows one", () => {
       expect(getNextPhase3ResetThreshold(16)).toBe(8);
       expect(getNextPhase3ResetThreshold(15)).toBe(8);
       expect(getNextPhase3ResetThreshold(11)).toBe(8);
+      expect(getNextPhase3ResetThreshold(9)).toBe(8);
       expect(getNextPhase3ResetThreshold(8)).toBe(4);
       expect(getNextPhase3ResetThreshold(7)).toBe(4);
-      expect(getNextPhase3ResetThreshold(4)).toBe(2);
-      expect(getNextPhase3ResetThreshold(3)).toBe(2);
-      expect(getNextPhase3ResetThreshold(2)).toBe(1);
-      expect(getNextPhase3ResetThreshold(1)).toBeNull();
-      expect(getNextPhase3ResetThreshold(0)).toBeNull();
-    });
-
-    it("returns the highest configured reset threshold below activeCount", () => {
-      expect(getNextPhase3ResetThreshold(9)).toBe(8);
       expect(getNextPhase3ResetThreshold(5)).toBe(4);
+      expect(getNextPhase3ResetThreshold(4)).toBe(2);
       expect(getNextPhase3ResetThreshold(3)).toBe(2);
     });
 
     it("falls back to activeCount-1 when no configured threshold remains", () => {
       expect(getNextPhase3ResetThreshold(2)).toBe(1);
-    });
-
-    it("returns null when the active player count is one or fewer", () => {
       expect(getNextPhase3ResetThreshold(1)).toBeNull();
       expect(getNextPhase3ResetThreshold(0)).toBeNull();
     });


### PR DESCRIPTION
Refs: #950\n\n## Summary\n- Add a shared test helper:  with .\n- Update BM route tests to use  in update response select assertions.\n- Update MR route tests similarly, so  and  share the same helper constant.\n\n## Validation\n- Automated tests not run locally in this step.\n- CI required on PR checks.\n