### PR TITLE
Remove expected-match-update-select alias indirection

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/route.test.ts
@@ -43,7 +43,7 @@ import { auth } from '@/lib/auth';
 import { createLogger } from '@/lib/logger';
 import { GET, POST, PUT } from '@/app/api/tournaments/[id]/bm/route';
 import { configureNextResponseMock } from '../../../../../helpers/next-response-mock';
-import { EXPECTED_MATCH_UPDATE_SELECT } from '../../../../../helpers/expected-match-update-select';
+import { BM_MR_MATCH_LEAN_SELECT } from '@/lib/prisma-selects';
 
 const requestUtilsMock = jest.requireMock('@/lib/request-utils') as { getServerSideIdentifier: jest.Mock };
 const _sanitizeMock = jest.requireMock('@/lib/sanitize') as { sanitizeInput: jest.Mock };
@@ -427,7 +427,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       expect(prisma.bMMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: null, completed: true },
-        select: EXPECTED_MATCH_UPDATE_SELECT,
+        select: BM_MR_MATCH_LEAN_SELECT,
       });
       expect(prisma.$executeRawUnsafe).toHaveBeenCalledTimes(1);
     });
@@ -457,7 +457,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       expect(prisma.bMMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 2, score2: 2, rounds: null, completed: true },
-        select: EXPECTED_MATCH_UPDATE_SELECT,
+        select: BM_MR_MATCH_LEAN_SELECT,
       });
     });
 
@@ -494,7 +494,7 @@ describe('BM API Route - /api/tournaments/[id]/bm', () => {
       expect(prisma.bMMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: [1, 2, 3, 4], completed: true },
-        select: EXPECTED_MATCH_UPDATE_SELECT,
+        select: BM_MR_MATCH_LEAN_SELECT,
       });
     });
 

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/route.test.ts
@@ -38,7 +38,7 @@ import { auth } from '@/lib/auth';
 import { createLogger } from '@/lib/logger';
 import { GET, POST, PUT } from '@/app/api/tournaments/[id]/mr/route';
 import { configureNextResponseMock } from '../../../../../helpers/next-response-mock';
-import { EXPECTED_MATCH_UPDATE_SELECT } from '../../../../../helpers/expected-match-update-select';
+import { BM_MR_MATCH_LEAN_SELECT } from '@/lib/prisma-selects';
 
 const _rateLimitMock = jest.requireMock('@/lib/rate-limit') as { getServerSideIdentifier: jest.Mock };
 const sanitizeMock = jest.requireMock('@/lib/sanitize') as { sanitizeInput: jest.Mock };
@@ -351,7 +351,7 @@ describe('MR API Route - /api/tournaments/[id]/mr', () => {
       expect(prisma.mRMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: null, completed: true },
-        select: EXPECTED_MATCH_UPDATE_SELECT,
+        select: BM_MR_MATCH_LEAN_SELECT,
       });
       expect(prisma.$executeRawUnsafe).toHaveBeenCalledTimes(1);
     });
@@ -404,7 +404,7 @@ describe('MR API Route - /api/tournaments/[id]/mr', () => {
       expect(prisma.mRMatch.update).toHaveBeenCalledWith({
         where: { id: 'm1', tournamentId: 't1' },
         data: { score1: 3, score2: 1, rounds: validRounds, completed: true },
-        select: EXPECTED_MATCH_UPDATE_SELECT,
+        select: BM_MR_MATCH_LEAN_SELECT,
       });
     });
 

--- a/smkc-score-app/__tests__/helpers/expected-match-update-select.ts
+++ b/smkc-score-app/__tests__/helpers/expected-match-update-select.ts
@@ -1,4 +1,0 @@
-import { BM_MR_MATCH_LEAN_SELECT } from '@/lib/prisma-selects';
-
-export const EXPECTED_MATCH_UPDATE_SELECT = BM_MR_MATCH_LEAN_SELECT;
-


### PR DESCRIPTION
## Summary
- Remove unnecessary test helper alias `expected-match-update-select.ts`.
- Use `BM_MR_MATCH_LEAN_SELECT` directly in BM/MR route tests.
- Reduce indirection to match review suggestion for issue #2239.

Issues: #2239

## Validation
- npm test -- --runInBand --runTestsByPath '__tests__/app/api/tournaments/[id]/bm/route.test.ts' '__tests__/app/api/tournaments/[id]/mr/route.test.ts'
