### PR TITLE
Fix TC-356 overflow-x-auto table scope

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -1376,6 +1376,62 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       );
     });
 
+    it('should ignore sudden-death winner on tied GP finals scores when player1 is sudden-death winner', async () => {
+      const mockMatch = {
+        id: 'm1',
+        tournamentId: 't1',
+        matchNumber: 1,
+        round: 'winners_qf',
+        stage: 'finals',
+        player1Id: 'player-19',
+        player2Id: 'player-8',
+        points1: 2,
+        points2: 2,
+        completed: false,
+        player1: { id: 'player-19', name: 'Player 19' },
+        player2: { id: 'player-8', name: 'Player 8' },
+      };
+
+      const updatedMatch = { ...mockMatch, points1: 2, points2: 2, completed: false, suddenDeathWinnerId: null };
+
+      (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+      (prisma.gPMatch.update as jest.Mock).mockResolvedValue(updatedMatch);
+      (generateBracketStructure as jest.Mock).mockReturnValue([
+        { matchNumber: 1, round: 'winners_qf', player1Seed: 1, player2Seed: 8, winnerGoesTo: 5, loserGoesTo: 9, position: 1 },
+      ]);
+      (prisma.gPMatch.findFirst as jest.Mock).mockResolvedValue({ id: 'm5' });
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/gp/finals', {
+        matchId: 'm1',
+        score1: 2,
+        score2: 2,
+        suddenDeathWinnerId: 'player-19',
+      });
+      const params = Promise.resolve({ id: 't1' });
+      const result = await PUT(request, { params });
+
+      expect(result.data).toEqual({
+        match: updatedMatch,
+        winnerId: null,
+        loserId: null,
+        isComplete: false,
+        champion: null,
+      });
+      expect(result.status).toBe(200);
+      expect(prisma.gPMatch.update).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          where: { id: 'm1' },
+          data: expect.objectContaining({
+            points1: 2,
+            points2: 2,
+            suddenDeathWinnerId: null,
+            completed: false,
+          }),
+        }),
+      );
+    });
+
     it('should allow GP playoff round 1 results to finish at first to 1', async () => {
       const mockMatch = {
         id: 'm1',

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -4338,14 +4338,18 @@ async function main() {
         const dialog = document.querySelector('[role="dialog"]');
         if (!(dialog instanceof HTMLElement)) return false;
         /* GP finals moved to cup-win score-only inputs. The mobile regression is
-         * now that both numeric fields stay inside the dialog viewport without
-         * requiring horizontal scroll. */
+         * now that both numeric fields stay inside the dialog score table and
+         * do not rely on page-level overflow handling. */
         const scoreInputs = [
           dialog.querySelector('#gp-finals-simple-score1'),
           dialog.querySelector('#gp-finals-simple-score2'),
         ].filter((node) => node instanceof HTMLElement);
         if (scoreInputs.length !== 2) return false;
-        const rect = dialog.getBoundingClientRect();
+        const scoreDialogTable = dialog.querySelector('table');
+        if (!(scoreDialogTable instanceof HTMLElement)) return false;
+        const scoreDialogOverflow = scoreDialogTable.closest('div.overflow-x-auto');
+        if (!(scoreDialogOverflow instanceof HTMLElement)) return false;
+        const rect = scoreDialogOverflow.getBoundingClientRect();
         const viewportWidth = document.documentElement.clientWidth;
         return rect.left >= 0 &&
           rect.right <= viewportWidth &&


### PR DESCRIPTION
## 変更内容
- e2e/tc-all.js の TC-356 を修正
  - スクロール判定をページ全体ではなく、スコアダイアログ内のテーブル配下の `div.overflow-x-auto` に限定
  - 該当要素が見つからない場合は `FAIL` として扱うため、ページ構造の劣化を見逃さない

## 検証
- テスト: Lint/Test, Cloudflare Workers Build, Cloudflare Preview build, claude-review を後続で監視

Closes #813
