### PR TITLE
Refine TC-357 h1 title assertion

### DIFF
--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -4391,8 +4391,11 @@ async function main() {
         };
         const hasExpectedTitle = await page.evaluate((titles) => {
           const headings = Array.from(document.querySelectorAll('h1'));
-          return headings.some((heading) =>
-            titles.some((title) => (heading.textContent || '').includes(title))
+          const normalizedHeadings = headings
+            .map((heading) => (heading.textContent || '').trim())
+            .filter(Boolean);
+          return normalizedHeadings.some((headingText) =>
+            titles.some((title) => headingText.includes(title))
           );
         }, expectedTitles[mode]);
         results357.push({ mode, hasH1: hasExpectedTitle });


### PR DESCRIPTION
## Summary
- Strengthen TC-357 mode-title assertion to normalize h1 text before matching expected mode titles, avoiding whitespace/null-title edge cases while preserving behavior.

## Issues
Closes #814

## Validation
- Not run locally in this automation (not requested)
