### PR TITLE
Reinforce MR report test for recalc path (#982)

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
@@ -342,6 +342,8 @@ describe('MR Score Report API Route - /api/tournaments/[id]/mr/match/[matchId]/r
         message: 'Scores confirmed and match completed',
         status: 200,
       });
+      expect(recalculatePlayersStats).toHaveBeenCalledWith(expect.any(Object), 't1', ['p1', 'p2']);
+      expect(prisma.mRQualification.updateMany).not.toHaveBeenCalled();
     });
 
     it('should save a participant correction for a completed MR match', async () => {
@@ -390,6 +392,7 @@ describe('MR Score Report API Route - /api/tournaments/[id]/mr/match/[matchId]/r
         }),
       }));
       expect(recalculatePlayersStats).toHaveBeenCalledWith(expect.any(Object), 't1', ['p1', 'p2']);
+      expect(prisma.mRQualification.updateMany).not.toHaveBeenCalled();
       expect(result).toEqual({
         data: { match: correctedMatch, corrected: true },
         message: 'Score correction saved',

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -4391,8 +4391,11 @@ async function main() {
         };
         const hasExpectedTitle = await page.evaluate((titles) => {
           const headings = Array.from(document.querySelectorAll('h1'));
-          return headings.some((heading) =>
-            titles.some((title) => (heading.textContent || '').includes(title))
+          const normalizedHeadings = headings
+            .map((heading) => (heading.textContent || '').trim())
+            .filter(Boolean);
+          return normalizedHeadings.some((headingText) =>
+            titles.some((title) => headingText.includes(title))
           );
         }, expectedTitles[mode]);
         results357.push({ mode, hasH1: hasExpectedTitle });


### PR DESCRIPTION
## Summary
- Add assertions to MR score report tests that recalc is driven through score-report-helpers and not direct mRQualification bulk update.
- Cover both auto-confirm and completed-match correction success paths.

## Issues
- Resolves #982

## Validation
- Automated checks via CI
