### PR TITLE
Add archive-focused suite isolation coverage (#1720)

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
@@ -342,6 +342,8 @@ describe('MR Score Report API Route - /api/tournaments/[id]/mr/match/[matchId]/r
         message: 'Scores confirmed and match completed',
         status: 200,
       });
+      expect(recalculatePlayersStats).toHaveBeenCalledWith(expect.any(Object), 't1', ['p1', 'p2']);
+      expect(prisma.mRQualification.updateMany).not.toHaveBeenCalled();
     });
 
     it('should save a participant correction for a completed MR match', async () => {
@@ -390,6 +392,7 @@ describe('MR Score Report API Route - /api/tournaments/[id]/mr/match/[matchId]/r
         }),
       }));
       expect(recalculatePlayersStats).toHaveBeenCalledWith(expect.any(Object), 't1', ['p1', 'p2']);
+      expect(prisma.mRQualification.updateMany).not.toHaveBeenCalled();
       expect(result).toEqual({
         data: { match: correctedMatch, corrected: true },
         message: 'Score correction saved',

--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -49,6 +49,15 @@ describe('tc-all focused suite registration', () => {
     expect(source).not.toContain('Legacy lightweight full-workflow and GP dialog UI checks were retired.');
   });
 
+  it('keeps archive qualification fetch isolation behavior contract', () => {
+    const archiveSource = fs.readFileSync(path.join(process.cwd(), 'e2e', 'tc-archive.js'), 'utf8');
+
+    expect(archiveSource).toContain('const targetPage = await page.context().newPage();');
+    expect(archiveSource).toContain('await targetPage.bringToFront();');
+    expect(archiveSource).toContain('await targetPage.close().catch(() => {});');
+    expect(archiveSource).toContain('result.status === \'FAIL\'');
+  });
+
   it('registers auth error and web vitals preview checks for TC-2070', () => {
     expect(source).toContain("log('TC-2070A'");
     expect(source).toContain('/auth/error?error=');

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -4391,8 +4391,11 @@ async function main() {
         };
         const hasExpectedTitle = await page.evaluate((titles) => {
           const headings = Array.from(document.querySelectorAll('h1'));
-          return headings.some((heading) =>
-            titles.some((title) => (heading.textContent || '').includes(title))
+          const normalizedHeadings = headings
+            .map((heading) => (heading.textContent || '').trim())
+            .filter(Boolean);
+          return normalizedHeadings.some((headingText) =>
+            titles.some((title) => headingText.includes(title))
           );
         }, expectedTitles[mode]);
         results357.push({ mode, hasH1: hasExpectedTitle });


### PR DESCRIPTION
## Summary
- add regression coverage in tc-all-registration test for tc-archive browser-isolation contract after source-scan cleanup.
- assert dedicated page creation and lifecycle checks are still present: new page + bringToFront + close path.
- keep focused on the original issue intent: archive qualification fetch isolation stays explicit and tested.

## Issues
- Resolves #1720

## Validation
- not run locally (as requested)

