### PR TITLE
test: Add regression test for GP suite TC-831/TC-832 order

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-gp-suite-order.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-gp-suite-order.test.ts
@@ -1,0 +1,31 @@
+import { createRequire } from 'module';
+import path from 'path';
+
+type TcTestCase = {
+  name: string;
+};
+
+const requireFromApp = createRequire(path.join(process.cwd(), 'package.json'));
+
+describe('tc-gp suite ordering', () => {
+  it('keeps TC-831 before TC-832', () => {
+    const { getSuite } = requireFromApp('./e2e/tc-gp');
+    const suite = getSuite();
+    const names = suite.tests.map((entry: TcTestCase) => entry.name);
+
+    const tc831Index = names.indexOf('TC-831');
+    const tc832Index = names.indexOf('TC-832');
+
+    expect(tc831Index).toBeGreaterThanOrEqual(0);
+    expect(tc832Index).toBeGreaterThan(tc831Index);
+  });
+
+  it('keeps TC-831 and TC-832 adjacent for readable log progression', () => {
+    const { getSuite } = requireFromApp('./e2e/tc-gp');
+    const suite = getSuite();
+    const names = suite.tests.map((entry: TcTestCase) => entry.name);
+
+    const tc831Index = names.indexOf('TC-831');
+    expect(names.slice(tc831Index, tc831Index + 2)).toEqual(['TC-831', 'TC-832']);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a regression test under e2e-focused unit coverage to ensure GP suite keeps TC-831 before TC-832 and keeps them adjacent.
- This prevents accidental reorder regressions of the reviewable log order in  and satisfies review follow-up #934.

## Issues
- Resolves #934

## Validation
- Not run locally in this automation run; CI review will validate.
