### PR TITLE
test: add tc831 presence guard in gp suite order

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-gp-suite-order.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-gp-suite-order.test.ts
@@ -26,6 +26,7 @@ describe('tc-gp suite ordering', () => {
     const names = suite.tests.map((entry: TcTestCase) => entry.name);
 
     const tc831Index = names.indexOf('TC-831');
+    expect(tc831Index).toBeGreaterThanOrEqual(0);
     expect(names.slice(tc831Index, tc831Index + 2)).toEqual(['TC-831', 'TC-832']);
   });
 });


### PR DESCRIPTION
## Summary\n- Add explicit guard for TC-831 index before slice assertion in tc-gp-suite-order test 2.\n- Makes failure reason explicit when TC-831 is missing from suite.\n\nCloses #2272