### PR TITLE
test: stabilize requireFromApp path in tc-gp-order

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-gp-suite-order.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-gp-suite-order.test.ts
@@ -5,7 +5,7 @@ type TcTestCase = {
   name: string;
 };
 
-const requireFromApp = createRequire(path.join(process.cwd(), 'package.json'));
+const requireFromApp = createRequire(path.resolve(__dirname, '../../package.json'));
 
 describe('tc-gp suite ordering', () => {
   it('keeps TC-831 before TC-832', () => {


### PR DESCRIPTION
## Summary\n- Replace process.cwd() based createRequire path with __dirname-based absolute path in tc-gp-suite-order.test.\n- Addresses review follow-up #2271.\n\nCloses #2271