### PR TITLE
test: lock phase3 sudden-death ordering against tie collisions

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -286,10 +286,11 @@ describe('E2E case drift coverage', () => {
 
   it('documents why GP TC-831 stays before TC-832 in the suite order', () => {
     // Regex intent:
-    // - [^\\n]* matches the first rationale comment line only.
-    // - (?:\\n\\s*//[^\\n]*)* allows wrapped rationale lines while rejecting code between comment and entry.
-    // - \\s* allows formatting drift in spaces and newlines between the comment and array entries.
+    // - [^\\n]* matches the first rationale comment line.
+    // - (?:\\n\\s*//[^\\n]*)* allows wrapped rationale comments while rejecting code.
+    // - \\s* tolerates formatting drift in whitespace between comment and suite entry.
     // - ['"] accepts either quote style around TC labels in the runner list.
+    // - TC-831 and TC-832 should remain adjacent and ordered for log readability.
     // Allow multiline comment formatting drift while requiring comment -> TC-831 -> TC-832 adjacency.
     expect(tcGp).toMatch(gpTc831Tc832OrderRationale);
   });

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -1418,6 +1418,69 @@ describe("TA Finals Phase Manager", () => {
         })
       );
     });
+
+    it("keeps non-sudden players from changing sudden-death ordering in phase3", async () => {
+      mockPrismaClient.tTPhaseSuddenDeathRound.findUnique.mockResolvedValue({
+        id: "sd1",
+        tournamentId: "t1",
+        phase: "phase3",
+        phaseRoundId: "round1",
+        targetPlayerIds: ["p4", "p5"],
+        resolved: false,
+        phaseRound: {
+          id: "round1",
+          course: "MC1",
+          results: [
+            { playerId: "p1", timeMs: 10000 },
+            { playerId: "p2", timeMs: 11000 },
+            { playerId: "p3", timeMs: 13001 },
+            { playerId: "p4", timeMs: 13000 },
+            { playerId: "p5", timeMs: 13005 },
+          ],
+        },
+      });
+      mockPrismaClient.tTEntry.findMany.mockResolvedValue([
+        { playerId: "p1", eliminated: false, lives: 3 },
+        { playerId: "p2", eliminated: false, lives: 3 },
+        { playerId: "p3", eliminated: false, lives: 3 },
+        { playerId: "p4", eliminated: false, lives: 1 },
+        { playerId: "p5", eliminated: false, lives: 1 },
+      ]);
+      mockPrismaClient.tTEntry.findUnique.mockImplementation(({ where }) => {
+        const playerId = where?.tournamentId_playerId_stage?.playerId;
+        const livesByPlayer = new Map([
+          ["p1", 3],
+          ["p2", 3],
+          ["p3", 3],
+          ["p4", 1],
+          ["p5", 1],
+        ]);
+        if (!playerId) return Promise.resolve(null);
+        return Promise.resolve({
+          id: `entry-${playerId}`,
+          lives: livesByPlayer.get(playerId) ?? 3,
+          eliminated: false,
+        });
+      });
+      mockPrismaClient.tTPhaseSuddenDeathRound.update.mockResolvedValue({});
+      mockPrismaClient.tTPhaseRound.update.mockResolvedValue({});
+      mockPrismaClient.tTEntry.update.mockResolvedValue({});
+
+      const result = await submitSuddenDeathResults(mockPrismaClient as any, context, "phase3", "sd1", [
+        { playerId: "p5", timeMs: 92000 },
+        { playerId: "p4", timeMs: 91000 },
+      ]);
+
+      expect(result.eliminatedIds).toEqual(["p4"]);
+      expect(mockPrismaClient.tTPhaseRound.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            eliminatedIds: ["p4"],
+            livesReset: false,
+          }),
+        })
+      );
+    });
   });
 
   // === AUDIT LOG .catch() ERROR PATH (#779) ===

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -1419,7 +1419,7 @@ describe("TA Finals Phase Manager", () => {
       );
     });
 
-    it("keeps non-sudden players from changing sudden-death ordering in phase3", async () => {
+    it("keeps non-sudden players from becoming an unintended elimination target in phase3", async () => {
       mockPrismaClient.tTPhaseSuddenDeathRound.findUnique.mockResolvedValue({
         id: "sd1",
         tournamentId: "t1",
@@ -1471,11 +1471,11 @@ describe("TA Finals Phase Manager", () => {
         { playerId: "p4", timeMs: 91000 },
       ]);
 
-      expect(result.eliminatedIds).toEqual(["p4"]);
+      expect(result.eliminatedIds).toEqual(["p5"]);
       expect(mockPrismaClient.tTPhaseRound.update).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
-            eliminatedIds: ["p4"],
+            eliminatedIds: ["p5"],
             livesReset: false,
           }),
         })


### PR DESCRIPTION
## Summary
- Add a regression test for phase3 sudden-death ordering so sudden-death ranking remains authoritative when non-sudden players have near-colliding times.
- This closes the review-followup issue by preventing future regressions of the +1/+2ms ordering approach.

Closes #824