### PR TITLE
chore: clarify TA sudden-death conflict diagnostics

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -286,10 +286,11 @@ describe('E2E case drift coverage', () => {
 
   it('documents why GP TC-831 stays before TC-832 in the suite order', () => {
     // Regex intent:
-    // - [^\\n]* matches the first rationale comment line only.
-    // - (?:\\n\\s*//[^\\n]*)* allows wrapped rationale lines while rejecting code between comment and entry.
-    // - \\s* allows formatting drift in spaces and newlines between the comment and array entries.
+    // - [^\\n]* matches the first rationale comment line.
+    // - (?:\\n\\s*//[^\\n]*)* allows wrapped rationale comments while rejecting code.
+    // - \\s* tolerates formatting drift in whitespace between comment and suite entry.
     // - ['"] accepts either quote style around TC labels in the runner list.
+    // - TC-831 and TC-832 should remain adjacent and ordered for log readability.
     // Allow multiline comment formatting drift while requiring comment -> TC-831 -> TC-832 adjacency.
     expect(tcGp).toMatch(gpTc831Tc832OrderRationale);
   });

--- a/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
@@ -1,10 +1,11 @@
-import {
+import * as tcAllExports from '../../e2e/tc-all';
+
+const {
   cdmE2eFinalsMatches,
   cdmE2eFinalsReadinessDetails,
   cdmE2eFinalsReadinessSummary,
   ensureCdmE2eFinalsFixture,
-} from '../../e2e/tc-all';
-import * as tcAllExports from '../../e2e/tc-all';
+} = tcAllExports;
 
 describe('TC-816A CDM finals fixture readiness', () => {
   it('counts slot-mappable playoff and finals matches by mode', () => {

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -932,7 +932,7 @@ describe("TA Finals Phase Manager", () => {
           { playerId: "p5", timeMs: 90000 },
         ])
       ).rejects.toThrow(
-        "Sudden-death round for phase1 changed during submission. Refresh and submit again. Current targets: [\"p4\", \"p5\"], submitted targets: [\"p1\", \"p2\"]"
+        /Current targets: \["p4","p5"\], submitted targets: \["p1","p2"\]/
       );
 
       expect(mockPrismaClient.tTPhaseSuddenDeathRound.create).toHaveBeenCalledTimes(1);

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -932,7 +932,7 @@ describe("TA Finals Phase Manager", () => {
           { playerId: "p5", timeMs: 90000 },
         ])
       ).rejects.toThrow(
-        /Current targets: \["p4","p5"\], submitted targets: \["p1","p2"\]/
+        /Computed targets \(this request\): \["p4","p5"\], Stored targets \(concurrent request\): \["p1","p2"\]/
       );
 
       expect(mockPrismaClient.tTPhaseSuddenDeathRound.create).toHaveBeenCalledTimes(1);

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -1418,6 +1418,69 @@ describe("TA Finals Phase Manager", () => {
         })
       );
     });
+
+    it("keeps non-sudden players from changing sudden-death ordering in phase3", async () => {
+      mockPrismaClient.tTPhaseSuddenDeathRound.findUnique.mockResolvedValue({
+        id: "sd1",
+        tournamentId: "t1",
+        phase: "phase3",
+        phaseRoundId: "round1",
+        targetPlayerIds: ["p4", "p5"],
+        resolved: false,
+        phaseRound: {
+          id: "round1",
+          course: "MC1",
+          results: [
+            { playerId: "p1", timeMs: 10000 },
+            { playerId: "p2", timeMs: 11000 },
+            { playerId: "p3", timeMs: 13001 },
+            { playerId: "p4", timeMs: 13000 },
+            { playerId: "p5", timeMs: 13005 },
+          ],
+        },
+      });
+      mockPrismaClient.tTEntry.findMany.mockResolvedValue([
+        { playerId: "p1", eliminated: false, lives: 3 },
+        { playerId: "p2", eliminated: false, lives: 3 },
+        { playerId: "p3", eliminated: false, lives: 3 },
+        { playerId: "p4", eliminated: false, lives: 1 },
+        { playerId: "p5", eliminated: false, lives: 1 },
+      ]);
+      mockPrismaClient.tTEntry.findUnique.mockImplementation(({ where }) => {
+        const playerId = where?.tournamentId_playerId_stage?.playerId;
+        const livesByPlayer = new Map([
+          ["p1", 3],
+          ["p2", 3],
+          ["p3", 3],
+          ["p4", 1],
+          ["p5", 1],
+        ]);
+        if (!playerId) return Promise.resolve(null);
+        return Promise.resolve({
+          id: `entry-${playerId}`,
+          lives: livesByPlayer.get(playerId) ?? 3,
+          eliminated: false,
+        });
+      });
+      mockPrismaClient.tTPhaseSuddenDeathRound.update.mockResolvedValue({});
+      mockPrismaClient.tTPhaseRound.update.mockResolvedValue({});
+      mockPrismaClient.tTEntry.update.mockResolvedValue({});
+
+      const result = await submitSuddenDeathResults(mockPrismaClient as any, context, "phase3", "sd1", [
+        { playerId: "p5", timeMs: 92000 },
+        { playerId: "p4", timeMs: 91000 },
+      ]);
+
+      expect(result.eliminatedIds).toEqual(["p4"]);
+      expect(mockPrismaClient.tTPhaseRound.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            eliminatedIds: ["p4"],
+            livesReset: false,
+          }),
+        })
+      );
+    });
   });
 
   // === AUDIT LOG .catch() ERROR PATH (#779) ===

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -931,7 +931,9 @@ describe("TA Finals Phase Manager", () => {
           { playerId: "p4", timeMs: 90000 },
           { playerId: "p5", timeMs: 90000 },
         ])
-      ).rejects.toThrow("Sudden-death round for phase1 changed during submission. Refresh and submit again.");
+      ).rejects.toThrow(
+        "Sudden-death round for phase1 changed during submission. Refresh and submit again. Current targets: [\"p4\", \"p5\"], submitted targets: [\"p1\", \"p2\"]"
+      );
 
       expect(mockPrismaClient.tTPhaseSuddenDeathRound.create).toHaveBeenCalledTimes(1);
       expect(mockPrismaClient.tTPhaseSuddenDeathRound.count).toHaveBeenCalledTimes(1);

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -1419,7 +1419,7 @@ describe("TA Finals Phase Manager", () => {
       );
     });
 
-    it("keeps non-sudden players from changing sudden-death ordering in phase3", async () => {
+    it("keeps non-sudden players from becoming an unintended elimination target in phase3", async () => {
       mockPrismaClient.tTPhaseSuddenDeathRound.findUnique.mockResolvedValue({
         id: "sd1",
         tournamentId: "t1",
@@ -1471,11 +1471,11 @@ describe("TA Finals Phase Manager", () => {
         { playerId: "p4", timeMs: 91000 },
       ]);
 
-      expect(result.eliminatedIds).toEqual(["p4"]);
+      expect(result.eliminatedIds).toEqual(["p5"]);
       expect(mockPrismaClient.tTPhaseRound.update).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
-            eliminatedIds: ["p4"],
+            eliminatedIds: ["p5"],
             livesReset: false,
           }),
         })

--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -1132,19 +1132,19 @@ async function createSuddenDeathRound(
           orderBy: { sequence: "desc" },
         });
         if (existing) {
-        if (!hasSameTargetPlayers(existing.targetPlayerIds, targetPlayerIds)) {
-          /*
-           * A different concurrent submission already created the sudden-death
-           * round. Returning it as success would pair this request's stored
-           * base-round results with another request's tiebreak targets, so the
-           * admin must refresh instead of continuing with mixed state.
-           */
-          throw new Error(
+          if (!hasSameTargetPlayers(existing.targetPlayerIds, targetPlayerIds)) {
+            /*
+             * A different concurrent submission already created the sudden-death
+             * round. Returning it as success would pair this request's stored
+             * base-round results with another request's tiebreak targets, so the
+             * admin must refresh instead of continuing with mixed state.
+             */
+            throw new Error(
               `Sudden-death round for ${phase} changed during submission. Refresh and submit again. ` +
-                `Current targets: ${JSON.stringify(targetPlayerIds)}, ` +
-                `submitted targets: ${JSON.stringify(existing.targetPlayerIds)}`
-          );
-        }
+                `Computed targets (this request): ${JSON.stringify(targetPlayerIds)}, ` +
+                `Stored targets (concurrent request): ${JSON.stringify(existing.targetPlayerIds)}`
+            );
+          }
           logger.warn("Sudden-death creation race condition detected, reusing existing round", {
             tournamentId,
             phase,

--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -1132,17 +1132,19 @@ async function createSuddenDeathRound(
           orderBy: { sequence: "desc" },
         });
         if (existing) {
-          if (!hasSameTargetPlayers(existing.targetPlayerIds, targetPlayerIds)) {
-            /*
-             * A different concurrent submission already created the sudden-death
-             * round. Returning it as success would pair this request's stored
-             * base-round results with another request's tiebreak targets, so the
-             * admin must refresh instead of continuing with mixed state.
-             */
-            throw new Error(
-              `Sudden-death round for ${phase} changed during submission. Refresh and submit again.`
-            );
-          }
+        if (!hasSameTargetPlayers(existing.targetPlayerIds, targetPlayerIds)) {
+          /*
+           * A different concurrent submission already created the sudden-death
+           * round. Returning it as success would pair this request's stored
+           * base-round results with another request's tiebreak targets, so the
+           * admin must refresh instead of continuing with mixed state.
+           */
+          throw new Error(
+              `Sudden-death round for ${phase} changed during submission. Refresh and submit again. ` +
+                `Current targets: ${JSON.stringify(targetPlayerIds)}, ` +
+                `submitted targets: ${JSON.stringify(existing.targetPlayerIds)}`
+          );
+        }
           logger.warn("Sudden-death creation race condition detected, reusing existing round", {
             tournamentId,
             phase,


### PR DESCRIPTION
Closes #827

## Summary
- Add explicit target lists to sudden-death concurrency-conflict error message.
- Keep retry/reuse behavior unchanged.
- Tighten test expectation for conflict path with explicit target diagnostics.

## Validation
- Commit: ae8d7d84