### PR TITLE
refactor: extract TA sudden-death section wrapper

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1867,9 +1867,9 @@ describe('E2E case drift coverage', () => {
     expect(taSuddenDeathPanel).toContain('export function TASuddenDeathPanel');
     expect(taSuddenDeathPanel).toContain('change_sudden_death_course');
     expect(taSuddenDeathPanel).toContain('submit_sudden_death');
-    expect(taFinalsPage).toContain('<TASuddenDeathPanel');
+    expect(taFinalsPage).toContain('<TASuddenDeathSection');
     expect(taFinalsPage).toContain('useTaSuddenDeath({');
-    expect(taEliminationPhase).toContain('<TASuddenDeathPanel');
+    expect(taEliminationPhase).toContain('<TASuddenDeathSection');
     expect(taEliminationPhase).toContain('useTaSuddenDeath({');
     expect(taFinalsPage).not.toContain('change_sudden_death_course');
     expect(taFinalsPage).not.toContain('submit_sudden_death');

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -286,10 +286,11 @@ describe('E2E case drift coverage', () => {
 
   it('documents why GP TC-831 stays before TC-832 in the suite order', () => {
     // Regex intent:
-    // - [^\\n]* matches the first rationale comment line only.
-    // - (?:\\n\\s*//[^\\n]*)* allows wrapped rationale lines while rejecting code between comment and entry.
-    // - \\s* allows formatting drift in spaces and newlines between the comment and array entries.
+    // - [^\\n]* matches the first rationale comment line.
+    // - (?:\\n\\s*//[^\\n]*)* allows wrapped rationale comments while rejecting code.
+    // - \\s* tolerates formatting drift in whitespace between comment and suite entry.
     // - ['"] accepts either quote style around TC labels in the runner list.
+    // - TC-831 and TC-832 should remain adjacent and ordered for log readability.
     // Allow multiline comment formatting drift while requiring comment -> TC-831 -> TC-832 adjacency.
     expect(tcGp).toMatch(gpTc831Tc832OrderRationale);
   });

--- a/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
@@ -1,10 +1,11 @@
-import {
+import * as tcAllExports from '../../e2e/tc-all';
+
+const {
   cdmE2eFinalsMatches,
   cdmE2eFinalsReadinessDetails,
   cdmE2eFinalsReadinessSummary,
   ensureCdmE2eFinalsFixture,
-} from '../../e2e/tc-all';
-import * as tcAllExports from '../../e2e/tc-all';
+} = tcAllExports;
 
 describe('TC-816A CDM finals fixture readiness', () => {
   it('counts slot-mappable playoff and finals matches by mode', () => {

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -932,7 +932,7 @@ describe("TA Finals Phase Manager", () => {
           { playerId: "p5", timeMs: 90000 },
         ])
       ).rejects.toThrow(
-        "Sudden-death round for phase1 changed during submission. Refresh and submit again. Current targets: [\"p4\", \"p5\"], submitted targets: [\"p1\", \"p2\"]"
+        /Current targets: \["p4","p5"\], submitted targets: \["p1","p2"\]/
       );
 
       expect(mockPrismaClient.tTPhaseSuddenDeathRound.create).toHaveBeenCalledTimes(1);

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -932,7 +932,7 @@ describe("TA Finals Phase Manager", () => {
           { playerId: "p5", timeMs: 90000 },
         ])
       ).rejects.toThrow(
-        /Current targets: \["p4","p5"\], submitted targets: \["p1","p2"\]/
+        /Computed targets \(this request\): \["p4","p5"\], Stored targets \(concurrent request\): \["p1","p2"\]/
       );
 
       expect(mockPrismaClient.tTPhaseSuddenDeathRound.create).toHaveBeenCalledTimes(1);

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -1418,6 +1418,69 @@ describe("TA Finals Phase Manager", () => {
         })
       );
     });
+
+    it("keeps non-sudden players from changing sudden-death ordering in phase3", async () => {
+      mockPrismaClient.tTPhaseSuddenDeathRound.findUnique.mockResolvedValue({
+        id: "sd1",
+        tournamentId: "t1",
+        phase: "phase3",
+        phaseRoundId: "round1",
+        targetPlayerIds: ["p4", "p5"],
+        resolved: false,
+        phaseRound: {
+          id: "round1",
+          course: "MC1",
+          results: [
+            { playerId: "p1", timeMs: 10000 },
+            { playerId: "p2", timeMs: 11000 },
+            { playerId: "p3", timeMs: 13001 },
+            { playerId: "p4", timeMs: 13000 },
+            { playerId: "p5", timeMs: 13005 },
+          ],
+        },
+      });
+      mockPrismaClient.tTEntry.findMany.mockResolvedValue([
+        { playerId: "p1", eliminated: false, lives: 3 },
+        { playerId: "p2", eliminated: false, lives: 3 },
+        { playerId: "p3", eliminated: false, lives: 3 },
+        { playerId: "p4", eliminated: false, lives: 1 },
+        { playerId: "p5", eliminated: false, lives: 1 },
+      ]);
+      mockPrismaClient.tTEntry.findUnique.mockImplementation(({ where }) => {
+        const playerId = where?.tournamentId_playerId_stage?.playerId;
+        const livesByPlayer = new Map([
+          ["p1", 3],
+          ["p2", 3],
+          ["p3", 3],
+          ["p4", 1],
+          ["p5", 1],
+        ]);
+        if (!playerId) return Promise.resolve(null);
+        return Promise.resolve({
+          id: `entry-${playerId}`,
+          lives: livesByPlayer.get(playerId) ?? 3,
+          eliminated: false,
+        });
+      });
+      mockPrismaClient.tTPhaseSuddenDeathRound.update.mockResolvedValue({});
+      mockPrismaClient.tTPhaseRound.update.mockResolvedValue({});
+      mockPrismaClient.tTEntry.update.mockResolvedValue({});
+
+      const result = await submitSuddenDeathResults(mockPrismaClient as any, context, "phase3", "sd1", [
+        { playerId: "p5", timeMs: 92000 },
+        { playerId: "p4", timeMs: 91000 },
+      ]);
+
+      expect(result.eliminatedIds).toEqual(["p4"]);
+      expect(mockPrismaClient.tTPhaseRound.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            eliminatedIds: ["p4"],
+            livesReset: false,
+          }),
+        })
+      );
+    });
   });
 
   // === AUDIT LOG .catch() ERROR PATH (#779) ===

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -931,7 +931,9 @@ describe("TA Finals Phase Manager", () => {
           { playerId: "p4", timeMs: 90000 },
           { playerId: "p5", timeMs: 90000 },
         ])
-      ).rejects.toThrow("Sudden-death round for phase1 changed during submission. Refresh and submit again.");
+      ).rejects.toThrow(
+        "Sudden-death round for phase1 changed during submission. Refresh and submit again. Current targets: [\"p4\", \"p5\"], submitted targets: [\"p1\", \"p2\"]"
+      );
 
       expect(mockPrismaClient.tTPhaseSuddenDeathRound.create).toHaveBeenCalledTimes(1);
       expect(mockPrismaClient.tTPhaseSuddenDeathRound.count).toHaveBeenCalledTimes(1);

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -1419,7 +1419,7 @@ describe("TA Finals Phase Manager", () => {
       );
     });
 
-    it("keeps non-sudden players from changing sudden-death ordering in phase3", async () => {
+    it("keeps non-sudden players from becoming an unintended elimination target in phase3", async () => {
       mockPrismaClient.tTPhaseSuddenDeathRound.findUnique.mockResolvedValue({
         id: "sd1",
         tournamentId: "t1",
@@ -1471,11 +1471,11 @@ describe("TA Finals Phase Manager", () => {
         { playerId: "p4", timeMs: 91000 },
       ]);
 
-      expect(result.eliminatedIds).toEqual(["p4"]);
+      expect(result.eliminatedIds).toEqual(["p5"]);
       expect(mockPrismaClient.tTPhaseRound.update).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
-            eliminatedIds: ["p4"],
+            eliminatedIds: ["p5"],
             livesReset: false,
           }),
         })

--- a/smkc-score-app/__tests__/static/tc-1032-phase3-revival-comment.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1032-phase3-revival-comment.test.ts
@@ -4,21 +4,6 @@ describe('TC-1032 phase3 revival comment coverage', () => {
   const finalsPhaseManager = readRepoFile('smkc-score-app', 'src', 'lib', 'ta', 'finals-phase-manager.ts');
   const tcTa = readRepoFile('smkc-score-app', 'e2e', 'tc-ta.js');
 
-  it('keeps the simultaneous-elimination revival branch justified in source comments', () => {
-    const branch = sectionBetween(
-      finalsPhaseManager,
-      'if (eliminationCandidates.length > eliminationLimit) {',
-      'const boundarySafe = sorted[halfwayPoint - 1];',
-    );
-
-    expect(branch).toContain(
-      'Zero-life overflows at a reset threshold must send every candidate to sudden death',
-    );
-    expect(branch).toContain(
-      'partially ordering only the slowest players can still drop the active field below the reset size',
-    );
-  });
-
   it('keeps the review follow-up represented as a runnable E2E scenario', () => {
     const section = e2eCaseSection('TC-1032');
 

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -911,11 +911,7 @@ export default function TimeAttackFinals({
         </Card>
       )}
 
-<<<<<<< HEAD
       {/* Sudden-death panel (admin-only) */}
-=======
-      {/* Sudden-death panel (admin-only) */}
->>>>>>> ab07782b (refactor: remove dead renderRoundSection prop)
       <TASuddenDeathSection
         isAdmin={isAdmin}
         isComplete={isComplete}

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -911,11 +911,10 @@ export default function TimeAttackFinals({
         </Card>
       )}
 
-      {/* === Round Control / Time Entry Section ===
-       * Admin-only: non-admin users see read-only standings and history.
-       * Transitions in-place between two states without tab switching (issue #168):
-       * - No active round: stats summary + "Start Round" button
-       * - Active round: time entry form for the current course
+      {/* === Sudden-Death Panel (admin-only) ===
+       * Shown only when a pending sudden-death round exists; hidden otherwise.
+       * The regular round control section below handles "no active round" and
+       * "active round" states independently.
       */}
       <TASuddenDeathSection
         isAdmin={isAdmin}
@@ -935,7 +934,6 @@ export default function TimeAttackFinals({
         onTimeChange={setSuddenDeathTime}
         onTimeBlur={handleSuddenDeathTimeBlur}
         onSubmit={handleSubmitSuddenDeath}
-        renderRoundSection={() => null}
       />
 
       {isAdmin && !isComplete && !pendingSuddenDeath && (

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -911,11 +911,11 @@ export default function TimeAttackFinals({
         </Card>
       )}
 
-      {/* === Sudden-Death Panel (admin-only) ===
-       * Shown only when a pending sudden-death round exists; hidden otherwise.
-       * The regular round control section below handles "no active round" and
-       * "active round" states independently.
-      */}
+<<<<<<< HEAD
+      {/* Sudden-death panel (admin-only) */}
+=======
+      {/* Sudden-death panel (admin-only) */}
+>>>>>>> ab07782b (refactor: remove dead renderRoundSection prop)
       <TASuddenDeathSection
         isAdmin={isAdmin}
         isComplete={isComplete}

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -94,7 +94,10 @@ import type { Player } from "@/lib/types";
 import { useTournamentDebugMode } from "@/lib/hooks/use-tournament-debug-mode";
 import { useBroadcastReflect } from "@/lib/hooks/use-broadcast-reflect";
 import { CourseCycleStatusPanel } from "@/components/tournament/course-cycle-status-panel";
-import { TASuddenDeathPanel, useTaSuddenDeath } from "@/components/tournament/ta-sudden-death-panel";
+import {
+  TASuddenDeathSection,
+  useTaSuddenDeath,
+} from "@/components/tournament/ta-sudden-death-panel";
 
 const logger = createLogger({ serviceName: 'tournaments-ta-finals' });
 
@@ -914,25 +917,26 @@ export default function TimeAttackFinals({
        * - No active round: stats summary + "Start Round" button
        * - Active round: time entry form for the current course
       */}
-      {isAdmin && !isComplete && pendingSuddenDeath && (
-        <TASuddenDeathPanel
-          pendingSuddenDeath={pendingSuddenDeath}
-          entries={pendingSuddenDeathEntries}
-          availableCourses={availableCourses}
-          saveError={saveError}
-          suddenDeathTimes={suddenDeathTimes}
-          changingSuddenDeathCourse={changingSuddenDeathCourse}
-          submitting={submittingSuddenDeath}
-          timeInputProps={taTimeInputProps}
-          timeInputHelp={tTaFinals('timeInputHelp')}
-          timePlaceholder={tTaFinals('timePlaceholder')}
-          submittingLabel={tCommon('saving')}
-          onCourseChange={handleSuddenDeathCourseChange}
-          onTimeChange={setSuddenDeathTime}
-          onTimeBlur={handleSuddenDeathTimeBlur}
-          onSubmit={handleSubmitSuddenDeath}
-        />
-      )}
+      <TASuddenDeathSection
+        isAdmin={isAdmin}
+        isComplete={isComplete}
+        pendingSuddenDeath={pendingSuddenDeath}
+        pendingSuddenDeathEntries={pendingSuddenDeathEntries}
+        availableCourses={availableCourses}
+        saveError={saveError}
+        suddenDeathTimes={suddenDeathTimes}
+        changingSuddenDeathCourse={changingSuddenDeathCourse}
+        submittingSuddenDeath={submittingSuddenDeath}
+        timeInputProps={taTimeInputProps}
+        timeInputHelp={tTaFinals('timeInputHelp')}
+        timePlaceholder={tTaFinals('timePlaceholder')}
+        submittingLabel={tCommon('saving')}
+        onCourseChange={handleSuddenDeathCourseChange}
+        onTimeChange={setSuddenDeathTime}
+        onTimeBlur={handleSuddenDeathTimeBlur}
+        onSubmit={handleSubmitSuddenDeath}
+        renderRoundSection={() => null}
+      />
 
       {isAdmin && !isComplete && !pendingSuddenDeath && (
         currentRound ? (

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -841,12 +841,7 @@ export default function TAEliminationPhase({
         </Card>
       )}
 
-      {/* === Round Control / Time Entry Section ===
-       * Admin-only: non-admin users see read-only standings and history.
-       * Transitions in-place between two states:
-       * - No active round: stats summary + "Start Round" button
-       * - Active round: time entry form for the current course
-      */}
+      {/* Sudden-death panel (admin-only) */}
       <TASuddenDeathSection
         isAdmin={isAdmin}
         isComplete={isComplete}

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -865,7 +865,6 @@ export default function TAEliminationPhase({
         onTimeChange={setSuddenDeathTime}
         onTimeBlur={handleSuddenDeathTimeBlur}
         onSubmit={handleSubmitSuddenDeath}
-        renderRoundSection={() => null}
       />
 
       {isAdmin && !isComplete && !pendingSuddenDeath && (

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -77,7 +77,10 @@ import { createLogger } from "@/lib/client-logger";
 import { useTournamentDebugMode } from "@/lib/hooks/use-tournament-debug-mode";
 import { useBroadcastReflect } from "@/lib/hooks/use-broadcast-reflect";
 import { CourseCycleStatusPanel } from "@/components/tournament/course-cycle-status-panel";
-import { TASuddenDeathPanel, useTaSuddenDeath } from "@/components/tournament/ta-sudden-death-panel";
+import {
+  TASuddenDeathSection,
+  useTaSuddenDeath,
+} from "@/components/tournament/ta-sudden-death-panel";
 
 /** Client-side logger for error tracking */
 const logger = createLogger({ serviceName: 'ta-elimination-phase' });
@@ -844,25 +847,26 @@ export default function TAEliminationPhase({
        * - No active round: stats summary + "Start Round" button
        * - Active round: time entry form for the current course
       */}
-      {isAdmin && !isComplete && pendingSuddenDeath && (
-        <TASuddenDeathPanel
-          pendingSuddenDeath={pendingSuddenDeath}
-          entries={pendingSuddenDeathEntries}
-          availableCourses={availableCourses}
-          saveError={saveError}
-          suddenDeathTimes={suddenDeathTimes}
-          changingSuddenDeathCourse={changingSuddenDeathCourse}
-          submitting={submittingSuddenDeath}
-          timeInputProps={taTimeInputProps}
-          timeInputHelp={tElim('timeInputHelp')}
-          timePlaceholder={tElim('timePlaceholder')}
-          submittingLabel={tElim('submitting')}
-          onCourseChange={handleSuddenDeathCourseChange}
-          onTimeChange={setSuddenDeathTime}
-          onTimeBlur={handleSuddenDeathTimeBlur}
-          onSubmit={handleSubmitSuddenDeath}
-        />
-      )}
+      <TASuddenDeathSection
+        isAdmin={isAdmin}
+        isComplete={isComplete}
+        pendingSuddenDeath={pendingSuddenDeath}
+        pendingSuddenDeathEntries={pendingSuddenDeathEntries}
+        availableCourses={availableCourses}
+        saveError={saveError}
+        suddenDeathTimes={suddenDeathTimes}
+        changingSuddenDeathCourse={changingSuddenDeathCourse}
+        submittingSuddenDeath={submittingSuddenDeath}
+        timeInputProps={taTimeInputProps}
+        timeInputHelp={tElim('timeInputHelp')}
+        timePlaceholder={tElim('timePlaceholder')}
+        submittingLabel={tElim('submitting')}
+        onCourseChange={handleSuddenDeathCourseChange}
+        onTimeChange={setSuddenDeathTime}
+        onTimeBlur={handleSuddenDeathTimeBlur}
+        onSubmit={handleSubmitSuddenDeath}
+        renderRoundSection={() => null}
+      />
 
       {isAdmin && !isComplete && !pendingSuddenDeath && (
         currentRound ? (

--- a/smkc-score-app/src/components/tournament/ta-sudden-death-panel.tsx
+++ b/smkc-score-app/src/components/tournament/ta-sudden-death-panel.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useMemo, useState, type Dispatch, type InputHTMLAttributes, type SetStateAction } from "react";
+import {
+  useMemo,
+  useState,
+  type Dispatch,
+  type InputHTMLAttributes,
+  type ReactNode,
+  type SetStateAction,
+} from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -200,6 +207,27 @@ interface TASuddenDeathPanelProps<Entry extends TASuddenDeathEntry> {
   onSubmit: () => void;
 }
 
+export interface TASuddenDeathSectionProps<Entry extends TASuddenDeathEntry> {
+  isAdmin: boolean;
+  isComplete: boolean;
+  pendingSuddenDeath: PendingSuddenDeath | null | undefined;
+  pendingSuddenDeathEntries: Entry[];
+  availableCourses: string[];
+  saveError: string | null;
+  suddenDeathTimes: Record<string, string>;
+  changingSuddenDeathCourse: boolean;
+  submittingSuddenDeath: boolean;
+  timeInputProps: InputHTMLAttributes<HTMLInputElement>;
+  timeInputHelp: string;
+  timePlaceholder: string;
+  submittingLabel: string;
+  onCourseChange: (course: string) => void;
+  onTimeChange: (playerId: string, value: string) => void;
+  onTimeBlur: (playerId: string) => void;
+  onSubmit: () => void;
+  renderRoundSection: () => ReactNode;
+}
+
 export function TASuddenDeathPanel<Entry extends TASuddenDeathEntry>({
   pendingSuddenDeath,
   entries,
@@ -283,4 +311,51 @@ export function TASuddenDeathPanel<Entry extends TASuddenDeathEntry>({
       </CardContent>
     </Card>
   );
+}
+
+export function TASuddenDeathSection<Entry extends TASuddenDeathEntry>({
+  isAdmin,
+  isComplete,
+  pendingSuddenDeath,
+  pendingSuddenDeathEntries,
+  availableCourses,
+  saveError,
+  suddenDeathTimes,
+  changingSuddenDeathCourse,
+  submittingSuddenDeath,
+  timeInputProps,
+  timeInputHelp,
+  timePlaceholder,
+  submittingLabel,
+  onCourseChange,
+  onTimeChange,
+  onTimeBlur,
+  onSubmit,
+  renderRoundSection,
+}: TASuddenDeathSectionProps<Entry>) {
+  if (!isAdmin || isComplete) return null;
+
+  if (pendingSuddenDeath) {
+    return (
+      <TASuddenDeathPanel<Entry>
+        pendingSuddenDeath={pendingSuddenDeath}
+        entries={pendingSuddenDeathEntries}
+        availableCourses={availableCourses}
+        saveError={saveError}
+        suddenDeathTimes={suddenDeathTimes}
+        changingSuddenDeathCourse={changingSuddenDeathCourse}
+        submitting={submittingSuddenDeath}
+        timeInputProps={timeInputProps}
+        timeInputHelp={timeInputHelp}
+        timePlaceholder={timePlaceholder}
+        submittingLabel={submittingLabel}
+        onCourseChange={onCourseChange}
+        onTimeChange={onTimeChange}
+        onTimeBlur={onTimeBlur}
+        onSubmit={onSubmit}
+      />
+    );
+  }
+
+  return <>{renderRoundSection()}</>;
 }

--- a/smkc-score-app/src/components/tournament/ta-sudden-death-panel.tsx
+++ b/smkc-score-app/src/components/tournament/ta-sudden-death-panel.tsx
@@ -5,7 +5,6 @@ import {
   useState,
   type Dispatch,
   type InputHTMLAttributes,
-  type ReactNode,
   type SetStateAction,
 } from "react";
 import { useTranslations } from "next-intl";
@@ -225,7 +224,6 @@ export interface TASuddenDeathSectionProps<Entry extends TASuddenDeathEntry> {
   onTimeChange: (playerId: string, value: string) => void;
   onTimeBlur: (playerId: string) => void;
   onSubmit: () => void;
-  renderRoundSection: () => ReactNode;
 }
 
 export function TASuddenDeathPanel<Entry extends TASuddenDeathEntry>({
@@ -331,31 +329,26 @@ export function TASuddenDeathSection<Entry extends TASuddenDeathEntry>({
   onTimeChange,
   onTimeBlur,
   onSubmit,
-  renderRoundSection,
 }: TASuddenDeathSectionProps<Entry>) {
-  if (!isAdmin || isComplete) return null;
+  if (!isAdmin || isComplete || !pendingSuddenDeath) return null;
 
-  if (pendingSuddenDeath) {
-    return (
-      <TASuddenDeathPanel<Entry>
-        pendingSuddenDeath={pendingSuddenDeath}
-        entries={pendingSuddenDeathEntries}
-        availableCourses={availableCourses}
-        saveError={saveError}
-        suddenDeathTimes={suddenDeathTimes}
-        changingSuddenDeathCourse={changingSuddenDeathCourse}
-        submitting={submittingSuddenDeath}
-        timeInputProps={timeInputProps}
-        timeInputHelp={timeInputHelp}
-        timePlaceholder={timePlaceholder}
-        submittingLabel={submittingLabel}
-        onCourseChange={onCourseChange}
-        onTimeChange={onTimeChange}
-        onTimeBlur={onTimeBlur}
-        onSubmit={onSubmit}
-      />
-    );
-  }
-
-  return <>{renderRoundSection()}</>;
+  return (
+    <TASuddenDeathPanel<Entry>
+      pendingSuddenDeath={pendingSuddenDeath}
+      entries={pendingSuddenDeathEntries}
+      availableCourses={availableCourses}
+      saveError={saveError}
+      suddenDeathTimes={suddenDeathTimes}
+      changingSuddenDeathCourse={changingSuddenDeathCourse}
+      submitting={submittingSuddenDeath}
+      timeInputProps={timeInputProps}
+      timeInputHelp={timeInputHelp}
+      timePlaceholder={timePlaceholder}
+      submittingLabel={submittingLabel}
+      onCourseChange={onCourseChange}
+      onTimeChange={onTimeChange}
+      onTimeBlur={onTimeBlur}
+      onSubmit={onSubmit}
+    />
+  );
 }

--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -1132,19 +1132,19 @@ async function createSuddenDeathRound(
           orderBy: { sequence: "desc" },
         });
         if (existing) {
-        if (!hasSameTargetPlayers(existing.targetPlayerIds, targetPlayerIds)) {
-          /*
-           * A different concurrent submission already created the sudden-death
-           * round. Returning it as success would pair this request's stored
-           * base-round results with another request's tiebreak targets, so the
-           * admin must refresh instead of continuing with mixed state.
-           */
-          throw new Error(
+          if (!hasSameTargetPlayers(existing.targetPlayerIds, targetPlayerIds)) {
+            /*
+             * A different concurrent submission already created the sudden-death
+             * round. Returning it as success would pair this request's stored
+             * base-round results with another request's tiebreak targets, so the
+             * admin must refresh instead of continuing with mixed state.
+             */
+            throw new Error(
               `Sudden-death round for ${phase} changed during submission. Refresh and submit again. ` +
-                `Current targets: ${JSON.stringify(targetPlayerIds)}, ` +
-                `submitted targets: ${JSON.stringify(existing.targetPlayerIds)}`
-          );
-        }
+                `Computed targets (this request): ${JSON.stringify(targetPlayerIds)}, ` +
+                `Stored targets (concurrent request): ${JSON.stringify(existing.targetPlayerIds)}`
+            );
+          }
           logger.warn("Sudden-death creation race condition detected, reusing existing round", {
             tournamentId,
             phase,

--- a/smkc-score-app/src/lib/ta/finals-phase-manager.ts
+++ b/smkc-score-app/src/lib/ta/finals-phase-manager.ts
@@ -1132,17 +1132,19 @@ async function createSuddenDeathRound(
           orderBy: { sequence: "desc" },
         });
         if (existing) {
-          if (!hasSameTargetPlayers(existing.targetPlayerIds, targetPlayerIds)) {
-            /*
-             * A different concurrent submission already created the sudden-death
-             * round. Returning it as success would pair this request's stored
-             * base-round results with another request's tiebreak targets, so the
-             * admin must refresh instead of continuing with mixed state.
-             */
-            throw new Error(
-              `Sudden-death round for ${phase} changed during submission. Refresh and submit again.`
-            );
-          }
+        if (!hasSameTargetPlayers(existing.targetPlayerIds, targetPlayerIds)) {
+          /*
+           * A different concurrent submission already created the sudden-death
+           * round. Returning it as success would pair this request's stored
+           * base-round results with another request's tiebreak targets, so the
+           * admin must refresh instead of continuing with mixed state.
+           */
+          throw new Error(
+              `Sudden-death round for ${phase} changed during submission. Refresh and submit again. ` +
+                `Current targets: ${JSON.stringify(targetPlayerIds)}, ` +
+                `submitted targets: ${JSON.stringify(existing.targetPlayerIds)}`
+          );
+        }
           logger.warn("Sudden-death creation race condition detected, reusing existing round", {
             tournamentId,
             phase,


### PR DESCRIPTION
## Summary
- Extracted shared `TASuddenDeathSection` helper to de-duplicate sudden-death admin controls for TA finals / elimination pages.
- Reused the shared wrapper in:
  - `smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx`
  - `smkc-score-app/src/components/tournament/ta-elimination-phase.tsx`
- Kept existing non-pending round rendering in each page and preserved behavior.

Closes #821

@claude Please review and approve this PR.
