### PR TITLE
test: preflight preview admin session

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -130,6 +130,18 @@
 - **期待結果**: 認証/ログ初期化だけの失敗は通常 preview E2E を本体開始前に止めず、schema missing / SQLite error / timeout / strict preflight は従来どおり診断つきで失敗する。TC-2161 の E2E scenario 文字列確認は `preview-schema-preflight.test.ts` 側に集約し、drift test は preview preflight 実装と補助テストの対応だけを監視する
 - **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
 
+## TC-2236: Preview E2E は共有 fixture 作成前に admin session 不在を fast-fail する
+- **URL**: n/a (runner configuration / preview suite)
+- **authRequired**: true (persistent preview admin profile)
+- **背景**: issue #2236。`npm run e2e:preview:all` は persistent profile の admin session が切れていると `/tournaments` の public list に進み、`createSharedE2eFixture` / `uiCreateTournament` 内で Create Tournament button を待ち続けて locator timeout になる。Wrangler/D1 preflight の認証警告とは別に、browser admin session 不在は共有 fixture 作成前に明示的に失敗させる必要がある。
+- **手順**:
+  1. `run-preview.js` が target script spawn 前に persistent preview profile で `/tournaments` を開く
+  2. 同じ browser context から `/api/auth/session-status` を `credentials: same-origin` で確認する
+  3. `data.authenticated === true` のときだけ target script を起動できることを確認する
+  4. `No active session` など未認証応答では `createSharedE2eFixture` に進まず、`npm run e2e:preview:login` と `E2E_PROFILE_DIR` を含む復旧案内つきで失敗することを確認する
+- **期待結果**: preview admin profile の session 切れは共有 fixture / Create Tournament locator timeout ではなく、preview runner の admin-session preflight failure として即座に判別できる。Wrangler/D1 preflight warning は従来どおり別系統の診断として扱われる。
+- **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/run-preview.test.ts`
+
 ## TC-2207: Preview D1 schema preflight は Wrangler schema drift 表記の追加パターンを migration guidance に分類する
 - **URL**: n/a (runner configuration / preview suite)
 - **authRequired**: true (Cloudflare D1 token is optional unless strict preflight is requested)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -398,6 +398,21 @@ describe('E2E case drift coverage', () => {
     expect(preflightTest).toContain('keeps Wrangler auth/log message helpers private to the preflight runner');
   });
 
+  it('keeps TC-2236 aligned with preview admin session preflight coverage', () => {
+    const section = e2eCaseSection('TC-2236');
+    const runner = readE2eScript('run-preview.js');
+    const runnerTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'run-preview.test.ts');
+
+    expect(section).toContain('issue #2236');
+    expect(section).toContain('/api/auth/session-status');
+    expect(section).toContain('createSharedE2eFixture');
+    expect(section).toContain('npm run e2e:preview:login');
+    expect(runner).toContain('assertPreviewAdminSession');
+    expect(runner).toContain('Preview E2E admin session preflight failed before shared fixture setup');
+    expect(runner).toContain('npm run e2e:preview:login');
+    expect(runnerTest).toContain('fails preview admin session preflight before fixture setup');
+  });
+
   it('keeps TC-2207 aligned with preview schema failure pattern coverage', () => {
     const section = e2eCaseSection('TC-2207');
     const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -105,6 +105,10 @@ describe('preview E2E runner', () => {
     expect(typeof runner.assertPreviewD1Schema).toBe('function');
   });
 
+  it('exposes preview admin session preflight for E2E startup checks', () => {
+    expect(typeof runner.assertPreviewAdminSession).toBe('function');
+  });
+
   it('regenerates Prisma Client before Cloudflare builds used by preview deploys', () => {
     expect(packageJson.scripts['prebuild:cf']).toBe('prisma generate');
     expect(packageJson.scripts['deploy:preview']).toContain('npm run build:cf');
@@ -185,6 +189,71 @@ describe('preview E2E runner', () => {
     ).resolves.toBeNull();
 
     expect(lookupMock).toHaveBeenCalledWith('preview-alt.example.com');
+  });
+
+  it('passes preview admin session preflight when session-status confirms admin auth', async () => {
+    const close = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const goto = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const evaluate = jest.fn<() => Promise<unknown>>().mockResolvedValue({
+      status: 200,
+      authenticated: true,
+      body: { data: { authenticated: true, user: { role: 'admin' } } },
+    });
+    const launchBrowser = jest.fn<() => Promise<unknown>>().mockResolvedValue({
+      pages: () => [{ goto, evaluate }],
+      close,
+    });
+
+    await expect(
+      runner.assertPreviewAdminSession({
+        E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
+        E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
+      }, launchBrowser as never),
+    ).resolves.toMatchObject({ authenticated: true });
+
+    expect(launchBrowser).toHaveBeenCalledWith({
+      E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
+      E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
+    });
+    expect(goto).toHaveBeenCalledWith(
+      'https://preview.smkc.bluemoon.works/tournaments',
+      { waitUntil: 'domcontentloaded', timeout: 30000 },
+    );
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('fails preview admin session preflight before fixture setup when the profile is unauthenticated', async () => {
+    const close = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const goto = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const evaluate = jest.fn<() => Promise<unknown>>().mockResolvedValue({
+      status: 200,
+      authenticated: false,
+      body: { success: false, error: 'No active session', requiresAuth: true },
+    });
+    const launchBrowser = jest.fn<() => Promise<unknown>>().mockResolvedValue({
+      pages: () => [{ goto, evaluate }],
+      close,
+    });
+
+    await expect(
+      runner.assertPreviewAdminSession({
+        E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
+        E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
+      }, launchBrowser as never),
+    ).rejects.toThrow(/Preview E2E admin session preflight failed/);
+    await expect(
+      runner.assertPreviewAdminSession({
+        E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
+        E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
+      }, launchBrowser as never),
+    ).rejects.toThrow(/No active session/);
+    await expect(
+      runner.assertPreviewAdminSession({
+        E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
+        E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
+      }, launchBrowser as never),
+    ).rejects.toThrow(/npm run e2e:preview:login/);
+    expect(close).toHaveBeenCalled();
   });
 
   it('falls back to public DNS when local resolution fails', async () => {

--- a/smkc-score-app/e2e/run-preview.js
+++ b/smkc-score-app/e2e/run-preview.js
@@ -71,6 +71,93 @@ function resolveHostViaPublicDns(hostname) {
   return null;
 }
 
+async function launchPreviewAdminSessionBrowser(env) {
+  const { launchPersistentChromiumContext } = require('./lib/common');
+  const previousEnv = {};
+  for (const [key, value] of Object.entries(env)) {
+    previousEnv[key] = process.env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await launchPersistentChromiumContext(env.E2E_PROFILE_DIR, {
+      headless: env.E2E_HEADLESS === '1',
+      viewport: { width: 1280, height: 720 },
+    });
+  } finally {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+async function queryPreviewAdminSession(page) {
+  return await page.evaluate(async () => {
+    try {
+      const response = await fetch('/api/auth/session-status', { credentials: 'same-origin' });
+      const body = await response.json().catch(() => null);
+      return {
+        status: response.status,
+        authenticated: body?.data?.authenticated === true,
+        body,
+      };
+    } catch (error) {
+      return {
+        status: 0,
+        authenticated: false,
+        body: null,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  });
+}
+
+function previewAdminSessionError(env, session) {
+  const detail = session?.error
+    ? session.error
+    : session?.body?.error
+      ? session.body.error
+      : JSON.stringify(session?.body ?? {});
+  return new Error([
+    'Preview E2E admin session preflight failed before shared fixture setup.',
+    `/api/auth/session-status returned HTTP ${session?.status ?? 'unknown'} and did not confirm an authenticated admin session.`,
+    `Detail: ${detail || '<empty response>'}.`,
+    `Restore the persistent preview admin profile with: E2E_PROFILE_DIR=${env.E2E_PROFILE_DIR} npm run e2e:preview:login`,
+    'Wrangler/D1 preflight warnings are separate; this browser admin session absence is blocking.',
+  ].join(' '));
+}
+
+async function assertPreviewAdminSession(env, launchBrowser = launchPreviewAdminSessionBrowser) {
+  if (env.E2E_SKIP_PREVIEW_ADMIN_PREFLIGHT === '1') {
+    return { skipped: true };
+  }
+
+  const browser = await launchBrowser(env);
+  try {
+    const page = browser.pages()[0] || await browser.newPage();
+    await page.goto(`${env.E2E_BASE_URL}/tournaments`, {
+      waitUntil: 'domcontentloaded',
+      timeout: 30000,
+    });
+    const session = await queryPreviewAdminSession(page);
+    if (!session.authenticated) {
+      throw previewAdminSessionError(env, session);
+    }
+    console.log(`[preview] admin session preflight passed for ${env.E2E_BASE_URL}`);
+    return session;
+  } finally {
+    await browser.close().catch(() => {});
+  }
+}
+
 async function runTargetScript(targetScript, env = buildPreviewRuntimeEnv()) {
   if (!targetScript) throw new Error('Missing preview E2E target script name.');
   const { hostname } = new URL(env.E2E_BASE_URL);
@@ -82,6 +169,7 @@ async function runTargetScript(targetScript, env = buildPreviewRuntimeEnv()) {
     childEnv.E2E_HOST_RESOLVER_RULES = `MAP ${hostname} ${fallbackAddress}`;
   }
   assertPreviewD1Schema(childEnv);
+  await assertPreviewAdminSession(childEnv);
 
   const targetPath = path.join(__dirname, targetScript);
   return await new Promise((resolve, reject) => {
@@ -118,6 +206,7 @@ if (require.main === module) {
 
 module.exports = {
   assertBaseUrlResolvable,
+  assertPreviewAdminSession,
   buildPreviewRuntimeEnv,
   resolveHostViaPublicDns,
   runTargetScript,

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -278,7 +278,7 @@ export default function TimeAttackFinals({
    * submit results, and eliminate players. Non-admin users see read-only
    * standings, history, and champion banner.
    */
-  const isAdmin = session?.user && session.user.role === 'admin';
+  const isAdmin = session?.user?.role === 'admin';
 
   // === State Management ===
   const [entries, setEntries] = useState<TTEntry[]>([]);

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -244,7 +244,7 @@ export default function TAEliminationPhase({
    * Admin role check: only admin users can start rounds, enter times,
    * and submit results. Non-admin users see read-only standings and history.
    */
-  const isAdmin = session?.user && session.user.role === 'admin';
+  const isAdmin = session?.user?.role === 'admin';
 
   // === State Management ===
   const [entries, setEntries] = useState<TTEntry[]>([]);


### PR DESCRIPTION
## Summary
- Add a preview admin-session preflight before spawning preview E2E target scripts so expired persistent profiles fail before shared fixture creation.
- Document TC-2236 and guard it with focused run-preview and docs drift tests.
- Fix build-blocking type regressions in TA sudden-death admin checks and server-ranking override sorting.

## Issues
Closes #2236

## Validation
- npm test -- --runTestsByPath __tests__/e2e/run-preview.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/server-ranking.test.ts --runInBand
- npm run lint
- npm run build:cf
