### PR TITLE
test: cover GP top-24 sudden-death preview

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -3135,6 +3135,20 @@
   8. クリーンアップ
 - **期待結果**: GP Top-24 バラッジの UI フローが全段階で正常動作する
 
+## TC-2234: GP Top-24 Phase 2 preview — suddenDeathWinnerId 付き同点 playoff winner
+- **URL**: /tournaments/[temp-id]/gp/finals
+- **authRequired**: true (admin)
+- **背景**: issue #2234。Top-24 playoff の Phase 2 preview は `playoff_r2` が同点で完了していても、旧データ互換の `suddenDeathWinnerId` があれば winner を確定できる。TC-534 の未解決 warning とは別に、解決済み同点 winner が Upper Bracket seed に入る正方向を runnable E2E で固定する。
+- **手順**:
+  1. 28名予選完了状態の GP トーナメントで既存ブラケットをリセットし、`POST /api/tournaments/[id]/gp/finals { topN: 24 }` で Top-24 playoff を作成する
+  2. `playoff_r1` M1〜M4 を API 入力し、`playoff_r2` の対戦者を確定する
+  3. `playoff_r2` M5 を `points1 === points2` かつ `suddenDeathWinnerId` が player2 の completed 状態として保存し、M6〜M8 は通常勝者で完了する
+  4. Phase 2 作成前に `GET /api/tournaments/[id]/gp/finals` で preview を取得する
+  5. `playoffStructure` の M5 `advancesToUpperSeed` に対応する `seededPlayers` が `suddenDeathWinnerId` の player を指すことを確認する
+  6. `playoffComplete=true` のまま phase は `playoff` で、Upper Bracket 作成前 preview にとどまることを確認する
+- **期待結果**: GP Top-24 Phase 2 preview は同点 playoff_r2 の `suddenDeathWinnerId` を winner として採用し、該当 Upper Bracket seed を欠落させない
+- **スクリプト**: tc-gp.js TC-2234
+
 ## TC-716: GP 予選ページの決勝ブラケット存在状態 + リセット
 - **URL**: /tournaments/[temp-id]/gp
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -269,6 +269,7 @@ describe('E2E case drift coverage', () => {
     ['TC-1109', tcGp],
     ['TC-1098', tcGp],
     ['TC-1106', tcGp],
+    ['TC-2234', tcGp],
     ['TC-725', tcGp],
     ['TC-1087', tcGp],
     ['TC-1083', tcMr],
@@ -2316,6 +2317,19 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('advancesToUpperSeed');
     expect(section).toContain('finals-route.test.ts');
     expect(section).toContain('server-side warning');
+  });
+
+  it('keeps TC-2234 aligned with the runnable GP Top-24 sudden-death preview coverage', () => {
+    const section = e2eCaseSection('TC-2234');
+
+    expect(section).toContain('issue #2234');
+    expect(section).toContain('suddenDeathWinnerId');
+    expect(section).toContain('playoff_r2');
+    expect(section).toContain('advancesToUpperSeed');
+    expect(section).toContain('tc-gp.js TC-2234');
+    expect(tcGp).toContain("log('TC-2234'");
+    expect(tcGp).toContain('apiSetGpFinalsScore(adminPage, tournamentId, match.id, 1, 1, suddenDeathWinnerId)');
+    expect(tcGp).toContain('seededWinner?.playerId === suddenDeathWinnerId');
   });
 
   it('documents TC-535 as BM Top-24 qualification label coverage', () => {

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -22,6 +22,7 @@
  *           Kept next to TC-718 because both cover finals score-save variants
  *           before the suite moves into the longer playoff UI flows.
  *   TC-1109 GP finals cup-form lock count uses the max-cups helper directly
+ *   TC-2234 GP Top-24 preview seeds tied playoff winners via suddenDeathWinnerId
  *   TC-719  GP tied cup extends non-grand-final bracket match
  *   TC-831  GP finals added cup form can be removed without stale scores
  *   TC-723  GP qualification standings show 0-1000 qualification points
@@ -1107,6 +1108,92 @@ async function runTc715(adminPage) {
   }
 }
 
+/* ───────── TC-2234: GP Top-24 preview uses suddenDeathWinnerId for tied playoff winners ─────────
+ * Builds a Top-24 playoff, completes one playoff_r2 match as a tied legacy
+ * score row with suddenDeathWinnerId, then verifies GET preview seeds that
+ * sudden-death winner into the Phase 2 Upper Bracket before creation. */
+async function runTc2234(adminPage) {
+  let setup = null;
+  try {
+    setup = await prepareSharedGpFinalsSetup(adminPage);
+    const { tournamentId } = setup;
+
+    await apiUpdateTournament(adminPage, tournamentId, { gpQualificationConfirmed: false });
+    const resetRes = await adminPage.evaluate(async (tid) => {
+      const r = await fetch(`/api/tournaments/${tid}/gp/finals`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reset: true }),
+      });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, tournamentId);
+    if (resetRes.s !== 200 && resetRes.s !== 201) {
+      throw new Error(`Bracket reset failed (${resetRes.s})`);
+    }
+
+    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { gpQualificationConfirmed: true });
+    if (confirmRes.s !== 200) throw new Error(`Failed to confirm qualification (${confirmRes.s})`);
+
+    const genRes = await apiGenerateGpFinals(adminPage, tournamentId, 24);
+    if (genRes.s !== 201) throw new Error(`Top-24 playoff generation failed (${genRes.s})`);
+
+    for (let mn = 1; mn <= 4; mn++) {
+      const state = await apiFetchGpFinalsState(adminPage, tournamentId);
+      const match = state.playoffMatches.find((m) => m.matchNumber === mn);
+      if (!match) throw new Error(`Playoff R1 M${mn} missing`);
+      const res = await apiSetGpFinalsWinner(adminPage, tournamentId, match, 1);
+      if (res.s !== 200) throw new Error(`Playoff R1 M${mn} score failed (${res.s})`);
+    }
+
+    let tiedR2Match = null;
+    let suddenDeathWinnerId = null;
+    for (let mn = 5; mn <= 8; mn++) {
+      const state = await apiFetchGpFinalsState(adminPage, tournamentId);
+      const match = state.playoffMatches.find((m) => m.matchNumber === mn);
+      if (!match) throw new Error(`Playoff R2 M${mn} missing`);
+
+      if (mn === 5) {
+        tiedR2Match = match;
+        suddenDeathWinnerId = match.player2Id;
+        if (!suddenDeathWinnerId) throw new Error('Playoff R2 M5 player2 missing after R1 routing');
+        const res = await apiSetGpFinalsScore(adminPage, tournamentId, match.id, 1, 1, suddenDeathWinnerId);
+        if (res.s !== 200) throw new Error(`Playoff R2 M5 sudden-death tie score failed (${res.s})`);
+      } else {
+        const res = await apiSetGpFinalsWinner(adminPage, tournamentId, match, 1);
+        if (res.s !== 200) throw new Error(`Playoff R2 M${mn} score failed (${res.s})`);
+      }
+    }
+
+    const preview = await apiFetchGpFinalsState(adminPage, tournamentId);
+    const playoffStructure = preview.raw?.data?.playoffStructure || [];
+    const upperSeed = playoffStructure.find((entry) => entry.matchNumber === tiedR2Match.matchNumber)?.advancesToUpperSeed;
+    const seededPlayers = preview.raw?.data?.seededPlayers || [];
+    const seededWinner = seededPlayers.find((player) => player.seed === upperSeed);
+    const tiedMatchPreview = preview.playoffMatches.find((match) => match.id === tiedR2Match.id);
+
+    const ok =
+      preview.phase === 'playoff' &&
+      preview.playoffComplete === true &&
+      upperSeed &&
+      seededWinner?.playerId === suddenDeathWinnerId &&
+      tiedMatchPreview?.suddenDeathWinnerId === suddenDeathWinnerId &&
+      tiedMatchPreview?.points1 === tiedMatchPreview?.points2;
+
+    log('TC-2234', ok ? 'PASS' : 'FAIL',
+      preview.phase !== 'playoff' ? `phase=${preview.phase}`
+      : preview.playoffComplete !== true ? 'playoffComplete not true'
+      : !upperSeed ? `upper seed missing for M${tiedR2Match?.matchNumber}`
+      : seededWinner?.playerId !== suddenDeathWinnerId ? `seed ${upperSeed} expected=${suddenDeathWinnerId} actual=${seededWinner?.playerId}`
+      : tiedMatchPreview?.suddenDeathWinnerId !== suddenDeathWinnerId ? 'suddenDeathWinnerId not persisted on tied R2 match'
+      : tiedMatchPreview?.points1 !== tiedMatchPreview?.points2 ? `R2 match not tied ${tiedMatchPreview?.points1}-${tiedMatchPreview?.points2}`
+      : '');
+  } catch (err) {
+    log('TC-2234', 'FAIL', err instanceof Error ? err.message : 'GP 2234 failed');
+  } finally {
+    if (setup) await setup.cleanup();
+  }
+}
+
 /* ───────── TC-716: GP qualification page finals-exists state + reset ─────────
  * Reset is hidden while qualification is locked and appears only after unlock. */
 async function runTc716(adminPage) {
@@ -1831,6 +1918,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-1103', fn: runTc1103 },
       { name: 'TC-1109', fn: runTc1109 },
       { name: 'TC-727', fn: runTc727 },
+      { name: 'TC-2234', fn: runTc2234 },
       { name: 'TC-715', fn: runTc715 },
       { name: 'TC-716', fn: runTc716 },
       { name: 'TC-710', fn: runTc710 },


### PR DESCRIPTION
## Summary
- Add TC-2234 docs and GP E2E runner coverage for Top-24 Phase 2 preview using `suddenDeathWinnerId` on a tied playoff_r2 match.
- Guard the new E2E case in docs drift tests.
- Carry forward build-blocking TypeScript fixes for TA admin boolean props and server-ranking override sorting.

## Issues
Closes #2234

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/server-ranking.test.ts --runInBand
- npm run lint
- npm run build:cf
- E2E_TEST=TC-2234 node e2e/tc-gp.js (blocked locally before test execution: Chromium launch crashed; first with Crashpad permission error, then with GPU process fatal after escalated rerun)
