### PR TITLE
test: cover MR report standings recalculation

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2009,7 +2009,8 @@
   3. 試合確定後、過去報告と `Correct Score` ボタンが表示されることを確認する
   4. `Correct Score` を開き、3-1 から 2-2 に修正して `Submit Correction` を送信する
   5. 管理者APIで対象マッチが completed のまま score1=2, score2=2 に更新されていることを確認する
-- **期待結果**: MR participant で過去報告を確認でき、確定済みスコアを参加者自身が修正できる
+  6. `/api/tournaments/[temp-id]/mr/standings` を再取得し、両プレイヤーの `matchesPlayed=1`, `ties=1`, `points=0`, `score=1` が修正後スコアを反映していることを確認する
+- **期待結果**: MR participant で過去報告を確認でき、確定済みスコアを参加者自身が修正でき、standings は 2-2 引き分けとして再計算される
 - **スクリプト**: `tc-mr.js TC-1083`
 
 ## TC-2108: MR report route は scoresConfirmed より先に認可する
@@ -2118,8 +2119,9 @@
   6. 別の一時ブラウザでP2としてログインし /mr/participant でスコア3-1を送信
   7. レスポンスに `autoConfirmed: true` が含まれることを確認
   8. 管理者APIでマッチが completed=true, score1=3, score2=1 であることを確認
-  9. クリーンアップ
-- **期待結果**: 双方が同じスコアを報告するとマッチが自動確定される
+  9. `/api/tournaments/[temp-id]/mr/standings` を再取得し、P1 は `matchesPlayed=1`, `wins=1`, `points=2`, `score=2`、P2 は `matchesPlayed=1`, `losses=1`, `points=-2`, `score=0` になっていることを確認する
+  10. クリーンアップ
+- **期待結果**: 双方が同じスコアを報告するとマッチが自動確定され、standings は 3-1 勝敗と round differential を即時反映する
 
 ## TC-609: MR二重報告 — 不一致でmismatch検出
 - **URL**: /tournaments/[temp-id]/mr/participant

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
@@ -427,7 +427,12 @@ describe('MR Score Report API Route - /api/tournaments/[id]/mr/match/[matchId]/r
         message: 'Scores confirmed and match completed',
         status: 200,
       });
-      expect(recalculatePlayersStats).toHaveBeenCalledWith(expect.any(Object), 't1', ['p1', 'p2']);
+      expect(recalculatePlayersStats).toHaveBeenCalledWith(expect.objectContaining({
+        matchModel: 'mRMatch',
+        qualificationModel: 'mRQualification',
+        scoreFields: { p1: 'score1', p2: 'score2' },
+        useRoundDifferential: true,
+      }), 't1', ['p1', 'p2']);
       expect(prisma.mRQualification.updateMany).not.toHaveBeenCalled();
     });
 
@@ -476,7 +481,12 @@ describe('MR Score Report API Route - /api/tournaments/[id]/mr/match/[matchId]/r
           player1ReportedPoints2: 2,
         }),
       }));
-      expect(recalculatePlayersStats).toHaveBeenCalledWith(expect.any(Object), 't1', ['p1', 'p2']);
+      expect(recalculatePlayersStats).toHaveBeenCalledWith(expect.objectContaining({
+        matchModel: 'mRMatch',
+        qualificationModel: 'mRQualification',
+        scoreFields: { p1: 'score1', p2: 'score2' },
+        useRoundDifferential: true,
+      }), 't1', ['p1', 'p2']);
       expect(prisma.mRQualification.updateMany).not.toHaveBeenCalled();
       expect(result).toEqual({
         data: { match: correctedMatch, corrected: true },

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -135,6 +135,12 @@ describe('E2E case drift coverage', () => {
     'report',
     'route.test.ts',
   );
+  const mrStandingsAssertionsTest = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'e2e',
+    'mr-standings-assertions.test.ts',
+  );
   const taFinalsPage = readRepoFile(
     'smkc-score-app',
     'src',
@@ -1687,9 +1693,16 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('Submit Correction');
     expect(section).toContain('player1ReportedPoints');
     expect(section).toContain('MrScoreEditor');
+    expect(section).toContain('/api/tournaments/[temp-id]/mr/standings');
+    expect(section).toContain('ties=1');
+    expect(section).toContain('score=1');
     expect(tc1083).toContain("log('TC-1083'");
     expect(tc1083).toContain('Previous Reports');
     expect(tc1083).toContain('apiFetchMr');
+    expect(tc1083).toContain('apiFetchMrStandings');
+    expect(tc1083).toContain('assertMrStandingStats');
+    expect(mrReportRouteTest).toContain('useRoundDifferential: true');
+    expect(mrStandingsAssertionsTest).toContain('MR standings ties for p2');
     expect(tc1083).not.toContain('waitForTimeout(3000)');
   });
 

--- a/smkc-score-app/__tests__/e2e/mr-standings-assertions.test.ts
+++ b/smkc-score-app/__tests__/e2e/mr-standings-assertions.test.ts
@@ -1,0 +1,58 @@
+import { assertMrStandingStats, normalizeMrStandingsPayload } from '../../e2e/lib/mr-standings-assertions';
+
+describe('MR standings E2E assertions', () => {
+  const standingsPayload = {
+    data: {
+      qualifications: [
+        {
+          playerId: 'p1',
+          matchesPlayed: 1,
+          wins: 1,
+          ties: 0,
+          losses: 0,
+          points: 2,
+          score: 2,
+        },
+        {
+          playerId: 'p2',
+          matchesPlayed: 1,
+          wins: 0,
+          ties: 0,
+          losses: 1,
+          points: -2,
+          score: 0,
+        },
+      ],
+    },
+  };
+
+  it('normalizes wrapped standings API responses', () => {
+    expect(normalizeMrStandingsPayload(standingsPayload)).toHaveLength(2);
+  });
+
+  it('accepts expected MR report recalculation stats', () => {
+    expect(() => {
+      assertMrStandingStats(standingsPayload, 'p1', {
+        matchesPlayed: 1,
+        wins: 1,
+        ties: 0,
+        losses: 0,
+        points: 2,
+        score: 2,
+      });
+    }).not.toThrow();
+  });
+
+  it('fails with a targeted stat diff', () => {
+    expect(() => {
+      assertMrStandingStats(standingsPayload, 'p2', {
+        matchesPlayed: 1,
+        wins: 0,
+        ties: 1,
+        losses: 0,
+        points: 0,
+        score: 1,
+      });
+    }).toThrow('MR standings ties for p2: expected 1, got 0');
+  });
+});

--- a/smkc-score-app/e2e/lib/mr-standings-assertions.js
+++ b/smkc-score-app/e2e/lib/mr-standings-assertions.js
@@ -1,0 +1,45 @@
+function normalizeMrStandingsPayload(payload) {
+  const data = payload?.data ?? payload ?? {};
+  return data.qualifications ?? data.standings ?? [];
+}
+
+function assertMrStandingStats(payload, playerId, expected) {
+  const standings = normalizeMrStandingsPayload(payload);
+  const standing = standings.find((entry) => entry.playerId === playerId);
+
+  if (!standing) {
+    throw new Error(`MR standings missing player ${playerId}`);
+  }
+
+  const actual = {
+    matchesPlayed: standing.matchesPlayed,
+    wins: standing.wins,
+    ties: standing.ties,
+    losses: standing.losses,
+    points: standing.points,
+    score: standing.score,
+  };
+  const expectedValues = {
+    matchesPlayed: expected.matchesPlayed,
+    wins: expected.wins,
+    ties: expected.ties,
+    losses: expected.losses,
+    points: expected.points,
+    score: expected.score,
+  };
+
+  for (const [field, expectedValue] of Object.entries(expectedValues)) {
+    if (actual[field] !== expectedValue) {
+      throw new Error(
+        `MR standings ${field} for ${playerId}: expected ${expectedValue}, got ${actual[field]}`
+      );
+    }
+  }
+
+  return standing;
+}
+
+module.exports = {
+  normalizeMrStandingsPayload,
+  assertMrStandingStats,
+};

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -63,6 +63,7 @@ const {
 } = require('./lib/common');
 const { createSharedE2eFixture, setupModePlayersViaUi, ensurePlayerPassword } = require('./lib/fixtures');
 const { runSuite } = require('./lib/runner');
+const { assertMrStandingStats } = require('./lib/mr-standings-assertions');
 
 const results = makeResults();
 const log = makeLog(results);
@@ -135,6 +136,14 @@ async function prepareSharedMrPair(adminPage, { dualReport = false } = {}) {
     p2: players[1],
     match,
   };
+}
+
+async function apiFetchMrStandings(page, tournamentId) {
+  return page.evaluate(async (url) => {
+    const r = await fetch(url, { headers: { 'If-None-Match': '*' } });
+    const j = await r.json().catch(() => ({}));
+    return j.data || j;
+  }, `/api/tournaments/${tournamentId}/mr/standings`);
 }
 
 /* Primed-once flag so every finals test reuses the shared normal
@@ -379,6 +388,23 @@ async function runTc1083(adminPage) {
 
     const correctedMr = await apiFetchMr(adminPage, tournamentId);
     const correctedMatch = (correctedMr.matches || []).find((m) => m.id === match.id);
+    const correctedStandings = await apiFetchMrStandings(adminPage, tournamentId);
+    assertMrStandingStats(correctedStandings, p1.id, {
+      matchesPlayed: 1,
+      wins: 0,
+      ties: 1,
+      losses: 0,
+      points: 0,
+      score: 1,
+    });
+    assertMrStandingStats(correctedStandings, match.player2Id, {
+      matchesPlayed: 1,
+      wins: 0,
+      ties: 1,
+      losses: 0,
+      points: 0,
+      score: 1,
+    });
     const ok =
       correctedMatch?.completed === true &&
       correctedMatch.score1 === 2 &&
@@ -749,6 +775,23 @@ async function runTc608(adminPage) {
     const finalCheck = await apiFetchMr(adminPage, tournamentId);
     const finalMatch = (finalCheck.matches || []).find((m) => m.id === match.id);
     const isComplete = finalMatch?.completed === true && finalMatch.score1 === 3 && finalMatch.score2 === 1;
+    const finalStandings = await apiFetchMrStandings(adminPage, tournamentId);
+    assertMrStandingStats(finalStandings, match.player1Id, {
+      matchesPlayed: 1,
+      wins: 1,
+      ties: 0,
+      losses: 0,
+      points: 2,
+      score: 2,
+    });
+    assertMrStandingStats(finalStandings, match.player2Id, {
+      matchesPlayed: 1,
+      wins: 0,
+      ties: 0,
+      losses: 1,
+      points: -2,
+      score: 0,
+    });
 
     log('TC-608',
       p1Waiting && stillPending && autoConfirmed && isComplete ? 'PASS' : 'FAIL',


### PR DESCRIPTION
Summary
- Add MR standings assertions to TC-1083 correction flow and TC-608 dual-report auto-confirm flow.
- Add a reusable MR standings E2E assertion helper plus unit coverage.
- Carry forward existing main build fixes for TA sudden-death `isAdmin` typing and server-ranking override sorting.

Issues: Closes #2273

Validation
- npm test -- --runTestsByPath __tests__/e2e/mr-standings-assertions.test.ts '__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts' __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/server-ranking.test.ts --ci --forceExit
- npm run lint
- npm run build:cf
- E2E_TEST=TC-608 node e2e/tc-mr.js (blocked before test execution: sandbox Crashpad permission failure; escalated rerun blocked by Chromium GPU process fatal before page creation)
