### PR TITLE
test: assert TA sudden-death non-target protection

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1144,6 +1144,18 @@ describe('E2E case drift coverage', () => {
     expect(taFlowRankAssertionsTypes).toContain('export function evaluateTaFlowRankAssertion');
   });
 
+  it('keeps TA sudden-death non-target protection explicitly asserted', () => {
+    const testCase = sectionBetween(
+      taFinalsPhaseManagerTest,
+      'keeps non-sudden players from becoming an unintended elimination target in phase3',
+      '    });\n  });',
+    );
+
+    expect(testCase).toContain('expect(result.eliminatedIds).toEqual(["p5"])');
+    expect(testCase).toContain('for (const protectedPlayerId of ["p1", "p2", "p3"])');
+    expect(testCase).toContain('expect(result.eliminatedIds).not.toContain(protectedPlayerId)');
+  });
+
   it('keeps TC-1060 aligned with complete TA finals position unit coverage', () => {
     const section = e2eCaseSection('TC-1060');
     const unitTest = readRepoFile(

--- a/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/finals-phase-manager.test.ts
@@ -1474,6 +1474,9 @@ describe("TA Finals Phase Manager", () => {
       ]);
 
       expect(result.eliminatedIds).toEqual(["p5"]);
+      for (const protectedPlayerId of ["p1", "p2", "p3"]) {
+        expect(result.eliminatedIds).not.toContain(protectedPlayerId);
+      }
       expect(mockPrismaClient.tTPhaseRound.update).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({


### PR DESCRIPTION
Summary
- Add explicit TA sudden-death assertions that protected non-target players stay out of eliminatedIds.
- Add drift coverage so the non-target assertions are not removed accidentally.
- Carry forward build blockers required for this branch to pass build:cf: boolean TASuddenDeathSection isAdmin props and server-ranking override sort typing.

Issues: Closes #2283

Validation
- npm test -- --ci --forceExit __tests__/lib/ta/finals-phase-manager.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/server-ranking.test.ts
- npm run lint
- npm run build:cf
