### PR TITLE
test: use named tc-all imports for TC-816A

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -776,6 +776,8 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('mode 別 match count と round 一覧');
     expect(section).toContain('__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts');
     // The unit test now decodes the real .xlsm and checks typed seed + score cells.
+    expect(cdmFinalsFixtureTest).toContain("} from '../../e2e/tc-all';");
+    expect(cdmFinalsFixtureTest).not.toContain("import * as tcAllExports from '../../e2e/tc-all';");
     expect(exportRouteTest).toContain('should place CDM finals seeds and scores in native bracket coordinates');
     expect(exportRouteTest).toContain("workbook.Sheets['BM Finals']");
     expect(exportRouteTest).toContain('sheet.S5.v');

--- a/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
@@ -1,11 +1,9 @@
-import * as tcAllExports from '../../e2e/tc-all';
-
-const {
+import {
   cdmE2eFinalsMatches,
   cdmE2eFinalsReadinessDetails,
   cdmE2eFinalsReadinessSummary,
   ensureCdmE2eFinalsFixture,
-} = tcAllExports;
+} from '../../e2e/tc-all';
 
 describe('TC-816A CDM finals fixture readiness', () => {
   it('counts slot-mappable playoff and finals matches by mode', () => {
@@ -128,6 +126,8 @@ describe('TC-816A CDM finals fixture readiness', () => {
   });
 
   it('keeps internal fixture helpers out of the tc-all public test API', () => {
+    const tcAllExports = jest.requireActual('../../e2e/tc-all') as Record<string, unknown>;
+
     expect(tcAllExports).not.toHaveProperty('fetchCdmE2eModeStates');
     expect(tcAllExports).not.toHaveProperty('generateCdmE2eMissingFinals');
     expect(tcAllExports).toHaveProperty('ensureCdmE2eFinalsFixture');


### PR DESCRIPTION
## Summary

- Switch TC-816A fixture coverage from module namespace import destructuring to explicit named imports.
- Add drift coverage so the TC-816A test keeps using named imports.
- Rebase onto current `main` so the PR diff only contains the TC-816A import/coverage change.

## Issues

Closes #2282

## Validation

- `npm test -- --runTestsByPath __tests__/e2e/tc-816a-cdm-finals-fixture.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/server-ranking.test.ts`
- GitHub checks after re-push: Lint & Test / Wait for Cloudflare Workers Build / Workers Builds: smkc passed; claude-review pending at last poll.
