### PR TITLE
test: dedupe GP suite order assertion

### DIFF
--- a/smkc-score-app/__tests__/e2e/tc-gp-suite-order.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-gp-suite-order.test.ts
@@ -8,18 +8,6 @@ type TcTestCase = {
 const requireFromApp = createRequire(path.resolve(__dirname, '../../package.json'));
 
 describe('tc-gp suite ordering', () => {
-  it('keeps TC-831 before TC-832', () => {
-    const { getSuite } = requireFromApp('./e2e/tc-gp');
-    const suite = getSuite();
-    const names = suite.tests.map((entry: TcTestCase) => entry.name);
-
-    const tc831Index = names.indexOf('TC-831');
-    const tc832Index = names.indexOf('TC-832');
-
-    expect(tc831Index).toBeGreaterThanOrEqual(0);
-    expect(tc832Index).toBeGreaterThan(tc831Index);
-  });
-
   it('keeps TC-831 and TC-832 adjacent for readable log progression', () => {
     const { getSuite } = requireFromApp('./e2e/tc-gp');
     const suite = getSuite();


### PR DESCRIPTION
Summary
- Deduplicate the TC-831/TC-832 suite-order Jest coverage by keeping the stronger adjacent-order assertion.
- Carry forward current main build fixes for TA sudden-death admin boolean props and server-ranking override sorting types.

Issues: Closes #2270

Validation
- npm test -- --runTestsByPath __tests__/e2e/tc-gp-suite-order.test.ts __tests__/lib/server-ranking.test.ts --ci --forceExit
- npm run lint
- npm run build:cf
