### PR TITLE
test: assert archive isolation mocks

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2953,6 +2953,21 @@
   - helper の isolation contract は root page navigation ではなく target page lifecycle の挙動で検証される
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/e2e/tc-all-registration.test.ts __tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2263: tc-archive isolation guard — モックしたページ操作を明示的に検証する
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #2263。`tc-all-registration.test.ts` の archive qualification fetch isolation guard では `targetPage.goto` と `targetPage.waitForFunction` をモックしていたが、呼び出し自体を検証していなかった。
+- **手順**:
+  1. `assertQualificationFetchesStartInParallel(rootPage, 'tournament-1', 'ta')` を mock page で実行する
+  2. root page ではなく isolated target page の `goto` が TA qualification URL へ呼ばれることを確認する
+  3. target page の hydration wait (`waitForFunction`) が timeout option 付きで呼ばれることを確認する
+  4. `resolves.toBe(0)` により「失敗数ゼロ」を返す contract を確認する
+- **期待結果**:
+  - archive isolation guard は `rootPage.goto` を呼ばず、fresh page の `targetPage.goto` を使う
+  - `targetPage.waitForFunction` の呼び出しが未検証に戻った場合は `tc-all-registration.test.ts` が失敗する
+  - E2E case drift guard が TC-2263 の文書化と mock assertion の存在を検証する
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/e2e/tc-all-registration.test.ts __tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-1009: 総合ランキング決勝順位 — 16人/Top-24 判定の matchNumber 閾値を明文化する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -405,6 +405,19 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('__tests__/static/tc-2136-finals-route-dead-helper.test.ts');
   });
 
+  it('keeps TC-2263 documented with asserted archive isolation mocks', () => {
+    const section = e2eCaseSection('TC-2263');
+    const registrationTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'tc-all-registration.test.ts');
+
+    expect(section).toContain('issue #2263');
+    expect(section).toContain('targetPage.goto');
+    expect(section).toContain('targetPage.waitForFunction');
+    expect(registrationTest).toContain('expect(rootPage.goto).not.toHaveBeenCalled()');
+    expect(registrationTest).toContain('expect(targetPage.goto).toHaveBeenCalledWith(');
+    expect(registrationTest).toContain('expect(targetPage.waitForFunction).toHaveBeenCalledWith(');
+    expect(registrationTest).toContain('.resolves.toBe(0)');
+  });
+
   it('keeps TC-2161 aligned with preview preflight implementation coverage', () => {
     const preflight = readE2eLib('preview-schema-preflight.js');
     const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');

--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -70,7 +70,17 @@ describe('tc-all focused suite registration', () => {
       .resolves.toBe(0);
     expect(rootPage.context).toHaveBeenCalled();
     expect(newPage).toHaveBeenCalled();
+    expect(rootPage.goto).not.toHaveBeenCalled();
     expect(targetPage.bringToFront).toHaveBeenCalled();
+    expect(targetPage.goto).toHaveBeenCalledWith(
+      expect.stringContaining('/tournaments/tournament-1/ta'),
+      { waitUntil: 'domcontentloaded' },
+    );
+    expect(targetPage.waitForFunction).toHaveBeenCalledWith(
+      expect.any(Function),
+      null,
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
     expect(targetPage.close).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Summary
- Assert tc-archive isolation mocks for target page navigation and hydration wait.
- Document TC-2263 and add drift coverage for the new guard.
- Carry forward current main build blockers for TA isAdmin booleans and server-ranking override typing.

Issues: Closes #2263

Validation
- npm test -- --runTestsByPath __tests__/e2e/tc-all-registration.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm test -- --runTestsByPath __tests__/lib/server-ranking.test.ts
- npm run lint
- npm run build:cf
