### PR TITLE
test: simplify archive isolation contract guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2939,6 +2939,20 @@
   - 旧 inline 実装が戻った場合は、整形差分に左右されず guard が失敗する
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/e2e/tc-all-registration.test.ts __tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2262: tc-archive isolation contract — export を直接読み込んで検証する
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #2262。`tc-all-registration.test.ts` の archive qualification fetch isolation guard が `tc-archive.js` のソース文字列を読んでから同じ module を `requireFromApp` で読み込むと、export contract ではなく関数宣言の形に依存して壊れやすい。
+- **手順**:
+  1. `tc-all-registration.test.ts` が `requireFromApp('./e2e/tc-archive')` で `assertQualificationFetchesStartInParallel` を直接読み込むことを確認する
+  2. 読み込んだ export が function であることを確認する
+  3. root page mock から target page を作り、qualification fetch isolation helper が target page を前面化して閉じることを確認する
+- **期待結果**:
+  - guard は `function assertQualificationFetchesStartInParallel(` というソーススキャンに依存しない
+  - export が消えた場合は direct import / typeof assertion で失敗する
+  - helper の isolation contract は root page navigation ではなく target page lifecycle の挙動で検証される
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/e2e/tc-all-registration.test.ts __tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-1009: 総合ランキング決勝順位 — 16人/Top-24 判定の matchNumber 閾値を明文化する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -67,11 +67,20 @@ describe('tc-all focused suite registration', () => {
 
     expect(rootPage.context).not.toHaveBeenCalled();
     await expect(assertQualificationFetchesStartInParallel(rootPage, 'tournament-1', 'ta'))
-      .resolves.toBeGreaterThanOrEqual(0);
+      .resolves.toBe(0);
     expect(rootPage.context).toHaveBeenCalled();
     expect(newPage).toHaveBeenCalled();
     expect(targetPage.bringToFront).toHaveBeenCalled();
     expect(targetPage.close).toHaveBeenCalled();
+  });
+
+  it('keeps TC-2262 documented as a direct archive contract import guard', () => {
+    const section = e2eCaseSection('TC-2262');
+
+    expect(section).toContain('issue #2262');
+    expect(section).toContain('tc-all-registration.test.ts');
+    expect(section).toContain('requireFromApp');
+    expect(section).toContain('ソーススキャン');
   });
 
   it('registers auth error and web vitals preview checks for TC-2070', () => {


### PR DESCRIPTION
Summary
- Simplify the tc-archive isolation contract guard to import the helper directly instead of scanning source text.
- Add TC-2262 E2E scenario documentation and a docs-backed registration assertion.
- Rebase the PR onto current main so the diff only covers the archive contract guard and docs.

Issues: Closes #2262

Validation
- npm test -- --runTestsByPath __tests__/e2e/tc-all-registration.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint
- npm run build:cf
