### PR TITLE
test: clarify GP sudden-death incomplete saves

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2596,6 +2596,18 @@
 - **期待結果**: 新仕様のカップ勝数表示を保ちつつ、旧サドンデス決着済みデータでも勝者表示が欠落しない
 - **スクリプト**: `__tests__/app/tournaments/gp-finals-page-wiring.test.tsx` / `__tests__/lib/gp-finals-match-winner.test.ts` / `__tests__/components/tournament/double-elimination-bracket.test.tsx` / `__tests__/components/tournament/playoff-bracket.test.tsx`
 
+## TC-2252: GP決勝 — 未完了の同点保存ではサドンデス勝者名に依存しない
+- **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)
+- **authRequired**: true (admin)
+- **背景**: issue #2252。GP決勝の新しい `cupResults` 方式では、2-2 など目標カップ数に届いていない同点状態を保存する場合、リクエストに古い `suddenDeathWinnerId` が含まれていても試合は未完了のまま残す。テスト名が「player1 が sudden-death winner」とだけ読めると、完了済み旧データの勝者判定と混同しやすい。
+- **手順**:
+  1. GP決勝 M1 を `points1=2, points2=2, completed=false` の状態で用意する
+  2. `suddenDeathWinnerId` が unmatched/player1/player2 の各ケースで PUT されることを確認する
+  3. いずれも `winnerId=null`、`loserId=null`、`isComplete=false`、`champion=null` で返ることを確認する
+  4. 保存時に `suddenDeathWinnerId` が `null` にクリアされることを確認する
+- **期待結果**: 未完了の同点保存ではプレイヤーIDの一致可否に依存せず、旧サドンデス勝者を無視する意図がテスト名と期待値から読める
+- **スクリプト**: `__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-831: GP決勝 — 上位ブラケットはカップ勝数のシンプル入力で保存できる
 - **URL**: /tournaments/[temp-id]/gp/finals
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -1319,7 +1319,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       expect(result.status).toBe(400);
     });
 
-    it('should ignore sudden-death winner on tied GP finals scores when sudden-death winner is unmatched', async () => {
+    it('should ignore sudden-death winner on tied GP finals scores while the match is incomplete, even when unmatched', async () => {
       const mockMatch = {
         id: 'm1',
         tournamentId: 't1',
@@ -1376,7 +1376,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       );
     });
 
-    it('should ignore sudden-death winner on tied GP finals scores when player1 is sudden-death winner', async () => {
+    it('should ignore sudden-death winner on tied GP finals scores while the match is incomplete, even when player1 is named', async () => {
       const mockMatch = {
         id: 'm1',
         tournamentId: 't1',
@@ -1432,7 +1432,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
       );
     });
 
-    it('should ignore sudden-death winner on tied GP finals scores when player2 is sudden-death winner', async () => {
+    it('should ignore sudden-death winner on tied GP finals scores while the match is incomplete, even when player2 is named', async () => {
       const mockMatch = {
         id: 'm1',
         tournamentId: 't1',

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -630,6 +630,29 @@ describe('E2E case drift coverage', () => {
     expect(tcGp).not.toMatch(/\{\s*name:\s*['"]TC-830['"]/);
   });
 
+  it('keeps TC-2252 naming tied to incomplete GP finals sudden-death saves', () => {
+    const section = e2eCaseSection('TC-2252');
+    const routeTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'app',
+      'api',
+      'tournaments',
+      '[id]',
+      'gp',
+      'finals',
+      'route.test.ts',
+    );
+
+    expect(section).toContain('issue #2252');
+    expect(section).toContain('completed=false');
+    expect(section).toContain('unmatched/player1/player2');
+    expect(section).toContain('suddenDeathWinnerId');
+    expect(routeTest).toContain('while the match is incomplete, even when player1 is named');
+    expect(routeTest).toContain('while the match is incomplete, even when player2 is named');
+    expect(routeTest).toContain('while the match is incomplete, even when unmatched');
+  });
+
   it('keeps TC-356 scoped to the GP finals dialog and failing on mobile layout regressions', () => {
     const section = e2eCaseSection('TC-356');
     const tc356Block = sectionBetween(tcAll, '// TC-356:', '// TC-357:');
@@ -2151,12 +2174,12 @@ describe('E2E case drift coverage', () => {
     );
     const player1WinnerCase = sectionBetween(
       routeTest,
-      'should ignore sudden-death winner on tied GP finals scores when player1 is sudden-death winner',
-      "it('should ignore sudden-death winner on tied GP finals scores when player2 is sudden-death winner'",
+      'should ignore sudden-death winner on tied GP finals scores while the match is incomplete, even when player1 is named',
+      "it('should ignore sudden-death winner on tied GP finals scores while the match is incomplete, even when player2 is named'",
     );
     const player2WinnerCase = sectionBetween(
       routeTest,
-      'should ignore sudden-death winner on tied GP finals scores when player2 is sudden-death winner',
+      'should ignore sudden-death winner on tied GP finals scores while the match is incomplete, even when player2 is named',
       "it('should allow GP playoff round 1 results to finish at first to 1'",
     );
 


### PR DESCRIPTION
Summary
- Rename GP finals sudden-death tied-save tests so they describe incomplete 2-2 saves instead of implying legacy winner resolution.
- Add TC-2252 E2E scenario documentation and docs drift coverage for the naming contract.
- Keep adjacent TC-2235 drift markers aligned with the renamed GP finals sudden-death cases.

Issues: Closes #2252

Validation
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts' __tests__/docs/e2e-cases-drift.test.ts
- npm run lint
- npm run build:cf
