### PR TITLE
test: simplify GP sudden-death updatedMatch fixtures

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2633,6 +2633,17 @@
 - **期待結果**: GP Winners Semi Final はFT2として完了し、Winners Final / Losers Semi Final / Losers Final / Grand Final はFT3として動作する
 - **スクリプト**: tc-gp.js TC-722
 
+## TC-2247: GP 決勝 — tied sudden-death unit fixture keeps only the changed field
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #2247。GP finals の tied sudden-death unit tests では `mockMatch` が既に `points1=2`、`points2=2`、`completed=false` を持つ。`updatedMatch` が同じ値を再指定すると、PUT後に変わる値が `suddenDeathWinnerId: null` だけである意図が読み取りにくくなる。
+- **手順**:
+  1. `gp/finals/route.test.ts` の tied sudden-death winner 無視ケースを確認する
+  2. `updatedMatch` が `mockMatch` をスプレッドし、追加で `suddenDeathWinnerId: null` だけを指定していることを確認する
+  3. `points1`、`points2`、`completed` の保存アサーションは `prisma.gPMatch.update` の `data` 検証側に残っていることを確認する
+- **期待結果**: テスト fixture は差分の意図だけを表し、API 更新内容の検証は既存の update data assertion で維持される
+- **スクリプト**: smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+
 ## TC-723: GP 予選順位表 — 0-1000 予選点列の表示
 - **URL**: /tournaments/[temp-id]/gp
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -1335,7 +1335,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         player2: { id: 'p2', name: 'Player 2' },
       };
 
-      const updatedMatch = { ...mockMatch, points1: 2, points2: 2, completed: false, suddenDeathWinnerId: null };
+      const updatedMatch = { ...mockMatch, suddenDeathWinnerId: null };
       const mockBracket = [
         { matchNumber: 1, round: 'winners_qf', player1Seed: 1, player2Seed: 8, winnerGoesTo: 5, loserGoesTo: 9, position: 1 },
       ];
@@ -1392,7 +1392,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         player2: { id: 'p2', name: 'Player 2' },
       };
 
-      const updatedMatch = { ...mockMatch, points1: 2, points2: 2, completed: false, suddenDeathWinnerId: null };
+      const updatedMatch = { ...mockMatch, suddenDeathWinnerId: null };
 
       (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
       (prisma.gPMatch.update as jest.Mock).mockResolvedValue(updatedMatch);
@@ -1448,7 +1448,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         player2: { id: 'p2', name: 'Player 2' },
       };
 
-      const updatedMatch = { ...mockMatch, points1: 2, points2: 2, completed: false, suddenDeathWinnerId: null };
+      const updatedMatch = { ...mockMatch, suddenDeathWinnerId: null };
 
       (prisma.gPMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
       (prisma.gPMatch.update as jest.Mock).mockResolvedValue(updatedMatch);

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -141,6 +141,17 @@ describe('E2E case drift coverage', () => {
     'e2e',
     'mr-standings-assertions.test.ts',
   );
+  const gpFinalsRouteTest = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'app',
+    'api',
+    'tournaments',
+    '[id]',
+    'gp',
+    'finals',
+    'route.test.ts',
+  );
   const taFinalsPage = readRepoFile(
     'smkc-score-app',
     'src',
@@ -247,6 +258,7 @@ describe('E2E case drift coverage', () => {
     ['TC-111', 'n/a (runner command)', 'smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts'],
     ['TC-726', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-finals-assigned-cups.test.ts'],
     ['TC-728', 'n/a (unit coverage)', 'smkc-score-app/__tests__/lib/gp-ranking.test.ts'],
+    ['TC-2247', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts'],
     ['TC-1009', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts'],
     ['TC-1080', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1080-qualification-route-comment.test.ts'],
     ['TC-1088', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1088-qualification-route-comment.test.ts'],
@@ -1871,6 +1883,22 @@ describe('E2E case drift coverage', () => {
     expect(tcGp).toContain('getLockedCupCountForMatch');
     expect(tcGp).toContain('/getGpFinalsMaxCups\\([A-Za-z_][A-Za-z0-9_]*\\)/g');
     expect(tcGp).toContain('directMatchCalls.length >= 2');
+  });
+
+  it('keeps TC-2247 aligned with minimal GP tied sudden-death updatedMatch fixtures', () => {
+    const section = e2eCaseSection('TC-2247');
+    const redundantUpdatedMatch =
+      /\{\s*\.\.\.mockMatch,\s*points1:\s*2,\s*points2:\s*2,\s*completed:\s*false,\s*suddenDeathWinnerId:\s*null\s*\}/;
+
+    expect(section).toContain('issue #2247');
+    expect(section).toContain('suddenDeathWinnerId: null');
+    expect(section).toContain('prisma.gPMatch.update');
+    expect(section).toContain('gp/finals/route.test.ts');
+    expect(gpFinalsRouteTest).toContain('const updatedMatch = { ...mockMatch, suddenDeathWinnerId: null };');
+    expect(gpFinalsRouteTest).not.toMatch(redundantUpdatedMatch);
+    expect(gpFinalsRouteTest).toContain('points1: 2');
+    expect(gpFinalsRouteTest).toContain('points2: 2');
+    expect(gpFinalsRouteTest).toContain('completed: false');
   });
 
   it('keeps TC-1098 aligned with shared GP driver-points max usage', () => {


### PR DESCRIPTION
Summary
- Simplify GP finals tied sudden-death `updatedMatch` fixtures so they only override `suddenDeathWinnerId: null`.
- Add TC-2247 docs/static coverage guarding the fixture shape.
- Rebase onto current `main` so the diff only contains the TC-2247 route-test and drift-guard changes.

Issues: Closes #2247

Validation
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts' __tests__/docs/e2e-cases-drift.test.ts --ci --forceExit`
- `npm run lint` (passes with existing warnings)
- `npm run build:cf`
