### PR TITLE
docs: align PR title type guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,4 +14,9 @@ Closes #
 
 - [ ] Summary only describes changes that are present in this PR diff.
 - [ ] Any planned or follow-up work that is not in this diff is listed outside Summary.
+<<<<<<< HEAD
 - [ ] Carried-forward or current-main fixes are mentioned only when they are visible in this PR diff.
+=======
+- [ ] PR title and Conventional Commit type match the actual diff.
+- [ ] Use `docs:` only when this PR changes documentation. Use `test:` or `refactor:` for test-only refactors.
+>>>>>>> a6dbf321 (docs: align PR title type guidance)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,9 +14,6 @@ Closes #
 
 - [ ] Summary only describes changes that are present in this PR diff.
 - [ ] Any planned or follow-up work that is not in this diff is listed outside Summary.
-<<<<<<< HEAD
 - [ ] Carried-forward or current-main fixes are mentioned only when they are visible in this PR diff.
-=======
 - [ ] PR title and Conventional Commit type match the actual diff.
 - [ ] Use `docs:` only when this PR changes documentation. Use `test:` or `refactor:` for test-only refactors.
->>>>>>> a6dbf321 (docs: align PR title type guidance)

--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -210,6 +210,17 @@
 - **期待結果**: 削除済みの旧 TC-816 だけが E2E 対象外として説明され、現行 TC-816 のスクリプト付き coverage と矛盾しない
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2242: PR タイトル種別は実際の diff と一致させる
+- **URL**: n/a (pull request authoring guard / docs drift guard)
+- **authRequired**: false
+- **背景**: issue #2242。PR タイトルや Summary が `docs:` を名乗っていても、実際の diff がテストリファクタリングや実装変更だけならレビュー時の判断材料がずれる。PR テンプレートは Summary と diff の一致だけでなく、Conventional Commits の type も変更内容に合わせるよう明示する必要がある。
+- **手順**:
+  1. PR テンプレートの diff check に、PR title / Conventional Commit type が実際の diff に一致することを確認する項目がある
+  2. 同じ案内が `docs:` はドキュメント変更に限り、テストリファクタリングだけなら `test:` または `refactor:` を使うことを明示している
+  3. docs drift test が TC-2242 と PR テンプレート単体テストの対応を検証する
+- **期待結果**: PR 作成者は diff と矛盾する `docs:` タイトルを避け、レビュー時にタイトル・本文・変更種別が一致した状態で確認できる
+- **スクリプト**: n/a (unit/docs drift coverage) — PR template unit test / docs drift test
+
 ## TC-008: Overall Ranking ページの表示
 - **URL**: /tournaments/[id]/overall-ranking
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -529,7 +529,6 @@ describe('E2E case drift coverage', () => {
     expect(currentTc816).toContain('tc-ta.js TC-816');
   });
 
-<<<<<<< HEAD
   it('keeps TC-2036 aligned with the TC ID reuse policy', () => {
     const section = e2eCaseSection('TC-2036');
     const e2eCases = readRepoFile('E2E_TEST_CASES.md');
@@ -548,7 +547,8 @@ describe('E2E case drift coverage', () => {
     expect(renameHistory).toContain('旧 TC-816');
     expect(renameHistory).toContain('TC-816 は別シナリオ');
     expect(currentTc816).toContain('tc-ta.js TC-816');
-=======
+  });
+
   it('keeps TC-2242 aligned with PR title/diff authoring guidance', () => {
     const section = e2eCaseSection('TC-2242');
     const prTemplate = readRepoFile('.github', 'pull_request_template.md');
@@ -566,7 +566,6 @@ describe('E2E case drift coverage', () => {
     expect(prTemplate).toContain('PR title and Conventional Commit type match the actual diff.');
     expect(prTemplate).toContain('Use `docs:` only when this PR changes documentation.');
     expect(prTemplateTest).toContain('align the PR title type with the actual diff');
->>>>>>> a6dbf321 (docs: align PR title type guidance)
   });
 
   it('keeps TC-2118 documented with the shared tournament-tab hydration guard', () => {

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -529,6 +529,7 @@ describe('E2E case drift coverage', () => {
     expect(currentTc816).toContain('tc-ta.js TC-816');
   });
 
+<<<<<<< HEAD
   it('keeps TC-2036 aligned with the TC ID reuse policy', () => {
     const section = e2eCaseSection('TC-2036');
     const e2eCases = readRepoFile('E2E_TEST_CASES.md');
@@ -547,6 +548,25 @@ describe('E2E case drift coverage', () => {
     expect(renameHistory).toContain('旧 TC-816');
     expect(renameHistory).toContain('TC-816 は別シナリオ');
     expect(currentTc816).toContain('tc-ta.js TC-816');
+=======
+  it('keeps TC-2242 aligned with PR title/diff authoring guidance', () => {
+    const section = e2eCaseSection('TC-2242');
+    const prTemplate = readRepoFile('.github', 'pull_request_template.md');
+    const prTemplateTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'docs',
+      'pr-template.test.ts',
+    );
+
+    expect(section).toContain('issue #2242');
+    expect(section).toContain('Conventional Commits');
+    expect(section).toContain('docs:');
+    expect(section).toContain('test:` または `refactor:');
+    expect(prTemplate).toContain('PR title and Conventional Commit type match the actual diff.');
+    expect(prTemplate).toContain('Use `docs:` only when this PR changes documentation.');
+    expect(prTemplateTest).toContain('align the PR title type with the actual diff');
+>>>>>>> a6dbf321 (docs: align PR title type guidance)
   });
 
   it('keeps TC-2118 documented with the shared tournament-tab hydration guard', () => {

--- a/smkc-score-app/__tests__/docs/pr-template.test.ts
+++ b/smkc-score-app/__tests__/docs/pr-template.test.ts
@@ -27,4 +27,10 @@ describe('pull request template', () => {
     expect(template).toContain('planned or follow-up work');
     expect(template).toContain('current-main fixes are mentioned only when they are visible in this PR diff.');
   });
+
+  it('requires authors to align the PR title type with the actual diff', () => {
+    expect(template).toContain('PR title and Conventional Commit type match the actual diff.');
+    expect(template).toContain('Use `docs:` only when this PR changes documentation.');
+    expect(template).toContain('Use `test:` or `refactor:` for test-only refactors.');
+  });
 });


### PR DESCRIPTION
## Summary

- Add TC-2242 to the E2E scenario ledger for PR title/type alignment with the actual diff.
- Extend the PR template and docs drift/unit coverage so `docs:` is reserved for documentation changes, while test-only refactors use `test:` or `refactor:`.
- Rebase onto current `main` so the PR diff only contains the PR-template/docs guidance change.

## Issues

Closes #2242

## Validation

- `npm test -- --runTestsByPath __tests__/docs/pr-template.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- GitHub checks after re-push were pending at last poll.
