### PR TITLE
test: cover TT qualification row cap

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -849,6 +849,17 @@
 - **期待結果**: 60人ちょうどでは Main Hub の有効範囲だけが書き込まれ、61行目相当の `B62` は生成されない
 - **スクリプト**: `__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`
 
+## TC-2180: CDM export — TT Qualifications の row 62 stale cells を保持する
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #2180。TT Qualifications は Main Hub と同じ60行のテンプレート容量を使うため、61件目の TT qualification entry を書き込むと row 62 の固定テンプレート領域を壊す。
+- **手順**:
+  1. TT Qualifications の `E62`/`F62`/`G62` に stale marker が残っている CDM workbook fixture を用意する
+  2. CDM export fixture に qualification stage の TT entries を61人分用意する
+  3. `GET /api/tournaments/:id/export?format=cdm` を実行する
+  4. TT Qualifications の `E2`/`F2` と `E61`/`F61` が1人目/60人目で埋まり、`E62`/`F62`/`G62` が stale marker のまま残ることを確認する
+- **期待結果**: TT Qualifications は `CDM_TT_QUAL_MAX_PLAYERS` を超えて書き込まず、row 62 のテンプレート領域を保持する
+- **スクリプト**: `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-1877A: CDM export — grand_final_reset の正規化で到達不能条件を残さない
 - **URL**: /api/tournaments/[id]/export?format=cdm
 - **背景**: issue #1877。`grand_final_reset` は native slot table で先に解決されるため、同じ round 文字列を後段の別条件に残すと読み手に誤解を与える。

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -444,6 +444,86 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       });
     });
 
+    it('should cap TT Qualifications rows at 60 and preserve row 62 template cells', async () => {
+      const staleWorkbook = {
+        Sheets: {
+          "Main Hub": {},
+          "TT Qualifications": {
+            E62: { v: 'TT-KEEP-OUT-OF-BOUNDS' },
+            F62: { v: 'TT-KEEP-OUT-OF-BOUNDS' },
+            G62: { v: 'TT-KEEP-OUT-OF-BOUNDS' },
+          },
+          "BM Qualifications": {},
+          "MR Qualifications": {},
+          "GP Qualifications": {},
+          "BM Finals": {},
+          "MR Finals": {},
+          "GP Finals": {},
+          "TT Finals": {},
+          "Overall Ranking": {},
+        },
+        Workbook: {},
+      };
+      (XLSX.read as jest.Mock).mockImplementationOnce(() => staleWorkbook as any);
+
+      const makePlayer = (index: number) => {
+        const n = String(index + 1).padStart(2, "0");
+        return {
+          playerId: `p${index + 1}`,
+          player: { id: `p${index + 1}`, name: `Name ${n}`, nickname: `Player ${n}` },
+          stage: 'qualification',
+          seeding: index + 1,
+          lives: 3,
+          eliminated: false,
+          totalTime: 12000 + index,
+          times: {
+            course1: 1000 + index,
+          },
+        };
+      };
+
+      const mockTournament = {
+        id: 't1',
+        name: 'CDM TT Qualification Cap',
+        date: new Date('2024-01-15'),
+        status: 'completed',
+        bmQualifications: [],
+        mrQualifications: [],
+        gpQualifications: [],
+        bmMatches: [],
+        mrMatches: [],
+        gpMatches: [],
+        ttEntries: Array.from({ length: 61 }, (_value, index) => makePlayer(index)),
+        ttPhaseRounds: [],
+        playerScores: [],
+      };
+
+      (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
+      });
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
+      const params = Promise.resolve({ id: 't1' });
+      await GET(request, { params });
+
+      const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
+      expect(workbook.Sheets["TT Qualifications"].E2.v).toBe(1);
+      expect(workbook.Sheets["TT Qualifications"].F2.v).toBe('Player 01');
+      expect(workbook.Sheets["TT Qualifications"].E61.v).toBe(60);
+      expect(workbook.Sheets["TT Qualifications"].F61.v).toBe('Player 60');
+      expect(workbook.Sheets["TT Qualifications"].E62).toEqual({
+        v: 'TT-KEEP-OUT-OF-BOUNDS',
+      });
+      expect(workbook.Sheets["TT Qualifications"].F62).toEqual({
+        v: 'TT-KEEP-OUT-OF-BOUNDS',
+      });
+      expect(workbook.Sheets["TT Qualifications"].G62).toEqual({
+        v: 'TT-KEEP-OUT-OF-BOUNDS',
+      });
+    });
+
     it('should use the first fallback CDM finals slot only for unknown rounds', async () => {
       const player = (id: string) => ({ id, name: `Name ${id}`, nickname: id.toUpperCase() });
       const mockTournament = {

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -701,6 +701,20 @@ describe('E2E case drift coverage', () => {
     expect(exportRoute).toContain('qualificationEntries.slice(0, CDM_TT_QUAL_MAX_PLAYERS)');
   });
 
+  it('documents TC-2180 as TT Qualifications row cap stale-row coverage', () => {
+    const section = e2eCaseSection('TC-2180');
+
+    expect(section).toContain('issue #2180');
+    expect(section).toContain('TT Qualifications');
+    expect(section).toContain('row 62');
+    expect(section).toContain('CDM_TT_QUAL_MAX_PLAYERS');
+    expect(section).toContain('route.test.ts');
+    expect(exportRoute).toContain('qualificationEntries.slice(0, CDM_TT_QUAL_MAX_PLAYERS)');
+    expect(exportRouteTest).toContain('should cap TT Qualifications rows at 60 and preserve row 62 template cells');
+    expect(exportRouteTest).toContain('TT Qualifications');
+    expect(exportRouteTest).toContain('TT-KEEP-OUT-OF-BOUNDS');
+  });
+
   it('documents TC-1872A as finals and TT round coordinate constants', () => {
     const section = e2eCaseSection('TC-1872A');
 

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -913,7 +913,7 @@ export default function TimeAttackFinals({
 
       {/* Sudden-death panel (admin-only) */}
       <TASuddenDeathSection
-        isAdmin={isAdmin}
+        isAdmin={Boolean(isAdmin)}
         isComplete={isComplete}
         pendingSuddenDeath={pendingSuddenDeath}
         pendingSuddenDeathEntries={pendingSuddenDeathEntries}

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -843,7 +843,7 @@ export default function TAEliminationPhase({
 
       {/* Sudden-death panel (admin-only) */}
       <TASuddenDeathSection
-        isAdmin={isAdmin}
+        isAdmin={Boolean(isAdmin)}
         isComplete={isComplete}
         pendingSuddenDeath={pendingSuddenDeath}
         pendingSuddenDeathEntries={pendingSuddenDeathEntries}

--- a/smkc-score-app/src/lib/server-ranking.ts
+++ b/smkc-score-app/src/lib/server-ranking.ts
@@ -133,12 +133,15 @@ function assignRanksForPartition<TQualification extends RankableQualification, T
     ranked.splice(0, ranked.length, ...resolved);
   }
 
-  const withOverrides = ranked.map((entry, index) => {
-    const overrideRank = entry.rankOverride != null;
-    return overrideRank
+  type RankedWithOrder = RankedQualification<TQualification> & { _rankingOrder: number };
+
+  const withOverrides: RankedWithOrder[] = ranked.map((entry, index) => {
+    const rankOverride = entry.rankOverride;
+    const hasRankOverride = rankOverride != null;
+    return hasRankOverride
       ? {
         ...entry,
-        _rank: entry.rankOverride,
+        _rank: rankOverride,
         _rankOverridden: true,
         _rankingOrder: index,
       }
@@ -161,7 +164,7 @@ function assignRanksForPartition<TQualification extends RankableQualification, T
     return (a._rankingOrder ?? 0) - (b._rankingOrder ?? 0);
   });
 
-  return withOverrides.map(({ _rankingOrder, ...entry }) => entry);
+  return withOverrides.map(({ _rankingOrder, ...entry }) => entry as RankedQualification<TQualification>);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add TC-2180 to the E2E scenario ledger for TT Qualifications row-cap preservation.
- Add docs drift coverage and a route unit test that protects TT Qualifications row 62 stale template cells when 61 TT entries are provided.
- Carry forward current main build fixes for TA sudden-death admin booleans and server-ranking override type narrowing.

## Issues

Closes #2180

## Validation

- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/export/route.test.ts' __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/server-ranking.test.ts --runInBand
- npm run lint
- npm run build:cf
