### PR TITLE
test: align GP sudden-death fixture IDs

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -3173,6 +3173,18 @@
 - **期待結果**: QF などの非 GF マッチでも同点カップは未決着扱いになり、次カップでFT到達時のみ進行する
 - **スクリプト**: tc-gp.js TC-719
 
+## TC-2235: GP finals sudden-death winner test IDs stay consistent
+- **URL**: /api/tournaments/[temp-id]/gp/finals (PUT)
+- **authRequired**: true (admin)
+- **背景**: issue #2235。GP finals route の suddenDeathWinnerId 退行テストは同じ describe 内で `p1` / `p2` の短い fixture ID を使っており、同種の player1/player2 winner ケースだけ `player-19` / `player-8` にするとレビュー時に Top-24 seed fixture と誤読されやすい。
+- **手順**:
+  1. GP finals route unit test の unmatched/player1/player2 sudden-death winner ケースを確認する
+  2. player1 winner ケースが `player1Id: 'p1'` と `suddenDeathWinnerId: 'p1'` を使うことを確認する
+  3. player2 winner ケースが `player2Id: 'p2'` と `suddenDeathWinnerId: 'p2'` を使うことを確認する
+  4. どちらのケースも tied GP finals score を未完了として保存し、`suddenDeathWinnerId: null` にクリアすることを確認する
+- **期待結果**: GP finals sudden-death winner 回帰テストの fixture ID は同じ describe 内で `p1` / `p2` に統一され、Top-24 固有 fixture ID と混同しない
+- **スクリプト**: `__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-820: MR match/[matchId] ページがview-onlyであることを確認
 - **URL**: /tournaments/[temp-id]/mr/match/[matchId]
 - **authRequired**: true (player)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts
@@ -1383,13 +1383,13 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         matchNumber: 1,
         round: 'winners_qf',
         stage: 'finals',
-        player1Id: 'player-19',
-        player2Id: 'player-8',
+        player1Id: 'p1',
+        player2Id: 'p2',
         points1: 2,
         points2: 2,
         completed: false,
-        player1: { id: 'player-19', name: 'Player 19' },
-        player2: { id: 'player-8', name: 'Player 8' },
+        player1: { id: 'p1', name: 'Player 1' },
+        player2: { id: 'p2', name: 'Player 2' },
       };
 
       const updatedMatch = { ...mockMatch, points1: 2, points2: 2, completed: false, suddenDeathWinnerId: null };
@@ -1405,7 +1405,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         matchId: 'm1',
         score1: 2,
         score2: 2,
-        suddenDeathWinnerId: 'player-19',
+        suddenDeathWinnerId: 'p1',
       });
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });
@@ -1439,13 +1439,13 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         matchNumber: 1,
         round: 'winners_qf',
         stage: 'finals',
-        player1Id: 'player-19',
-        player2Id: 'player-8',
+        player1Id: 'p1',
+        player2Id: 'p2',
         points1: 2,
         points2: 2,
         completed: false,
-        player1: { id: 'player-19', name: 'Player 19' },
-        player2: { id: 'player-8', name: 'Player 8' },
+        player1: { id: 'p1', name: 'Player 1' },
+        player2: { id: 'p2', name: 'Player 2' },
       };
 
       const updatedMatch = { ...mockMatch, points1: 2, points2: 2, completed: false, suddenDeathWinnerId: null };
@@ -1461,7 +1461,7 @@ describe('GP Finals API Route - /api/tournaments/[id]/gp/finals', () => {
         matchId: 'm1',
         score1: 2,
         score2: 2,
-        suddenDeathWinnerId: 'player-8',
+        suddenDeathWinnerId: 'p2',
       });
       const params = Promise.resolve({ id: 't1' });
       const result = await PUT(request, { params });

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -2020,6 +2020,41 @@ describe('E2E case drift coverage', () => {
     expect(preflightTest).toContain('keeps generic schema or migration stderr out of migration guidance');
   });
 
+  it('keeps TC-2235 aligned with GP finals sudden-death fixture ID consistency', () => {
+    const section = e2eCaseSection('TC-2235');
+    const routeTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'app',
+      'api',
+      'tournaments',
+      '[id]',
+      'gp',
+      'finals',
+      'route.test.ts',
+    );
+    const player1WinnerCase = sectionBetween(
+      routeTest,
+      'should ignore sudden-death winner on tied GP finals scores when player1 is sudden-death winner',
+      "it('should ignore sudden-death winner on tied GP finals scores when player2 is sudden-death winner'",
+    );
+    const player2WinnerCase = sectionBetween(
+      routeTest,
+      'should ignore sudden-death winner on tied GP finals scores when player2 is sudden-death winner',
+      "it('should allow GP playoff round 1 results to finish at first to 1'",
+    );
+
+    expect(section).toContain('issue #2235');
+    expect(section).toContain("`p1` / `p2`");
+    expect(section).toContain('Top-24');
+    expect(player1WinnerCase).toContain("player1Id: 'p1'");
+    expect(player1WinnerCase).toContain("suddenDeathWinnerId: 'p1'");
+    expect(player1WinnerCase).not.toContain('player-19');
+    expect(player2WinnerCase).toContain("player2Id: 'p2'");
+    expect(player2WinnerCase).toContain("suddenDeathWinnerId: 'p2'");
+    expect(player2WinnerCase).not.toContain('player-8');
+  });
+
   it('documents TC-825 as a full Prisma migration JSON type guard for D1', () => {
     const section = e2eCaseSection('TC-825');
 


### PR DESCRIPTION
Summary
- Add TC-2235 documentation and docs-drift coverage for GP finals sudden-death fixture ID consistency.
- Align the player1/player2 sudden-death route tests to the existing p1/p2 fixture style.
- Carry forward current main build blockers for TA sudden-death admin booleans and server-ranking override narrowing.

Issues: Closes #2235

Validation
- npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/gp/finals/route.test.ts' '__tests__/docs/e2e-cases-drift.test.ts' '__tests__/lib/server-ranking.test.ts' --runInBand
- npm run lint
- npm run build:cf