### PR TITLE
test: preserve CDM E2E string diagnostics

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -995,6 +995,15 @@
 - **期待結果**: fixture 生成APIの失敗は、workbook検証前に mode 別の具体的な HTTP status として報告される
 - **スクリプト**: `tc-all.js TC-816A`, `__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2186A: CDM export — finals fixture 生成失敗の文字列 body をそのまま報告する
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #2186。TC-816A の不足 finals generation が `"Internal Server Error"` のような primitive string body を返す場合、診断で JSON.stringify すると余分なクォートが付き、実際のエラーメッセージが読みづらくなる。
+- **手順**:
+  1. finals generation の失敗結果が primitive string body を返すケースを unit test で再現する
+  2. `CDM finals fixture generation failed` の mode/status 診断に文字列 body が余分な JSON クォートなしで含まれることを確認する
+- **期待結果**: E2E fixture 生成失敗の診断は `HTTP 500: Internal Server Error` のように実際の body 文字列をそのまま表示する
+- **スクリプト**: `tc-all.js TC-816A`, `__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-2187A: CDM export — TC-816A fixture helper の公開 API を最小化する
 - **URL**: /api/tournaments/[id]/export?format=cdm
 - **背景**: issue #2187。`fetchCdmE2eModeStates` と `generateCdmE2eMissingFinals` は `ensureCdmE2eFinalsFixture` の内部処理であり、直接 import するテストがない状態で `tc-all.js` の公開 API に出すと不要な依存先になる。

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -838,6 +838,7 @@ describe('E2E case drift coverage', () => {
     const parallelSection = e2eCaseSection('TC-2098A');
     const roundSection = e2eCaseSection('TC-2099A');
     const generatorSection = e2eCaseSection('TC-2182A');
+    const generatorStringSection = e2eCaseSection('TC-2186A');
     const publicApiSection = e2eCaseSection('TC-2187A');
 
     expect(parallelSection).toContain('issue #2098');
@@ -847,6 +848,8 @@ describe('E2E case drift coverage', () => {
     expect(roundSection).toContain('.filter(Boolean)');
     expect(generatorSection).toContain('issue #2182');
     expect(generatorSection).toContain('CDM finals fixture generation failed');
+    expect(generatorStringSection).toContain('issue #2186');
+    expect(generatorStringSection).toContain('HTTP 500: Internal Server Error');
     expect(publicApiSection).toContain('issue #2187');
     expect(publicApiSection).toContain('公開 API を最小化');
     expect(tcAll).toContain('async function fetchCdmE2eModeStates');
@@ -863,6 +866,7 @@ describe('E2E case drift coverage', () => {
     expect(tcAllExports).toContain('ensureCdmE2eFinalsFixture');
     expect(cdmFinalsFixtureTest).toContain('fetches mode readiness states in parallel');
     expect(cdmFinalsFixtureTest).toContain('reports failed finals generator status');
+    expect(cdmFinalsFixtureTest).toContain('reports primitive string finals generator bodies without JSON quotes');
     expect(cdmFinalsFixtureTest).toContain('keeps internal fixture helpers out of the tc-all public test API');
   });
 

--- a/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts
@@ -111,6 +111,22 @@ describe('TC-816A CDM finals fixture readiness', () => {
     );
   });
 
+  it('reports primitive string finals generator bodies without JSON quotes', async () => {
+    const emptyState = { playoffMatches: [], matches: [] };
+    const api = {
+      fetchBmFinalsState: jest.fn(() => Promise.resolve(emptyState)),
+      fetchMrFinalsState: jest.fn(() => Promise.resolve(emptyState)),
+      fetchGpFinalsState: jest.fn(() => Promise.resolve(emptyState)),
+      generateBmFinals: jest.fn(() => Promise.resolve({ s: 500, b: 'Internal Server Error' })),
+      generateMrFinals: jest.fn(() => Promise.resolve({ s: 201, b: {} })),
+      generateGpFinals: jest.fn(() => Promise.resolve({ s: 200, b: {} })),
+    };
+
+    await expect(ensureCdmE2eFinalsFixture({} as never, 't1', api)).rejects.toThrow(
+      'CDM finals fixture generation failed: BM HTTP 500: Internal Server Error',
+    );
+  });
+
   it('keeps internal fixture helpers out of the tc-all public test API', () => {
     expect(tcAllExports).not.toHaveProperty('fetchCdmE2eModeStates');
     expect(tcAllExports).not.toHaveProperty('generateCdmE2eMissingFinals');

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -272,6 +272,7 @@ function cdmE2eGenerationResultDetail(result) {
   const body = result?.b;
   const message = typeof body?.error === 'string' ? body.error
     : typeof body?.message === 'string' ? body.message
+    : typeof body === 'string' ? body
     : JSON.stringify(body ?? {});
   return `HTTP ${status}${message && message !== '{}' ? `: ${message}` : ''}`;
 }


### PR DESCRIPTION
## Summary
- Add TC-2186A coverage for primitive string CDM finals generation failures.
- Preserve string response bodies in TC-816A fixture diagnostics without extra JSON quotes.
- Carry forward current main build fixes for TA sudden-death admin booleans and server-ranking type narrowing.

## Issues
Closes #2186

## Validation
- npm test -- --runTestsByPath __tests__/lib/server-ranking.test.ts __tests__/e2e/tc-816a-cdm-finals-fixture.test.ts __tests__/docs/e2e-cases-drift.test.ts --runInBand
- npm run lint
- npm run build:cf
