### PR TITLE
test: cover TC-939 null marker reporting

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2939,6 +2939,19 @@
   - 旧 inline 実装が戻った場合は、整形差分に左右されず guard が失敗する
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/e2e/tc-all-registration.test.ts __tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2185: TC-939 lib reporting — null SPA marker failure detail を明示する
+- **URL**: n/a (unit/static coverage)
+- **authRequired**: false
+- **背景**: issue #2185。PR #2183 で重複 E2E reporting test を削除した後も、`describeTc939TabNavigation({ spaMarker: null, cleanClasses: false })` が full reload と hydrated className failure の両方を同じ detail に残すことを lib test 側で直接保証する必要がある。
+- **手順**:
+  1. `__tests__/lib/tc939-reporting.test.ts` が `spaMarker: null` と `cleanClasses: false` の組み合わせを直接呼び出すことを確認する
+  2. 戻り値が `status: "FAIL"` になることを確認する
+  3. detail に `Tab click caused a full document reload` と `Hydrated tab className contains extra whitespace` の両方が含まれることを確認する
+- **期待結果**:
+  - 削除済み E2E reporting test の null marker regression が lib test で明示的に保護される
+  - TC-939 の reload/className 両方の診断が片方だけに退化した場合、unit/doc drift coverage が失敗する
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/lib/tc939-reporting.test.ts __tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-2262: tc-archive isolation contract — export を直接読み込んで検証する
 - **URL**: n/a (unit/static coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -599,6 +599,19 @@ describe('E2E case drift coverage', () => {
     expect(staticTest).toContain('keeps the hydration guard class value as string or undefined');
   });
 
+  it('keeps TC-2185 aligned with TC-939 null marker reporting coverage', () => {
+    const section = e2eCaseSection('TC-2185');
+    const libTest = readRepoFile('smkc-score-app', '__tests__', 'lib', 'tc939-reporting.test.ts');
+
+    expect(section).toContain('issue #2185');
+    expect(section).toContain('spaMarker: null');
+    expect(section).toContain('cleanClasses: false');
+    expect(section).toContain('__tests__/lib/tc939-reporting.test.ts');
+    expect(libTest).toContain('reports null SPA markers as full reload failures with className detail');
+    expect(libTest).toContain('spaMarker: null');
+    expect(libTest).toContain('Tab click caused a full document reload / Hydrated tab className contains extra whitespace');
+  });
+
   it('keeps TC-830 aligned with runtime unit and bracket component coverage', () => {
     const section = e2eCaseSection('TC-830');
     const pageWiringTest = readRepoFile('smkc-score-app', '__tests__', 'app', 'tournaments', 'gp-finals-page-wiring.test.tsx');

--- a/smkc-score-app/__tests__/lib/tc939-reporting.test.ts
+++ b/smkc-score-app/__tests__/lib/tc939-reporting.test.ts
@@ -31,6 +31,16 @@ describe('describeTc939TabNavigation', () => {
     });
   });
 
+  it('reports null SPA markers as full reload failures with className detail', async () => {
+    expect(describeTc939TabNavigation({
+      spaMarker: null,
+      cleanClasses: false,
+    })).toEqual({
+      status: 'FAIL',
+      detail: 'Tab click caused a full document reload / Hydrated tab className contains extra whitespace',
+    });
+  });
+
   it('reports reload-only failure without className issues', async () => {
     expect(describeTc939TabNavigation({
       spaMarker: 'reload-only',


### PR DESCRIPTION
Summary
- Add explicit TC-2185 coverage for `describeTc939TabNavigation({ spaMarker: null, cleanClasses: false })`.
- Document the TC-2185 unit/static coverage contract and guard it in docs drift tests.
- Rebase the PR onto current `main` so the diff only contains the TC-2185 reporting coverage.

Issues: Closes #2185

Validation
- `npm test -- --runTestsByPath __tests__/lib/tc939-reporting.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- `npm run lint` (passes with existing warnings)
- `npm run build:cf`
