### PR TITLE
test: harden TC-2088 meta coverage

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -875,14 +875,14 @@
 
 ## TC-2088: CDM export — Main Hub は60人ちょうどで B62 を空のままにする
 - **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #2088。Main Hub の player rows は B2 から B61 までの60行に限定される。60人ちょうどの境界テストでは、最終行 B61 への書き込みだけでなく、範囲外の B62 が作成されないことも明示的に確認する必要がある。
+- **背景**: issue #2088/#2193。Main Hub の player rows は B2 から B61 までの60行に限定される。60人ちょうどの境界テストでは、最終行 B61 への書き込みだけでなく、範囲外の B62 が作成されないことも明示的に確認する必要がある。メタテストは整形済みソース文字列ではなく TypeScript AST で 60件 fixture と B62 未書き込みアサーションを確認する。
 - **手順**:
   1. CDM export fixture に TT entries を60人だけ用意する
   2. `GET /api/tournaments/:id/export?format=cdm` を実行する
   3. Main Hub の `B2` が1人目、`B61`/`C61` が60人目の name/nickname で埋まることを確認する
   4. Main Hub の `B62` が `undefined` のままであることを確認する
 - **期待結果**: 60人ちょうどでは Main Hub の有効範囲だけが書き込まれ、61行目相当の `B62` は生成されない
-- **スクリプト**: `__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`
+- **スクリプト**: `__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
 
 ## TC-2087: CDM export — Main Hub 境界テストは共通 player fixture を使う
 - **URL**: /api/tournaments/[id]/export?format=cdm

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -226,6 +226,12 @@ describe('E2E case drift coverage', () => {
     'export',
     'route.test.ts',
   );
+  const tc2088BoundaryTest = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'e2e',
+    'tc-2088-cdm-main-hub-boundary.test.ts',
+  );
   const enMessages = readRepoFile('smkc-score-app', 'messages', 'en.json');
   const jaMessages = readRepoFile('smkc-score-app', 'messages', 'ja.json');
   const tc109ClassifiedRows: Array<[string, string, string]> = [
@@ -858,6 +864,19 @@ describe('E2E case drift coverage', () => {
     expect(exportRoute).toContain('Math.min(start + CDM_TT_ROUND_BLOCK_END_OFFSET, CDM_TT_ROUND_LAST_COLUMN)');
     expect(exportRoute).not.toContain('CDM_FINALS_BLOCK_WIDTH');
     expect(exportRoute).not.toContain('CDM_TT_ROUND_BLOCK_WIDTH');
+  });
+
+  it('keeps TC-2088 aligned with AST-backed Main Hub boundary coverage', () => {
+    const section = e2eCaseSection('TC-2088');
+
+    expect(section).toContain('issue #2088/#2193');
+    expect(section).toContain('TypeScript AST');
+    expect(section).toContain('tc-2088-cdm-main-hub-boundary.test.ts');
+    expect(tc2088BoundaryTest).toContain('bodyHasArrayFromLength60');
+    expect(tc2088BoundaryTest).toContain('bodyExpectsMainHubCellToBeUndefined');
+    expect(tc2088BoundaryTest).not.toContain("toContain('Array.from({ length: 60 }')");
+    expect(tc2088BoundaryTest).not.toContain('B62).toBeUndefined()');
+    expect(exportRouteTest).toContain('should write the Main Hub player rows for exactly 60 players');
   });
 
   it('keeps TC-1010 aligned with the BM 16-player finals regression coverage', () => {

--- a/smkc-score-app/__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts
@@ -1,32 +1,141 @@
+import ts from 'typescript';
 import { e2eCaseSection, readRepoFile } from '../helpers/e2e-cases';
+
+function routeTestSource() {
+  const source = readRepoFile(
+    'smkc-score-app',
+    '__tests__',
+    'app',
+    'api',
+    'tournaments',
+    '[id]',
+    'export',
+    'route.test.ts',
+  );
+  return {
+    source,
+    sourceFile: ts.createSourceFile('route.test.ts', source, ts.ScriptTarget.Latest, true),
+  };
+}
+
+function findItBody(sourceFile: ts.SourceFile, testName: string) {
+  let body: ts.ConciseBody | null = null;
+
+  function visit(node: ts.Node) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'it' &&
+      ts.isStringLiteral(node.arguments[0]) &&
+      node.arguments[0].text === testName
+    ) {
+      const callback = node.arguments[1];
+      if (callback && (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback))) {
+        body = callback.body;
+        return;
+      }
+    }
+
+    if (!body) ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  if (!body) throw new Error(`it block not found: ${testName}`);
+  return body;
+}
+
+function bodyHasArrayFromLength60(body: ts.Node, sourceFile: ts.SourceFile) {
+  let found = false;
+
+  function visit(node: ts.Node) {
+    if (found) return;
+
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.getText(sourceFile) === 'Array.from' &&
+      ts.isObjectLiteralExpression(node.arguments[0])
+    ) {
+      found = node.arguments[0].properties.some((property) =>
+        ts.isPropertyAssignment(property) &&
+        ts.isIdentifier(property.name) &&
+        property.name.text === 'length' &&
+        ts.isNumericLiteral(property.initializer) &&
+        property.initializer.text === '60',
+      );
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(body);
+  return found;
+}
+
+function isMainHubCellAccess(node: ts.Node, cell: string) {
+  if (!ts.isPropertyAccessExpression(node) || node.name.text !== cell) return false;
+  const sheetAccess = node.expression;
+  return (
+    ts.isElementAccessExpression(sheetAccess) &&
+    ts.isStringLiteral(sheetAccess.argumentExpression) &&
+    sheetAccess.argumentExpression.text === 'Main Hub' &&
+    ts.isPropertyAccessExpression(sheetAccess.expression) &&
+    sheetAccess.expression.expression.getText() === 'workbook' &&
+    sheetAccess.expression.name.text === 'Sheets'
+  );
+}
+
+function bodyExpectsMainHubCellToBeUndefined(
+  body: ts.Node,
+  sourceFile: ts.SourceFile,
+  cell: string,
+) {
+  let found = false;
+
+  function visit(node: ts.Node) {
+    if (found) return;
+
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === 'toBeUndefined' &&
+      ts.isCallExpression(node.expression.expression) &&
+      ts.isIdentifier(node.expression.expression.expression) &&
+      node.expression.expression.expression.text === 'expect'
+    ) {
+      const [expectArgument] = node.expression.expression.arguments;
+      found = Boolean(expectArgument && isMainHubCellAccess(expectArgument, cell));
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(body);
+  return found;
+}
 
 describe('TC-2088 CDM Main Hub boundary coverage', () => {
   it('documents the exactly-60 Main Hub boundary scenario', () => {
     const section = e2eCaseSection('TC-2088');
 
-    expect(section).toContain('issue #2088');
+    expect(section).toContain('issue #2088/#2193');
     expect(section).toContain('B61');
     expect(section).toContain('B62');
     expect(section).toContain('undefined');
     expect(section).toContain('__tests__/app/api/tournaments/[id]/export/route.test.ts');
+    expect(section).toContain('AST');
   });
 
-  it('keeps the unit test asserting B62 stays unwritten at exactly 60 players', () => {
-    const routeTest = readRepoFile(
-      'smkc-score-app',
-      '__tests__',
-      'app',
-      'api',
-      'tournaments',
-      '[id]',
-      'export',
-      'route.test.ts',
+  it('keeps the unit test asserting B62 stays unwritten at exactly 60 players via AST', () => {
+    const { sourceFile } = routeTestSource();
+    const body = findItBody(
+      sourceFile,
+      'should write the Main Hub player rows for exactly 60 players',
     );
 
-    expect(routeTest).toContain('should write the Main Hub player rows for exactly 60 players');
-    expect(routeTest).toContain('Array.from({ length: 60 }');
-    expect(routeTest).toContain('workbook.Sheets["Main Hub"].B61.v');
-    expect(routeTest).toContain('workbook.Sheets["Main Hub"].B62).toBeUndefined()');
+    expect(bodyHasArrayFromLength60(body, sourceFile)).toBe(true);
+    expect(bodyExpectsMainHubCellToBeUndefined(body, sourceFile, 'B62')).toBe(true);
   });
 
   it('documents TC-2087 as shared fixture and sentinel consistency coverage', () => {

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -876,12 +876,10 @@ export function createFinalsHandlers(config: FinalsConfig) {
         const bOverride = b.qualification.rankOverride != null;
         if (aOverride !== bOverride) return aOverride ? -1 : 1;
         if (aOverride) {
-          // After the inequality guard above, `aOverride` and `bOverride` are both true
-          // only when both qualifications have non-null `rankOverride` values.
-          const aRankOverride = a.qualification.rankOverride ?? Number.POSITIVE_INFINITY;
-          const bRankOverride = b.qualification.rankOverride ?? Number.POSITIVE_INFINITY;
-          // `Number.POSITIVE_INFINITY` is defensive; nullish values here should not occur
-          // after the above guard, but this keeps ordering logic type-safe.
+          if (b.qualification.rankOverride == null) return -1;
+          if (a.qualification.rankOverride == null) return 1;
+          const aRankOverride = a.qualification.rankOverride;
+          const bRankOverride = b.qualification.rankOverride;
           if (aRankOverride !== bRankOverride) return aRankOverride - bRankOverride;
 
           // When manual overrides collide on the same rank value, prefer the


### PR DESCRIPTION
## Summary
- Replace TC-2088 source-string meta assertions with AST-backed checks for the exactly-60 Main Hub route test.
- Document issue #2193 ownership in the TC-2088 E2E scenario.
- Add docs drift coverage for the TC-2088 AST helper contract.

## Issues
Closes #2193

## Validation
- npm test -- --runInBand __tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm run lint
- npm run build:cf
