### PR TITLE
test: cover MR dual-report player sessions

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -3166,6 +3166,19 @@
   5. クリーンアップ
 - **期待結果**: scoresConfirmed後のスコア報告は400で拒否され、MRMatch.scoresConfirmed=true が保持される
 
+### TC-2109: MR dual-report scoresConfirmed guard uses real player sessions
+- **URL**: /api/tournaments/[temp-id]/mr/match/[matchId]/report (POST)
+- **authRequired**: true (player)
+- **Issue**: #2109
+- **背景**: TC-822 が admin session だけで P1/P2 の報告を送ると、dual-report の本人セッション経路を検証できない。
+- **手順**:
+  1. dualReportEnabled=true の共有 MR match を作成する
+  2. P1 と P2 をそれぞれ `loginSharedPlayer` で個別ログインする
+  3. P1 session から `reportingPlayer: 1`、P2 session から `reportingPlayer: 2` の不一致スコアを POST する
+  4. 管理者が match detail PUT で `scoresConfirmed=true` に確定する
+  5. P1 session から再報告し、400 で拒否されることを確認する
+- **期待結果**: TC-822 は admin 代理報告ではなく P1/P2 の本人 session で mismatch を作り、scoresConfirmed 後の participant report block を検証する
+
 ## TC-823: セクション公開トグル — レイアウトタブの「未公開」バッジがリアルタイム更新される (issue #621)
 - **URL**: /tournaments/[id]/bm, /tournaments/[id]/overall-ranking
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts
@@ -251,6 +251,50 @@ describe('MR Score Report API Route - /api/tournaments/[id]/mr/match/[matchId]/r
       expect(prisma.mRMatch.update).not.toHaveBeenCalled();
     });
 
+    it.each([
+      [1, 'player2'],
+      [2, 'player1'],
+    ])('should delegate reportingPlayer %s participant auth before waiting for the peer report', async (reportingPlayer, waitingFor) => {
+      const mockMatch = {
+        id: 'm1',
+        tournamentId: 't1',
+        version: 1,
+        player1Id: 'p1',
+        player2Id: 'p2',
+        player1ReportedPoints1: null,
+        player1ReportedPoints2: null,
+        player2ReportedPoints1: null,
+        player2ReportedPoints2: null,
+        player1: { id: 'p1', userId: 'u1' },
+        player2: { id: 'p2', userId: 'u2' },
+      };
+
+      const updatedMatch = {
+        ...mockMatch,
+        ...(reportingPlayer === 1
+          ? { player1ReportedPoints1: 3, player1ReportedPoints2: 1 }
+          : { player2ReportedPoints1: 3, player2ReportedPoints2: 1 }),
+      };
+
+      (prisma.mRMatch.findUnique as jest.Mock).mockResolvedValue(mockMatch);
+      (prisma.mRMatch.update as jest.Mock).mockResolvedValue(updatedMatch);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/mr/match/m1/report', {
+        reportingPlayer,
+        score1: 3,
+        score2: 1,
+      });
+      const params = Promise.resolve({ id: 't1', matchId: 'm1' });
+      const result = await POST(request, { params });
+
+      expect(result.status).toBe(200);
+      expect(checkScoreReportAuth).toHaveBeenCalledWith(request, 't1', reportingPlayer, mockMatch);
+      expect(createSuccessResponse).toHaveBeenCalledWith(
+        { match: updatedMatch, waitingFor },
+        'Score reported successfully',
+      );
+    });
+
     // Success case - Both players' scores match → auto-confirm
     it('should report score successfully for authenticated player', async () => {
       const mockMatch = {

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -2019,6 +2019,19 @@ describe('E2E case drift coverage', () => {
     expect(mrReportRouteTest).toContain('should return auth failure before scoresConfirmed for unauthorized users');
   });
 
+  it('documents TC-2109 as MR dual-report player-session coverage', () => {
+    const section = e2eCaseSection('TC-2109');
+
+    expect(section).toContain('Issue**: #2109');
+    expect(section).toContain('P1 session');
+    expect(section).toContain('P2 session');
+    expect(tcMr).toContain('const p1Context = await loginSharedPlayer(adminPage, p1)');
+    expect(tcMr).toContain('const p2Context = await loginSharedPlayer(adminPage, p2)');
+    expect(tcMr).toContain('const p1Report = await p1Context.page.evaluate');
+    expect(tcMr).toContain('const p2Report = await p2Context.page.evaluate');
+    expect(tcMr).toContain('const rejectedReport = await p1Context.page.evaluate');
+  });
+
   it('documents TC-821A as shared TA sudden-death UI and logic coverage', () => {
     const section = e2eCaseSection('TC-821A');
 

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -1485,11 +1485,17 @@ async function runTc616(adminPage) {
  * Dual-report mismatch can be finalized by an admin. Once the admin marks the
  * match scoresConfirmed, participant report POSTs must be rejected. */
 async function runTc822(adminPage) {
+  let p1Browser = null;
+  let p2Browser = null;
   try {
-    const { tournamentId, match } = await prepareSharedMrPair(adminPage, { dualReport: true });
+    const { tournamentId, p1, p2, match } = await prepareSharedMrPair(adminPage, { dualReport: true });
     const reportUrl = `/api/tournaments/${tournamentId}/mr/match/${match.id}/report`;
+    const p1Context = await loginSharedPlayer(adminPage, p1);
+    p1Browser = p1Context.browser;
+    const p2Context = await loginSharedPlayer(adminPage, p2);
+    p2Browser = p2Context.browser;
 
-    const p1Report = await adminPage.evaluate(async ([url, body]) => {
+    const p1Report = await p1Context.page.evaluate(async ([url, body]) => {
       const r = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -1498,7 +1504,7 @@ async function runTc822(adminPage) {
       return { s: r.status, b: await r.json().catch(() => ({})) };
     }, [reportUrl, { reportingPlayer: 1, score1: 3, score2: 1 }]);
 
-    const p2Report = await adminPage.evaluate(async ([url, body]) => {
+    const p2Report = await p2Context.page.evaluate(async ([url, body]) => {
       const r = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -1530,7 +1536,7 @@ async function runTc822(adminPage) {
       version: pendingMatch.version,
     }]);
 
-    const rejectedReport = await adminPage.evaluate(async ([url, body]) => {
+    const rejectedReport = await p1Context.page.evaluate(async ([url, body]) => {
       const r = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -1552,6 +1558,9 @@ async function runTc822(adminPage) {
       : '');
   } catch (err) {
     log('TC-822', 'FAIL', err instanceof Error ? err.message : 'MR TC-822 scoresConfirmed failed');
+  } finally {
+    if (p1Browser) await p1Browser.close().catch(() => {});
+    if (p2Browser) await p2Browser.close().catch(() => {});
   }
 }
 


### PR DESCRIPTION
## Summary
- document TC-2109 and make TC-822 establish MR dual-report mismatch through real P1/P2 player sessions
- add route/unit and docs drift coverage for the participant-session contract
- rebase onto current main and keep the PR diff scoped to MR dual-report coverage

## Issues
Closes #2109

## Validation
- npm test -- --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts '__tests__/app/api/tournaments/[id]/mr/match/[matchId]/report/route.test.ts' --ci --forceExit
- npm run lint
- npm run build:cf
