### PR TITLE
Fix TA loading skeleton action placeholder

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1173,6 +1173,16 @@
 - **期待結果**: 4モードすべてで fallback/client loading 期間中もモード名見出しが存在し、遅いデータ取得でも見出しセレクタが安定する
 - **スクリプト**: tc-all.js TC-357
 
+## TC-2094: TA qualification loading skeleton — action placeholder is omitted
+- **authRequired**: false
+- **背景**: TA qualification page header has no first-load action button, while BM/MR/GP keep bracket/debug actions. The shared client loading skeleton must keep its default action placeholder for action-bearing modes, but TA must opt out to avoid a misleading button skeleton.
+- **手順**:
+  1. `QualificationClientLoadingState` exposes a default-on `showActionButton` contract.
+  2. TA page-client passes `showActionButton={false}` during first-load skeleton rendering.
+  3. BM/MR/GP page-clients keep the default action placeholder contract.
+- **期待結果**: TA loading state renders the title/text/card skeletons without `qualification-action-skeleton`; BM/MR/GP retain the default action placeholder.
+- **スクリプト**: tc-all.js TC-2094
+
 ## TC-401: 全モードトーナメント — TA/BM/MR/GP の予選データが正しく存在する
 - **authRequired**: true (admin)
 - **背景**: `setupAllModes28PlayerQualification` で28名 × 4モードの予選を完了させた後、各モード API が有効なデータを返すことを確認する統合テスト。

--- a/smkc-score-app/__tests__/components/ui/loading-skeleton.test.tsx
+++ b/smkc-score-app/__tests__/components/ui/loading-skeleton.test.tsx
@@ -35,4 +35,16 @@ describe('QualificationClientLoadingState', () => {
 
     expect(screen.getByRole('heading', { level: 1, name: 'バトルモード' })).toBeInTheDocument();
   });
+
+  it('renders the action-button placeholder by default', () => {
+    render(<QualificationClientLoadingState title="マッチレース" />);
+
+    expect(screen.getByTestId('qualification-action-skeleton')).toBeInTheDocument();
+  });
+
+  it('can omit the action-button placeholder for TA loading', () => {
+    render(<QualificationClientLoadingState title="タイムアタック" showActionButton={false} />);
+
+    expect(screen.queryByTestId('qualification-action-skeleton')).not.toBeInTheDocument();
+  });
 });

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -194,6 +194,13 @@ describe('E2E case drift coverage', () => {
     'ui',
     'loading-skeleton.test.tsx',
   );
+  const loadingSkeleton = readRepoFile(
+    'smkc-score-app',
+    'src',
+    'components',
+    'ui',
+    'loading-skeleton.tsx',
+  );
   const groupSetupHelperTest = readRepoFile(
     'smkc-score-app',
     '__tests__',
@@ -580,6 +587,24 @@ describe('E2E case drift coverage', () => {
     expect(tc357Block).toContain("mr: ['マッチレース', 'Match Race']");
     expect(tc357Block).toContain("gp: ['グランプリ', 'Grand Prix']");
     expect(tc357Block).toContain("ta: ['タイムアタック', 'Time Attack', 'Time Trial']");
+  });
+
+  it('documents and guards TC-2094 TA loading skeleton action placeholder opt-out', () => {
+    const section = e2eCaseSection('TC-2094');
+    const tc2094Block = sectionBetween(tcAll, '// TC-2094:', '// TC-104:');
+
+    expect(section).toContain('TA qualification page header has no first-load action button');
+    expect(section).toContain('showActionButton={false}');
+    expect(section).toContain('qualification-action-skeleton');
+    expect(loadingSkeleton).toContain('showActionButton = true');
+    expect(loadingSkeleton).toContain('qualification-action-skeleton');
+    expect(qualificationFallbackTest).toContain('renders the action-button placeholder by default');
+    expect(qualificationFallbackTest).toContain('can omit the action-button placeholder for TA loading');
+    expect(taPageClient).toContain('showActionButton={false}');
+    expect(tc2094Block).toContain("fs.readFileSync('src/components/ui/loading-skeleton.tsx'");
+    expect(tc2094Block).toContain("fs.readFileSync('src/app/tournaments/[id]/ta/page-client.tsx'");
+    expect(tc2094Block).toContain('otherModesUseDefault2094');
+    expect(tc2094Block).toContain("'TC-2094'");
   });
 
   it('documents TC-816A as CDM finals native bracket coordinate coverage', () => {

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -4420,6 +4420,29 @@ async function main() {
     log('TC-357', 'SKIP', 'TID not available');
   }
 
+  // TC-2094: TA loading skeleton does not show an action-button placeholder.
+  try {
+    const loadingSkeletonSource2094 = fs.readFileSync('src/components/ui/loading-skeleton.tsx', 'utf8');
+    const taPageClientSource2094 = fs.readFileSync('src/app/tournaments/[id]/ta/page-client.tsx', 'utf8');
+    const bmPageClientSource2094 = fs.readFileSync('src/app/tournaments/[id]/bm/page-client.tsx', 'utf8');
+    const mrPageClientSource2094 = fs.readFileSync('src/app/tournaments/[id]/mr/page-client.tsx', 'utf8');
+    const gpPageClientSource2094 = fs.readFileSync('src/app/tournaments/[id]/gp/page-client.tsx', 'utf8');
+    const sharedHasOptOut2094 =
+      loadingSkeletonSource2094.includes('showActionButton = true') &&
+      loadingSkeletonSource2094.includes('qualification-action-skeleton');
+    const taOptsOut2094 = taPageClientSource2094.includes('showActionButton={false}');
+    const otherModesUseDefault2094 = [bmPageClientSource2094, mrPageClientSource2094, gpPageClientSource2094]
+      .every((source) => !source.includes('showActionButton={false}'));
+    const pass2094 = sharedHasOptOut2094 && taOptsOut2094 && otherModesUseDefault2094;
+    log(
+      'TC-2094',
+      pass2094 ? 'PASS' : 'FAIL',
+      `sharedOptOut=${sharedHasOptOut2094} taOptOut=${taOptsOut2094} otherModesDefault=${otherModesUseDefault2094}`,
+    );
+  } catch (e) {
+    log('TC-2094', 'FAIL', e instanceof Error ? e.message : String(e));
+  }
+
   // TC-104: Player delete (deferred from earlier in the file — see comment above
   // TC-304. Must run last for the shared `pid` so any TC that invoked
   // uiSetupTaPlayers with that player can find the label in the setup dialog.)

--- a/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/page-client.tsx
@@ -681,7 +681,7 @@ export default function TimeAttackPageClient({
 
   // === Loading State (only on first visit with no cached data) ===
   if (!pollData) {
-    return <QualificationClientLoadingState title={t('title')} titleSkeletonClassName="w-48" />;
+    return <QualificationClientLoadingState title={t('title')} titleSkeletonClassName="w-48" showActionButton={false} />;
   }
 
   // === Error State ===

--- a/smkc-score-app/src/components/ui/loading-skeleton.tsx
+++ b/smkc-score-app/src/components/ui/loading-skeleton.tsx
@@ -19,6 +19,8 @@
  */
 "use client";
 
+import type { HTMLAttributes } from "react";
+
 import { cn } from "@/lib/utils";
 
 /**
@@ -27,7 +29,7 @@ import { cn } from "@/lib/utils";
  *   dimensions (e.g., "h-4 w-3/4") since the skeleton renders as an
  *   empty div that relies on explicit sizing.
  */
-export interface SkeletonProps {
+export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
   className?: string;
 }
 
@@ -46,7 +48,7 @@ export interface SkeletonProps {
  * <Skeleton className="h-10 w-10 rounded-full" />  // Avatar placeholder
  * ```
  */
-export function Skeleton({ className }: SkeletonProps) {
+export function Skeleton({ className, ...props }: SkeletonProps) {
   return (
     <div
       className={cn(
@@ -55,6 +57,7 @@ export function Skeleton({ className }: SkeletonProps) {
       )}
       role="status"
       aria-label="Loading content"
+      {...props}
     />
   );
 }
@@ -160,9 +163,11 @@ export function QualificationFallback({ title }: { title?: string } = {}) {
 export function QualificationClientLoadingState({
   title,
   titleSkeletonClassName = "w-32",
+  showActionButton = true,
 }: {
   title: string;
   titleSkeletonClassName?: string;
+  showActionButton?: boolean;
 }) {
   return (
     <div className="space-y-6">
@@ -171,7 +176,7 @@ export function QualificationClientLoadingState({
           <h1 className="text-2xl font-semibold">{title}</h1>
           <Skeleton className={cn("h-5", titleSkeletonClassName)} />
         </div>
-        <Skeleton className="h-10 w-24" />
+        {showActionButton && <Skeleton className="h-10 w-24" data-testid="qualification-action-skeleton" />}
       </div>
       <CardSkeleton />
     </div>


### PR DESCRIPTION
## Summary
- add a default-on `showActionButton` contract to the shared qualification client loading skeleton
- opt TA first-load skeleton out of the action placeholder while keeping BM/MR/GP on the default
- add TC-2094 E2E/source guard, docs drift coverage, component tests, and carry current main build fixes for TA sudden-death/admin typing plus server-ranking narrowing

## Issues
Closes #2094

## Validation
- npm test -- --runTestsByPath __tests__/components/ui/loading-skeleton.test.tsx __tests__/docs/e2e-cases-drift.test.ts --ci --forceExit
- npm test -- --runTestsByPath __tests__/lib/server-ranking.test.ts __tests__/components/ui/loading-skeleton.test.tsx __tests__/docs/e2e-cases-drift.test.ts --ci --forceExit
- npm run lint
- npm run build:cf
- node e2e/tc-all.js --help (local Chromium launched instead of showing help and failed before test execution with GPU process fatal)
