### PR TITLE
test: share CDM Main Hub export fixtures

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -884,6 +884,16 @@
 - **期待結果**: 60人ちょうどでは Main Hub の有効範囲だけが書き込まれ、61行目相当の `B62` は生成されない
 - **スクリプト**: `__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`
 
+## TC-2087: CDM export — Main Hub 境界テストは共通 player fixture を使う
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #2087 / issue #2091。60人ちょうどと61人超の境界テストが同じ player fixture を別々に定義すると、片方だけ変わってテスト意図がずれる。範囲外 sentinel も列ごとに表記ゆれがあると、保護対象セルの読み取りが紛らわしくなる。
+- **手順**:
+  1. CDM Main Hub 境界テストが shared helper `makeCdmMainHubPlayer` を使って60人/61人の TT entries を生成することを確認する
+  2. 61人超ケースの stale workbook が `B62` から `L62` まで同じ `KEEP-OUT-OF-BOUNDS` sentinel を保持することを確認する
+  3. `GET /api/tournaments/:id/export?format=cdm` 後も `B62` から `L62` が stale sentinel のまま残ることを確認する
+- **期待結果**: Main Hub の境界テストは単一 fixture helper を共有し、範囲外 row の sentinel 表記が揃っている
+- **スクリプト**: `__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`
+
 ## TC-2089A: CDM export — Main Hub の 60行上限で row 62 を保護する
 - **URL**: /api/tournaments/[id]/export?format=cdm
 - **背景**: issue #2089/#2092/#2093。CDM Main Hub は 60人分の固定テンプレート領域だけを書き換えるため、61人以上のデータが来ても row 62 の既存セルを上書きしてはならない。

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -78,6 +78,18 @@ class MockNextRequest {
 
 describe('Export API Route - /api/tournaments/[id]/export', () => {
   const loggerMock = { error: jest.fn(), warn: jest.fn() };
+  const makeCdmMainHubPlayer = (index: number) => {
+    const n = String(index + 1).padStart(2, "0");
+    return {
+      playerId: `p${index + 1}`,
+      player: { id: `p${index + 1}`, name: `Name ${n}`, nickname: `Player ${n}` },
+      stage: 'qualification',
+      seeding: index + 1,
+      lives: 3,
+      eliminated: false,
+      totalTime: 12000 + index,
+    };
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -318,19 +330,6 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
     });
 
     it('should write the Main Hub player rows for exactly 60 players', async () => {
-      const makePlayer = (index: number) => {
-        const n = String(index + 1).padStart(2, "0");
-        return {
-          playerId: `p${index + 1}`,
-          player: { id: `p${index + 1}`, name: `Name ${n}`, nickname: `Player ${n}` },
-          stage: 'qualification',
-          seeding: index + 1,
-          lives: 3,
-          eliminated: false,
-          totalTime: 12000 + index,
-        };
-      };
-
       const mockTournament = {
         id: 't1',
         name: 'CDM Player Hub Cap',
@@ -342,7 +341,7 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         bmMatches: [],
         mrMatches: [],
         gpMatches: [],
-        ttEntries: Array.from({ length: 60 }, (_value, index) => makePlayer(index)),
+        ttEntries: Array.from({ length: 60 }, (_value, index) => makeCdmMainHubPlayer(index)),
         ttPhaseRounds: [],
         playerScores: [],
       };
@@ -394,19 +393,6 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       };
       (XLSX.read as jest.Mock).mockImplementationOnce(() => staleWorkbook as any);
 
-      const makePlayer = (index: number) => {
-        const n = String(index + 1).padStart(2, "0");
-        return {
-          playerId: `p${index + 1}`,
-          player: { id: `p${index + 1}`, name: `Name ${n}`, nickname: `Player ${n}` },
-          stage: 'qualification',
-          seeding: index + 1,
-          lives: 3,
-          eliminated: false,
-          totalTime: 12000 + index,
-        };
-      };
-
       const mockTournament = {
         id: 't1',
         name: 'CDM Player Hub Cap',
@@ -418,7 +404,7 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         bmMatches: [],
         mrMatches: [],
         gpMatches: [],
-        ttEntries: Array.from({ length: 61 }, (_value, index) => makePlayer(index)),
+        ttEntries: Array.from({ length: 61 }, (_value, index) => makeCdmMainHubPlayer(index)),
         ttPhaseRounds: [],
         playerScores: [],
       };
@@ -436,8 +422,8 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
       expect(workbook.Sheets["Main Hub"].B2.v).toBe('Name 01');
       expect(workbook.Sheets["Main Hub"].B61.v).toBe('Name 60');
-      for (const col of ["B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"]) {
-        expect(workbook.Sheets["Main Hub"][`${col}62`]).toEqual({
+      for (const column of ['B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L']) {
+        expect(workbook.Sheets["Main Hub"][`${column}62`]).toEqual({
           v: 'KEEP-OUT-OF-BOUNDS',
         });
       }
@@ -467,7 +453,7 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       };
       (XLSX.read as jest.Mock).mockImplementationOnce(() => staleWorkbook as any);
 
-      const makePlayer = (index: number) => {
+      const makeTtQualificationPlayer = (index: number) => {
         const n = String(index + 1).padStart(2, "0");
         return {
           playerId: `p${index + 1}`,
@@ -492,7 +478,7 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         bmMatches: [],
         mrMatches: [],
         gpMatches: [],
-        ttEntries: Array.from({ length: 61 }, (_value, index) => makePlayer(index)),
+        ttEntries: Array.from({ length: 61 }, (_value, index) => makeTtQualificationPlayer(index)),
         ttPhaseRounds: [],
         playerScores: [],
       };

--- a/smkc-score-app/__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts
@@ -28,4 +28,28 @@ describe('TC-2088 CDM Main Hub boundary coverage', () => {
     expect(routeTest).toContain('workbook.Sheets["Main Hub"].B61.v');
     expect(routeTest).toContain('workbook.Sheets["Main Hub"].B62).toBeUndefined()');
   });
+
+  it('documents TC-2087 as shared fixture and sentinel consistency coverage', () => {
+    const section = e2eCaseSection('TC-2087');
+    const routeTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'app',
+      'api',
+      'tournaments',
+      '[id]',
+      'export',
+      'route.test.ts',
+    );
+
+    expect(section).toContain('issue #2087');
+    expect(section).toContain('issue #2091');
+    expect(section).toContain('makeCdmMainHubPlayer');
+    expect(section).toContain('KEEP-OUT-OF-BOUNDS');
+    expect(routeTest).toContain('const makeCdmMainHubPlayer = (index: number) => {');
+    expect(routeTest).not.toContain('const makePlayer = (index: number) => {');
+    expect(routeTest.match(/makeCdmMainHubPlayer\(index\)/g)).toHaveLength(2);
+    expect(routeTest).toContain("for (const column of ['B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L'])");
+    expect(routeTest).not.toContain('KEEP-OUT-BOUNDS');
+  });
 });


### PR DESCRIPTION
## Summary
- Document TC-2087 for CDM Main Hub boundary fixture consistency.
- Extract the duplicated Main Hub player fixture helper and assert B62-L62 stale sentinels stay consistent.
- Carry current main TypeScript build fixes for TA sudden-death `isAdmin` props and server-ranking override narrowing.

## Issues
Closes #2087
Closes #2091
Closes #2092
Closes #2093

## Validation
- `npm test -- --runTestsByPath __tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts '__tests__/app/api/tournaments/[id]/export/route.test.ts' __tests__/lib/server-ranking.test.ts --ci --forceExit`\n- `npm run lint` (passes with existing warnings)\n- `npm run build:cf`\n