### PR TITLE
test: align TC-2070B vitals payload

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -98,7 +98,7 @@
 - **authRequired**: false
 - **背景**: issue #2070。`WebVitalsReporter` は root layout に常時マウントされるが、通常環境では `PERF_LOG !== '1'` のため `/api/internal/vitals` が副作用なしに 204 を返すことを preview で確認する。`PERF_LOG=1` のログ内容は環境依存なので単体テストで補助する。
 - **手順**:
-  1. ブラウザコンテキストから `/api/internal/vitals` に最小 payload を POST する
+  1. ブラウザコンテキストから `/api/internal/vitals` に `navigationType: 'navigate'` を含む payload を POST する
   2. 通常 preview 設定で 204 が返ることを確認する
   3. トップページに遷移し、Web Vitals reporter のマウントでページロードが壊れないことを確認する
 - **期待結果**: 通常設定では vitals endpoint は 204 を返し、トップページは JS エラーなしに表示される

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -290,6 +290,13 @@ describe('E2E case drift coverage', () => {
     expect(tcAll).toContain('hasRecoveryLinks=${hasRecoveryLinks}');
   });
 
+  it('keeps TC-2070B documented with the same navigationType payload used by tc-all.js', () => {
+    const section = e2eCaseSection('TC-2070B');
+
+    expect(section).toContain("navigationType: 'navigate'");
+    expect(tcAll).toContain("navigationType: 'navigate'");
+  });
+
   const gpSuiteDefinition = sectionBetween(tcGp, '    tests: [', '    ],');
 
   const gpTc831Tc832OrderRationale =

--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -90,6 +90,7 @@ describe('tc-all focused suite registration', () => {
 
     expect(source).toContain("log('TC-2070B'");
     expect(source).toContain('/api/internal/vitals');
+    expect(source).toContain("navigationType: 'navigate'");
     expect(source).toContain('vitalsStatus === 204');
   });
 

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -506,7 +506,14 @@ async function main() {
     const response = await fetch('/api/internal/vitals', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: 'tc-2070', name: 'LCP', value: 1, rating: 'good', path: '/' }),
+      body: JSON.stringify({
+        id: 'tc-2070',
+        name: 'LCP',
+        value: 1,
+        rating: 'good',
+        navigationType: 'navigate',
+        path: '/',
+      }),
     });
     return response.status;
   }).catch(() => 0);


### PR DESCRIPTION
## Summary
- Align TC-2070B runnable E2E Web Vitals payload with the route unit test by including `navigationType: 'navigate'`.
- Add docs drift and E2E registration coverage that guards the TC-2070B navigationType contract.

## Issues
Closes #2082

## Validation
- `npm test -- --runTestsByPath __tests__/e2e/tc-all-registration.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/app/api/internal/vitals/route.test.ts --ci --forceExit`
- `npm run lint`
