### PR TITLE
test: add TC-2070A failure diagnostics

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -90,6 +90,7 @@
   3. `/auth/error?error=NotWhitelisted` にアクセスする
   4. 管理者未登録の安全な説明文と復帰導線を確認する
 - **期待結果**: エラー詳細はユーザー向けの安全な文言で表示され、再ログインとトップページへのリンクが常に存在する
+- **診断**: FAIL時は対象error codeごとに `hasSafeCopy` と `hasRecoveryLinks` の真偽値をログ詳細に出す
 - **スクリプト**: tc-all.js TC-2070A
 
 ## TC-2070B: Web Vitals ingestion は通常設定で 204 を返しページ表示を壊さない

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -280,6 +280,16 @@ describe('E2E case drift coverage', () => {
     expect(scriptSource).toContain(`log('${tc}'`);
   });
 
+  it('keeps TC-2070A failure diagnostics documented and logged', () => {
+    const section = e2eCaseSection('TC-2070A');
+
+    expect(section).toContain('hasSafeCopy');
+    expect(section).toContain('hasRecoveryLinks');
+    expect(tcAll).toContain('tc2070AFailures');
+    expect(tcAll).toContain('hasSafeCopy=${hasSafeCopy}');
+    expect(tcAll).toContain('hasRecoveryLinks=${hasRecoveryLinks}');
+  });
+
   const gpSuiteDefinition = sectionBetween(tcGp, '    tests: [', '    ],');
 
   const gpTc831Tc832OrderRationale =

--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -84,6 +84,9 @@ describe('tc-all focused suite registration', () => {
     expect(source).toContain('/auth/error?error=');
     expect(source).toContain('CredentialsSignin');
     expect(source).toContain('NotWhitelisted');
+    expect(source).toContain('tc2070AFailures');
+    expect(source).toContain('hasSafeCopy=${hasSafeCopy}');
+    expect(source).toContain('hasRecoveryLinks=${hasRecoveryLinks}');
 
     expect(source).toContain("log('TC-2070B'");
     expect(source).toContain('/api/internal/vitals');

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -484,7 +484,7 @@ async function main() {
   log('TC-007', hasPlayerTab ? 'PASS' : 'FAIL');
 
   // TC-2070A: auth error page renders safe copy and recovery links
-  let tc2070A = true;
+  const tc2070AFailures = [];
   for (const { code, expected } of [
     { code: 'CredentialsSignin', expected: ['Invalid nickname or password', 'ニックネームまたはパスワード'] },
     { code: 'NotWhitelisted', expected: ['not registered as an administrator', '管理者として登録されていません'] },
@@ -495,9 +495,11 @@ async function main() {
     const hasRecoveryLinks =
       await page.locator('a[href="/auth/signin"]').count() > 0 &&
       await page.locator('a[href="/"]').count() > 0;
-    if (!hasSafeCopy || !hasRecoveryLinks) tc2070A = false;
+    if (!hasSafeCopy || !hasRecoveryLinks) {
+      tc2070AFailures.push(`${code} hasSafeCopy=${hasSafeCopy} hasRecoveryLinks=${hasRecoveryLinks}`);
+    }
   }
-  log('TC-2070A', tc2070A ? 'PASS' : 'FAIL');
+  log('TC-2070A', tc2070AFailures.length === 0 ? 'PASS' : 'FAIL', tc2070AFailures.join('; '));
 
   // TC-2070B: web vitals endpoint is preview-safe with PERF_LOG disabled
   const vitalsStatus = await page.evaluate(async () => {


### PR DESCRIPTION
## Summary
- Add TC-2070A failure details for each auth error code, including `hasSafeCopy` and `hasRecoveryLinks`.
- Guard the TC-2070A diagnostic contract in E2E registration and docs drift tests.

## Issues
Closes #2081

## Validation
- `npm test -- --runTestsByPath __tests__/e2e/tc-all-registration.test.ts __tests__/docs/e2e-cases-drift.test.ts --ci --forceExit`
- `npm run lint`
- `npm run build:cf`
