### PR TITLE
test: share TA time input prop alias

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -338,6 +338,17 @@
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
 - **補助検証**: `smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts`
 
+## TC-2031: TA time input props は共有型 alias を使う
+- **URL**: n/a (static/doc coverage)
+- **authRequired**: false
+- **背景**: issue #2031。TA の participant / phase1・phase2 elimination / finals の時間入力 row は同じ `timeInputProps` contract を共有しているため、各ファイルで `Partial<ComponentPropsWithoutRef<typeof Input>>` をインライン定義すると型名と修正箇所が分散する。
+- **手順**:
+  1. `time-entry-layout.ts` が `TaTimeInputProps` を export していることを確認する
+  2. participant row、TA elimination row、finals row が `timeInputProps: TaTimeInputProps` を使うことを確認する
+  3. 3ファイルに inline の `Partial<ComponentPropsWithoutRef<typeof Input>>` が戻っていないことを確認する
+- **期待結果**: TA 時間入力 props の型 contract は共有 alias に集約され、同じ row contract の変更点が1箇所にまとまる
+- **スクリプト**: n/a (static/doc coverage) — `smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts`, `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-2034: TC-109 drift guard は補助テストの実装文字列を固定しない
 - **URL**: n/a (static/doc coverage)
 - **authRequired**: false

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -236,6 +236,7 @@ describe('E2E case drift coverage', () => {
     ['TC-1454-1455', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-1457', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/helpers/e2e-cases.ts'],
     ['TC-2006-2007', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/lib/prisma-selects.test.ts'],
+    ['TC-2031', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts'],
     ['TC-2034', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts'],
     ['TC-2041', 'n/a (static/doc coverage)', 'smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts'],
     ['TC-1528', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/e2e/ta-phase-submit-helper.test.ts'],
@@ -1647,6 +1648,7 @@ describe('E2E case drift coverage', () => {
       'TC-1454-1455',
       'TC-1457',
       'TC-2006-2007',
+      'TC-2031',
       'TC-2034',
       'TC-1528',
       'TC-1669',
@@ -1656,6 +1658,18 @@ describe('E2E case drift coverage', () => {
 
     expect(indexes.every((index) => index >= 0)).toBe(true);
     expect(indexes).toEqual([...indexes].sort((a, b) => a - b));
+  });
+
+  it('keeps TC-2031 aligned with the shared TA time input prop alias', () => {
+    const section = e2eCaseSection('TC-2031');
+    const timeEntryLayout = readRepoFile('smkc-score-app', 'src', 'lib', 'ta', 'time-entry-layout.ts');
+    const staticTest = readRepoFile('smkc-score-app', '__tests__', 'static', 'ta-time-input-props-usememo.test.ts');
+
+    expect(section).toContain('issue #2031');
+    expect(section).toContain('TaTimeInputProps');
+    expect(section).toContain('__tests__/static/ta-time-input-props-usememo.test.ts');
+    expect(timeEntryLayout).toContain('export type TaTimeInputProps');
+    expect(staticTest).toContain('timeInputProps: TaTimeInputProps');
   });
 
   it('keeps TC-2006-2007 aligned with shallow BM/MR lean select payload coverage', () => {

--- a/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
+++ b/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
@@ -71,6 +71,26 @@ describe('TA row component memo wrapping', () => {
   );
 });
 
+describe('TA time input prop type alias', () => {
+  it('exports one shared TaTimeInputProps alias for TA row components', () => {
+    const source = readRepoFile('smkc-score-app', 'src', 'lib', 'ta', 'time-entry-layout.ts');
+
+    expect(source).toContain('export type TaTimeInputProps');
+    expect(source).toContain('Partial<ComponentPropsWithoutRef<typeof Input>>');
+  });
+
+  it.each(memoizedRowTargets)(
+    'uses the shared TaTimeInputProps alias in $label',
+    ({ path }) => {
+      const source = readRepoFile('smkc-score-app', ...path);
+
+      expect(source).toMatch(/type\s+TaTimeInputProps\b/);
+      expect(source).toContain('timeInputProps: TaTimeInputProps');
+      expect(source).not.toContain('timeInputProps: Partial<ComponentPropsWithoutRef<typeof Input>>');
+    },
+  );
+});
+
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -27,7 +27,7 @@
  * - 3-second auto-refresh for live tracking
  */
 
-import { ComponentPropsWithoutRef, memo, useState, useEffect, useCallback, use, useMemo, useRef } from "react";
+import { memo, useState, useEffect, useCallback, use, useMemo, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -83,6 +83,7 @@ import {
   TA_FINALS_ROUND_PLAYER_NAME_CLASS,
   TA_FINALS_TIME_INPUT_CLASS,
   TA_TIME_INPUT_HELP_CLASS,
+  type TaTimeInputProps,
   getTaTimeInputProps,
   parseTvNumberInput,
 } from "@/lib/ta/time-entry-layout";
@@ -158,8 +159,6 @@ function renderLives(lives: number, eliminated: boolean, eliminatedLabel: string
   }
   return <span>{hearts}</span>;
 }
-
-type TaTimeInputProps = Partial<ComponentPropsWithoutRef<typeof Input>>;
 
 type TaFinalsTimeEntryRowProps = {
   playerId: string;
@@ -913,7 +912,7 @@ export default function TimeAttackFinals({
 
       {/* Sudden-death panel (admin-only) */}
       <TASuddenDeathSection
-        isAdmin={isAdmin}
+        isAdmin={Boolean(isAdmin)}
         isComplete={isComplete}
         pendingSuddenDeath={pendingSuddenDeath}
         pendingSuddenDeathEntries={pendingSuddenDeathEntries}

--- a/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
@@ -25,7 +25,7 @@
  * - Namespaces: participant, ta, common
  */
 
-import { memo, useState, useEffect, useCallback, use, useMemo, ComponentPropsWithoutRef } from 'react';
+import { memo, useState, useEffect, useCallback, use, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSession } from 'next-auth/react';
 import { usePolling } from '@/lib/hooks/usePolling';
@@ -38,7 +38,7 @@ import { AlertTriangle, Trophy, Users, Timer, LogIn, Dice5, Lock } from 'lucide-
 import Link from 'next/link';
 import { COURSE_INFO, POLLING_INTERVAL, TOTAL_COURSES } from '@/lib/constants';
 import { autoFormatTime, generateRandomTimeString, msToDisplayTime } from '@/lib/ta/time-utils';
-import { TA_TIME_ENTRY_CUP_GRID_CLASS, TA_TIME_INPUT_HELP_CLASS, getTaTimeInputProps } from '@/lib/ta/time-entry-layout';
+import { TA_TIME_ENTRY_CUP_GRID_CLASS, TA_TIME_INPUT_HELP_CLASS, type TaTimeInputProps, getTaTimeInputProps } from '@/lib/ta/time-entry-layout';
 import { toast } from 'sonner';
 import { createLogger } from '@/lib/client-logger';
 import { fetchWithRetry } from "@/lib/fetch-with-retry";
@@ -84,7 +84,7 @@ type TaParticipantTimeInputRowProps = {
   placeholder: string;
   disabled: boolean;
   inputClassName: string;
-  timeInputProps: Partial<ComponentPropsWithoutRef<typeof Input>>;
+  timeInputProps: TaTimeInputProps;
   onChange: (course: string, value: string) => void;
   onBlur: (course: string) => void;
 };

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -20,7 +20,7 @@
  * - Auto-refresh every 3 seconds for live tournament tracking
  */
 
-import { memo, useState, useEffect, useCallback, useMemo, useRef, ComponentPropsWithoutRef } from "react";
+import { memo, useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -66,6 +66,7 @@ import {
   TA_FINALS_ROUND_PLAYER_NAME_CLASS,
   TA_FINALS_TIME_INPUT_CLASS,
   TA_TIME_INPUT_HELP_CLASS,
+  type TaTimeInputProps,
   getTaTimeInputProps,
   parseTvNumberInput,
 } from "@/lib/ta/time-entry-layout";
@@ -106,7 +107,7 @@ type TAEliminationPhaseRowProps = {
   isEditingDisabled: boolean;
   retryLabel: string;
   retryTitle: string;
-  timeInputProps: Partial<ComponentPropsWithoutRef<typeof Input>>;
+  timeInputProps: TaTimeInputProps;
   onTvChange: (playerId: string, value: number | null) => void;
   onTimeChange: (playerId: string, value: string) => void;
   onTimeBlur: (playerId: string) => void;
@@ -843,7 +844,7 @@ export default function TAEliminationPhase({
 
       {/* Sudden-death panel (admin-only) */}
       <TASuddenDeathSection
-        isAdmin={isAdmin}
+        isAdmin={Boolean(isAdmin)}
         isComplete={isComplete}
         pendingSuddenDeath={pendingSuddenDeath}
         pendingSuddenDeathEntries={pendingSuddenDeathEntries}

--- a/smkc-score-app/src/lib/server-ranking.ts
+++ b/smkc-score-app/src/lib/server-ranking.ts
@@ -133,24 +133,28 @@ function assignRanksForPartition<TQualification extends RankableQualification, T
     ranked.splice(0, ranked.length, ...resolved);
   }
 
-  const withOverrides = ranked.map((entry, index) => {
-    const overrideRank = entry.rankOverride != null;
-    return overrideRank
-      ? {
+  type RankedWithOrder = RankedQualification<TQualification> & { _rankingOrder: number };
+
+  const withOverrides: RankedWithOrder[] = ranked.map((entry, index) => {
+    if (entry.rankOverride != null) {
+      const rankOverride = entry.rankOverride;
+      return {
         ...entry,
-        _rank: entry.rankOverride,
+        _rank: rankOverride,
         _rankOverridden: true,
         _rankingOrder: index,
-      }
-      : {
-        ...entry,
-        _rankingOrder: index,
       };
+    }
+
+    return {
+      ...entry,
+      _rankingOrder: index,
+    };
   });
 
   withOverrides.sort((
-    a: { _rank: number; rankOverride?: number | null; _rankingOrder?: number },
-    b: { _rank: number; rankOverride?: number | null; _rankingOrder?: number },
+    a: { _rank: number; rankOverride?: number | null; _rankingOrder: number },
+    b: { _rank: number; rankOverride?: number | null; _rankingOrder: number },
   ) => {
     if (a._rank !== b._rank) return a._rank - b._rank;
 
@@ -158,10 +162,10 @@ function assignRanksForPartition<TQualification extends RankableQualification, T
     const bOverride = b.rankOverride != null;
     if (aOverride !== bOverride) return aOverride ? -1 : 1;
 
-    return (a._rankingOrder ?? 0) - (b._rankingOrder ?? 0);
+    return a._rankingOrder - b._rankingOrder;
   });
 
-  return withOverrides.map(({ _rankingOrder, ...entry }) => entry);
+  return withOverrides.map(({ _rankingOrder, ...entry }) => entry as RankedQualification<TQualification>);
 }
 
 /**

--- a/smkc-score-app/src/lib/ta/time-entry-layout.ts
+++ b/smkc-score-app/src/lib/ta/time-entry-layout.ts
@@ -1,4 +1,9 @@
+import type { ComponentPropsWithoutRef } from "react";
+import type { Input } from "@/components/ui/input";
+
 export const TA_TIME_ENTRY_CUP_GRID_CLASS = "grid grid-cols-1 gap-4 md:grid-cols-2";
+
+export type TaTimeInputProps = Partial<ComponentPropsWithoutRef<typeof Input>>;
 
 export const TA_TIME_INPUT_BASE_PROPS = {
   inputMode: "decimal",


### PR DESCRIPTION
## Summary
- Add shared `TaTimeInputProps` export for TA time input row props.
- Update participant, elimination, and finals TA rows to consume the shared alias.
- Add TC-2031 static/doc coverage and carry current `build:cf` TypeScript fixes for TA sudden-death admin props and server-ranking override narrowing.

## Issues
Closes #2031

## Validation
- `npm test -- --ci --forceExit __tests__/static/ta-time-input-props-usememo.test.ts __tests__/docs/e2e-cases-drift.test.ts __tests__/lib/server-ranking.test.ts`
- `npm test -- --ci --forceExit`
- `npm run lint`
- `npm run build:cf`
