### PR TITLE
docs: clarify PR summary diff scope

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,4 @@ Closes #
 
 - [ ] Summary only describes changes that are present in this PR diff.
 - [ ] Any planned or follow-up work that is not in this diff is listed outside Summary.
+- [ ] Carried-forward or current-main fixes are mentioned only when they are visible in this PR diff.

--- a/smkc-score-app/__tests__/docs/pr-template.test.ts
+++ b/smkc-score-app/__tests__/docs/pr-template.test.ts
@@ -25,5 +25,6 @@ describe('pull request template', () => {
     expect(template).toContain('## PR Body Diff Check');
     expect(template).toContain('Summary only describes changes that are present in this PR diff.');
     expect(template).toContain('planned or follow-up work');
+    expect(template).toContain('current-main fixes are mentioned only when they are visible in this PR diff.');
   });
 });


### PR DESCRIPTION
## Summary
- Clarify that carried-forward or current-main fixes belong in Summary only when they are visible in the PR diff.
- Extend the PR template contract test to guard the new Summary diff-scope checklist item.

## Issues
Closes #2332

## Validation
- `npm test -- --runTestsByPath __tests__/docs/pr-template.test.ts --ci --forceExit`
- `npm run lint`
