### PR TITLE
fix: surface preview browser install hint

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -339,8 +339,9 @@
   9. Chromium 引数生成はディレクトリ作成などの I/O を行わず、launch config 作成時に必要な browser home / cache / Crashpad ディレクトリを準備することを確認する
   10. `E2E_BROWSER_CHANNEL=chrome` または `E2E_EXECUTABLE_PATH=...` を明示した場合だけ、その指定が子プロセスへ渡ることを確認する
   11. `npm run e2e:install-browser` と preview runner が同じ `PLAYWRIGHT_BROWSERS_PATH` を使い、`playwright` import 前に子プロセスへ渡ることを補助検証で確認する
-  12. run-preview 側の Crashpad launch helper 補助テストは `fs.mkdirSync` をモックし、実際の `/tmp` 配下へテスト副作用を残さないことを確認する
-- **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / Crashpad permission failure で停止しない
+  12. managed browser cache が空で Playwright が `Executable doesn't exist` を返す場合、fatal log に汎用 `npx playwright install` だけでなく `npm run e2e:install-browser` と同じ `PLAYWRIGHT_BROWSERS_PATH` が表示されることを確認する
+  13. run-preview 側の Crashpad launch helper 補助テストは `fs.mkdirSync` をモックし、実際の `/tmp` 配下へテスト副作用を残さないことを確認する
+- **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / empty managed browser cache / Crashpad permission failure で停止しても project-specific bootstrap guidance が表示される
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`
 - **補助検証**: `smkc-score-app/__tests__/e2e/run-preview.test.ts`, `smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts`（どちらも runner command 扱いで、URL 欄には環境変数名を入れない）
 

--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -173,4 +173,17 @@ describe('E2E browser launch helpers', () => {
     expect(mkdirSyncSpy).toHaveBeenCalledWith('/tmp/jsmkc-browser-home/.cache', { recursive: true });
     expect(mkdirSyncSpy).toHaveBeenCalledWith('/tmp/jsmkc-browser-home/Crashpad', { recursive: true });
   });
+
+  it('keeps the install-browser bootstrap hint visible when Playwright provides a stack', () => {
+    process.env.PLAYWRIGHT_BROWSERS_PATH = '/tmp/jsmkc-browser-home/ms-playwright';
+    common = loadCommon();
+    const error = new Error("Executable doesn't exist at /tmp/jsmkc-browser-home/ms-playwright/chromium/chrome");
+    error.stack = 'browserType.launchPersistentContext: Executable does not exist stack';
+
+    const formatted = common.formatE2EErrorForLog(common.addChromiumLaunchHelp(error));
+
+    expect(formatted).toContain('Recommended bootstrap:');
+    expect(formatted).toContain('PLAYWRIGHT_BROWSERS_PATH=/tmp/jsmkc-browser-home/ms-playwright npm run e2e:install-browser');
+    expect(formatted).toContain('E2E_EXECUTABLE_PATH=/absolute/path/to/chromium-compatible-browser');
+  });
 });

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -375,7 +375,21 @@ function addChromiumLaunchHelp(error) {
     `  E2E_BROWSER_CHANNEL=chrome`;
 
   error.message = `${msg}${installHint}`;
+  if (error.stack && !error.stack.includes('Recommended bootstrap:')) {
+    error.stack = `${error.stack}${installHint}`;
+  }
   return error;
+}
+
+function formatE2EErrorForLog(error) {
+  if (!(error instanceof Error)) return error;
+  const stack = error.stack || '';
+  const message = error.message || '';
+  if (!stack) return message;
+  if (message.includes('Recommended bootstrap:') && !stack.includes('Recommended bootstrap:')) {
+    return `${stack}\n${message}`;
+  }
+  return stack || message;
 }
 
 async function launchChromium(options = {}) {
@@ -2865,6 +2879,8 @@ module.exports = {
   resolveE2EBrowserHome,
   resolvePlaywrightBrowsersPath,
   getChromiumLaunchConfig,
+  addChromiumLaunchHelp,
+  formatE2EErrorForLog,
   launchChromium,
   launchPersistentChromiumContext,
   /* retry */

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -44,6 +44,7 @@ const {
   resolveAllTies,
   launchChromium,
   launchPersistentChromiumContext,
+  formatE2EErrorForLog,
   BASE,
   resolveE2EProfileDir,
 } = require('./lib/common');
@@ -4505,7 +4506,7 @@ if (require.main === module) {
   main()
     .then((exitCode) => process.exit(exitCode))
     .catch((err) => {
-      console.error('[tc-all] fatal error:', err instanceof Error ? err.stack || err.message : err);
+      console.error('[tc-all] fatal error:', formatE2EErrorForLog(err));
       process.exit(1);
     });
 }


### PR DESCRIPTION
## Summary
- Keep the project-specific `npm run e2e:install-browser` bootstrap hint visible when Playwright reports a missing managed-cache Chromium executable with a stack.
- Route `tc-all` fatal errors through the shared E2E formatter so stack-first logging cannot hide appended launch guidance.
- Document TC-109 coverage for empty managed browser cache failures and add focused Jest coverage for the formatting path.

## Issues
Closes #2335

## Validation
- `npm test -- --runInBand __tests__/lib/e2e-browser-launch.test.ts`
- `npm test -- --runInBand __tests__/docs/e2e-cases-drift.test.ts`
- `npm run lint`
- `npm run build:cf`
