### PR TITLE
Rewrite CDM workbook export as formula-preserving template patching

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -873,7 +873,7 @@
      - 名前セル（+2）は**値として書かれている場合のみ**（8人縮退パス）プレイヤー nickname と一致
      - スコアセル（+4）は完了済み match のみ score1/score2（GP は points1/points2）と一致（順序は集合一致で losers_final 反転を許容）
      - シード番号セル（+1）は typed slot で B-position 1..24 の整数（faithful パスで全 mode が ≥1 件を満たす）
-     - BM/MR のシードリスト B3:B26 に書かれた nickname は当該 mode の finals 参加者であること（GP の B 列は数式スピルなので読まない）
+     - BM/MR のシードリスト B3:B26 に書かれた nickname は当該 mode の finals 参加者**または予選ロスター**であること（playoff-only の途中状態では設計書§3.4 により B-position 1..12 が予選順位フォールバックで埋まるため。テンプレート残骸名の混入検出が目的。GP の B 列は数式スピルなので読まない）
 - **期待結果**: finals 入力セルは CDM 2025 テンプレートの native bracket coordinates に配置され、テンプレートの数式網（tables/richData）と calc 設定が壊れていないこと。チェック件数0は FAIL。
 - **スクリプト**: `tc-all.js TC-816A`, `__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
 

--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -864,13 +864,17 @@
 
 ## TC-816A: CDM export — finals をテンプレートの bracket 座標へ配置する
 - **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #816。CDM Finals シートは dense table ではなく固定 bracket レイアウトなので、match を順番に詰めると Barrage / Top 16 / Upper / Lower / GF / Reset の位置がずれる。
+- **背景**: issue #816。CDM Finals シートは dense table ではなく固定 bracket レイアウトなので、match を順番に詰めると Barrage / Top 16 / Upper / Lower / GF / Reset の位置がずれる。CDM workbook 再設計（ZIP 外科手術）後はラベルや cupResults 要約を書かず、テンプレート数式を保存して**入力セルのみ**を native 座標へ書く（`src/lib/cdm-export/`）。E2E はエクスポートを解凍して構造と入力セルを検証する。
 - **手順**:
   1. 共有大会の BM/MR/GP finals state を確認し、slot-mappable finals match がない mode は top 24 の finals を生成して CDM export fixture を準備する
   2. 生成後も finals match がない mode は、mode 別 match count と round 一覧を診断ログに出して失敗する
-  3. BM/MR/GP Finals の round が `CDM_FINALS_BRACKET_SLOTS` の block/row 座標へ配置されることを確認する
-  4. GP Finals の cupResults summary が移動先の bracket slot に残ることを確認する
-- **期待結果**: finals match は CDM 2025 テンプレートの native bracket coordinates に配置され、GP の cup/points 補足情報も失われない
+  3. 応答バイトを fflate で解凍し、旧実装が壊していた構造（`xl/tables/table1.xml`・`xl/richData/rdrichvalue.xml` の存在、`xl/calcChain.xml` の不在、`xl/workbook.xml` の `fullCalcOnLoad="1"`）を回帰ガードとして確認する
+  4. BM/MR/GP Finals の各 slot-mappable match について、`src/lib/cdm-export/cdm-constants.ts` の `FINALS_BRACKET_SLOTS` 座標で実際にエクスポータが書いた入力セルを検証する（数式セルは SheetJS の `.f` で除外）:
+     - 名前セル（+2）は**値として書かれている場合のみ**（8人縮退パス）プレイヤー nickname と一致
+     - スコアセル（+4）は完了済み match のみ score1/score2（GP は points1/points2）と一致（順序は集合一致で losers_final 反転を許容）
+     - シード番号セル（+1）は typed slot で B-position 1..24 の整数（faithful パスで全 mode が ≥1 件を満たす）
+     - BM/MR のシードリスト B3:B26 に書かれた nickname は当該 mode の finals 参加者であること（GP の B 列は数式スピルなので読まない）
+- **期待結果**: finals 入力セルは CDM 2025 テンプレートの native bracket coordinates に配置され、テンプレートの数式網（tables/richData）と calc 設定が壊れていないこと。チェック件数0は FAIL。
 - **スクリプト**: `tc-all.js TC-816A`, `__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
 
 ## TC-2088: CDM export — Main Hub は60人ちょうどで B62 を空のままにする
@@ -896,59 +900,59 @@
 
 ## TC-2089A: CDM export — Main Hub の 60行上限で row 62 を保護する
 - **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #2089/#2092/#2093。CDM Main Hub は 60人分の固定テンプレート領域だけを書き換えるため、61人以上のデータが来ても row 62 の既存セルを上書きしてはならない。
+- **背景**: issue #2089/#2092/#2093。CDM Main Hub は 60人分の固定テンプレート領域（B2〜L61）だけを書き換える。CDM workbook 再設計では ZIP 外科手術で実テンプレートをパッチするため、61人以上のデータが来ても row 62 は一切アドレスされない（テンプレートに B62〜L62 のセルが存在しない＝未書き込みのまま）。
 - **手順**:
-  1. `Main Hub` の B62〜L62 に stale sentinel 値を持つ CDM workbook fixture を用意する
-  2. 61件の TT entries を持つ tournament を CDM export する
-  3. B61/C61 には60人目が出力され、B62〜L62 の sentinel がすべて残ることを確認する
-- **期待結果**: Main Hub は 60人目までを書き込み、row 62 以降のテンプレートセルを保持する
+  1. 61件の TT entries を持つ tournament を CDM export し、応答バイトを fflate で解凍する
+  2. B61/C61 には60人目が出力されることを確認する
+  3. 61人目は切り捨てられ、Main Hub の B62〜L62 が undefined（未書き込み）のままであることを確認する
+- **期待結果**: Main Hub は 60人目までを書き込み、固定テーブル外の row 62 を一切作成しない
 - **スクリプト**: `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
 
-## TC-2180A: CDM export — TT Qualifications の 60行上限で row 62 を保護する
+## TC-2180A: CDM export — TT Qualifications の 47行上限で row 62 を保護する
 - **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #2180。TT Qualifications も Main Hub と同じ 60行固定テンプレート領域を使うため、61件目の qualification entry で row 62 のテンプレートセルを上書きしてはならない。
+- **背景**: issue #2180。TT Qualifications シートは Main Hub とは別の固定テンプレート領域（rows 2〜48＝最大47人）を使う。CDM workbook 再設計では入力はコースタイム列（G〜Z）のみで、固定テーブル外の row 62（E62〜Z62）は一切アドレスされない。
 - **手順**:
-  1. `TT Qualifications` の E62〜Z62 に stale sentinel 値を持つ CDM workbook fixture を用意する
-  2. 61件の TT qualification entries を持つ tournament を CDM export する
-  3. E61/F61 には60人目が出力され、E62〜Z62 の sentinel がすべて残ることを確認する
-- **期待結果**: TT Qualifications は 60件目までを書き込み、row 62 以降のテンプレートセルを保持する
+  1. 61件の TT qualification entries を持つ tournament を CDM export し、応答バイトを解凍する
+  2. ニックネーム昇順の先頭エントリのコースタイムが G2 に出力されることを確認する（E61/F61 など固定テーブル内）
+  3. TT Qualifications の E62〜Z62 が undefined（未書き込み）のままであることを確認する
+- **期待結果**: TT Qualifications は 47人上限の固定テーブルだけを書き込み、row 62 以降を一切作成しない
 - **スクリプト**: `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
 
 ## TC-1877A: CDM export — grand_final_reset の正規化で到達不能条件を残さない
 - **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #1877。`grand_final_reset` は native slot table で先に解決されるため、同じ round 文字列を後段の別条件に残すと読み手に誤解を与える。
+- **背景**: issue #1877。`grand_final_reset` は bracket slot table で先に解決されるため、同じ round 文字列を後段の別条件に残すと読み手に誤解を与える。CDM workbook 再設計で round 正規化は `src/lib/cdm-export/fill/finals.ts` の `normalizeRound` に移った。
 - **手順**:
-  1. `cdmFinalsSlotRound` が slot table lookup 後に `bracketPosition.includes("reset")` だけで reset alias を扱うことを確認する
+  1. `normalizeRound` が slot table lookup 後に `bracketPosition.includes("reset")` だけで reset alias を扱うことを確認する
   2. `round === "grand_final_reset" || bracketPosition.includes("reset")` が残っていないことを確認する
 - **期待結果**: grand_final_reset の正規化条件に到達不能な round 判定が残らない
 - **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
 
-## TC-1878A: CDM export — fallback 座標カウンタは unknown round だけで進める
+## TC-1878A: CDM export — マップ不能な round は fallback せず skip+warn する
 - **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #1878。既知 round が native slot に配置された後で unknown round が来ても、fallback の最初の空き座標から配置される必要がある。
+- **背景**: issue #1878。旧実装は未知 round を fallback 座標へ詰めていたが、CDM 2025 テンプレートは固定 bracket 数式網なので、マップ不能な round を任意の空き座標へ書くと数式の帰属が壊れる。再設計では `normalizeRound` が null を返した round は配置せず warn する（design §3.4.1）。
 - **手順**:
-  1. `winners_qf` と、sort 順で `winners_qf` より後に来る `zz_custom_showmatch` を含む CDM export fixture を作る
-  2. `winners_qf` が native slot `Y7` に配置されることを確認する
-  3. `zz_custom_showmatch` が既知 round 数に影響されず fallback slot `D5` に配置されることを確認する
-- **期待結果**: fallbackIndex は fallback 使用時だけ増え、unknown round の fallback 座標がずれない
+  1. `winners_qf` と、bracket にマップできない `zz_custom_showmatch` を含む CDM export fixture を作る
+  2. `winners_qf` が認識され（8人縮退パスでスコアセル AC7/AC8 に配置）ることを確認する
+  3. `zz_custom_showmatch` はどの bracket セルにも書かれないことを確認する
+- **期待結果**: マップ不能な round は fallback 配置されず skip され、数式網が保護される
 - **スクリプト**: `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
 
-## TC-1879A: CDM export — E2E の座標期待値は route.ts と同期する前提を明記する
+## TC-1879A: CDM export — E2E の座標期待値は production slot table と同期する前提を明記する
 - **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #1879。E2E は workbook を実際に読むが、期待セルの座標表は production の slot table と同期していないと誤検知を起こす。
+- **背景**: issue #1879。E2E は workbook を実際に読むが、期待セルの座標表は production の slot table と同期していないと誤検知を起こす。CDM 再設計で production の slot table は `src/lib/cdm-export/cdm-constants.ts` の `FINALS_BRACKET_SLOTS` に移った（旧 export route の slot table は削除済み）。
 - **手順**:
-  1. `tc-all.js` の CDM Finals E2E slot table 付近に route.ts の `CDM_FINALS_BRACKET_SLOTS` と同期する旨のコメントがあることを確認する
+  1. `tc-all.js` の CDM Finals E2E slot table 付近に `src/lib/cdm-export/cdm-constants.ts` の `FINALS_BRACKET_SLOTS` と同期する旨のコメントがあることを確認する
   2. TC-816A が XLSM workbook を読み、座標表に基づいて BM/MR/GP のセル値を検証することを確認する
 - **期待結果**: E2E の重複座標表は同期前提が明示され、乖離時のレビュー観点が残る
 - **スクリプト**: `tc-all.js TC-816A`, `__tests__/docs/e2e-cases-drift.test.ts`
 
-## TC-1880A: CDM export — GP cupResults がない環境でも座標検証を false failure にしない
+## TC-1880A: CDM export — スコア未入力の生成直後 fixture でも座標検証を false failure にしない
 - **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #1880。GP finals に cupResults がない fixture でも、ブラケット座標自体が正しければ TC-816A は失敗すべきではない。
+- **背景**: issue #1880。GP finals の cupResults 要約セルは再設計後のエクスポータには存在しないため、旧 `gpCupResultsChecked` ゲートは廃止された。その本来の意図（生成直後で**完了済み match が無い** fixture でも、ブラケット座標自体が正しければ TC-816A は失敗すべきでない）は、スコアセル検証を完了済み match に限定し、常に書かれるシード番号 / シードリスト anchor で各 mode を ≥1 件に保つことで担保する。
 - **手順**:
-  1. TC-816A の PASS 条件が `gpCupResultsChecked` を必須にしていないことを確認する
-  2. `gpCupResultsChecked` が false の場合は detail に summary-cell check skipped として記録することを確認する
-- **期待結果**: cupResults 検証は補助チェックになり、BM/MR/GP 座標検証が通れば TC-816A は PASS できる
+  1. スコアセル（+4）検証が `match.completed` の場合のみ実行されることを確認する（未完了 match はクリア/空白なので比較しない）
+  2. TC-816A の PASS 条件が構造ガード・チェック件数 > 0・mode 欠落なし・failures なしを要求することを確認する
+- **期待結果**: スコア未入力の生成直後 fixture でも、座標 anchor（シード番号 / 名前 / シードリスト）が通れば TC-816A は PASS できる
 - **スクリプト**: `tc-all.js TC-816A`, `__tests__/docs/e2e-cases-drift.test.ts`
 
 ## TC-2098A: CDM export — finals readiness state を並列取得する
@@ -991,61 +995,61 @@
 
 ## TC-817B: CDM export — CSV では CDM 専用 include を取得しない
 - **URL**: /api/tournaments/[id]/export
-- **背景**: issue #817。CSV 出力は MR/GP qualification seed、TT phase rounds、overall playerScores を使用しないため、CDM 専用 include を無条件に付けると不要な JOIN が増える。
+- **背景**: issue #817。CSV 出力は MR/GP qualification seed と TT phase rounds を使用しないため、CDM 専用 include を無条件に付けると不要な JOIN が増える。CDM workbook 再設計後は Overall Ranking シートが数式駆動になり playerScores を一切書かないため、CDM include からも playerScores を外す（design §3.6）。
 - **手順**:
   1. `GET /api/tournaments/:id/export` を呼ぶ
   2. Prisma `findUnique` の include に `mrQualifications` / `gpQualifications` / `ttPhaseRounds` / `playerScores` が含まれないことを確認する
-  3. `GET /api/tournaments/:id/export?format=cdm` では上記 CDM 専用 include が含まれることを確認する
-- **期待結果**: CSV は軽量 include、CDM は workbook に必要な include を使い分ける
+  3. `GET /api/tournaments/:id/export?format=cdm` では `mrQualifications` / `gpQualifications` / `ttPhaseRounds` が含まれ、`playerScores` は含まれないことを確認する
+- **期待結果**: CSV は軽量 include、CDM は workbook の数式が読む seed/phase だけの include を使い分け、どちらも playerScores を取得しない
 - **スクリプト**: `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
 
-## TC-818A: CDM export — timeValueForCDM の冗長 wrapper を削除する
+## TC-818A: CDM export — TT タイム変換を cdm-export モジュールに集約する
 - **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #818。`timeValueForCDM` は `parseTimeMs` と等価な wrapper で、CDM 時刻書き込みの意図を増やさず間接参照だけを増やしている。
+- **背景**: issue #818。CDM workbook 再設計で TT タイムの MSSCC 変換は `src/lib/cdm-export/time-format.ts` の `timeStringToCdmTime` / `msToCdmTime` に移り、`fill/tt-qualifications.ts` がそれを使う。export route 側に時刻変換 helper（旧 `timeValueForCDM` / `parseTimeMs`）を残すと二重定義になる。
 - **手順**:
-  1. export route に `timeValueForCDM` 関数が残っていないことを確認する
-  2. TT qualification の CDM コース時刻書き込みが `parseTimeMs(times[course])` を直接使うことを確認する
-- **期待結果**: CDM export の時刻変換は単一 helper `parseTimeMs` に集約される
+  1. export route に `timeValueForCDM` も `parseTimeMs` も残っていないことを確認する
+  2. TT qualification の CDM コース時刻書き込みが cdm-export モジュールの `timeStringToCdmTime(times[course])` を使うことを確認する
+- **期待結果**: CDM export の時刻変換は cdm-export モジュールの単一 helper に集約され、route は変換ロジックを持たない
 - **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
 
 ## TC-819A: CDM export — テンプレート座標の固定値に根拠コメントを付ける
 - **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #819。CDM 2025 テンプレートの行数・列ブロックは workbook 側の固定座標であり、コメントなしの数値にすると通常の大会上限と誤読されやすい。
+- **背景**: issue #819。CDM 2025 テンプレートの行数・列ブロックは workbook 側の固定座標であり、コメントなしの数値にすると通常の大会上限と誤読されやすい。CDM workbook 再設計でこれらの座標は `src/lib/cdm-export/cdm-constants.ts` に集約され、テンプレートのセルダンプ検証コメント付きの名前付き定数として表現される。
 - **手順**:
-  1. export route に CDM 2025 workbook template coordinates のコメントがあることを確認する
-  2. Main Hub、qualification、finals block、`CDM_TT_ROUND_START_COLUMNS`、overall ranking の固定範囲が名前付き定数で表現されることを確認する
-  3. 書き込み処理がそれらの定数を使うことを確認する
+  1. `cdm-constants.ts` に template coordinates の根拠コメント（実セルダンプ検証）があることを確認する
+  2. Main Hub、TT qualification、qualification block、finals block、TT round の固定範囲が名前付き定数（`MAIN_HUB_*` / `TT_QUAL_*` / `QUAL_BLOCK_*` / `FINALS_*` / `TT_FINALS_*`）で表現されることを確認する
+  3. fill モジュールがそれらの定数を使うことを確認する
 - **期待結果**: CDM テンプレート由来の固定値は、どの workbook 範囲を守るための値か読める
 - **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
 
 ## TC-1871A: CDM export — TT Qualifications の範囲定数を専用名にする
 - **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #1871。TT Qualifications は Main Hub と同じ行レイアウトだが、`CDM_PLAYER_HUB_*` を直接使うと別シートの範囲が Main Hub に依存しているように読める。
+- **背景**: issue #1871。TT Qualifications は固定 47 行のテンプレート領域を持つ。CDM workbook 再設計で範囲は `cdm-constants.ts` の `TT_QUAL_*` 専用定数として表現され、`fill/tt-qualifications.ts` がそれを使う。
 - **手順**:
-  1. `CDM_TT_QUAL_FIRST_ROW` / `CDM_TT_QUAL_MAX_PLAYERS` が存在することを確認する
-  2. `writeTTQualifications` が TT 専用定数を使って clear と slice を行うことを確認する
-  3. TT 専用定数が Main Hub と同じレイアウトである理由コメントを持つことを確認する
-- **期待結果**: TT Qualifications の固定範囲は、Main Hub の実装詳細ではなく TT シートの範囲として読める
+  1. `TT_QUAL_FIRST_ROW` / `TT_QUAL_MAX_PLAYERS` / `TT_QUAL_FIRST_TIME_COLUMN` が `cdm-constants.ts` に存在することを確認する
+  2. `fill/tt-qualifications.ts` が TT 専用定数を使って clear と slice を行うことを確認する
+  3. TT 専用定数がシートのコース列レイアウトの理由コメントを持つことを確認する
+- **期待結果**: TT Qualifications の固定範囲は、TT シートの範囲として専用定数で読める
 - **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
 
-## TC-1872A: CDM export — finals/TT round の残存座標を名前付き定数にする
+## TC-1872A: CDM export — finals/TT round の座標を名前付き定数にする
 - **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #1872。`writeMatchFinalsSheet` / `writeTTFinals` の clearRange に残った `107`, `5`, `524`, `1`, `26` は CDM 2025 テンプレート由来の固定座標であり、数値直書きのままだと根拠が追いにくい。
+- **背景**: issue #1872。finals bracket block と TT round block の座標は CDM 2025 テンプレート由来の固定値であり、数値直書きにすると根拠が追いにくい。CDM workbook 再設計でこれらは `cdm-constants.ts` の `FINALS_*` / `TT_FINALS_*` 定数として表現される。
 - **手順**:
-  1. finals block の幅、最終列、match 開始行が `CDM_FINALS_*` 定数で表現されることを確認する
-  2. TT round block の幅、最終列、開始/終了行が `CDM_TT_ROUND_*` 定数で表現されることを確認する
-  3. `clearRange` がこれらの定数を使い、数値直書きを残していないことを確認する
+  1. finals の seed list 列、seed/name/score オフセット、bracket block 座標が `FINALS_*` 定数で表現されることを確認する
+  2. TT round block の stride、入力/表示先頭列、データ行範囲が `TT_FINALS_*` 定数で表現されることを確認する
+  3. fill モジュールがこれらの定数を使うことを確認する
 - **期待結果**: finals/TT round のテンプレート座標はすべて名前付き定数経由で参照される
 - **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
 
-## TC-1874A: CDM export — clearRange の inclusive end を offset 命名で表現する
+## TC-1874A: CDM export — fill マップは数式セルを書かず入力セルだけを扱う
 - **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #1874。`clearRange` の end column は inclusive なので、`start + 6` / `start + 5` を幅として命名すると実際のクリア列数とずれて読める。
+- **背景**: issue #1874。旧実装は SheetJS で read→write し、スピル範囲へ値を書いて #SPILL! を起こした。CDM workbook 再設計では `sheet-xml-patcher.ts` が数式セルへの値書込を拒否（例外）し、`clearValue` は数式・スタイルを残して値だけ落とす。fill マップは入力セルだけを clear/set し、数式セルには触れない。
 - **手順**:
-  1. `clearRange` が end column / row を inclusive に扱うことをコメントで確認する
-  2. finals block と TT round block の派生 end column が `*_BLOCK_END_OFFSET` 定数で表現されることを確認する
-  3. `CDM_FINALS_BLOCK_WIDTH` / `CDM_TT_ROUND_BLOCK_WIDTH` が残っていないことを確認する
-- **期待結果**: CDM テンプレートのブロック終端は「幅」ではなく inclusive end offset として読める
+  1. `sheet-xml-patcher.ts` が数式セルへの number/inlineString 書込を拒否することを確認する
+  2. `clearValue` 系 op が数式・スタイルを保持することを確認する
+  3. 旧 `CDM_FINALS_BLOCK_WIDTH` / `CDM_TT_ROUND_BLOCK_WIDTH` のような幅命名が export route に残っていないことを確認する
+- **期待結果**: CDM export は数式網を破壊せず、入力セルだけを精密にパッチする
 - **スクリプト**: `__tests__/docs/e2e-cases-drift.test.ts`
 
 ## TC-348: キャラクター統計 API — admin のみアクセス可 (TC-328 と重複なし: 形式チェック)

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -23,24 +23,14 @@
 jest.mock('@/lib/logger', () => ({ createLogger: jest.fn(() => ({ error: jest.fn(), warn: jest.fn() })) }));
 jest.mock('@/lib/excel', () => ({ formatDate: jest.fn(() => '2024-01-15'), formatTime: jest.fn(() => '1:23.456') }));
 jest.mock('@/lib/auth', () => ({ auth: jest.fn() }));
-jest.mock('@e965/xlsx', () => ({
-  read: jest.fn(() => ({
-    Sheets: {
-      "Main Hub": {},
-      "TT Qualifications": {},
-      "BM Qualifications": {},
-      "MR Qualifications": {},
-      "GP Qualifications": {},
-      "BM Finals": {},
-      "MR Finals": {},
-      "GP Finals": {},
-      "TT Finals": {},
-      "Overall Ranking": {},
-    },
-    Workbook: {},
-  })),
-  write: jest.fn(() => Buffer.from('xlsm-data')),
-}), { virtual: true });
+/*
+ * The CDM export no longer round-trips through SheetJS; it performs ZIP surgery
+ * on the real template (public/templates/cdm-2025-template.xlsm) via fflate.
+ * These tests therefore feed the REAL template bytes through the ASSETS mock and
+ * decode the response bytes with fflate to assert on the patched worksheet XML.
+ * The previous jest.mock('@e965/xlsx') stub is gone — there is nothing left to
+ * mock once the exporter writes OOXML directly.
+ */
 /*
  * NextResponse is used as both a constructor (new NextResponse(csvContent, options))
  * for success CSV responses, and via its static .json() method for error/404 responses.
@@ -59,6 +49,9 @@ jest.mock('next/server', () => {
   return { NextResponse: MockNextResponse };
 });
 
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { unzipSync, strFromU8 } from 'fflate';
 import prisma from '@/lib/prisma';
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import { createLogger } from '@/lib/logger';
@@ -66,7 +59,6 @@ import { formatDate, formatTime } from '@/lib/excel';
 import { auth } from '@/lib/auth';
 import { GET } from '@/app/api/tournaments/[id]/export/route';
 import { NextResponse } from 'next/server';
-import * as XLSX from '@e965/xlsx';
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 
 class MockNextRequest {
@@ -74,6 +66,99 @@ class MockNextRequest {
   headers = {
     get: () => undefined,
   };
+}
+
+/** The real CDM template path; loaded fresh per call so a patch can't mutate it. */
+const CDM_TEMPLATE_PATH = join(process.cwd(), 'public', 'templates', 'cdm-2025-template.xlsm');
+function loadRealTemplate(): ArrayBuffer {
+  const buf = readFileSync(CDM_TEMPLATE_PATH);
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+}
+
+/**
+ * Wire the ASSETS mock to serve the real CDM template bytes, mirroring the
+ * Cloudflare runtime path the route prefers (ASSETS.fetch over global fetch).
+ * Returns the asset fetch mock so a test can assert the URL it was called with.
+ */
+function mockRealTemplateAsset(): jest.Mock {
+  const assetFetch = jest.fn().mockResolvedValue({
+    ok: true,
+    arrayBuffer: jest.fn().mockResolvedValue(loadRealTemplate()),
+  });
+  (getCloudflareContext as jest.Mock).mockReturnValue({ env: { DB: {}, ASSETS: { fetch: assetFetch } } });
+  return assetFetch;
+}
+
+/** Sheet display name → worksheet part path of the CDM template (verified order). */
+const CDM_SHEET_PATHS: Record<string, string> = {
+  'Main Hub': 'xl/worksheets/sheet1.xml',
+  'TT Qualifications': 'xl/worksheets/sheet3.xml',
+  'TT Finals': 'xl/worksheets/sheet4.xml',
+  'BM Qualifications': 'xl/worksheets/sheet6.xml',
+  'BM Finals': 'xl/worksheets/sheet7.xml',
+  'MR Qualifications': 'xl/worksheets/sheet8.xml',
+  'MR Finals': 'xl/worksheets/sheet9.xml',
+  'GP Qualifications': 'xl/worksheets/sheet10.xml',
+  'GP Finals': 'xl/worksheets/sheet11.xml',
+  'Overall Ranking': 'xl/worksheets/sheet12.xml',
+};
+
+/**
+ * Parse one worksheet's XML into a SheetJS-compatible cell map so the CDM tests
+ * can keep reading `sheet.D5.v` / `workbook.Sheets["Main Hub"].B62`. Each <c>
+ * becomes `{ v }` where v is the numeric value, the inline-string text, or the
+ * sharedString index (template originals that were left untouched). Cleared /
+ * absent cells are simply not present, so `sheet.REF` is `undefined` for them —
+ * which is exactly the "row 62 stays unwritten" assertion the boundary tests make.
+ */
+function parseSheet(xml: string): Record<string, { v: number | string }> {
+  const cells: Record<string, { v: number | string }> = {};
+  const cellRe = /<c r="([A-Z]+\d+)"([^>]*?)(?:\/>|>([\s\S]*?)<\/c>)/g;
+  let m: RegExpExecArray | null;
+  while ((m = cellRe.exec(xml)) !== null) {
+    const ref = m[1];
+    const attrs = m[2];
+    const inner = m[3];
+    if (inner === undefined || inner === '') continue; // self-closing / cleared cell -> absent
+    const isInline = /\bt="inlineStr"/.test(attrs);
+    if (isInline) {
+      const t = /<t[^>]*>([\s\S]*?)<\/t>/.exec(inner);
+      if (t) cells[ref] = { v: decodeXml(t[1]) };
+      continue;
+    }
+    const v = /<v>([\s\S]*?)<\/v>/.exec(inner);
+    if (!v) continue; // formula-only cell with no cached value
+    const raw = v[1];
+    const num = Number(raw);
+    cells[ref] = { v: Number.isNaN(num) || raw.trim() === '' ? raw : num };
+  }
+  return cells;
+}
+
+function decodeXml(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+/**
+ * Decode a CDM export response (Uint8Array of .xlsm bytes) into a SheetJS-like
+ * `{ Sheets: { [name]: cellMap } }` view plus the raw zip parts (for byte-level
+ * regression checks on the parts the old exporter used to drop).
+ */
+function cdmWorkbookFromResult(result: { data: Uint8Array }): {
+  Sheets: Record<string, Record<string, { v: number | string }>>;
+  parts: Record<string, Uint8Array>;
+} {
+  const parts = unzipSync(result.data);
+  const Sheets: Record<string, Record<string, { v: number | string }>> = {};
+  for (const [name, path] of Object.entries(CDM_SHEET_PATHS)) {
+    Sheets[name] = parts[path] ? parseSheet(strFromU8(parts[path])) : {};
+  }
+  return { Sheets, parts };
 }
 
 describe('Export API Route - /api/tournaments/[id]/export', () => {
@@ -162,12 +247,6 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
           player: { id: 'p1', name: 'Player One', nickname: 'P1' },
           seeding: 1,
           group: 'A',
-          mp: 1,
-          wins: 1,
-          ties: 0,
-          losses: 0,
-          winRounds: 4,
-          lossRounds: 1,
           points: 3,
           score: 1000,
         }],
@@ -198,35 +277,19 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
           totalTime: 12345,
         }],
         ttPhaseRounds: [],
-        playerScores: [{
-          player: { id: 'p1', name: 'Player One', nickname: 'P1' },
-          taQualificationPoints: 1000,
-          bmQualificationPoints: 1000,
-          mrQualificationPoints: 0,
-          gpQualificationPoints: 0,
-          taFinalsPoints: 0,
-          bmFinalsPoints: 2000,
-          mrFinalsPoints: 0,
-          gpFinalsPoints: 0,
-          totalPoints: 4000,
-          overallRank: 1,
-        }],
       };
 
       (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
-      const assetFetch = jest.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
-      });
-      (getCloudflareContext as jest.Mock).mockReturnValue({
-        env: { DB: {}, ASSETS: { fetch: assetFetch } },
-      });
+      const assetFetch = mockRealTemplateAsset();
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
       const params = Promise.resolve({ id: 't1' });
       const result = await GET(request, { params });
 
       expect(assetFetch).toHaveBeenCalledWith(new URL('/templates/cdm-2025-template.xlsm', 'https://assets.local'));
+      // The CDM include carries the MR/GP seeds and TT phase rounds the workbook
+      // reads, but NOT playerScores: the Overall Ranking sheet is formula-driven
+      // and the exporter never writes it (design §3.6).
       expect(prisma.tournament.findUnique).toHaveBeenCalledWith({
         where: { id: 't1' },
         include: {
@@ -238,18 +301,32 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
           mrQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
           gpQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
           ttPhaseRounds: true,
-          playerScores: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
         },
       });
       expect(global.fetch).toBeUndefined();
       expect(result.data).toBeInstanceOf(Uint8Array);
       expect(result.headers['Content-Type']).toBe('application/vnd.ms-excel.sheet.macroEnabled.12');
       expect(result.headers['Content-Disposition']).toContain('.xlsm');
+
+      // Decode the real .xlsm bytes and verify the Main Hub player + TT time landed.
+      const workbook = cdmWorkbookFromResult(result);
+      expect(workbook.Sheets['Main Hub'].B2.v).toBe('Player One');
+      expect(workbook.Sheets['Main Hub'].C2.v).toBe('P1');
+      // 0:12.345 -> 0*10000 + 12*100 + 35 (half-up centiseconds) = 1235.
+      expect(workbook.Sheets['TT Qualifications'].G2.v).toBe(1235);
+      // The parts the old SheetJS exporter destroyed must survive untouched.
+      expect(workbook.parts['xl/tables/table1.xml']).toBeDefined();
+      expect(workbook.parts['xl/richData/rdrichvalue.xml']).toBeDefined();
+      expect(workbook.parts['xl/calcChain.xml']).toBeUndefined();
     });
 
-    it('should place CDM finals matches in native bracket coordinates', async () => {
+    it('should place CDM finals seeds and scores in native bracket coordinates', async () => {
+      // A full 24-player faithful bracket: winners_r1 (8) names the direct
+      // qualifiers, playoff_r1/r2 seed entrants 13..24, and the upper/lower/GF
+      // rounds advance by formula. The exporter writes typed seed cells and
+      // identity-resolved scores; it must NOT touch the advancement formulas.
       const player = (id: string) => ({ id, name: `Name ${id}`, nickname: id.toUpperCase() });
-      const match = (round: string, matchNumber: number, p1: string, p2: string, stage = 'finals') => ({
+      const match = (round: string, matchNumber: number, p1: string, p2: string, stage: string) => ({
         matchNumber,
         stage,
         round,
@@ -257,28 +334,24 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         isGrandFinal: round === 'gf',
         player1: player(p1),
         player2: player(p2),
-        score1: 2,
-        score2: 1,
-        points1: 2,
-        points2: 1,
+        score1: 4,
+        score2: 2,
+        points1: 4,
+        points2: 2,
         completed: true,
       });
-      const finalsMatches = [
-        match('playoff_r1', 1, 'p1', 'p2', 'playoff'),
-        match('playoff_r2', 5, 'p3', 'p4', 'playoff'),
-        match('winners_r1', 1, 'p5', 'p6'),
-        match('winners_qf', 9, 'p7', 'p8'),
-        match('winners_sf', 13, 'p9', 'p10'),
-        match('winners_final', 15, 'p11', 'p12'),
-        match('losers_r1', 16, 'p13', 'p14'),
-        match('losers_r2', 20, 'p15', 'p16'),
-        match('losers_r3', 24, 'p17', 'p18'),
-        match('losers_r4', 26, 'p19', 'p20'),
-        match('losers_sf', 28, 'p21', 'p22'),
-        match('losers_final', 29, 'p23', 'p24'),
-        match('gf', 30, 'p25', 'p26'),
-        match('grand_final_reset', 31, 'p27', 'p28'),
-      ];
+      // winners_r1 has 8 matches (indices 0..7), each two direct qualifiers.
+      const winnersR1 = Array.from({ length: 8 }, (_v, i) =>
+        match('winners_r1', i + 1, `w${2 * i + 1}`, `w${2 * i + 2}`, 'finals'),
+      );
+      // playoff_r1 has 4 matches; playoff_r2 has 4 matches (the BYE seeds).
+      const playoffR1 = Array.from({ length: 4 }, (_v, i) =>
+        match('playoff_r1', 100 + i, `b${2 * i + 1}`, `b${2 * i + 2}`, 'playoff'),
+      );
+      const playoffR2 = Array.from({ length: 4 }, (_v, i) =>
+        match('playoff_r2', 200 + i, `q${i + 1}`, `r${i + 1}`, 'playoff'),
+      );
+      const finalsMatches = [...playoffR1, ...playoffR2, ...winnersR1];
       const mockTournament = {
         id: 't1',
         name: 'CDM Bracket Coordinates',
@@ -292,41 +365,35 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         gpMatches: finalsMatches,
         ttEntries: [],
         ttPhaseRounds: [],
-        playerScores: [],
       };
 
       (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
-      });
+      mockRealTemplateAsset();
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
       const params = Promise.resolve({ id: 't1' });
-      await GET(request, { params });
+      const result = await GET(request, { params });
 
-      const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
-      const sheet = workbook.Sheets["BM Finals"];
-      expect(sheet.D5.v).toBe('playoff_r1');
-      expect(sheet.K5.v).toBe('playoff_r2');
-      expect(sheet.R5.v).toBe('winners_r1');
-      expect(sheet.Y7.v).toBe('winners_qf');
-      expect(sheet.AF11.v).toBe('winners_sf');
-      expect(sheet.AM19.v).toBe('winners_final');
-      expect(sheet.AT19.v).toBe('GF');
-      expect(sheet.BA19.v).toBe('GF Reset');
-      expect(sheet.R41.v).toBe('losers_r1');
-      expect(sheet.Y41.v).toBe('losers_r2');
-      expect(sheet.AF43.v).toBe('losers_r3');
-      expect(sheet.AM43.v).toBe('losers_r4');
-      expect(sheet.AT47.v).toBe('losers_sf');
-      expect(sheet.BA47.v).toBe('losers_final');
-      expect(sheet.AC7.v).toBe(2);
-      expect(sheet.AC8.v).toBe(1);
-      expect(workbook.Sheets["MR Finals"].Y7.v).toBe('winners_qf');
-      expect(workbook.Sheets["MR Finals"].AT19.v).toBe('GF');
-      expect(workbook.Sheets["GP Finals"].Y7.v).toBe('winners_qf');
-      expect(workbook.Sheets["GP Finals"].BA47.v).toBe('losers_final');
+      const workbook = cdmWorkbookFromResult(result);
+      const sheet = workbook.Sheets['BM Finals'];
+      // winners_r1[0] slot1 is upper seed 1 -> B-position 1, typed into S5.
+      expect(sheet.S5.v).toBe(1);
+      // winners_r1[0] slot2 is a "Winner of B2,1" reverse-lookup FORMULA cell
+      // (S6 = XLOOKUP(T6,...)); the faithful path must leave it untouched, so its
+      // cached template value (17) survives — the exporter never typed it.
+      expect(sheet.S6.v).toBe(17);
+      // winners_r1[0] is a completed 4-2: slot1 score in V5, slot2 score in V6.
+      expect(sheet.V5.v).toBe(4);
+      expect(sheet.V6.v).toBe(2);
+      // playoff_r1[0] both slots are typed seeds (E column, rows 5/6).
+      expect(typeof sheet.E5.v).toBe('number');
+      expect(typeof sheet.E6.v).toBe('number');
+      // The seed list (B3:B26) names the qualifiers by B-position.
+      expect(typeof sheet.B3.v).toBe('string');
+      // GP finals use the same geometry (driver points written as scores).
+      expect(workbook.Sheets['GP Finals'].S5.v).toBe(1);
+      expect(workbook.Sheets['GP Finals'].V5.v).toBe(4);
+      expect(workbook.Sheets['MR Finals'].S5.v).toBe(1);
     });
 
     it('should write the Main Hub player rows for exactly 60 players', async () => {
@@ -343,56 +410,26 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         gpMatches: [],
         ttEntries: Array.from({ length: 60 }, (_value, index) => makeCdmMainHubPlayer(index)),
         ttPhaseRounds: [],
-        playerScores: [],
       };
 
       (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
-      });
+      mockRealTemplateAsset();
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
       const params = Promise.resolve({ id: 't1' });
-      await GET(request, { params });
+      const result = await GET(request, { params });
 
-      const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
+      const workbook = cdmWorkbookFromResult(result);
+      // Universe sorted by name asc: Name 01..Name 60 land on rows 2..61.
       expect(workbook.Sheets["Main Hub"].B2.v).toBe('Name 01');
       expect(workbook.Sheets["Main Hub"].B61.v).toBe('Name 60');
       expect(workbook.Sheets["Main Hub"].C61.v).toBe('Player 60');
+      // Row 62 is past the fixed 60-row table; the template has no B62 and the
+      // exporter must never address it, so the decoded cell stays undefined.
       expect(workbook.Sheets["Main Hub"].B62).toBeUndefined();
     });
 
     it('should cap Main Hub player rows at 60 when more players are provided', async () => {
-      const staleWorkbook = {
-        Sheets: {
-          "Main Hub": {
-            B62: { v: 'KEEP-OUT-OF-BOUNDS' },
-            C62: { v: 'KEEP-OUT-OF-BOUNDS' },
-            D62: { v: 'KEEP-OUT-OF-BOUNDS' },
-            E62: { v: 'KEEP-OUT-OF-BOUNDS' },
-            F62: { v: 'KEEP-OUT-OF-BOUNDS' },
-            G62: { v: 'KEEP-OUT-OF-BOUNDS' },
-            H62: { v: 'KEEP-OUT-OF-BOUNDS' },
-            I62: { v: 'KEEP-OUT-OF-BOUNDS' },
-            J62: { v: 'KEEP-OUT-OF-BOUNDS' },
-            K62: { v: 'KEEP-OUT-OF-BOUNDS' },
-            L62: { v: 'KEEP-OUT-OF-BOUNDS' },
-          },
-          "TT Qualifications": {},
-          "BM Qualifications": {},
-          "MR Qualifications": {},
-          "GP Qualifications": {},
-          "BM Finals": {},
-          "MR Finals": {},
-          "GP Finals": {},
-          "TT Finals": {},
-          "Overall Ranking": {},
-        },
-        Workbook: {},
-      };
-      (XLSX.read as jest.Mock).mockImplementationOnce(() => staleWorkbook as any);
-
       const mockTournament = {
         id: 't1',
         name: 'CDM Player Hub Cap',
@@ -406,26 +443,22 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         gpMatches: [],
         ttEntries: Array.from({ length: 61 }, (_value, index) => makeCdmMainHubPlayer(index)),
         ttPhaseRounds: [],
-        playerScores: [],
       };
 
       (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
-      });
+      mockRealTemplateAsset();
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
       const params = Promise.resolve({ id: 't1' });
-      await GET(request, { params });
+      const result = await GET(request, { params });
 
-      const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
+      const workbook = cdmWorkbookFromResult(result);
+      // The 60th player still lands on B61; the 61st is dropped (truncate + log),
+      // and no row-62 cell is ever created (KEEP-OUT-OF-BOUNDS of the fixed table).
       expect(workbook.Sheets["Main Hub"].B2.v).toBe('Name 01');
       expect(workbook.Sheets["Main Hub"].B61.v).toBe('Name 60');
       for (const column of ['B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L']) {
-        expect(workbook.Sheets["Main Hub"][`${column}62`]).toEqual({
-          v: 'KEEP-OUT-OF-BOUNDS',
-        });
+        expect(workbook.Sheets["Main Hub"][`${column}62`]).toBeUndefined();
       }
     });
 
@@ -434,24 +467,6 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O",
         "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
       ];
-      const staleWorkbook = {
-        Sheets: {
-          "Main Hub": {},
-          "TT Qualifications": Object.fromEntries(
-            ttBoundaryColumns.map((col) => [`${col}62`, { v: `KEEP-TT-${col}62` }]),
-          ),
-          "BM Qualifications": {},
-          "MR Qualifications": {},
-          "GP Qualifications": {},
-          "BM Finals": {},
-          "MR Finals": {},
-          "GP Finals": {},
-          "TT Finals": {},
-          "Overall Ranking": {},
-        },
-        Workbook: {},
-      };
-      (XLSX.read as jest.Mock).mockImplementationOnce(() => staleWorkbook as any);
 
       const makeTtQualificationPlayer = (index: number) => {
         const n = String(index + 1).padStart(2, "0");
@@ -462,7 +477,7 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
           seeding: index + 1,
           lives: 3,
           eliminated: false,
-          times: {},
+          times: { MC1: `0:0${(index % 9) + 1}.000` },
           totalTime: 12000 + index,
         };
       };
@@ -480,36 +495,89 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         gpMatches: [],
         ttEntries: Array.from({ length: 61 }, (_value, index) => makeTtQualificationPlayer(index)),
         ttPhaseRounds: [],
-        playerScores: [],
       };
 
       (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
-      });
+      mockRealTemplateAsset();
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
       const params = Promise.resolve({ id: 't1' });
-      await GET(request, { params });
+      const result = await GET(request, { params });
 
-      const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
-      expect(workbook.Sheets["TT Qualifications"].E2.v).toBe(1);
-      expect(workbook.Sheets["TT Qualifications"].F2.v).toBe('Player 01');
-      expect(workbook.Sheets["TT Qualifications"].E61.v).toBe(60);
-      expect(workbook.Sheets["TT Qualifications"].F61.v).toBe('Player 60');
+      const workbook = cdmWorkbookFromResult(result);
+      // The TT Qualifications sheet caps at 47 finalists (rows 2..48), not 60:
+      // its template table is smaller than Main Hub's. Row 2 gets the first
+      // nickname-sorted entry's MC1 time; the row-62 cells stay unwritten.
+      // (Nicknames "Player 01".."Player 61" sort ascending, so Player 01 -> row 2.)
+      expect(workbook.Sheets["TT Qualifications"].G2.v).toBe(100); // 0:01.000 -> 100
       for (const col of ttBoundaryColumns) {
-        expect(workbook.Sheets["TT Qualifications"][`${col}62`]).toEqual({
-          v: `KEEP-TT-${col}62`,
-        });
+        expect(workbook.Sheets["TT Qualifications"][`${col}62`]).toBeUndefined();
       }
     });
 
-    it('should use the first fallback CDM finals slot only for unknown rounds', async () => {
+    it('should clear stale template TT times on in-range spare rows', async () => {
+      // The shipped template is the populated CDM 2025 workbook: rows 2..48 of
+      // TT Qualifications hold that event's real times. Unlike the row-62 check
+      // above (absent in the template, so undefined is trivial), G3/G48 DO hold
+      // stale values in the template — their absence here proves the exporter
+      // actively cleared the spare in-table rows for a smaller tournament.
+      const player = { id: 'p1', name: 'Solo Runner', nickname: 'Solo' };
+      const mockTournament = {
+        id: 't1',
+        name: 'CDM TT Stale Clear',
+        date: new Date('2024-01-15'),
+        status: 'completed',
+        bmQualifications: [],
+        mrQualifications: [],
+        gpQualifications: [],
+        bmMatches: [],
+        mrMatches: [],
+        gpMatches: [],
+        ttEntries: [{
+          playerId: 'p1',
+          player,
+          stage: 'qualification',
+          seeding: 1,
+          lives: 3,
+          eliminated: false,
+          times: { MC1: '1:10.34' },
+          totalTime: 70340,
+        }],
+        ttPhaseRounds: [],
+      };
+
+      (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
+      mockRealTemplateAsset();
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
+      const params = Promise.resolve({ id: 't1' });
+      const result = await GET(request, { params });
+
+      const workbook = cdmWorkbookFromResult(result);
+      const ttSheet = workbook.Sheets["TT Qualifications"];
+      // The single qualifier lands on row 2 with the MSSCC-encoded time...
+      expect(ttSheet.G2.v).toBe(11034); // 1:10.34
+      // ...and the stale 2025 times on the spare rows are gone (template G3=5979,
+      // G48 populated — both must be cleared, across the full course range G..Z).
+      expect(ttSheet.G3).toBeUndefined();
+      expect(ttSheet.Z3).toBeUndefined();
+      expect(ttSheet.G48).toBeUndefined();
+      expect(ttSheet.Z48).toBeUndefined();
+      // The roster spill anchor E2 stays untouched: it still carries the
+      // template's cached SEQUENCE value 1 (formula retention itself is
+      // enforced by SheetXmlPatcher's formula guard and its unit tests; the
+      // value-level parser here can only observe the cached <v>).
+      expect(ttSheet.E2.v).toBe(1);
+    });
+
+    it('should skip an unknown CDM finals round instead of using a fallback slot', async () => {
+      // The new exporter has no positional fallback: a round that does not map to
+      // a bracket geometry is skipped with a warning (design §3.4.1), so only the
+      // recognized winners_qf round produces typed cells.
       const player = (id: string) => ({ id, name: `Name ${id}`, nickname: id.toUpperCase() });
       const mockTournament = {
         id: 't1',
-        name: 'CDM Unknown Round Fallback',
+        name: 'CDM Unknown Round Skip',
         date: new Date('2024-01-15'),
         status: 'completed',
         bmQualifications: [],
@@ -517,7 +585,7 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         gpQualifications: [],
         bmMatches: [
           {
-            matchNumber: 9,
+            matchNumber: 13,
             stage: 'finals',
             round: 'winners_qf',
             player1: player('p1'),
@@ -541,23 +609,24 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         gpMatches: [],
         ttEntries: [],
         ttPhaseRounds: [],
-        playerScores: [],
       };
 
       (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
-      });
+      mockRealTemplateAsset();
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
       const params = Promise.resolve({ id: 't1' });
-      await GET(request, { params });
+      const result = await GET(request, { params });
 
-      const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
+      const workbook = cdmWorkbookFromResult(result);
       const sheet = workbook.Sheets["BM Finals"];
-      expect(sheet.Y7.v).toBe('winners_qf');
-      expect(sheet.D5.v).toBe('zz_custom_showmatch');
+      // winners_qf[0] is a degraded-8 path (winners_qf is the first round): the
+      // template's row-7 score cells (AC7/AC8) get the overwritten 2-1 result.
+      expect(sheet.AC7.v).toBe(2);
+      expect(sheet.AC8.v).toBe(1);
+      // The unused Barrage block is stripped in degraded-8 mode, so its typed
+      // seed cell E5 is cleared (was 17) — the unknown round never landed there.
+      expect(sheet.E5).toBeUndefined();
     });
 
     it('should return 401 when CDM export is requested without authentication', async () => {
@@ -606,7 +675,6 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         gpMatches: [],
         ttEntries: [],
         ttPhaseRounds: [],
-        playerScores: [],
       };
 
       (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
@@ -630,7 +698,9 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         status: 404,
         tournamentId: 't1',
       });
-      expect(XLSX.read).not.toHaveBeenCalled();
+      // The workbook generator is never reached on a template-load failure, so
+      // the response carries the error object, not the .xlsm byte payload.
+      expect(result.data).not.toBeInstanceOf(Uint8Array);
     });
 
     it('should return 503 when ASSETS.fetch throws during CDM template loading', async () => {
@@ -647,7 +717,6 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         gpMatches: [],
         ttEntries: [],
         ttPhaseRounds: [],
-        playerScores: [],
       };
       const fetchError = new Error('ASSETS unavailable');
       const assetFetch = jest.fn().mockRejectedValue(fetchError);
@@ -676,7 +745,8 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         error: fetchError,
         tournamentId: 't1',
       });
-      expect(XLSX.read).not.toHaveBeenCalled();
+      // The workbook generator is never reached on a template-load failure.
+      expect(result.data).not.toBeInstanceOf(Uint8Array);
     });
 
     it('should not pollute Object.prototype when CDM export receives malicious player names', async () => {
@@ -692,12 +762,6 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
           player: { id: 'p1', name: '__proto__', nickname: '__proto__', country: 'constructor' },
           seeding: 1,
           group: 'A',
-          mp: 1,
-          wins: 1,
-          ties: 0,
-          losses: 0,
-          winRounds: 4,
-          lossRounds: 1,
           points: 3,
           score: 1000,
         }],
@@ -717,34 +781,20 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
           totalTime: 12345,
         }],
         ttPhaseRounds: [],
-        playerScores: [{
-          player: { id: 'p1', name: '__proto__', nickname: '__proto__', country: 'constructor' },
-          taQualificationPoints: 1000,
-          bmQualificationPoints: 1000,
-          mrQualificationPoints: 0,
-          gpQualificationPoints: 0,
-          taFinalsPoints: 0,
-          bmFinalsPoints: 0,
-          mrFinalsPoints: 0,
-          gpFinalsPoints: 0,
-          totalPoints: 2000,
-          overallRank: 1,
-        }],
       };
 
       (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
-      });
+      mockRealTemplateAsset();
 
       try {
         const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
         const params = Promise.resolve({ id: 't1' });
         const result = await GET(request, { params });
-        const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
+        const workbook = cdmWorkbookFromResult(result);
 
         expect(result.headers['Content-Disposition']).toContain('__proto__-cdm-2024-01-15.xlsm');
+        // Nicknames are written as inline strings (never as object keys/formulas),
+        // so the malicious "__proto__" / "constructor" time keys cannot pollute.
         expect(workbook.Sheets["Main Hub"].B2.v).toBe('__proto__');
         expect(workbook.Sheets["Main Hub"].C2.v).toBe('__proto__');
         expect(({} as Record<string, unknown>)[pollutionKey]).toBeUndefined();
@@ -754,7 +804,12 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       }
     });
 
-    it('should write GP finals cupResults details into the CDM workbook', async () => {
+    it('should write GP finals scores from points1/points2 into the CDM workbook', async () => {
+      // Spec change (design §3.4): the CDM GP Finals score cell holds the FT
+      // progress points (points1/points2), NOT a cupResults summary string. The
+      // per-cup detail stays in the app; the workbook's formulas only need the
+      // match points. winners_final block = AM column; score offset +4 = AQ,
+      // rows 19/20.
       const mockTournament = {
         id: 't1',
         name: 'GP Finals CDM',
@@ -765,42 +820,54 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         gpQualifications: [],
         bmMatches: [],
         mrMatches: [],
-        gpMatches: [{
-          matchNumber: 1,
-          stage: 'playoff',
-          round: 'winners_final',
-          bracketPosition: 'WF',
-          player1: { id: 'p1', name: 'Player One', nickname: 'P1' },
-          player2: { id: 'p2', name: 'Player Two', nickname: 'P2' },
-          points1: 2,
-          points2: 1,
-          cup: 'Star',
-          cupResults: [
-            { cup: 'Mushroom', points1: 45, points2: 30, winner: 1 },
-            { cup: 'Flower', points1: 24, points2: 45, winner: 2 },
-            { cup: 'Star', points1: 48, points2: 21, winner: 1 },
-          ],
-          completed: true,
-        }],
+        gpMatches: [
+          // winners_qf present -> 8-player bracket (degraded mode), which is the
+          // path that writes the winners_final score cells from points1/points2.
+          ...Array.from({ length: 4 }, (_v, i) => ({
+            matchNumber: 13 + i,
+            stage: 'finals',
+            round: 'winners_qf',
+            player1: { id: `q${2 * i + 1}`, name: `Name ${2 * i + 1}`, nickname: `Q${2 * i + 1}` },
+            player2: { id: `q${2 * i + 2}`, name: `Name ${2 * i + 2}`, nickname: `Q${2 * i + 2}` },
+            points1: 9,
+            points2: 6,
+            completed: true,
+          })),
+          {
+            matchNumber: 28,
+            stage: 'finals',
+            round: 'winners_final',
+            bracketPosition: 'WF',
+            player1: { id: 'p1', name: 'Player One', nickname: 'P1' },
+            player2: { id: 'p2', name: 'Player Two', nickname: 'P2' },
+            points1: 2,
+            points2: 1,
+            cup: 'Star',
+            cupResults: [
+              { cup: 'Mushroom', points1: 45, points2: 30, winner: 1 },
+              { cup: 'Flower', points1: 24, points2: 45, winner: 2 },
+              { cup: 'Star', points1: 48, points2: 21, winner: 1 },
+            ],
+            completed: true,
+          },
+        ],
         ttEntries: [],
         ttPhaseRounds: [],
-        playerScores: [],
       };
 
       (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
-      });
+      mockRealTemplateAsset();
 
       const request = new MockNextRequest('http://localhost:3000/api/tournaments/t1/export?format=cdm');
       const params = Promise.resolve({ id: 't1' });
-      await GET(request, { params });
+      const result = await GET(request, { params });
 
-      const workbook = (XLSX.write as jest.Mock).mock.calls[0][0];
+      const workbook = cdmWorkbookFromResult(result);
+      // 8-player degraded bracket: winners_final[0] score cells AQ19/AQ20 are
+      // value-overwritten from the GP match points1/points2 (2-1) — no cupResults
+      // summary string is written anywhere (the per-cup detail stays in the app).
       expect(workbook.Sheets["GP Finals"].AQ19.v).toBe(2);
       expect(workbook.Sheets["GP Finals"].AQ20.v).toBe(1);
-      expect(workbook.Sheets["GP Finals"].AR19.v).toBe('Mushroom: 45-30; Flower: 24-45; Star: 48-21');
     });
 
     it('should export BM qualification data grouped by group', async () => {

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -659,41 +659,63 @@ describe('E2E case drift coverage', () => {
 
   it('documents TC-816A as CDM finals native bracket coordinate coverage', () => {
     const section = e2eCaseSection('TC-816A');
+    const cdmConstants = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'cdm-constants.ts');
+    const finalsFill = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'fill', 'finals.ts');
 
     expect(section).toContain('issue #816');
-    expect(section).toContain('CDM_FINALS_BRACKET_SLOTS');
+    expect(section).toContain('FINALS_BRACKET_SLOTS');
     expect(section).toContain('native bracket coordinates');
-    expect(exportRoute).toContain('const CDM_FINALS_BRACKET_SLOTS');
-    expect(exportRoute).toContain('playoff_r1');
-    expect(exportRoute).toContain('winners_r1');
-    expect(exportRoute).toContain('losers_final');
-    expect(exportRoute).toContain('cdmFinalsSlotRound');
-    expect(exportRoute).toContain('cdmFinalsSlotForMatch');
-    expect(exportRoute).toContain('cdmFinalsMatchLabel');
+    // The bracket geometry table moved to cdm-constants.ts; the fill map resolves
+    // each round through it. The route no longer carries the old slot helpers.
+    expect(cdmConstants).toContain('FINALS_BRACKET_SLOTS');
+    expect(cdmConstants).toContain('playoff_r1');
+    expect(cdmConstants).toContain('winners_r1');
+    expect(cdmConstants).toContain('losers_final');
+    expect(finalsFill).toContain('function normalizeRound');
+    expect(finalsFill).toContain('FINALS_BRACKET_SLOTS');
+    expect(exportRoute).not.toContain('cdmFinalsSlotRound');
+    expect(exportRoute).not.toContain('cdmFinalsSlotForMatch');
+    expect(exportRoute).not.toContain('cdmFinalsMatchLabel');
+    // The E2E script (tc-all.js) reads the exported workbook and keeps its own slot
+    // table synchronized with cdm-constants.ts. After the ZIP-surgery rewrite it
+    // verifies the structural parts the old exporter destroyed plus the input cells
+    // the new exporter writes at native coordinates (seed numbers, written names,
+    // completed-match scores, BM/MR seed list) — it no longer reads label/cup cells.
     expect(tcAll).toContain('TC-816A');
     expect(tcAll).toContain('CDM_FINALS_E2E_SLOTS');
     expect(tcAll).toContain('XLSX.read(Buffer.from(exportResp.bytes)');
-    expect(tcAll).toContain('cdmE2eGpCupResultsSummary');
-    expect(tcAll).toContain('gpCupResultsChecked');
+    expect(tcAll).toContain('cellFormula: true');
+    expect(tcAll).toContain('cdmE2eStructuralFailures');
+    expect(tcAll).toContain("require('fflate')");
+    expect(tcAll).toContain("xl/tables/table1.xml");
+    expect(tcAll).toContain('xl/richData/rdrichvalue.xml');
+    expect(tcAll).toContain('xl/calcChain.xml');
+    expect(tcAll).toContain('fullCalcOnLoad="1"');
+    expect(tcAll).toContain('cdmE2eIsWrittenValue');
+    expect(tcAll).toContain('cdmE2eSeedListSet');
     expect(tcAll).toContain('checkedByMode');
     expect(tcAll).toContain('ensureCdmE2eFinalsFixture');
     expect(tcAll).toContain("if (missingModes.has('BM')) generators.push({ mode: 'BM'");
     expect(tcAll).toContain("if (missingModes.has('MR')) generators.push({ mode: 'MR'");
     expect(tcAll).toContain('cdmE2eFinalsReadinessSummary');
-    expect(tcAll).toContain('slot.blockStart + 5');
+    // The old label/cup-summary reads are gone (route no longer writes them).
+    expect(tcAll).not.toContain('cdmE2eMatchLabel');
+    expect(tcAll).not.toContain('cdmE2eGpCupResultsSummary');
+    expect(tcAll).not.toContain('slot.blockStart + 5');
     expect(section).toContain('mode 別 match count と round 一覧');
     expect(section).toContain('__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts');
-    expect(exportRouteTest).toContain('should place CDM finals matches in native bracket coordinates');
-    expect(exportRouteTest).toContain('sheet.Y7.v');
-    expect(exportRouteTest).toContain('sheet.BA47.v');
-    expect(exportRouteTest).toContain('workbook.Sheets["MR Finals"].AT19.v');
-    expect(exportRouteTest).toContain('workbook.Sheets["GP Finals"].BA47.v');
-    expect(exportRouteTest).toContain('workbook.Sheets["GP Finals"].AR19.v');
+    // The unit test now decodes the real .xlsm and checks typed seed + score cells.
+    expect(exportRouteTest).toContain('should place CDM finals seeds and scores in native bracket coordinates');
+    expect(exportRouteTest).toContain("workbook.Sheets['BM Finals']");
+    expect(exportRouteTest).toContain('sheet.S5.v');
+    expect(exportRouteTest).toContain('sheet.V5.v');
+    expect(exportRouteTest).toContain("workbook.Sheets['GP Finals'].S5.v");
   });
 
   it('documents CDM export row-cap coverage for Main Hub and TT Qualifications', () => {
     const mainHubSection = e2eCaseSection('TC-2089A');
     const ttQualificationsSection = e2eCaseSection('TC-2180A');
+    const cdmConstants = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'cdm-constants.ts');
 
     expect(mainHubSection).toContain('issue #2089/#2092/#2093');
     expect(mainHubSection).toContain('B62〜L62');
@@ -703,14 +725,18 @@ describe('E2E case drift coverage', () => {
     expect(ttQualificationsSection).toContain('E62〜Z62');
     expect(ttQualificationsSection).toContain('E61/F61');
     expect(ttQualificationsSection).toContain('__tests__/app/api/tournaments/[id]/export/route.test.ts');
-    expect(exportRoute).toContain('const CDM_PLAYER_HUB_ROW_SPAN = 60');
-    expect(exportRoute).toContain('const CDM_TT_QUAL_MAX_PLAYERS = CDM_PLAYER_HUB_MAX_PLAYERS');
+    // The Main Hub caps at 60 rows; TT Qualifications caps at its own 47-row table.
+    expect(cdmConstants).toContain('MAIN_HUB_MAX_PLAYERS = 60');
+    expect(cdmConstants).toContain('TT_QUAL_MAX_PLAYERS = 47');
     expect(exportRouteTest).toContain('should cap Main Hub player rows at 60 when more players are provided');
     expect(exportRouteTest).toContain('should cap TT Qualifications rows at 60 when more entries are provided');
+    // Row-62 protection is now "the fixed table never addresses row 62", verified
+    // by decoding the real .xlsm and asserting the row-62 cells stay undefined.
     expect(exportRouteTest).toContain('KEEP-OUT-OF-BOUNDS');
     expect(exportRouteTest).not.toContain('KEEP-OUT-BOUNDS');
     expect(exportRouteTest).toContain('ttBoundaryColumns');
-    expect(exportRouteTest).toContain('KEEP-TT-${col}62');
+    expect(exportRouteTest).toContain('`${column}62`]).toBeUndefined()');
+    expect(exportRouteTest).toContain('`${col}62`]).toBeUndefined()');
   });
 
   it('documents TC-808A as TA TV3/TV4 broadcast warning coverage', () => {
@@ -737,42 +763,59 @@ describe('E2E case drift coverage', () => {
 
   it('documents TC-1877A as reachable grand-final reset alias coverage', () => {
     const section = e2eCaseSection('TC-1877A');
+    const finalsFill = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'fill', 'finals.ts');
 
     expect(section).toContain('issue #1877');
     expect(section).toContain('bracketPosition.includes("reset")');
-    expect(exportRoute).toContain('if (bracketPosition.includes("reset")) return "grand_final_reset"');
-    expect(exportRoute).not.toContain('round === "grand_final_reset" || bracketPosition.includes("reset")');
+    expect(section).toContain('normalizeRound');
+    // Round normalization moved into the finals fill map's normalizeRound.
+    expect(finalsFill).toContain('if (bracketPosition.includes("reset")) return "grand_final_reset"');
+    expect(finalsFill).not.toContain('round === "grand_final_reset" || bracketPosition.includes("reset")');
+    expect(exportRoute).not.toContain('function cdmFinalsSlotRound');
   });
 
-  it('documents TC-1878A as unknown-round fallback counter coverage', () => {
+  it('documents TC-1878A as unmappable-round skip coverage', () => {
     const section = e2eCaseSection('TC-1878A');
+    const finalsFill = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'fill', 'finals.ts');
 
     expect(section).toContain('issue #1878');
     expect(section).toContain('zz_custom_showmatch');
-    expect(exportRoute).toContain('isFallback: true');
-    expect(exportRoute).toContain('if (slot.isFallback) fallbackIndex++');
-    expect(exportRouteTest).toContain('should use the first fallback CDM finals slot only for unknown rounds');
+    expect(section).toContain('skip');
+    // No positional fallback: an unmapped round returns null and is skipped.
+    expect(finalsFill).toContain('return null; // unmapped: caller skips');
+    expect(exportRoute).not.toContain('isFallback: true');
+    expect(exportRouteTest).toContain('should skip an unknown CDM finals round instead of using a fallback slot');
     expect(exportRouteTest).toContain('zz_custom_showmatch');
-    expect(exportRouteTest).toContain('sheet.D5.v');
   });
 
   it('documents TC-1879A as E2E slot table synchronization coverage', () => {
     const section = e2eCaseSection('TC-1879A');
 
     expect(section).toContain('issue #1879');
-    expect(section).toContain('CDM_FINALS_BRACKET_SLOTS');
-    expect(tcAll).toContain('Keep this expectation map synchronized with route.ts CDM_FINALS_BRACKET_SLOTS');
+    expect(section).toContain('FINALS_BRACKET_SLOTS');
+    // The production slot table moved to cdm-constants.ts (the old route.ts
+    // CDM_FINALS_BRACKET_SLOTS was deleted in the rewrite); the E2E sync comment
+    // now points there.
+    expect(tcAll).toContain('Keep this expectation map synchronized with src/lib/cdm-export/cdm-constants.ts');
+    expect(tcAll).toContain('FINALS_BRACKET_SLOTS');
+    expect(tcAll).not.toContain('route.ts CDM_FINALS_BRACKET_SLOTS');
     expect(tcAll).toContain('XLSX.read(Buffer.from(exportResp.bytes)');
   });
 
-  it('documents TC-1880A as optional GP cupResults E2E coverage', () => {
+  it('documents TC-1880A as score-cell completion-gated E2E coverage', () => {
     const section = e2eCaseSection('TC-1880A');
 
     expect(section).toContain('issue #1880');
-    expect(section).toContain('gpCupResultsChecked');
-    expect(tcAll).toContain('GP cupResults not available; skipped summary-cell check');
-    expect(tcAll).toContain('checked > 0 && missingModes.length === 0 && failures.length === 0');
-    expect(tcAll).not.toContain('missingModes.length === 0 && gpCupResultsChecked && failures.length === 0');
+    // The GP cup-summary cell no longer exists in the rewritten exporter, so the
+    // old gpCupResultsChecked gate is gone. Its surviving intent — a freshly
+    // generated bracket with no completed match must not false-fail — now lives in
+    // the completion-gated score check plus the always-written seed-number / seed-
+    // list anchors that keep every mode at >=1 check.
+    expect(section).toContain('completed');
+    expect(tcAll).not.toContain('gpCupResultsChecked');
+    expect(tcAll).not.toContain('GP cupResults not available; skipped summary-cell check');
+    expect(tcAll).toContain('if (match.completed)');
+    expect(tcAll).toContain('structuralFailures.length === 0 && checked > 0 && missingModes.length === 0 && failures.length === 0');
   });
 
   it('documents CDM E2E finals readiness parallel fetch and generator diagnostics', () => {
@@ -821,77 +864,99 @@ describe('E2E case drift coverage', () => {
     expect(exportRouteTest).toContain('should export tournament data with summary section');
     expect(exportRouteTest).toContain('should export a populated CDM macro workbook when requested');
     expect(exportRouteTest).toContain('ttPhaseRounds: true');
-    expect(exportRouteTest).toContain('playerScores: { include: { player: { select: PLAYER_PUBLIC_SELECT } } }');
+    // The CDM include carries MR/GP qualification seeds and TT phase rounds, but
+    // NOT playerScores: the Overall Ranking sheet is formula-driven and the
+    // rewritten exporter never writes it (design §3.6).
+    expect(exportRoute).not.toContain('playerScores: { include:');
+    expect(exportRouteTest).not.toContain('playerScores: { include: { player: { select: PLAYER_PUBLIC_SELECT } } }');
   });
 
-  it('documents TC-818A as direct CDM time parser usage coverage', () => {
+  it('documents TC-818A as cdm-export module time-conversion coverage', () => {
     const section = e2eCaseSection('TC-818A');
+    const timeFormat = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'time-format.ts');
+    const ttQualFill = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'fill', 'tt-qualifications.ts');
 
     expect(section).toContain('issue #818');
     expect(section).toContain('timeValueForCDM');
-    expect(section).toContain('parseTimeMs(times[course])');
+    expect(section).toContain('timeStringToCdmTime');
+    // The route no longer owns any time conversion; it delegates to the module.
     expect(exportRoute).not.toContain('function timeValueForCDM');
-    expect(exportRoute).toContain('parseTimeMs(times[course])');
+    expect(exportRoute).not.toContain('function parseTimeMs');
+    expect(timeFormat).toContain('export function timeStringToCdmTime');
+    expect(ttQualFill).toContain('timeStringToCdmTime(times[course])');
   });
 
   it('documents TC-819A as CDM template coordinate comment coverage', () => {
     const section = e2eCaseSection('TC-819A');
+    const cdmConstants = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'cdm-constants.ts');
+    const mainHubFill = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'fill', 'main-hub.ts');
 
     expect(section).toContain('issue #819');
-    expect(section).toContain('CDM 2025 workbook template coordinates');
-    expect(section).toContain('CDM_TT_ROUND_START_COLUMNS');
-    expect(exportRoute).toContain('CDM 2025 workbook template coordinates');
-    expect(exportRoute).toContain('CDM_PLAYER_HUB_MAX_PLAYERS');
-    expect(exportRoute).toContain('CDM_QUALIFICATION_MAX_ROWS');
-    expect(exportRoute).toContain('CDM_FINALS_BLOCK_START_COLUMNS');
-    expect(exportRoute).toContain('CDM_TT_ROUND_START_COLUMNS');
-    expect(exportRoute).toContain('CDM_OVERALL_MAX_ROWS');
+    expect(section).toContain('cdm-constants.ts');
+    expect(section).toContain('TT_FINALS_*');
+    // The template coordinates moved to cdm-constants.ts with verification comments.
+    expect(cdmConstants).toContain('template coordinates');
+    expect(cdmConstants).toContain('verified against a full cell dump');
+    expect(cdmConstants).toContain('MAIN_HUB_MAX_PLAYERS');
+    expect(cdmConstants).toContain('TT_QUAL_MAX_PLAYERS');
+    expect(cdmConstants).toContain('QUAL_BLOCK_MAX_BLOCKS');
+    expect(cdmConstants).toContain('FINALS_BRACKET_SLOTS');
+    expect(cdmConstants).toContain('TT_FINALS_MAX_ROUNDS');
+    // A fill module actually consumes the named constants.
+    expect(mainHubFill).toContain('MAIN_HUB_MAX_PLAYERS');
+    // The route no longer carries any CDM coordinate constants.
+    expect(exportRoute).not.toContain('CDM_TT_ROUND_START_COLUMNS');
+    expect(exportRoute).not.toContain('CDM_PLAYER_HUB_MAX_PLAYERS');
   });
 
   it('documents TC-1871A as TT Qualifications sheet-specific range names', () => {
     const section = e2eCaseSection('TC-1871A');
+    const cdmConstants = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'cdm-constants.ts');
+    const ttQualFill = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'fill', 'tt-qualifications.ts');
 
     expect(section).toContain('issue #1871');
-    expect(section).toContain('CDM_TT_QUAL_FIRST_ROW');
-    expect(section).toContain('CDM_TT_QUAL_MAX_PLAYERS');
-    expect(section).toContain('Main Hub と同じ行レイアウト');
-    expect(exportRoute).toContain('const CDM_TT_QUAL_FIRST_ROW = CDM_PLAYER_HUB_FIRST_ROW');
-    expect(exportRoute).toContain('const CDM_TT_QUAL_MAX_PLAYERS = CDM_PLAYER_HUB_MAX_PLAYERS');
-    expect(exportRoute).toContain('TT Qualifications uses the same rows as Main Hub');
-    expect(exportRoute).toContain('CDM_TT_QUAL_FIRST_ROW + CDM_TT_QUAL_MAX_PLAYERS');
-    expect(exportRoute).toContain('qualificationEntries.slice(0, CDM_TT_QUAL_MAX_PLAYERS)');
+    expect(section).toContain('TT_QUAL_FIRST_ROW');
+    expect(section).toContain('TT_QUAL_MAX_PLAYERS');
+    expect(cdmConstants).toContain('TT_QUAL_FIRST_ROW');
+    expect(cdmConstants).toContain('TT_QUAL_MAX_PLAYERS');
+    expect(cdmConstants).toContain('TT_QUAL_FIRST_TIME_COLUMN');
+    // The fill module clears/slices using the TT-specific constants.
+    expect(ttQualFill).toContain('TT_QUAL_FIRST_ROW + TT_QUAL_MAX_PLAYERS');
+    expect(ttQualFill).toContain('.slice(0, TT_QUAL_MAX_PLAYERS)');
   });
 
   it('documents TC-1872A as finals and TT round coordinate constants', () => {
     const section = e2eCaseSection('TC-1872A');
+    const cdmConstants = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'cdm-constants.ts');
+    const finalsFill = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'fill', 'finals.ts');
+    const ttFinalsFill = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'fill', 'tt-finals.ts');
 
     expect(section).toContain('issue #1872');
-    expect(section).toContain('CDM_FINALS_*');
-    expect(section).toContain('CDM_TT_ROUND_*');
-    expect(exportRoute).toContain('CDM_FINALS_BLOCK_END_OFFSET');
-    expect(exportRoute).toContain('CDM_FINALS_LAST_COLUMN');
-    expect(exportRoute).toContain('CDM_FINALS_MATCH_FIRST_ROW');
-    expect(exportRoute).toContain('CDM_TT_ROUND_BLOCK_END_OFFSET');
-    expect(exportRoute).toContain('CDM_TT_ROUND_LAST_COLUMN');
-    expect(exportRoute).toContain('CDM_TT_ROUND_FIRST_ROW');
-    expect(exportRoute).toContain('CDM_TT_ROUND_LAST_ROW');
-    expect(exportRoute).toContain('Math.min(start + CDM_FINALS_BLOCK_END_OFFSET, CDM_FINALS_LAST_COLUMN)');
-    expect(exportRoute).toContain('Math.min(start + CDM_TT_ROUND_BLOCK_END_OFFSET, CDM_TT_ROUND_LAST_COLUMN)');
+    expect(section).toContain('FINALS_*');
+    expect(section).toContain('TT_FINALS_*');
+    expect(cdmConstants).toContain('FINALS_SEED_LIST_COLUMN');
+    expect(cdmConstants).toContain('FINALS_BLOCK_SEED_OFFSET');
+    expect(cdmConstants).toContain('FINALS_BLOCK_SCORE_OFFSET');
+    expect(cdmConstants).toContain('TT_FINALS_ROUND_STRIDE');
+    expect(cdmConstants).toContain('TT_FINALS_INPUT_FIRST_COLUMN');
+    expect(cdmConstants).toContain('TT_FINALS_DISPLAY_FIRST_COLUMN');
+    expect(finalsFill).toContain('FINALS_BLOCK_SCORE_OFFSET');
+    expect(ttFinalsFill).toContain('TT_FINALS_ROUND_STRIDE');
   });
 
-  it('documents TC-1874A as inclusive clearRange end-offset naming', () => {
+  it('documents TC-1874A as patcher formula-cell protection coverage', () => {
     const section = e2eCaseSection('TC-1874A');
+    const patcher = readRepoFile('smkc-score-app', 'src', 'lib', 'cdm-export', 'sheet-xml-patcher.ts');
 
     expect(section).toContain('issue #1874');
-    expect(section).toContain('end column は inclusive');
-    expect(section).toContain('*_BLOCK_END_OFFSET');
-    expect(exportRoute).toContain('The end column and row are inclusive');
-    expect(exportRoute).toContain('const CDM_FINALS_BLOCK_END_OFFSET = 6');
-    expect(exportRoute).toContain('const CDM_TT_ROUND_BLOCK_END_OFFSET = 5');
-    expect(exportRoute).toContain('Math.min(start + CDM_FINALS_BLOCK_END_OFFSET, CDM_FINALS_LAST_COLUMN)');
-    expect(exportRoute).toContain('Math.min(start + CDM_TT_ROUND_BLOCK_END_OFFSET, CDM_TT_ROUND_LAST_COLUMN)');
+    expect(section).toContain('#SPILL!');
+    expect(section).toContain('sheet-xml-patcher.ts');
+    // The patcher refuses to write a value over a formula cell (no more #SPILL!).
+    expect(patcher).toContain('refusing to write a value over the formula cell');
+    // The old width-named coordinate constants are gone from the route.
     expect(exportRoute).not.toContain('CDM_FINALS_BLOCK_WIDTH');
     expect(exportRoute).not.toContain('CDM_TT_ROUND_BLOCK_WIDTH');
+    expect(exportRoute).not.toContain('CDM_FINALS_BLOCK_END_OFFSET');
   });
 
   it('keeps TC-2088 aligned with AST-backed Main Hub boundary coverage', () => {

--- a/smkc-score-app/__tests__/lib/cdm-export/fill/finals-slot-semantics.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/fill/finals-slot-semantics.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for the CDM finals slot-semantics table.
+ *
+ * The table is the machine-readable form of design doc §3.4.1 and of the
+ * advancement formulas dumped from the template
+ * (/tmp/cdm-analysis/sheet2025/sheet_BM_Finals.txt). Each round/slot is one
+ * of:
+ *   - { kind: "seed" }                 — the template holds a *typed value*
+ *     cell here (a B-position number), e.g. S5=1 in winners_r1[0] slot1.
+ *   - { kind: "winnerOf"|"loserOf", round, index } — the template holds an
+ *     advancement *formula* here, e.g. T6 = INDEX(SORTBY(...)) "Winner of B2,1"
+ *     which is the winner of playoff_r2[0].
+ *
+ * These tests pin the table to the exact formulas in the dump so a future
+ * edit cannot silently desync the fill map from the template.
+ */
+
+import {
+  FINALS_SLOT_SEMANTICS,
+  getSlotSemantics,
+  type FinalsSlotRef,
+} from "@/lib/cdm-export/fill/finals-slot-semantics";
+
+describe("FINALS_SLOT_SEMANTICS", () => {
+  it("marks both playoff_r1 slots as typed seeds (template E5/E6 are values)", () => {
+    expect(getSlotSemantics("playoff_r1", 0, 0)).toEqual({ kind: "seed" });
+    expect(getSlotSemantics("playoff_r1", 0, 1)).toEqual({ kind: "seed" });
+  });
+
+  it("playoff_r2 slot1 is the bye seed (typed), slot2 is winnerOf playoff_r1[k]", () => {
+    // Template M6 = IF(COUNTA(H5:H6)<2,"Winner of B1,1", ...) → winner of barrage1 match 1.
+    expect(getSlotSemantics("playoff_r2", 0, 0)).toEqual({ kind: "seed" });
+    expect(getSlotSemantics("playoff_r2", 0, 1)).toEqual({
+      kind: "winnerOf",
+      round: "playoff_r1",
+      index: 0,
+    });
+    expect(getSlotSemantics("playoff_r2", 2, 1)).toEqual({
+      kind: "winnerOf",
+      round: "playoff_r1",
+      index: 2,
+    });
+  });
+
+  it("even winners_r1 slot2 is winnerOf playoff_r2[k]; odd is fully typed", () => {
+    // Template T6 = "Winner of B2,1" → winner of barrage2 (playoff_r2) match 1.
+    expect(getSlotSemantics("winners_r1", 0, 0)).toEqual({ kind: "seed" });
+    expect(getSlotSemantics("winners_r1", 0, 1)).toEqual({
+      kind: "winnerOf",
+      round: "playoff_r2",
+      index: 0,
+    });
+    expect(getSlotSemantics("winners_r1", 2, 1)).toEqual({
+      kind: "winnerOf",
+      round: "playoff_r2",
+      index: 1,
+    });
+    // Odd index (idx1) both typed: S9=8, S10=9.
+    expect(getSlotSemantics("winners_r1", 1, 0)).toEqual({ kind: "seed" });
+    expect(getSlotSemantics("winners_r1", 1, 1)).toEqual({ kind: "seed" });
+  });
+
+  it("winners_qf slots reference the two feeding winners_r1 matches", () => {
+    // Template AA7 = "Winner of 1" (winners_r1 match 1) and AA8 = "Winner of 2".
+    expect(getSlotSemantics("winners_qf", 0, 0)).toEqual({
+      kind: "winnerOf",
+      round: "winners_r1",
+      index: 0,
+    });
+    expect(getSlotSemantics("winners_qf", 0, 1)).toEqual({
+      kind: "winnerOf",
+      round: "winners_r1",
+      index: 1,
+    });
+    expect(getSlotSemantics("winners_qf", 3, 1)).toEqual({
+      kind: "winnerOf",
+      round: "winners_r1",
+      index: 7,
+    });
+  });
+
+  it("winners_sf and winners_final chain the winners path", () => {
+    expect(getSlotSemantics("winners_sf", 0, 0)).toEqual({
+      kind: "winnerOf",
+      round: "winners_qf",
+      index: 0,
+    });
+    expect(getSlotSemantics("winners_sf", 0, 1)).toEqual({
+      kind: "winnerOf",
+      round: "winners_qf",
+      index: 1,
+    });
+    expect(getSlotSemantics("winners_final", 0, 0)).toEqual({
+      kind: "winnerOf",
+      round: "winners_sf",
+      index: 0,
+    });
+    expect(getSlotSemantics("winners_final", 0, 1)).toEqual({
+      kind: "winnerOf",
+      round: "winners_sf",
+      index: 1,
+    });
+  });
+
+  it("losers_r1 slots are the losers of the two feeding winners_r1 matches", () => {
+    // Template T41 = "Loser of 1", T42 = "Loser of 2".
+    expect(getSlotSemantics("losers_r1", 0, 0)).toEqual({
+      kind: "loserOf",
+      round: "winners_r1",
+      index: 0,
+    });
+    expect(getSlotSemantics("losers_r1", 0, 1)).toEqual({
+      kind: "loserOf",
+      round: "winners_r1",
+      index: 1,
+    });
+  });
+
+  it("losers_r2 slot1 is loserOf winners_qf[3-k] (reverse), slot2 winnerOf losers_r1[k]", () => {
+    // Template AA41 = "Loser of 16" (winners_qf match 16 = qf index 3) for losers_r2[0].
+    // AA45 = "Loser of 15" (qf index 2) for losers_r2[1], etc.
+    expect(getSlotSemantics("losers_r2", 0, 0)).toEqual({
+      kind: "loserOf",
+      round: "winners_qf",
+      index: 3,
+    });
+    expect(getSlotSemantics("losers_r2", 1, 0)).toEqual({
+      kind: "loserOf",
+      round: "winners_qf",
+      index: 2,
+    });
+    expect(getSlotSemantics("losers_r2", 0, 1)).toEqual({
+      kind: "winnerOf",
+      round: "losers_r1",
+      index: 0,
+    });
+  });
+
+  it("losers_final reverses app p1/p2: slot1 loserOf winners_final, slot2 winnerOf losers_sf", () => {
+    // Template BC47 = "Loser of 28"? No — the BM dump shows BC47 = "Loser of 28"
+    // is losers_sf area; losers_final block (BA col, row 47) BC47 references
+    // the winners_final loser and BC48 the losers_sf winner.
+    expect(getSlotSemantics("losers_final", 0, 0)).toEqual({
+      kind: "loserOf",
+      round: "winners_final",
+      index: 0,
+    });
+    expect(getSlotSemantics("losers_final", 0, 1)).toEqual({
+      kind: "winnerOf",
+      round: "losers_sf",
+      index: 0,
+    });
+  });
+
+  it("grand_final and reset chain the two champions", () => {
+    expect(getSlotSemantics("grand_final", 0, 0)).toEqual({
+      kind: "winnerOf",
+      round: "winners_final",
+      index: 0,
+    });
+    expect(getSlotSemantics("grand_final", 0, 1)).toEqual({
+      kind: "winnerOf",
+      round: "losers_final",
+      index: 0,
+    });
+    expect(getSlotSemantics("grand_final_reset", 0, 0)).toEqual({
+      kind: "winnerOf",
+      round: "grand_final",
+      index: 0,
+    });
+    expect(getSlotSemantics("grand_final_reset", 0, 1)).toEqual({
+      kind: "loserOf",
+      round: "grand_final",
+      index: 0,
+    });
+  });
+
+  it("getSlotSemantics returns null for unknown round or out-of-range index", () => {
+    expect(getSlotSemantics("not_a_round", 0, 0)).toBeNull();
+    expect(getSlotSemantics("winners_final", 9, 0)).toBeNull();
+  });
+
+  it("every referenced round exists in the table (no dangling refs)", () => {
+    const refs: FinalsSlotRef[] = [];
+    for (const slots of Object.values(FINALS_SLOT_SEMANTICS)) {
+      for (const matchSlots of slots) {
+        for (const slot of matchSlots) {
+          if (slot.kind !== "seed") refs.push(slot);
+        }
+      }
+    }
+    for (const ref of refs) {
+      expect(FINALS_SLOT_SEMANTICS[ref.round]).toBeDefined();
+      expect(FINALS_SLOT_SEMANTICS[ref.round].length).toBeGreaterThan(ref.index);
+    }
+  });
+});

--- a/smkc-score-app/__tests__/lib/cdm-export/fill/finals.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/fill/finals.test.ts
@@ -1,0 +1,644 @@
+/**
+ * Tests for the BM/MR/GP Finals fill map (buildFinalsWrites).
+ *
+ * The Finals sheet is a formula-driven 24-player double-elimination bracket. The
+ * fill map reconstructs each slot's B-position from the app match records (no DB
+ * seed column) using the canonical structures in double-elimination.ts, writes
+ * only the typed seed cells + score cells in faithful mode, and value-overwrites
+ * the degraded 16-/8-player brackets the template formulas cannot represent.
+ *
+ * Ground truth for cell coordinates is the verified template dump
+ * /tmp/cdm-analysis/sheet2025/sheet_BM_Finals.txt; the B-position map below was
+ * hand-derived from generateBracketStructure(16)/generatePlayoffStructure(12)
+ * and cross-checked against that dump (e.g. S5=B-pos1, S9=B-pos8, S10=B-pos9).
+ */
+
+import { buildFinalsWrites } from "@/lib/cdm-export/fill/finals";
+import type {
+  CdmMatch,
+  CdmModeQualification,
+  CdmPlayer,
+  CdmTournamentData,
+  CdmVersusMode,
+} from "@/lib/cdm-export/types";
+import { createLogger } from "@/lib/logger";
+import {
+  indexWrites,
+  expectString,
+  expectNumber,
+  expectClear,
+  expectUntouched,
+} from "./write-helpers";
+
+jest.mock("@/lib/logger", () => {
+  const warn = jest.fn();
+  return {
+    createLogger: () => ({ warn, info: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+  };
+});
+const warnMock = (createLogger("x") as unknown as { warn: jest.Mock }).warn;
+
+beforeEach(() => warnMock.mockClear());
+
+/* ----------------------------------------------------------------- *
+ * Fixture helpers — players are named "B{n}" for the B-position n they hold,
+ * so assertions read directly (e.g. seed list B5 should hold nickname "B1").
+ * ----------------------------------------------------------------- */
+
+function bp(n: number): CdmPlayer {
+  return { id: `bp${n}`, name: `Name ${n}`, nickname: `B${n}` };
+}
+
+function emptyData(over: Partial<CdmTournamentData> = {}): CdmTournamentData {
+  return {
+    name: "T",
+    date: new Date("2025-01-01"),
+    bmQualifications: [],
+    mrQualifications: [],
+    gpQualifications: [],
+    bmMatches: [],
+    mrMatches: [],
+    gpMatches: [],
+    ttEntries: [],
+    ttPhaseRounds: [],
+    ...over,
+  };
+}
+
+interface MatchSpec {
+  matchNumber: number;
+  stage: string;
+  round: string;
+  p1: number; // B-position of player1
+  p2: number; // B-position of player2
+  s1?: number; // score1 (BM/MR) — omit for incomplete
+  s2?: number;
+  bracketPosition?: string;
+}
+
+function mk(spec: MatchSpec, mode: CdmVersusMode = "bm"): CdmMatch {
+  const completed = spec.s1 != null && spec.s2 != null;
+  const base: CdmMatch = {
+    matchNumber: spec.matchNumber,
+    stage: spec.stage,
+    round: spec.round,
+    bracketPosition: spec.bracketPosition,
+    player1: bp(spec.p1),
+    player2: bp(spec.p2),
+    completed,
+  };
+  if (completed) {
+    if (mode === "gp") {
+      base.points1 = spec.s1;
+      base.points2 = spec.s2;
+    } else {
+      base.score1 = spec.s1;
+      base.score2 = spec.s2;
+    }
+  }
+  return base;
+}
+
+/**
+ * Build a full 24-player faithful bracket's winners_r1 + playoff matches with the
+ * B-positions wired exactly as the structures dictate. The four playoff winners
+ * are the BYE seeds (B13/B16/B15/B14), which advance into winners_r1 slot2 of the
+ * even matches (upper seeds 16/12/14/10 -> winners_r1 idx 0/2/4/6).
+ */
+function build24WinnersAndPlayoff(mode: CdmVersusMode = "bm"): CdmMatch[] {
+  // winners_r1: [p1 Bpos, p2 Bpos]. slot1 always direct; even-match slot2 is the
+  // advanced playoff winner, odd-match slot2 is a direct qualifier.
+  const wr1: Array<[number, number]> = [
+    [1, 13], // idx0: B1 vs playoff winner B13
+    [8, 9], // idx1
+    [5, 16], // idx2: B5 vs playoff winner B16
+    [4, 11], // idx3
+    [3, 15], // idx4: B3 vs playoff winner B15
+    [6, 10], // idx5
+    [7, 14], // idx6: B7 vs playoff winner B14
+    [2, 12], // idx7
+  ];
+  const winnersR1 = wr1.map(([p1, p2], i) =>
+    mk({ matchNumber: i + 1, stage: "finals", round: "winners_r1", p1, p2, s1: 4, s2: 1 }, mode),
+  );
+
+  // playoff_r1 (matches 1-4): structural pairs map to B-positions.
+  const pr1: Array<[number, number]> = [
+    [23, 22], // pSeed 11 vs 10
+    [19, 18], // 7 vs 6
+    [17, 20], // 5 vs 8
+    [21, 24], // 9 vs 12
+  ];
+  const playoffR1 = pr1.map(([p1, p2], i) =>
+    mk({ matchNumber: i + 1, stage: "playoff", round: "playoff_r1", p1, p2, s1: 4, s2: 0 }, mode),
+  );
+
+  // playoff_r2 (matches 5-8): BYE seed (B13/16/15/14) beats the r1 winner and
+  // advances. p2 = the r1 winner (the slot0 player of each r1 match).
+  const pr2: Array<[number, number]> = [
+    [13, 23], // bye seed1 B13 vs r1[0] winner B23
+    [16, 19], // bye seed4 B16 vs r1[1] winner B19
+    [15, 17], // bye seed3 B15 vs r1[2] winner B17
+    [14, 21], // bye seed2 B14 vs r1[3] winner B21
+  ];
+  const playoffR2 = pr2.map(([p1, p2], i) =>
+    mk({ matchNumber: i + 5, stage: "playoff", round: "playoff_r2", p1, p2, s1: 4, s2: 1 }, mode),
+  );
+
+  return [...playoffR1, ...playoffR2, ...winnersR1];
+}
+
+const SHEET_BY_MODE: Record<CdmVersusMode, "BM Finals" | "MR Finals" | "GP Finals"> = {
+  bm: "BM Finals",
+  mr: "MR Finals",
+  gp: "GP Finals",
+};
+
+/* ----------------------------------------------------------------- *
+ * Faithful 24-player bracket.
+ * ----------------------------------------------------------------- */
+
+describe("buildFinalsWrites — faithful 24-player bracket", () => {
+  const data = emptyData({ bmMatches: build24WinnersAndPlayoff() });
+  const map = indexWrites(buildFinalsWrites(data, "bm"), "BM Finals");
+
+  it("writes the seed list B3:B26 with the nickname at each B-position", () => {
+    // B-position p -> row p+2; player bp(p) has nickname "B{p}".
+    expectString(map, "B3", "B1"); // B-pos 1
+    expectString(map, "B10", "B8"); // B-pos 8
+    expectString(map, "B11", "B9"); // B-pos 9
+    expectString(map, "B15", "B13"); // B-pos 13 (first playoff entrant)
+    expectString(map, "B26", "B24"); // B-pos 24 (last)
+  });
+
+  it("writes typed winners_r1 seed cells as B-positions and never the formula slot2 of even matches", () => {
+    // winners_r1[0] slot0 typed (S5 = B-pos 1); slot1 is a "Winner of B2,1"
+    // formula (S6) and must stay untouched.
+    expectNumber(map, "S5", 1);
+    expectUntouched(map, "S6");
+    // winners_r1[1] both typed: S9 = B-pos 8, S10 = B-pos 9.
+    expectNumber(map, "S9", 8);
+    expectNumber(map, "S10", 9);
+    // winners_r1[3] both typed: S17 = B-pos 4, S18 = B-pos 11.
+    expectNumber(map, "S17", 4);
+    expectNumber(map, "S18", 11);
+  });
+
+  it("writes typed playoff seed cells (E both slots, L slot1 only)", () => {
+    // playoff_r1[0]: E5 = B23, E6 = B22 (both typed).
+    expectNumber(map, "E5", 23);
+    expectNumber(map, "E6", 22);
+    // playoff_r2[0]: L5 = B13 (BYE seed typed); M6 is a "Winner of B1,1" formula.
+    expectNumber(map, "L5", 13);
+    expectUntouched(map, "L6");
+  });
+
+  it("never writes a name/advancement formula cell (faithful path)", () => {
+    for (const ref of ["F5", "T5", "T6", "M6", "AA7", "AV19", "BC47"]) {
+      expectUntouched(map, ref);
+    }
+  });
+
+  it("writes scores by identity resolution into the slot the template expects", () => {
+    // winners_r1[1] both typed: bp8 (slot0, score 4) -> V9, bp9 (slot1, score 1) -> V10.
+    expectNumber(map, "V9", 4);
+    expectNumber(map, "V10", 1);
+    // winners_r1[0]: slot0=bp1(score4)->V5; slot1 expects winner of playoff_r2[0]
+    // = bp13 (BYE seed won) which is this match's player2 (score1) -> V6.
+    expectNumber(map, "V5", 4);
+    expectNumber(map, "V6", 1);
+  });
+
+  it("writes playoff match scores by identity resolution", () => {
+    // playoff_r1[0]: bp23 (slot0, score 4) -> H5, bp22 (slot1, score 0) -> H6.
+    expectNumber(map, "H5", 4);
+    expectNumber(map, "H6", 0);
+    // playoff_r2[0]: bye seed bp13 (slot0, score 4) -> O5; slot1 expects the
+    // winner of playoff_r1[0] = bp23 (this match's player2, score 1) -> O6.
+    expectNumber(map, "O5", 4);
+    expectNumber(map, "O6", 1);
+  });
+
+  it("does not emit duplicate ops for any cell (clear-then-write collapsed)", () => {
+    // indexWrites throws on a duplicate ref; reaching here means it held.
+    expect(map.size).toBeGreaterThan(0);
+  });
+});
+
+describe("buildFinalsWrites — losers_final slot reversal (faithful)", () => {
+  it("writes the WF loser's score to slot1 and the LSF winner's score to slot2", () => {
+    // App losers_final: player1 = Losers-SF winner, player2 = Winners-Final loser.
+    // Template slot1 (BE47) = loserOf winners_final; slot2 (BE48) = winnerOf losers_sf.
+    // Stack the feeders onto a real 24 bracket so the faithful path is selected.
+    const matches: CdmMatch[] = [
+      ...build24WinnersAndPlayoff(),
+      // winners_final[0]: bp101 beats bp102 -> WF loser = bp102.
+      mk({ matchNumber: 28, stage: "finals", round: "winners_final", p1: 101, p2: 102, s1: 4, s2: 2 }),
+      // losers_sf[0]: bp201 beats bp202 -> LSF winner = bp201.
+      mk({ matchNumber: 27, stage: "finals", round: "losers_sf", p1: 201, p2: 202, s1: 4, s2: 0 }),
+      // losers_final[0]: app p1 = LSF winner (bp201), app p2 = WF loser (bp102).
+      mk({ matchNumber: 29, stage: "finals", round: "losers_final", p1: 201, p2: 102, s1: 1, s2: 4 }),
+    ];
+    const map = indexWrites(buildFinalsWrites(emptyData({ bmMatches: matches }), "bm"), "BM Finals");
+    // bp102 (WF loser, app player2, score 4) -> template slot1 score cell BE47.
+    expectNumber(map, "BE47", 4);
+    // bp201 (LSF winner, app player1, score 1) -> template slot2 score cell BE48.
+    expectNumber(map, "BE48", 1);
+  });
+});
+
+/* ----------------------------------------------------------------- *
+ * Identity-resolution fallback.
+ * ----------------------------------------------------------------- */
+
+describe("buildFinalsWrites — identity fallback", () => {
+  it("falls back to positional score mapping and warns when the record disagrees", () => {
+    // Real 24 bracket (winners of winners_r1[0]/[1] resolve to bp1/bp8), plus a
+    // winners_qf[0] whose recorded players (bp97/bp98) match NEITHER expected
+    // winner -> resolution disagrees -> positional fallback + warn.
+    const matches: CdmMatch[] = [
+      ...build24WinnersAndPlayoff(),
+      mk({ matchNumber: 13, stage: "finals", round: "winners_qf", p1: 97, p2: 98, s1: 4, s2: 3 }),
+    ];
+    const map = indexWrites(buildFinalsWrites(emptyData({ bmMatches: matches }), "bm"), "BM Finals");
+    // Positional: player1 score (4) -> slot1 (AC7), player2 score (3) -> slot2 (AC8).
+    expectNumber(map, "AC7", 4);
+    expectNumber(map, "AC8", 3);
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining("positional fallback"),
+      expect.objectContaining({ round: "winners_qf" }),
+    );
+  });
+});
+
+/* ----------------------------------------------------------------- *
+ * Incomplete matches + Grand Final reset absence.
+ * ----------------------------------------------------------------- */
+
+describe("buildFinalsWrites — incomplete matches and GF reset", () => {
+  it("clears the score cells of an incomplete match", () => {
+    const matches = build24WinnersAndPlayoff();
+    // Make winners_r1[1] incomplete (drop its scores).
+    const incomplete = matches.map((m) =>
+      m.round === "winners_r1" && m.matchNumber === 2
+        ? { ...m, completed: false, score1: undefined, score2: undefined }
+        : m,
+    );
+    const map = indexWrites(buildFinalsWrites(emptyData({ bmMatches: incomplete }), "bm"), "BM Finals");
+    expectClear(map, "V9"); // winners_r1[1] slot0 score cleared
+    expectClear(map, "V10"); // slot1 score cleared
+  });
+
+  it("clears the GF2 (reset) score cells when no reset match exists", () => {
+    const map = indexWrites(
+      buildFinalsWrites(emptyData({ bmMatches: build24WinnersAndPlayoff() }), "bm"),
+      "BM Finals",
+    );
+    // grand_final_reset score cells BE19 / BE20 — no reset match -> cleared.
+    expectClear(map, "BE19");
+    expectClear(map, "BE20");
+  });
+
+  it("maps a grand_final_reset match flagged only via bracketPosition='reset'", () => {
+    // round is NOT a known bracket round (empty) so the bracketPosition="reset"
+    // alias is what routes this match to the GF2 (reset) block — mirrors the
+    // export route's cdmFinalsSlotRound precedence.
+    const matches: CdmMatch[] = [
+      ...build24WinnersAndPlayoff(),
+      mk({
+        matchNumber: 31,
+        stage: "finals",
+        round: "",
+        bracketPosition: "reset",
+        p1: 1,
+        p2: 2,
+        s1: 4,
+        s2: 3,
+      }),
+    ];
+    const map = indexWrites(buildFinalsWrites(emptyData({ bmMatches: matches }), "bm"), "BM Finals");
+    // The reset match scores land in GF2 cells (positional fallback: no feeders).
+    expectNumber(map, "BE19", 4);
+    expectNumber(map, "BE20", 3);
+  });
+});
+
+/* ----------------------------------------------------------------- *
+ * 24-player, playoff-only partial state.
+ * ----------------------------------------------------------------- */
+
+describe("buildFinalsWrites — 24-player playoff-only partial", () => {
+  function qual(p: CdmPlayer, seeding: number, score = 0): CdmModeQualification {
+    return { player: p, group: "A", seeding, points: 0, score };
+  }
+  it("fills B13..24 from the playoff and B1..12 from the qualification-rank fallback", () => {
+    // Playoff matches only (no winners_r1). 12 direct qualifiers q1..q12 ranked by
+    // seeding ascending fill B1..12; the 12 playoff entrants fill B13..24.
+    const playoff = build24WinnersAndPlayoff().filter((m) => m.stage === "playoff");
+    const directQuals = Array.from({ length: 12 }, (_, i) =>
+      qual({ id: `q${i + 1}`, name: `Q${i + 1}`, nickname: `Q${i + 1}` }, i + 1),
+    );
+    const data = emptyData({ bmMatches: playoff, bmQualifications: directQuals });
+    const map = indexWrites(buildFinalsWrites(data, "bm"), "BM Finals");
+    // B1 = top seed Q1, B12 = Q12.
+    expectString(map, "B3", "Q1");
+    expectString(map, "B14", "Q12");
+    // B13 = first playoff entrant (B13 player), B24 = last.
+    expectString(map, "B15", "B13");
+    expectString(map, "B26", "B24");
+    // Playoff seed cells still typed (E5 = B23).
+    expectNumber(map, "E5", 23);
+  });
+});
+
+/* ----------------------------------------------------------------- *
+ * Degraded 16-player bracket (no playoff).
+ * ----------------------------------------------------------------- */
+
+describe("buildFinalsWrites — degraded 16-player", () => {
+  // 16 direct qualifiers; B-position = upper seed 1..16. winners_r1 wiring uses
+  // the structure pairs directly (no playoff slot).
+  function build16(): CdmMatch[] {
+    const pairs: Array<[number, number]> = [
+      [1, 16], [8, 9], [5, 12], [4, 13], [3, 14], [6, 11], [7, 10], [2, 15],
+    ];
+    return pairs.map(([p1, p2], i) =>
+      mk({ matchNumber: i + 1, stage: "finals", round: "winners_r1", p1, p2, s1: 4, s2: 1 }),
+    );
+  }
+  // Built per-`it` so the warn mock (cleared by beforeEach) captures this call.
+  const map16 = () => indexWrites(buildFinalsWrites(emptyData({ bmMatches: build16() }), "bm"), "BM Finals");
+
+  it("writes the 16-player seed list and B-positions equal to the upper seeds", () => {
+    const map = map16();
+    expectString(map, "B3", "B1"); // B-pos 1
+    expectString(map, "B18", "B16"); // B-pos 16
+    expectClear(map, "B19"); // B-pos 17 unused -> cleared
+  });
+
+  it("value-overwrites the even-match slot2 (former 'Winner of B2,k' formula) seed + name", () => {
+    const map = map16();
+    // winners_r1[0] slot1 (S6/T6) was the Barrage formula -> overwrite both.
+    expect(map.get("S6")).toMatchObject({ op: "overwriteNumber", value: 16 }); // B-pos 16
+    expect(map.get("T6")).toMatchObject({ op: "overwriteString", value: "B16" });
+    // The genuinely-typed slot0 stays a plain typed number.
+    expect(map.get("S5")).toMatchObject({ op: "number", value: 1 });
+  });
+
+  it("strips the unused Barrage blocks (seed, name and score cells)", () => {
+    const map = map16();
+    for (const ref of ["E5", "F5", "H5", "L5", "M5", "O5"]) {
+      expect(map.get(ref)?.op).toBe("strip");
+    }
+  });
+
+  it("logs the degradation", () => {
+    map16();
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining("16-player"),
+      expect.objectContaining({ mode: "bm" }),
+    );
+  });
+});
+
+/* ----------------------------------------------------------------- *
+ * Degraded 8-player bracket.
+ * ----------------------------------------------------------------- */
+
+describe("buildFinalsWrites — degraded 8-player", () => {
+  // 8-player structure winners_qf seedPairs [1,8],[4,5],[2,7],[3,6]; B-pos 1..8.
+  function build8(): CdmMatch[] {
+    const qf: Array<[number, number]> = [[1, 8], [4, 5], [2, 7], [3, 6]];
+    const qfMatches = qf.map(([p1, p2], i) =>
+      mk({ matchNumber: i + 1, stage: "finals", round: "winners_qf", p1, p2, s1: 4, s2: 2 }),
+    );
+    // Add a winners_final so we can check name overwrite on a downstream block.
+    const wf = mk({ matchNumber: 7, stage: "finals", round: "winners_final", p1: 1, p2: 4, s1: 4, s2: 1 });
+    return [...qfMatches, wf];
+  }
+  const map8 = () => indexWrites(buildFinalsWrites(emptyData({ bmMatches: build8() }), "bm"), "BM Finals");
+
+  it("writes the 8-player seed list (B1..8)", () => {
+    const map = map8();
+    expectString(map, "B3", "B1");
+    expectString(map, "B10", "B8");
+    expectClear(map, "B11"); // B-pos 9 unused
+  });
+
+  it("value-overwrites winners_qf slot names and scores from the records", () => {
+    const map = map8();
+    // winners_qf[0]: slot0 name Z->AA7 = "B1", score AC7 = 4; slot1 AA8 = "B8", AC8 = 2.
+    expect(map.get("AA7")).toMatchObject({ op: "overwriteString", value: "B1" });
+    expect(map.get("AC7")).toMatchObject({ op: "overwriteNumber", value: 4 });
+    expect(map.get("AA8")).toMatchObject({ op: "overwriteString", value: "B8" });
+    expect(map.get("AC8")).toMatchObject({ op: "overwriteNumber", value: 2 });
+  });
+
+  it("value-overwrites a downstream winners_final name from the record", () => {
+    const map = map8();
+    expect(map.get("AO19")).toMatchObject({ op: "overwriteString", value: "B1" });
+    expect(map.get("AO20")).toMatchObject({ op: "overwriteString", value: "B4" });
+  });
+
+  it("strips unused regions (Top16, Barrage, losers_r4, surplus losers slots)", () => {
+    const map = map8();
+    // Top16 winners_r1 name cell, Barrage, losers_r4 name, and losers_r1 idx2 (row49).
+    expect(map.get("T5")?.op).toBe("strip"); // winners_r1[0] slot0 name (unused)
+    expect(map.get("F5")?.op).toBe("strip"); // Barrage1 name
+    expect(map.get("AO43")?.op).toBe("strip"); // losers_r4[0] name (unused)
+    expect(map.get("T49")?.op).toBe("strip"); // losers_r1[2] name (row 49, surplus)
+  });
+
+  it("empties unused seed cells per type: typed -> clearValue, formula -> strip", () => {
+    const map = map8();
+    // Top16 winners_r1[0] slot0 seed (S5) is a TYPED seed cell -> cleared.
+    expect(map.get("S5")?.op).toBe("clearValue");
+    // losers_r4[0] slot0 seed (AN43) is a reverse-lookup FORMULA cell -> stripped.
+    expect(map.get("AN43")?.op).toBe("strip");
+  });
+
+  it("logs the 8-player degradation", () => {
+    map8();
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining("8-player"),
+      expect.objectContaining({ mode: "bm" }),
+    );
+  });
+});
+
+/* ----------------------------------------------------------------- *
+ * No finals — everything cleared.
+ * ----------------------------------------------------------------- */
+
+describe("buildFinalsWrites — no finals", () => {
+  const map = indexWrites(buildFinalsWrites(emptyData(), "bm"), "BM Finals");
+
+  it("clears the whole seed list B3:B26", () => {
+    expectClear(map, "B3");
+    expectClear(map, "B26");
+  });
+
+  it("clears every typed seed and score cell and touches no formula cell", () => {
+    expectClear(map, "S5"); // a typed seed
+    expectClear(map, "V5"); // a score cell
+    expectClear(map, "E5"); // playoff seed
+    expectUntouched(map, "T5"); // name formula never touched
+    expectUntouched(map, "F5"); // playoff name formula never touched
+    // Formula seed cells (reverse XLOOKUP in formula slots) stay intact too, so
+    // the empty template recomputes a clean blank bracket.
+    expectUntouched(map, "Z7"); // winners_qf[0] slot0 reverse-lookup seed cell
+    expectUntouched(map, "AA7"); // winners_qf[0] slot0 advancement formula
+  });
+});
+
+/* ----------------------------------------------------------------- *
+ * GP mode uses points instead of scores; MR/GP target their own sheets.
+ * ----------------------------------------------------------------- */
+
+describe("buildFinalsWrites — GP points and per-mode sheet targeting", () => {
+  it("writes GP scores from points1/points2", () => {
+    const matches = build24WinnersAndPlayoff("gp");
+    const map = indexWrites(buildFinalsWrites(emptyData({ gpMatches: matches }), "gp"), "GP Finals");
+    // winners_r1[1] both typed: bp8 points 4 -> V9, bp9 points 1 -> V10.
+    expectNumber(map, "V9", 4);
+    expectNumber(map, "V10", 1);
+  });
+
+  it("writes MR scores from score1/score2 onto the MR Finals sheet", () => {
+    const matches = build24WinnersAndPlayoff("mr");
+    const map = indexWrites(buildFinalsWrites(emptyData({ mrMatches: matches }), "mr"), "MR Finals");
+    expectNumber(map, "V9", 4);
+    expectNumber(map, "V10", 1);
+    expectString(map, "B3", "B1"); // seed list lands on the MR sheet
+  });
+
+  it("targets the sheet that matches the mode", () => {
+    for (const mode of ["bm", "mr", "gp"] as const) {
+      const writes = buildFinalsWrites(emptyData(), mode);
+      expect(writes.every((w) => w.sheet === SHEET_BY_MODE[mode])).toBe(true);
+      expect(writes.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+/* ----------------------------------------------------------------- *
+ * GP seed list is a formula spill — never written (regression for the bug
+ * found during route integration: GP Finals B3 is an array-spill XLOOKUP with
+ * ref="B3:B26", so B3:B26 are formula/spill cells, unlike BM/MR's typed seeds).
+ * buildFinalsWrites returns writes (it never throws — the patcher does), so the
+ * only way to lock this in at the unit level is to positively assert the seed
+ * list is untouched for GP while it IS written/cleared for BM/MR.
+ * ----------------------------------------------------------------- */
+
+describe("buildFinalsWrites — GP seed list is a formula spill (never written)", () => {
+  it("writes GP scores but emits no write to the B3:B26 seed list", () => {
+    const map = indexWrites(
+      buildFinalsWrites(emptyData({ gpMatches: build24WinnersAndPlayoff("gp") }), "gp"),
+      "GP Finals",
+    );
+    // Scores still land (GP uses points1/points2): winners_r1[1] bp8/bp9 -> V9/V10.
+    expectNumber(map, "V9", 4);
+    expectNumber(map, "V10", 1);
+    // The seed list (B3:B26) is a formula spill on GP and must stay untouched.
+    for (let row = 3; row <= 26; row++) expectUntouched(map, `B${row}`);
+  });
+
+  it("does not clear the GP seed list on the no-finals path but still clears typed seeds", () => {
+    const map = indexWrites(buildFinalsWrites(emptyData(), "gp"), "GP Finals");
+    // The GP skip is scoped to the seed list — NOT an early return: the typed
+    // seed cells are still cleared so a blank GP bracket recomputes cleanly.
+    for (let row = 3; row <= 26; row++) expectUntouched(map, `B${row}`);
+    expectClear(map, "S5"); // a typed winners_r1 seed cell is still cleared.
+  });
+
+  it("contrast: BM/MR DO write the typed seed list while GP does not", () => {
+    const bm = indexWrites(
+      buildFinalsWrites(emptyData({ bmMatches: build24WinnersAndPlayoff("bm") }), "bm"),
+      "BM Finals",
+    );
+    const gp = indexWrites(
+      buildFinalsWrites(emptyData({ gpMatches: build24WinnersAndPlayoff("gp") }), "gp"),
+      "GP Finals",
+    );
+    expectString(bm, "B3", "B1"); // BM seed list is a typed input.
+    expectUntouched(gp, "B3"); // GP seed list is a formula spill.
+  });
+});
+
+/* ----------------------------------------------------------------- *
+ * Edge cases: unmappable matches, excess match index, ranking tiebreaks.
+ * ----------------------------------------------------------------- */
+
+describe("buildFinalsWrites — unmappable matches", () => {
+  it("clears to a blank bracket and warns when no match maps to a bracket round", () => {
+    // A non-finals stray (qualification stage, unknown round) maps to no bracket
+    // round and is not a playoff -> treated as blank.
+    const matches: CdmMatch[] = [
+      mk({ matchNumber: 1, stage: "qualification", round: "qualification", p1: 1, p2: 2, s1: 4, s2: 1 }),
+    ];
+    const map = indexWrites(buildFinalsWrites(emptyData({ bmMatches: matches }), "bm"), "BM Finals");
+    expectClear(map, "B3"); // seed list cleared
+    expectClear(map, "S5"); // typed seed cleared
+    expectUntouched(map, "T5"); // formula preserved
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining("no recognizable bracket rounds"),
+      expect.objectContaining({ mode: "bm", count: 1 }),
+    );
+  });
+});
+
+describe("buildFinalsWrites — excess match index in a round", () => {
+  it("skips and warns when a round has more matches than its geometry", () => {
+    // winners_final geometry holds 1 match; supply 2 (a corrupt record) on top of
+    // a real bracket so the faithful path runs and the surplus is skipped.
+    const matches: CdmMatch[] = [
+      ...build24WinnersAndPlayoff(),
+      mk({ matchNumber: 28, stage: "finals", round: "winners_final", p1: 1, p2: 2, s1: 4, s2: 1 }),
+      mk({ matchNumber: 99, stage: "finals", round: "winners_final", p1: 3, p2: 4, s1: 4, s2: 1 }),
+    ];
+    buildFinalsWrites(emptyData({ bmMatches: matches }), "bm");
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining("exceeds round geometry"),
+      expect.objectContaining({ round: "winners_final", matchIndex: 1 }),
+    );
+  });
+});
+
+describe("buildFinalsWrites — playoff-only B1..12 ranking tiebreaks", () => {
+  function qual(
+    id: string,
+    over: Partial<CdmModeQualification> = {},
+  ): CdmModeQualification {
+    return {
+      player: { id, name: id, nickname: id },
+      group: "A",
+      seeding: null,
+      points: 0,
+      score: 0,
+      ...over,
+    };
+  }
+  it("orders direct qualifiers rankOverride asc (nulls last) then score/points/nickname", () => {
+    const playoff = build24WinnersAndPlayoff().filter((m) => m.stage === "playoff");
+    const quals: CdmModeQualification[] = [
+      qual("zNickHighScore", { score: 50 }), // no rankOverride; highest score
+      qual("aNickLowScore", { score: 10 }), // no rankOverride; lower score
+      qual("ranked1", { rankOverride: 1, score: 0 }), // explicit rank wins
+      qual("tieA", { score: 30, points: 5 }), // tie on score -> points decides
+      qual("tieB", { score: 30, points: 9 }), // higher points first
+    ];
+    const data = emptyData({ bmMatches: playoff, bmQualifications: quals });
+    const map = indexWrites(buildFinalsWrites(data, "bm"), "BM Finals");
+    // Expected order: ranked1 (rankOverride 1) -> tieB (score30/pts9) ->
+    // tieA (score30/pts5) -> zNickHighScore (score50? no: it has no rankOverride,
+    // so it sorts after all rankOverride rows) ...
+    // rankOverride rows first: only ranked1. Then null-rankOverride rows by score
+    // desc: zNickHighScore(50) -> tieB(30) -> tieA(30) -> aNickLowScore(10).
+    // Within score-30 tie, points desc: tieB before tieA.
+    expectString(map, "B3", "ranked1"); // B-pos 1
+    expectString(map, "B4", "zNickHighScore"); // B-pos 2 (highest score, no rank)
+    expectString(map, "B5", "tieB"); // B-pos 3 (score30, points9)
+    expectString(map, "B6", "tieA"); // B-pos 4 (score30, points5)
+    expectString(map, "B7", "aNickLowScore"); // B-pos 5 (lowest score)
+  });
+});

--- a/smkc-score-app/__tests__/lib/cdm-export/fill/main-hub.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/fill/main-hub.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for the Main Hub fill map (Registration table + Qualifying/Groups inputs).
+ *
+ * Ground truth: /tmp/cdm-analysis/sheet2025/sheet_Main_Hub.txt
+ *   - Rows are sorted by Name (column B), case-insensitive ascending
+ *     (B2 "Alessandro Sona" … B5 "Charly Greffier" … not by Nickname).
+ *   - B=name C=nickname D=country E..H=TT/BM/MR/GP Order I..L=Yes/No.
+ *   - O3..R3 Qualifying counts (TT,BM,MR,GP), O4..R4 group counts.
+ *   - A (=ROW()-1), N2:R2 (COUNTIF), T/U (spills) are formulas — never written.
+ */
+
+import { buildMainHubWrites } from "@/lib/cdm-export/fill/main-hub";
+import type {
+  CdmMatch,
+  CdmModeQualification,
+  CdmPlayer,
+  CdmTTEntry,
+  CdmTournamentData,
+} from "@/lib/cdm-export/types";
+import {
+  indexWrites,
+  expectString,
+  expectNumber,
+  expectClear,
+  expectUntouched,
+  writtenRefs,
+} from "./write-helpers";
+
+const SHEET = "Main Hub" as const;
+
+function player(id: string, name: string, nickname: string, country: string | null = null): CdmPlayer {
+  return { id, name, nickname, country };
+}
+
+function qual(p: CdmPlayer, group: string, seeding: number | null): CdmModeQualification {
+  return { player: p, group, seeding, points: 0, score: 0 };
+}
+
+function tt(p: CdmPlayer, stage: string, seeding: number | null): CdmTTEntry {
+  return { player: p, playerId: p.id, stage, seeding, lives: 3, eliminated: false };
+}
+
+function emptyData(over: Partial<CdmTournamentData> = {}): CdmTournamentData {
+  return {
+    name: "T",
+    date: new Date("2025-01-01"),
+    bmQualifications: [],
+    mrQualifications: [],
+    gpQualifications: [],
+    bmMatches: [],
+    mrMatches: [],
+    gpMatches: [],
+    ttEntries: [],
+    ttPhaseRounds: [],
+    ...over,
+  };
+}
+
+describe("buildMainHubWrites — player rows", () => {
+  it("sorts the player universe by name, case-insensitive ascending", () => {
+    const ann = player("p1", "ann lower", "Z-nick");
+    const bob = player("p2", "Bob Upper", "A-nick");
+    const cara = player("p3", "Cara", "M-nick");
+    const data = emptyData({
+      // Deliberately out of order; TT-only player included in the universe.
+      bmQualifications: [qual(cara, "A", 1), qual(bob, "A", 2)],
+      ttEntries: [tt(ann, "qualification", 5)],
+    });
+    const map = indexWrites(buildMainHubWrites(data), SHEET);
+    // name asc: "ann lower" < "Bob Upper" < "Cara"
+    expectString(map, "B2", "ann lower");
+    expectString(map, "B3", "Bob Upper");
+    expectString(map, "B4", "Cara");
+    expectString(map, "C2", "Z-nick");
+  });
+
+  it("writes nickname, country text, and clears null country", () => {
+    const a = player("p1", "Aaa", "Anick", "France");
+    const b = player("p2", "Bbb", "Bnick", null);
+    const data = emptyData({ bmQualifications: [qual(a, "A", 1), qual(b, "A", 2)] });
+    const map = indexWrites(buildMainHubWrites(data), SHEET);
+    expectString(map, "C2", "Anick");
+    expectString(map, "D2", "France");
+    expectString(map, "C3", "Bnick");
+    expectClear(map, "D3"); // null country -> clearValue (was a rich image)
+  });
+
+  it("never writes the formula columns A, M, N or the spill columns T/U", () => {
+    const a = player("p1", "Aaa", "Anick", "FR");
+    const data = emptyData({ bmQualifications: [qual(a, "A", 1)] });
+    const map = indexWrites(buildMainHubWrites(data), SHEET);
+    for (const ref of ["A2", "M2", "N2", "T2", "U2"]) expectUntouched(map, ref);
+  });
+});
+
+describe("buildMainHubWrites — Order columns E..H and Yes/No I..L", () => {
+  it("writes TT Order from the qualification entry seeding and TT=Yes", () => {
+    const a = player("p1", "Aaa", "Anick");
+    const data = emptyData({ ttEntries: [tt(a, "qualification", 7)] });
+    const map = indexWrites(buildMainHubWrites(data), SHEET);
+    expectNumber(map, "E2", 7); // TT Order
+    expectString(map, "I2", "Yes"); // TT participation
+    expectString(map, "J2", "No"); // BM not entered
+  });
+
+  it("clears TT Order when the qualification entry has null seeding but keeps TT=Yes", () => {
+    const a = player("p1", "Aaa", "Anick");
+    const data = emptyData({ ttEntries: [tt(a, "qualification", null)] });
+    const map = indexWrites(buildMainHubWrites(data), SHEET);
+    expectClear(map, "E2"); // null seeding -> clearValue (NOT a fallback number)
+    expectString(map, "I2", "Yes");
+  });
+
+  it("treats non-qualification TT stages as not TT-participating", () => {
+    const a = player("p1", "Aaa", "Anick");
+    // Only a phase1 entry (no qualification): TT="No", Order cleared.
+    const data = emptyData({ ttEntries: [tt(a, "phase1", 3)] });
+    const map = indexWrites(buildMainHubWrites(data), SHEET);
+    expectString(map, "I2", "No");
+    expectClear(map, "E2");
+  });
+
+  it("writes BM/MR/GP synthesized Order and Yes for participants", () => {
+    // Single group of two; G=1 so Orders are 1 and 2 by seeding.
+    const a = player("p1", "Aaa", "Anick");
+    const b = player("p2", "Bbb", "Bnick");
+    const data = emptyData({
+      bmQualifications: [qual(a, "A", 1), qual(b, "A", 2)],
+      mrQualifications: [qual(b, "A", 1), qual(a, "A", 2)],
+    });
+    const map = indexWrites(buildMainHubWrites(data), SHEET);
+    // BM (F col): a seed1 -> Order 1, b seed2 -> Order 2
+    expectNumber(map, "F2", 1); // a's BM Order
+    expectString(map, "J2", "Yes"); // a in BM
+    expectNumber(map, "F3", 2); // b's BM Order
+    // MR (G col): b seed1 -> 1, a seed2 -> 2
+    expectNumber(map, "G2", 2); // a's MR Order
+    expectString(map, "K2", "Yes"); // a in MR
+    // GP: neither entered
+    expectString(map, "L2", "No");
+    expectClear(map, "H2"); // a not in GP -> Order cleared
+  });
+});
+
+describe("buildMainHubWrites — Qualifying counts O3..R3 and Groups O4..R4", () => {
+  it("uses min(24, count) when there are no finals/playoff matches", () => {
+    const players = Array.from({ length: 8 }, (_, i) =>
+      player(`p${i}`, `Name${i}`, `Nick${i}`),
+    );
+    const data = emptyData({
+      bmQualifications: players.map((p, i) => qual(p, i < 4 ? "A" : "B", (i % 4) + 1)),
+      ttEntries: players.map((p) => tt(p, "qualification", 1)),
+    });
+    const map = indexWrites(buildMainHubWrites(data), SHEET);
+    // TT count = min(24, 8) = 8 at O3; BM count = min(24, 8) = 8 at P3.
+    expectNumber(map, "O3", 8);
+    expectNumber(map, "P3", 8);
+    // Group counts: TT=0 (O4), BM=2 distinct groups (P4).
+    expectNumber(map, "O4", 0);
+    expectNumber(map, "P4", 2);
+  });
+
+  it("reports 24 when a playoff stage match exists, 16 for winners_r1, 8 for winners_qf", () => {
+    const a = player("p1", "Aaa", "An");
+    const b = player("p2", "Bbb", "Bn");
+    const mk = (round: string | null, stage: string): CdmMatch => ({
+      matchNumber: 1,
+      stage,
+      round,
+      player1: a,
+      player2: b,
+      completed: true,
+    });
+    // BM: a playoff match -> 24. MR: winners_r1 -> 16. GP: winners_qf only -> 8.
+    const data = emptyData({
+      bmQualifications: [qual(a, "A", 1)],
+      mrQualifications: [qual(a, "A", 1)],
+      gpQualifications: [qual(a, "A", 1)],
+      bmMatches: [mk(null, "playoff")],
+      mrMatches: [mk("winners_r1", "finals")],
+      gpMatches: [mk("winners_qf", "finals")],
+    });
+    const map = indexWrites(buildMainHubWrites(data), SHEET);
+    expectNumber(map, "P3", 24); // BM
+    expectNumber(map, "Q3", 16); // MR
+    expectNumber(map, "R3", 8); // GP
+  });
+
+  it("keeps O3 at min(24, qualifier count) even while phase rounds exist", () => {
+    // O3 sizes the TT Finals roster spill
+    // (B3 = OFFSET('TT Qualifications'!CN2,0,0,O3)), and the lives replay
+    // writes a row for every top-min(24,N) qualifier with non-runners at
+    // Time=0 (CDM 2025 convention). Mid-phase the phase rounds only contain a
+    // subset (phase1 = ranks 17..24), so the distinct phase-player count must
+    // NOT shrink O3 — otherwise the roster spill and the replay's rows
+    // disagree about the row universe.
+    const players = Array.from({ length: 12 }, (_, i) =>
+      player(`p${i}`, `N${i}`, `K${i}`),
+    );
+    const data = emptyData({
+      ttEntries: players.map((p) => tt(p, "qualification", 1)),
+      ttPhaseRounds: [
+        {
+          phase: "phase1",
+          roundNumber: 1,
+          course: "MC1",
+          results: [
+            { playerId: "p0", timeMs: 1000 },
+            { playerId: "p1", timeMs: 1000 },
+            { playerId: "p2", timeMs: 1000 },
+          ],
+          livesReset: false,
+        },
+      ],
+    });
+    const map = indexWrites(buildMainHubWrites(data), SHEET);
+    expectNumber(map, "O3", 12);
+  });
+
+  it("falls back to distinct phase players for O3 when no qualification entries exist", () => {
+    const a = player("p1", "Aaa", "An");
+    const b = player("p2", "Bbb", "Bn");
+    const data = emptyData({
+      ttEntries: [tt(a, "phase1", 1), tt(b, "phase1", 2)],
+      ttPhaseRounds: [
+        {
+          phase: "phase1",
+          roundNumber: 1,
+          course: "MC1",
+          results: [
+            { playerId: "p1", timeMs: 1000 },
+            { playerId: "p2", timeMs: 2000 },
+          ],
+          livesReset: false,
+        },
+      ],
+    });
+    const map = indexWrites(buildMainHubWrites(data), SHEET);
+    expectNumber(map, "O3", 2);
+  });
+});
+
+describe("buildMainHubWrites — spare rows and bounds", () => {
+  it("clears B..L on every row after the players (up to row 61)", () => {
+    const a = player("p1", "Aaa", "An");
+    const data = emptyData({ bmQualifications: [qual(a, "A", 1)] });
+    const map = indexWrites(buildMainHubWrites(data), SHEET);
+    // 1 player on row 2; row 3 onward must clear B..L.
+    for (const col of ["B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"]) {
+      expectClear(map, `${col}3`);
+      expectClear(map, `${col}61`);
+    }
+    // But never row 62 (out of the 60-row Registration table).
+    expectUntouched(map, "B62");
+  });
+
+  it("truncates to 60 players and never writes row 62", () => {
+    const players = Array.from({ length: 65 }, (_, i) =>
+      // zero-pad so name sort is the numeric order
+      player(`p${i}`, `Name${String(i).padStart(3, "0")}`, `Nick${i}`),
+    );
+    const data = emptyData({ bmQualifications: players.map((p) => qual(p, "A", 1)) });
+    const writes = buildMainHubWrites(data);
+    const map = indexWrites(writes, SHEET);
+    expectString(map, "B2", "Name000");
+    expectString(map, "B61", "Name059"); // 60th player on row 61
+    expectUntouched(map, "B62"); // 61st+ dropped
+    // No write should reference a row > 61.
+    for (const ref of writtenRefs(writes, SHEET)) {
+      const row = Number(ref.replace(/[A-Z]/g, ""));
+      expect(row).toBeLessThanOrEqual(61);
+    }
+  });
+});

--- a/smkc-score-app/__tests__/lib/cdm-export/fill/qualifications.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/fill/qualifications.test.ts
@@ -1,0 +1,488 @@
+/**
+ * Tests for the BM/MR/GP Qualifications fill map (per-player match blocks).
+ *
+ * Ground truth: /tmp/cdm-analysis/sheet2025/sheet_{BM,MR,GP}_Qualifications.txt
+ *
+ *   Block 0 data rows 2..16 (15 rows), header row 17 ('Match','TV #',…),
+ *   block 1 data rows 18..32, stride 16. Owner column V is constant per block
+ *   (e.g. V2..V16 all 'Drew'); block 1 owner is 'KVD' on row 18.
+ *
+ *   Per row (owner perspective):
+ *     S = match #            (S2 = 1)
+ *     T = TV #               (blank when unset)
+ *     U = owner side         (U2 = 2)
+ *     V = owner nickname     (V2 = 'Drew')
+ *     W = owner score        (BM/MR: rounds won 0..4; GP: driver points 0..45)
+ *     X = '-'                (literal — never touched)
+ *     Z = opponent nickname  (Z2 = 'Break' for a BYE)
+ *     AA = opponent side     (AA2 = 1)
+ *
+ *   BM:  Y2 = '=IF(W2="","",4-W2)' (formula), AB2/AC2/AD2 = W/T/L formulas.
+ *   MR:  Y2 formula; AB..AE = Round 1..4 courses (inputs); AF/AG/AH formulas.
+ *   GP:  Y2 = 0 (a RAW number input = opponent points); AB = cup (input);
+ *        AC/AD/AE = W/T/L formulas.
+ *
+ * The fill map writes only S,T,U,V,W,Z,AA (+ GP:Y, AB; MR:AB..AE) and clears
+ * unused input cells. It must never touch X, the BM/MR Y formula, the W/T/L
+ * columns, the standings E..Q, or anything from AF onward.
+ */
+
+import { buildQualificationWrites } from "@/lib/cdm-export/fill/qualifications";
+import {
+  QUAL_BLOCK_FIRST_DATA_ROW,
+  QUAL_BLOCK_STRIDE,
+} from "@/lib/cdm-export/cdm-constants";
+import type {
+  CdmMatch,
+  CdmModeQualification,
+  CdmPlayer,
+  CdmTournamentData,
+  CdmVersusMode,
+} from "@/lib/cdm-export/types";
+import {
+  indexWrites,
+  expectString,
+  expectNumber,
+  expectClear,
+  expectUntouched,
+  writtenRefs,
+} from "./write-helpers";
+
+const BREAK_PLAYER_ID = "__BREAK__";
+
+function player(id: string, nickname: string, name = nickname): CdmPlayer {
+  return { id, name, nickname };
+}
+
+const BREAK_PLAYER: CdmPlayer = player(BREAK_PLAYER_ID, "Break");
+
+function qual(p: CdmPlayer, group: string, seeding: number | null): CdmModeQualification {
+  return { player: p, group, seeding, points: 0, score: 0 };
+}
+
+interface MatchOpts {
+  matchNumber: number;
+  roundNumber?: number | null;
+  tvNumber?: number | null;
+  player1: CdmPlayer;
+  player2: CdmPlayer;
+  player1Side?: number | null;
+  player2Side?: number | null;
+  score1?: number | null;
+  score2?: number | null;
+  points1?: number | null;
+  points2?: number | null;
+  completed?: boolean;
+  assignedCourses?: unknown;
+  cup?: string | null;
+  isBye?: boolean;
+}
+
+function match(opts: MatchOpts): CdmMatch {
+  return {
+    stage: "qualification",
+    completed: opts.completed ?? true,
+    ...opts,
+  };
+}
+
+function emptyData(over: Partial<CdmTournamentData> = {}): CdmTournamentData {
+  return {
+    name: "T",
+    date: new Date("2025-01-01"),
+    bmQualifications: [],
+    mrQualifications: [],
+    gpQualifications: [],
+    bmMatches: [],
+    mrMatches: [],
+    gpMatches: [],
+    ttEntries: [],
+    ttPhaseRounds: [],
+    ...over,
+  };
+}
+
+/** First data row of block i (i 0-based). */
+function blockRow(i: number, offset = 0): number {
+  return QUAL_BLOCK_FIRST_DATA_ROW + i * QUAL_BLOCK_STRIDE + offset;
+}
+
+/** Build a 2-player, single-group BM tournament with one real match. */
+function twoPlayerBm(
+  matchOver: Partial<MatchOpts> = {},
+): { data: CdmTournamentData; a: CdmPlayer; b: CdmPlayer } {
+  const a = player("pa", "Drew");
+  const b = player("pb", "Lio");
+  const data = emptyData({
+    bmQualifications: [qual(a, "A", 1), qual(b, "A", 2)],
+    bmMatches: [
+      match({
+        matchNumber: 1,
+        roundNumber: 1,
+        player1: a,
+        player2: b,
+        player1Side: 1,
+        player2Side: 2,
+        score1: 4,
+        score2: 1,
+        ...matchOver,
+      }),
+    ],
+  });
+  return { data, a, b };
+}
+
+const sheetOf: Record<CdmVersusMode, "BM Qualifications" | "MR Qualifications" | "GP Qualifications"> = {
+  bm: "BM Qualifications",
+  mr: "MR Qualifications",
+  gp: "GP Qualifications",
+};
+
+describe("buildQualificationWrites — block placement", () => {
+  it("owns block i to computeSheetPlayerOrder[i] (group A seed asc, then B)", () => {
+    const a1 = player("a1", "A1");
+    const a2 = player("a2", "A2");
+    const b1 = player("b1", "B1");
+    const b2 = player("b2", "B2");
+    const data = emptyData({
+      bmQualifications: [
+        qual(a1, "A", 1),
+        qual(a2, "A", 2),
+        qual(b1, "B", 1),
+        qual(b2, "B", 2),
+      ],
+      // One real match between a1 and b1 so each owner's block has a row.
+      bmMatches: [
+        match({
+          matchNumber: 5,
+          roundNumber: 1,
+          player1: a1,
+          player2: b1,
+          player1Side: 1,
+          player2Side: 2,
+          score1: 4,
+          score2: 0,
+        }),
+      ],
+    });
+    const map = indexWrites(buildQualificationWrites(data, "bm"), sheetOf.bm);
+    // Block order: a1(0), a2(1), b1(2), b2(3).
+    expectString(map, `V${blockRow(0)}`, "A1"); // a1 owns block 0
+    expectString(map, `V${blockRow(2)}`, "B1"); // b1 owns block 2
+    // a1's block 0 row 0: match 5 vs B1.
+    expectNumber(map, `S${blockRow(0)}`, 5);
+    expectString(map, `Z${blockRow(0)}`, "B1");
+    // b1's block 2 row 0: same match, owner B1 vs A1.
+    expectNumber(map, `S${blockRow(2)}`, 5);
+    expectString(map, `Z${blockRow(2)}`, "A1");
+  });
+
+  it("never writes the header row 17 (between block 0 and block 1)", () => {
+    // 17 players forces a block 1; the header row 17 must be left intact.
+    // Sequential seeds so the block order is deterministic; one group of 17.
+    const players = Array.from({ length: 17 }, (_, i) =>
+      player(`p${i}`, `N${String(i).padStart(2, "0")}`),
+    );
+    const data = emptyData({
+      bmQualifications: players.map((p, i) => qual(p, "A", i + 1)),
+    });
+    const writes = buildQualificationWrites(data, "bm");
+    const map = indexWrites(writes, sheetOf.bm);
+    for (const col of ["S", "T", "U", "V", "W", "Z", "AA"]) {
+      expectUntouched(map, `${col}17`); // header row never written or cleared
+    }
+  });
+});
+
+describe("buildQualificationWrites — owner-perspective row (BM)", () => {
+  it("writes S,T,U,V,W,Z,AA from the owner's side", () => {
+    const { data } = twoPlayerBm({ tvNumber: 7, player1Side: 2, player2Side: 1 });
+    const map = indexWrites(buildQualificationWrites(data, "bm"), sheetOf.bm);
+    // a (Drew) is player1, owns block 0.
+    expectNumber(map, `S${blockRow(0)}`, 1); // matchNumber
+    expectNumber(map, `T${blockRow(0)}`, 7); // tvNumber
+    expectNumber(map, `U${blockRow(0)}`, 2); // owner side = player1Side
+    expectString(map, `V${blockRow(0)}`, "Drew");
+    expectNumber(map, `W${blockRow(0)}`, 4); // owner score = score1
+    expectString(map, `Z${blockRow(0)}`, "Lio");
+    expectNumber(map, `AA${blockRow(0)}`, 1); // opponent side = player2Side
+  });
+
+  it("writes the opponent's perspective in the other player's block", () => {
+    const { data } = twoPlayerBm({ player1Side: 1, player2Side: 2 });
+    const map = indexWrites(buildQualificationWrites(data, "bm"), sheetOf.bm);
+    // b (Lio) owns block 1; from Lio's view owner score = score2 = 1.
+    expectString(map, `V${blockRow(1)}`, "Lio");
+    expectNumber(map, `U${blockRow(1)}`, 2); // Lio is player2 -> side 2
+    expectNumber(map, `W${blockRow(1)}`, 1); // owner score = score2
+    expectString(map, `Z${blockRow(1)}`, "Drew");
+    expectNumber(map, `AA${blockRow(1)}`, 1); // opponent (Drew) side
+  });
+
+  it("clears T when tvNumber is null and defaults sides when null", () => {
+    const { data } = twoPlayerBm({ tvNumber: null, player1Side: null, player2Side: null });
+    const map = indexWrites(buildQualificationWrites(data, "bm"), sheetOf.bm);
+    expectClear(map, `T${blockRow(0)}`); // null tvNumber -> clear
+    expectNumber(map, `U${blockRow(0)}`, 1); // player1 default side 1
+    expectNumber(map, `AA${blockRow(0)}`, 2); // player2 default side 2
+  });
+
+  it("never writes X, the BM Y formula, or the W/T/L formula columns", () => {
+    const { data } = twoPlayerBm();
+    const map = indexWrites(buildQualificationWrites(data, "bm"), sheetOf.bm);
+    for (const col of ["X", "Y", "AB", "AC", "AD"]) {
+      expectUntouched(map, `${col}${blockRow(0)}`);
+    }
+  });
+});
+
+describe("buildQualificationWrites — incomplete matches", () => {
+  it("clears the BM score (W) when the match is not completed", () => {
+    const { data } = twoPlayerBm({ completed: false, score1: 0, score2: 0 });
+    const map = indexWrites(buildQualificationWrites(data, "bm"), sheetOf.bm);
+    // Match meta still written, but the score is cleared (never a bogus 0).
+    expectNumber(map, `S${blockRow(0)}`, 1);
+    expectString(map, `V${blockRow(0)}`, "Drew");
+    expectClear(map, `W${blockRow(0)}`);
+    expectClear(map, `W${blockRow(1)}`); // opponent block too
+  });
+
+  it("clears both GP scores (W and Y) when the match is not completed", () => {
+    const a = player("pa", "Lafungo");
+    const b = player("pb", "Rival");
+    const data = emptyData({
+      gpQualifications: [qual(a, "A", 1), qual(b, "A", 2)],
+      gpMatches: [
+        match({
+          matchNumber: 1,
+          roundNumber: 1,
+          player1: a,
+          player2: b,
+          points1: 0,
+          points2: 0,
+          completed: false,
+          cup: "Star",
+        }),
+      ],
+    });
+    const map = indexWrites(buildQualificationWrites(data, "gp"), sheetOf.gp);
+    expectClear(map, `W${blockRow(0)}`);
+    expectClear(map, `Y${blockRow(0)}`); // GP opponent points also cleared
+    // Cup is metadata and is still written even while scores are pending.
+    expectString(map, `AB${blockRow(0)}`, "Star");
+  });
+});
+
+describe("buildQualificationWrites — BYE matches", () => {
+  it("places a BYE only in the real player's block with opponent 'Break' (BM W=4)", () => {
+    const a = player("pa", "Drew");
+    const data = emptyData({
+      bmQualifications: [qual(a, "A", 1)],
+      bmMatches: [
+        match({
+          matchNumber: 1,
+          roundNumber: 1,
+          player1: a, // real player is always player1 for a BYE
+          player2: BREAK_PLAYER,
+          player1Side: 2,
+          player2Side: 1,
+          score1: 4,
+          score2: 0,
+          isBye: true,
+        }),
+      ],
+    });
+    const writes = buildQualificationWrites(data, "bm");
+    const map = indexWrites(writes, sheetOf.bm);
+    expectString(map, `V${blockRow(0)}`, "Drew");
+    expectString(map, `Z${blockRow(0)}`, "Break"); // opponent shown as Break
+    expectNumber(map, `W${blockRow(0)}`, 4); // BYE auto-win
+    expectNumber(map, `AA${blockRow(0)}`, 1); // Break side
+    // The BREAK player must NOT own a block (no block whose owner nickname is Break).
+    for (const ref of writtenRefs(writes, sheetOf.bm)) {
+      if (ref.startsWith("V")) {
+        const w = map.get(ref);
+        if (w && w.op === "inlineString") expect(w.value).not.toBe("Break");
+      }
+    }
+  });
+
+  it("writes the real GP BYE points into Y (45 / 0)", () => {
+    const a = player("pa", "Lafungo");
+    const data = emptyData({
+      gpQualifications: [qual(a, "A", 1)],
+      gpMatches: [
+        match({
+          matchNumber: 1,
+          roundNumber: 1,
+          player1: a,
+          player2: BREAK_PLAYER,
+          points1: 45,
+          points2: 0,
+          cup: "Star",
+          isBye: true,
+        }),
+      ],
+    });
+    const map = indexWrites(buildQualificationWrites(data, "gp"), sheetOf.gp);
+    expectNumber(map, `W${blockRow(0)}`, 45); // owner points
+    expectNumber(map, `Y${blockRow(0)}`, 0); // opponent (Break) points
+    expectString(map, `Z${blockRow(0)}`, "Break");
+  });
+});
+
+describe("buildQualificationWrites — MR courses and GP cup", () => {
+  it("writes MR assignedCourses[0..3] to AB..AE and clears missing slots", () => {
+    const a = player("pa", "Sami");
+    const b = player("pb", "Lio");
+    const data = emptyData({
+      mrQualifications: [qual(a, "A", 1), qual(b, "A", 2)],
+      mrMatches: [
+        match({
+          matchNumber: 1,
+          roundNumber: 1,
+          player1: a,
+          player2: b,
+          score1: 4,
+          score2: 0,
+          assignedCourses: ["BC1", "DP1", "VL1"], // only 3 -> AE cleared
+        }),
+      ],
+    });
+    const map = indexWrites(buildQualificationWrites(data, "mr"), sheetOf.mr);
+    expectString(map, `AB${blockRow(0)}`, "BC1");
+    expectString(map, `AC${blockRow(0)}`, "DP1");
+    expectString(map, `AD${blockRow(0)}`, "VL1");
+    expectClear(map, `AE${blockRow(0)}`); // 4th course absent -> clear
+    // MR must never touch Y (it is the =4-W formula) or the W/T/L cols AF..AH.
+    for (const col of ["Y", "AF", "AG", "AH"]) {
+      expectUntouched(map, `${col}${blockRow(0)}`);
+    }
+  });
+
+  it("writes GP cup to AB and clears it when null", () => {
+    const a = player("pa", "Lafungo");
+    const b = player("pb", "Rival");
+    const data = emptyData({
+      gpQualifications: [qual(a, "A", 1), qual(b, "A", 2)],
+      gpMatches: [
+        match({
+          matchNumber: 1,
+          roundNumber: 1,
+          player1: a,
+          player2: b,
+          points1: 30,
+          points2: 15,
+          cup: null, // -> clear
+        }),
+      ],
+    });
+    const map = indexWrites(buildQualificationWrites(data, "gp"), sheetOf.gp);
+    expectClear(map, `AB${blockRow(0)}`);
+    // GP writes opponent points into Y for completed matches.
+    expectNumber(map, `Y${blockRow(0)}`, 15);
+  });
+});
+
+describe("buildQualificationWrites — ordering within a block", () => {
+  it("lists the owner's matches by roundNumber then matchNumber ascending", () => {
+    const a = player("pa", "Drew");
+    const b = player("pb", "Lio");
+    const c = player("pc", "KVD");
+    const data = emptyData({
+      bmQualifications: [qual(a, "A", 1), qual(b, "A", 2), qual(c, "A", 3)],
+      bmMatches: [
+        // Intentionally out of order; round 2 before round 1, higher match# first.
+        match({ matchNumber: 9, roundNumber: 2, player1: a, player2: c, score1: 4, score2: 1 }),
+        match({ matchNumber: 2, roundNumber: 1, player1: a, player2: b, score1: 4, score2: 0 }),
+      ],
+    });
+    const map = indexWrites(buildQualificationWrites(data, "bm"), sheetOf.bm);
+    // Drew owns block 0. Row 0 = round1 (match 2 vs Lio), row 1 = round2 (match 9 vs KVD).
+    expectNumber(map, `S${blockRow(0, 0)}`, 2);
+    expectString(map, `Z${blockRow(0, 0)}`, "Lio");
+    expectNumber(map, `S${blockRow(0, 1)}`, 9);
+    expectString(map, `Z${blockRow(0, 1)}`, "KVD");
+  });
+
+  it("ignores non-qualification matches (finals/playoff)", () => {
+    const a = player("pa", "Drew");
+    const b = player("pb", "Lio");
+    const data = emptyData({
+      bmQualifications: [qual(a, "A", 1), qual(b, "A", 2)],
+      bmMatches: [
+        match({ matchNumber: 1, roundNumber: 1, player1: a, player2: b, score1: 4, score2: 0, stage: "finals" } as MatchOpts & { stage: string }),
+      ],
+    });
+    const map = indexWrites(buildQualificationWrites(data, "bm"), sheetOf.bm);
+    // No qualification match -> block 0 row 0 input cells are all cleared.
+    expectClear(map, `S${blockRow(0)}`);
+    expectClear(map, `V${blockRow(0)}`);
+  });
+});
+
+describe("buildQualificationWrites — clearing unused rows and blocks", () => {
+  it("clears the input cells of unused rows within an owned block", () => {
+    const { data } = twoPlayerBm();
+    const map = indexWrites(buildQualificationWrites(data, "bm"), sheetOf.bm);
+    // Block 0 (Drew) has exactly one match on row 0; rows 1..14 are cleared.
+    for (const col of ["S", "T", "U", "V", "W", "Z", "AA"]) {
+      expectClear(map, `${col}${blockRow(0, 1)}`);
+      expectClear(map, `${col}${blockRow(0, 14)}`); // last data row of block 0 (row 16)
+    }
+  });
+
+  it("clears all 48 blocks' input cells even when far more blocks exist than players", () => {
+    const { data } = twoPlayerBm();
+    const writes = buildQualificationWrites(data, "bm");
+    const map = indexWrites(writes, sheetOf.bm);
+    // Block 2 (unused, row 34) input cells cleared; block 47 (last) too.
+    expectClear(map, `S${blockRow(2)}`);
+    expectClear(map, `V${blockRow(47)}`);
+    // Last block's last data row = 2 + 47*16 + 14 = 768.
+    expectClear(map, `S${blockRow(47, 14)}`);
+    // Nothing is written below the table (row 769+).
+    for (const ref of writtenRefs(writes, sheetOf.bm)) {
+      const row = Number(ref.replace(/[A-Z]/g, ""));
+      expect(row).toBeLessThanOrEqual(768);
+    }
+  });
+
+  it("clears GP Y and AB on unused rows, MR AB..AE on unused rows", () => {
+    const a = player("pa", "Lafungo");
+    const dataGp = emptyData({
+      gpQualifications: [qual(a, "A", 1)],
+      gpMatches: [], // no matches -> all rows of block 0 cleared
+    });
+    const mapGp = indexWrites(buildQualificationWrites(dataGp, "gp"), sheetOf.gp);
+    expectClear(mapGp, `Y${blockRow(0)}`);
+    expectClear(mapGp, `AB${blockRow(0)}`);
+
+    const s = player("ps", "Sami");
+    const dataMr = emptyData({
+      mrQualifications: [qual(s, "A", 1)],
+      mrMatches: [],
+    });
+    const mapMr = indexWrites(buildQualificationWrites(dataMr, "mr"), sheetOf.mr);
+    for (const col of ["AB", "AC", "AD", "AE"]) {
+      expectClear(mapMr, `${col}${blockRow(0)}`);
+    }
+  });
+});
+
+describe("buildQualificationWrites — empty input and never touching standings", () => {
+  it("emits only clears (no values) for a mode with no qualifiers", () => {
+    const data = emptyData();
+    const writes = buildQualificationWrites(data, "bm");
+    for (const w of writes) expect(w.op).toBe("clearValue");
+  });
+
+  it("never writes the standings columns E..Q or the match-area header column", () => {
+    const { data } = twoPlayerBm();
+    const map = indexWrites(buildQualificationWrites(data, "bm"), sheetOf.bm);
+    for (const col of ["A", "B", "C", "E", "F", "G", "H", "I", "O", "P", "Q"]) {
+      expectUntouched(map, `${col}${blockRow(0)}`);
+      expectUntouched(map, `${col}3`);
+    }
+  });
+});

--- a/smkc-score-app/__tests__/lib/cdm-export/fill/sheet-player-order.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/fill/sheet-player-order.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for the CDM qualification "sheet player order" helpers.
+ *
+ * These helpers reproduce, in JavaScript, the row/block ordering that the
+ * CDM template derives via its own dynamic-array formulas. Getting the order
+ * exactly right is what lets the fill maps place a match into the correct
+ * player block without ever writing to a formula cell.
+ *
+ * Ground truth for the formulas lives in the template cell dumps:
+ *   /tmp/cdm-analysis/sheet2025/sheet_BM_Qualifications.txt
+ *     F2 = VSTACK(IF(P4>0, SEQUENCE(P2/P4,1,1,P4), ""), IF(P4>1, ...2,P4), ...)
+ *     G2 = XLOOKUP(F2, Order, Nickname)  -> the G2# spill order we reproduce.
+ */
+
+import {
+  computeSheetPlayerOrder,
+  synthesizeModeOrders,
+  excelCaseInsensitiveCompare,
+} from "@/lib/cdm-export/fill/sheet-player-order";
+import type { CdmModeQualification, CdmPlayer } from "@/lib/cdm-export/types";
+
+function player(id: string, nickname: string, name = nickname): CdmPlayer {
+  return { id, name, nickname };
+}
+
+function qual(
+  id: string,
+  group: string,
+  seeding: number | null,
+  nickname = id,
+): CdmModeQualification {
+  return {
+    player: player(id, nickname),
+    seeding,
+    group,
+    points: 0,
+    score: 0,
+  };
+}
+
+describe("excelCaseInsensitiveCompare", () => {
+  it("sorts case-insensitively ascending", () => {
+    const input = ["banana", "Apple", "cherry", "Berry"];
+    const sorted = [...input].sort(excelCaseInsensitiveCompare);
+    expect(sorted).toEqual(["Apple", "banana", "Berry", "cherry"]);
+  });
+
+  it("treats upper and lower case of the same letter as equal for ordering", () => {
+    // "Ale" vs "ale" compare equal case-insensitively; stable tie-break by
+    // raw code units keeps a deterministic order ('A'=65 < 'a'=97).
+    expect(excelCaseInsensitiveCompare("Ale", "ale")).toBeLessThan(0);
+    expect(excelCaseInsensitiveCompare("ale", "Ale")).toBeGreaterThan(0);
+  });
+
+  it("returns 0 for identical strings", () => {
+    expect(excelCaseInsensitiveCompare("Drew", "Drew")).toBe(0);
+  });
+
+  it("orders by the first differing character, not by length, when prefixes match case-insensitively", () => {
+    expect(excelCaseInsensitiveCompare("ab", "ABC")).toBeLessThan(0); // shorter prefix sorts first
+    expect(excelCaseInsensitiveCompare("ABC", "ab")).toBeGreaterThan(0);
+  });
+});
+
+describe("synthesizeModeOrders", () => {
+  it("interleaves groups so the sheet re-derives the app groups (2 groups of 4)", () => {
+    // Group A (gi=0): seeds 1..4 -> Orders 1, 3, 5, 7 (1 + k*G, G=2)
+    // Group B (gi=1): seeds 1..4 -> Orders 2, 4, 6, 8 (2 + k*G)
+    const quals = [
+      qual("a1", "A", 1),
+      qual("a2", "A", 2),
+      qual("a3", "A", 3),
+      qual("a4", "A", 4),
+      qual("b1", "B", 1),
+      qual("b2", "B", 2),
+      qual("b3", "B", 3),
+      qual("b4", "B", 4),
+    ];
+    const orders = synthesizeModeOrders(quals);
+    expect(orders.get("a1")).toBe(1);
+    expect(orders.get("a2")).toBe(3);
+    expect(orders.get("a3")).toBe(5);
+    expect(orders.get("a4")).toBe(7);
+    expect(orders.get("b1")).toBe(2);
+    expect(orders.get("b2")).toBe(4);
+    expect(orders.get("b3")).toBe(6);
+    expect(orders.get("b4")).toBe(8);
+  });
+
+  it("orders players within a group by app seeding ascending (not by input order)", () => {
+    const quals = [
+      qual("a3", "A", 3),
+      qual("a1", "A", 1),
+      qual("a2", "A", 2),
+    ];
+    const orders = synthesizeModeOrders(quals); // 1 group, G=1 -> Order=1+k
+    expect(orders.get("a1")).toBe(1);
+    expect(orders.get("a2")).toBe(2);
+    expect(orders.get("a3")).toBe(3);
+  });
+
+  it("handles three groups (G=3): A=1,4,7 B=2,5,8 C=3,6,9", () => {
+    const quals = [
+      qual("a1", "A", 1),
+      qual("a2", "A", 2),
+      qual("a3", "A", 3),
+      qual("b1", "B", 1),
+      qual("b2", "B", 2),
+      qual("b3", "B", 3),
+      qual("c1", "C", 1),
+      qual("c2", "C", 2),
+      qual("c3", "C", 3),
+    ];
+    const orders = synthesizeModeOrders(quals);
+    expect([orders.get("a1"), orders.get("a2"), orders.get("a3")]).toEqual([1, 4, 7]);
+    expect([orders.get("b1"), orders.get("b2"), orders.get("b3")]).toEqual([2, 5, 8]);
+    expect([orders.get("c1"), orders.get("c2"), orders.get("c3")]).toEqual([3, 6, 9]);
+  });
+
+  it("places players with null seeding after seeded players, in stable input order", () => {
+    const quals = [
+      qual("a2", "A", 2),
+      qual("aX", "A", null),
+      qual("a1", "A", 1),
+      qual("aY", "A", null),
+    ];
+    const orders = synthesizeModeOrders(quals); // G=1
+    expect(orders.get("a1")).toBe(1);
+    expect(orders.get("a2")).toBe(2);
+    expect(orders.get("aX")).toBe(3); // first null in input order
+    expect(orders.get("aY")).toBe(4);
+  });
+});
+
+describe("computeSheetPlayerOrder", () => {
+  it("returns group A players then group B players, each by app seeding ascending", () => {
+    const quals = [
+      qual("b2", "B", 2),
+      qual("a2", "A", 2),
+      qual("b1", "B", 1),
+      qual("a1", "A", 1),
+    ];
+    const order = computeSheetPlayerOrder(quals).map((q) => q.player.id);
+    expect(order).toEqual(["a1", "a2", "b1", "b2"]);
+  });
+
+  it("matches the index used to assign player blocks (block i owner = order[i])", () => {
+    const quals = [
+      qual("a1", "A", 1),
+      qual("a2", "A", 2),
+      qual("b1", "B", 1),
+      qual("b2", "B", 2),
+    ];
+    const order = computeSheetPlayerOrder(quals);
+    // Block 0 -> a1, block 1 -> a2, block 2 -> b1, block 3 -> b2
+    expect(order[0].player.id).toBe("a1");
+    expect(order[2].player.id).toBe("b1");
+  });
+
+  it("is consistent with synthesizeModeOrders ascending values", () => {
+    const quals = [
+      qual("a1", "A", 1),
+      qual("a2", "A", 2),
+      qual("b1", "B", 1),
+      qual("b2", "B", 2),
+    ];
+    const orders = synthesizeModeOrders(quals);
+    const seq = computeSheetPlayerOrder(quals);
+    // The G2# spill walks Order values 1,2,3,... so the i-th block owner is the
+    // player whose synthesized Order makes it land at spill position i.
+    // For this even 2x2 case spill order is a1(1), b1(2), a2(3), b2(4)?? No:
+    // F2 lists group A first (Orders 1,3), then group B (Orders 2,4). XLOOKUP
+    // keeps that listing order, so spill = a1, a2, b1, b2.
+    expect(seq.map((q) => q.player.id)).toEqual(["a1", "a2", "b1", "b2"]);
+    // Sanity: Orders are the interleaved synthesis.
+    expect(orders.get("a1")).toBe(1);
+    expect(orders.get("a2")).toBe(3);
+    expect(orders.get("b1")).toBe(2);
+    expect(orders.get("b2")).toBe(4);
+  });
+
+  it("returns an empty array for no qualifications", () => {
+    expect(computeSheetPlayerOrder([])).toEqual([]);
+  });
+});

--- a/smkc-score-app/__tests__/lib/cdm-export/fill/tt-finals.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/fill/tt-finals.test.ts
@@ -1,0 +1,947 @@
+/**
+ * Tests for the CDM "TT Finals" fill map and its life-replay helper.
+ *
+ * Two units are exercised here:
+ *
+ *   1. replayTTFinals(data) — reconstructs, for every sheet round, who ran
+ *      (and their time), who lost a life, what bonus lives were granted, and
+ *      the input/display row orders. Its rules MUST match
+ *      src/lib/ta/finals-phase-manager.ts (the authoritative engine) and the
+ *      canonical in-memory replay in undoLastPhaseRound (same file). The tests
+ *      pin each phase transition (phase1/2 single elimination, phase3 bottom-
+ *      half life loss, phase-3 entry +2 grant, life reset to 3).
+ *
+ *   2. buildTTFinalsWrites(data) — turns the replay into CdmCellWrite[] against
+ *      the verified template geometry (cdm-constants.ts, and the dump at
+ *      /tmp/cdm-analysis/sheet2025/sheet_TT_Finals.txt). Column facts pinned by
+ *      the dump:
+ *        r=1: Left=C Gain=D Time=E   display Lost=K   (C3..C26=1, E19..E26=time)
+ *        r=2: Left=P Gain=Q Time=R   display Lost=X   (P3 = SORT formula → never written)
+ *        r=9: Gain=DD Time=DE        (DD3=2 phase-3 entry grant, DE3=5452)
+ *        r=40: Left=SP Gain=SQ Time=SR display Lost=SX
+ */
+
+import {
+  replayTTFinals,
+  type TTFinalsReplayRound,
+} from "@/lib/cdm-export/fill/tt-lives-replay";
+import { buildTTFinalsWrites } from "@/lib/cdm-export/fill/tt-finals";
+import {
+  TT_FINALS_MAX_ROUNDS,
+  TT_FINALS_FIRST_DATA_ROW,
+  TT_FINALS_MAX_FINALISTS,
+  CDM_COURSE_NAMES,
+} from "@/lib/cdm-export/cdm-constants";
+import { msToCdmTime } from "@/lib/cdm-export/time-format";
+import type {
+  CdmCellWrite,
+  CdmPlayer,
+  CdmTournamentData,
+  CdmTTEntry,
+  CdmTTPhaseRound,
+} from "@/lib/cdm-export/types";
+import {
+  indexWrites,
+  expectNumber,
+  expectClear,
+  expectString,
+  expectUntouched,
+} from "./write-helpers";
+
+// --------------------------------------------------------------------------
+// Fixture builders
+// --------------------------------------------------------------------------
+
+function player(id: string): CdmPlayer {
+  return { id, name: `Name ${id}`, nickname: id };
+}
+
+/**
+ * Build a qualification-stage TT entry. `rank` drives the round-1 universe row
+ * order (1..24); points/time are only consulted on rank ties.
+ */
+function qualEntry(
+  playerId: string,
+  rank: number,
+  opts: { points?: number; totalTime?: number } = {},
+): CdmTTEntry {
+  return {
+    player: player(playerId),
+    playerId,
+    stage: "qualification",
+    seeding: rank,
+    lives: 0,
+    eliminated: false,
+    totalTime: opts.totalTime ?? rank * 1000,
+    qualificationPoints: opts.points ?? 1000 - rank,
+    rank,
+  } as CdmTTEntry & { rank: number };
+}
+
+interface RoundResult {
+  playerId: string;
+  timeMs: number;
+}
+
+function phaseRound(
+  phase: "phase1" | "phase2" | "phase3",
+  roundNumber: number,
+  course: string,
+  results: RoundResult[],
+  opts: { eliminatedIds?: string[]; livesReset?: boolean } = {},
+): CdmTTPhaseRound {
+  return {
+    phase,
+    roundNumber,
+    course,
+    results: results.map((r) => ({ ...r, isRetry: false })),
+    eliminatedIds: opts.eliminatedIds ?? null,
+    livesReset: opts.livesReset ?? false,
+  };
+}
+
+/** A 24-player qualification universe (ranks 1..24 → ids p01..p24). */
+function universe24(): CdmTTEntry[] {
+  return Array.from({ length: 24 }, (_, i) =>
+    qualEntry(`p${String(i + 1).padStart(2, "0")}`, i + 1),
+  );
+}
+
+function id(n: number): string {
+  return `p${String(n).padStart(2, "0")}`;
+}
+
+function emptyData(overrides: Partial<CdmTournamentData> = {}): CdmTournamentData {
+  return {
+    name: "T",
+    date: new Date("2025-01-01"),
+    bmQualifications: [],
+    mrQualifications: [],
+    gpQualifications: [],
+    bmMatches: [],
+    mrMatches: [],
+    gpMatches: [],
+    ttEntries: [],
+    ttPhaseRounds: [],
+    ...overrides,
+  };
+}
+
+// --------------------------------------------------------------------------
+// replayTTFinals — universe and ordering
+// --------------------------------------------------------------------------
+
+describe("replayTTFinals — universe", () => {
+  it("returns no rounds when there are no phase rounds", () => {
+    expect(replayTTFinals(emptyData())).toEqual([]);
+  });
+
+  it("orders the round-1 input rows by qualification rank 1..24", () => {
+    const data = emptyData({
+      ttEntries: universe24(),
+      // One phase1 round so a round exists to inspect the row order.
+      ttPhaseRounds: [
+        phaseRound("phase1", 1, "MC1", [
+          { playerId: id(17), timeMs: 60000 },
+          { playerId: id(18), timeMs: 61000 },
+          { playerId: id(19), timeMs: 62000 },
+          { playerId: id(20), timeMs: 63000 },
+          { playerId: id(21), timeMs: 64000 },
+          { playerId: id(22), timeMs: 65000 },
+          { playerId: id(23), timeMs: 66000 },
+          { playerId: id(24), timeMs: 99000 },
+        ], { eliminatedIds: [id(24)] }),
+      ],
+    });
+    const rounds = replayTTFinals(data);
+    expect(rounds[0].inputRowOrder).toEqual(
+      Array.from({ length: 24 }, (_, i) => id(i + 1)),
+    );
+  });
+
+  it("breaks rank ties with the documented comparator (points DESC, time ASC)", () => {
+    // Two entries share rank 5; comparator must place higher points first.
+    const entries: CdmTTEntry[] = [
+      qualEntry(id(1), 1),
+      qualEntry("tieLow", 5, { points: 100, totalTime: 5000 }),
+      qualEntry("tieHigh", 5, { points: 200, totalTime: 9000 }),
+    ];
+    const data = emptyData({
+      ttEntries: entries,
+      ttPhaseRounds: [
+        phaseRound("phase1", 1, "MC1", [
+          { playerId: id(1), timeMs: 60000 },
+          { playerId: "tieHigh", timeMs: 61000 },
+          { playerId: "tieLow", timeMs: 99000 },
+        ], { eliminatedIds: ["tieLow"] }),
+      ],
+    });
+    const rounds = replayTTFinals(data);
+    // p01 (rank1) first, then tieHigh (more points) before tieLow.
+    expect(rounds[0].inputRowOrder).toEqual([id(1), "tieHigh", "tieLow"]);
+  });
+});
+
+// --------------------------------------------------------------------------
+// replayTTFinals — phase 1/2 single elimination
+// --------------------------------------------------------------------------
+
+describe("replayTTFinals — phase1/phase2 elimination", () => {
+  it("marks exactly the eliminated runner as losing a life; survivors keep Left=1", () => {
+    const runners = [17, 18, 19, 20, 21, 22, 23, 24];
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        phaseRound(
+          "phase1",
+          1,
+          "MC1",
+          runners.map((n, i) => ({ playerId: id(n), timeMs: 60000 + i * 1000 })),
+          { eliminatedIds: [id(24)] },
+        ),
+      ],
+    });
+    const r1 = replayTTFinals(data)[0];
+
+    expect(r1.lostLife).toEqual(new Set([id(24)]));
+    // The eliminated runner ends at 0 lives; everyone else stays at 1.
+    expect(r1.livesAfter.get(id(24))).toBe(0);
+    expect(r1.livesAfter.get(id(17))).toBe(1);
+    // Non-runners (ranks 1..16) also keep their single life.
+    expect(r1.livesAfter.get(id(1))).toBe(1);
+    // No bonus lives in phase 1.
+    expect(r1.gains.size).toBe(0);
+  });
+
+  it("carries lives forward across two phase-1 rounds", () => {
+    const r1Runners = [17, 18, 19, 20, 21, 22, 23, 24];
+    const r2Runners = [17, 18, 19, 20, 21, 22, 23]; // p24 eliminated in r1
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        phaseRound(
+          "phase1",
+          1,
+          "MC1",
+          r1Runners.map((n, i) => ({ playerId: id(n), timeMs: 60000 + i * 1000 })),
+          { eliminatedIds: [id(24)] },
+        ),
+        phaseRound(
+          "phase1",
+          2,
+          "DP1",
+          r2Runners.map((n, i) => ({ playerId: id(n), timeMs: 60000 + i * 1000 })),
+          { eliminatedIds: [id(23)] },
+        ),
+      ],
+    });
+    const rounds = replayTTFinals(data);
+    expect(rounds).toHaveLength(2);
+    // After r2, p23 is out (0), p24 still 0 from r1, the rest 1.
+    expect(rounds[1].livesAfter.get(id(23))).toBe(0);
+    expect(rounds[1].livesAfter.get(id(24))).toBe(0);
+    expect(rounds[1].livesAfter.get(id(17))).toBe(1);
+  });
+
+  it("loses no life when eliminatedIds is empty (survivor floor reached)", () => {
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        phaseRound("phase2", 1, "MC1", [
+          { playerId: id(1), timeMs: 60000 },
+          { playerId: id(2), timeMs: 61000 },
+          { playerId: id(3), timeMs: 62000 },
+          { playerId: id(4), timeMs: 63000 },
+        ]),
+      ],
+    });
+    const r = replayTTFinals(data)[0];
+    expect(r.lostLife.size).toBe(0);
+  });
+});
+
+// --------------------------------------------------------------------------
+// replayTTFinals — phase 3 life system
+// --------------------------------------------------------------------------
+
+describe("replayTTFinals — phase3 bottom-half life loss", () => {
+  it("the bottom half by ascending time each lose one life; phase-3 entrants get +2", () => {
+    // 4 phase-3 runners; bottom half = slowest 2 lose a life.
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        phaseRound("phase3", 1, "MC1", [
+          { playerId: id(1), timeMs: 60000 }, // fastest -> safe
+          { playerId: id(2), timeMs: 61000 }, // safe
+          { playerId: id(3), timeMs: 62000 }, // bottom half -> lose
+          { playerId: id(4), timeMs: 63000 }, // bottom half -> lose
+        ]),
+      ],
+    });
+    const r = replayTTFinals(data)[0];
+
+    // Bottom half = ceil(4/2)=2 → indices 2,3 → p03,p04.
+    expect(r.lostLife).toEqual(new Set([id(3), id(4)]));
+    // Entry grant: every runner topped from 1 → 3 (Gain +2).
+    for (const n of [1, 2, 3, 4]) {
+      expect(r.gains.get(id(n))).toBe(2);
+    }
+    // After: safe players 3 lives, bottom-half players 3-1=2.
+    expect(r.livesAfter.get(id(1))).toBe(3);
+    expect(r.livesAfter.get(id(2))).toBe(3);
+    expect(r.livesAfter.get(id(3))).toBe(2);
+    expect(r.livesAfter.get(id(4))).toBe(2);
+  });
+
+  it("treats a null time as slowest so it falls in the bottom half", () => {
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        {
+          phase: "phase3",
+          roundNumber: 1,
+          course: "MC1",
+          results: [
+            { playerId: id(1), timeMs: 60000 },
+            { playerId: id(2), timeMs: 61000 },
+            { playerId: id(3), timeMs: 62000 },
+            { playerId: id(4), timeMs: null }, // no time → slowest
+          ],
+          eliminatedIds: null,
+          livesReset: false,
+        } as CdmTTPhaseRound,
+      ],
+    });
+    const r = replayTTFinals(data)[0];
+    expect(r.lostLife.has(id(4))).toBe(true);
+  });
+
+  it("grants the +2 entry top-up only once across multiple phase-3 rounds", () => {
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        phaseRound("phase3", 1, "MC1", [
+          { playerId: id(1), timeMs: 60000 },
+          { playerId: id(2), timeMs: 61000 },
+          { playerId: id(3), timeMs: 62000 },
+          { playerId: id(4), timeMs: 63000 },
+        ]),
+        phaseRound("phase3", 2, "DP1", [
+          { playerId: id(1), timeMs: 60000 },
+          { playerId: id(2), timeMs: 61000 },
+          { playerId: id(3), timeMs: 62000 },
+          { playerId: id(4), timeMs: 63000 },
+        ]),
+      ],
+    });
+    const rounds = replayTTFinals(data);
+    // Round 1 grants +2 to all; round 2 grants nothing (already entered).
+    for (const n of [1, 2, 3, 4]) expect(rounds[0].gains.get(id(n))).toBe(2);
+    expect(rounds[1].gains.size).toBe(0);
+  });
+
+  it("applies a life reset to 3 after eliminations hit a threshold (realistic 3-round wear-down)", () => {
+    // Realistic reset: 4 phase-3 entrants start on 3 lives (round 1 grants +2
+    // each). p03 and p04 are the slowest each round so they lose a life every
+    // round: 3 → 2 → 1 → 0. In round 3 they reach 0 and are eliminated; the
+    // active count drops to 2, which is a [8,4,2] reset threshold, so the
+    // engine resets the two survivors (p01,p02) back to 3 lives (livesReset).
+    // This mirrors processPhase3Result's updateMany(eliminated:false → 3).
+    const fourRunners = (slowA: number, slowB: number) => [
+      { playerId: id(1), timeMs: 60000 },
+      { playerId: id(2), timeMs: 61000 },
+      { playerId: id(slowA), timeMs: 62000 },
+      { playerId: id(slowB), timeMs: 63000 },
+    ];
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        phaseRound("phase3", 1, "MC1", fourRunners(3, 4)),
+        phaseRound("phase3", 2, "DP1", fourRunners(3, 4)),
+        phaseRound("phase3", 3, "GV1", fourRunners(3, 4), {
+          eliminatedIds: [id(3), id(4)],
+          livesReset: true,
+        }),
+      ],
+    });
+    const rounds = replayTTFinals(data);
+    const r3 = rounds[2];
+    // Survivors reset to 3 (display Left); the two eliminated players to 0.
+    expect(r3.livesAfter.get(id(1))).toBe(3);
+    expect(r3.livesAfter.get(id(2))).toBe(3);
+    expect(r3.livesAfter.get(id(3))).toBe(0);
+    expect(r3.livesAfter.get(id(4))).toBe(0);
+    // p01/p02 never lost a life, so they carried 3 lives into round 3. The
+    // reset target is also 3, so no extra Gain is needed (display Left =
+    // carried(3) + Gain(0) - Lost(0) = 3). The replay correctly emits no Gain.
+    expect(r3.gains.get(id(1))).toBeUndefined();
+    expect(r3.gains.get(id(2))).toBeUndefined();
+  });
+
+  it("encodes the reset top-up as Gain when a surviving player lost a life on the reset round", () => {
+    // 6 phase-3 entrants (3 lives each after round 1). We wear the field so that
+    // entering the reset round one survivor sits at 2 lives and loses a life on
+    // that round, then is reset to 3 — exercising the Gain top-up path:
+    //   display Left = carried + Gain - Lost = 3  →  Gain = 3 - carried + Lost.
+    // Construction: rounds 1..3 always have the same 6 runners with p05 & p06
+    // slowest, plus we rotate p04 into the bottom half on round 3 so it loses a
+    // life there while surviving the reset.
+    const six = (slow: number[]) => {
+      const fast = [1, 2, 3, 4, 5, 6].filter((n) => !slow.includes(n));
+      return [
+        ...fast.map((n, i) => ({ playerId: id(n), timeMs: 60000 + i * 1000 })),
+        ...slow.map((n, i) => ({ playerId: id(n), timeMs: 80000 + i * 1000 })),
+      ];
+    };
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        // bottom half of 6 = 3 slowest. p05,p06 lose every round; the 3rd
+        // bottom-half slot rotates so p04 reaches the reset round at 2 lives.
+        phaseRound("phase3", 1, "MC1", six([2, 5, 6])), // p02,p05,p06 → 2 lives
+        phaseRound("phase3", 2, "DP1", six([2, 5, 6])), // p02,p05,p06 → 1 life
+        // Round 3: p05,p06 reach 0 (eliminated) → count 4 hits threshold; p04
+        // is also in the bottom half (loses a life 3→2) but survives → reset to 3.
+        phaseRound("phase3", 3, "GV1", six([4, 5, 6]), {
+          eliminatedIds: [id(5), id(6)],
+          livesReset: true,
+        }),
+      ],
+    });
+    const r3 = replayTTFinals(data)[2];
+    // p04 lost a life this round (carried 3 → 2 after loss) then reset to 3:
+    // Gain = 3 - 3 + 1 = 1.
+    expect(r3.lostLife.has(id(4))).toBe(true);
+    expect(r3.livesAfter.get(id(4))).toBe(3);
+    expect(r3.gains.get(id(4))).toBe(1);
+    // Eliminated players end at 0.
+    expect(r3.livesAfter.get(id(5))).toBe(0);
+    expect(r3.livesAfter.get(id(6))).toBe(0);
+  });
+
+  it("does NOT reset universe bystanders that never entered phase 3", () => {
+    // The engine resets only phase-3 participants (processPhase3Result:793-802 —
+    // updateMany where stage:"phase3", eliminated:false). A universe finalist who
+    // never ran a phase-3 round still holds their single starting life and must
+    // stay at 1 through a reset round — not be lifted to 3 (which would corrupt
+    // the ledger and the next round's SORTBY-by-ending-lives input order).
+    // 6-player universe; only p01..p04 ever run (all in phase 3). p05,p06 are
+    // bystanders. Round 3 eliminates the worn-down pair and triggers a reset.
+    const four = (slowA: number, slowB: number) => [
+      { playerId: id(1), timeMs: 60000 },
+      { playerId: id(2), timeMs: 61000 },
+      { playerId: id(slowA), timeMs: 62000 },
+      { playerId: id(slowB), timeMs: 63000 },
+    ];
+    const data = emptyData({
+      ttEntries: Array.from({ length: 6 }, (_, i) => qualEntry(id(i + 1), i + 1)),
+      ttPhaseRounds: [
+        phaseRound("phase3", 1, "MC1", four(3, 4)),
+        phaseRound("phase3", 2, "DP1", four(3, 4)),
+        phaseRound("phase3", 3, "GV1", four(3, 4), {
+          eliminatedIds: [id(3), id(4)],
+          livesReset: true,
+        }),
+      ],
+    });
+    const r3 = replayTTFinals(data)[2];
+    // Bystanders keep their single life and receive no bonus Gain.
+    expect(r3.livesAfter.get(id(5))).toBe(1);
+    expect(r3.livesAfter.get(id(6))).toBe(1);
+    expect(r3.gains.get(id(5))).toBeUndefined();
+    expect(r3.gains.get(id(6))).toBeUndefined();
+    // Phase-3 survivors still reset to 3.
+    expect(r3.livesAfter.get(id(1))).toBe(3);
+    expect(r3.livesAfter.get(id(2))).toBe(3);
+  });
+});
+
+// --------------------------------------------------------------------------
+// replayTTFinals — row ordering across rounds
+// --------------------------------------------------------------------------
+
+describe("replayTTFinals — row ordering", () => {
+  it("round r>=2 input order = previous display order sorted by ending lives DESC (stable)", () => {
+    // Round 1: 4 runners, p03 & p04 lose a life (end at 0 / single-life model
+    // via phase1). Round 2 input order should put higher-lives players first,
+    // keeping prior display order among equal lives.
+    const data = emptyData({
+      ttEntries: Array.from({ length: 4 }, (_, i) => qualEntry(id(i + 1), i + 1)),
+      ttPhaseRounds: [
+        phaseRound(
+          "phase1",
+          1,
+          "MC1",
+          [
+            { playerId: id(1), timeMs: 60000 },
+            { playerId: id(2), timeMs: 61000 },
+            { playerId: id(3), timeMs: 62000 },
+            { playerId: id(4), timeMs: 99000 },
+          ],
+          { eliminatedIds: [id(4)] },
+        ),
+        phaseRound(
+          "phase1",
+          2,
+          "DP1",
+          [
+            { playerId: id(1), timeMs: 60000 },
+            { playerId: id(2), timeMs: 61000 },
+            { playerId: id(3), timeMs: 62000 },
+          ],
+          { eliminatedIds: [id(3)] },
+        ),
+      ],
+    });
+    const rounds = replayTTFinals(data);
+    // After r1: p04 has 0 lives, p01..p03 have 1. r2 input = survivors-first,
+    // preserving r1 display order, with p04 (0 lives) last.
+    const r2Input = rounds[1].inputRowOrder;
+    expect(r2Input[r2Input.length - 1]).toBe(id(4)); // lowest lives last
+    expect(new Set(r2Input)).toEqual(new Set([id(1), id(2), id(3), id(4)]));
+  });
+
+  it("display order = input order sorted by this round's time ASC; non-runners (time 0) first", () => {
+    const data = emptyData({
+      ttEntries: Array.from({ length: 4 }, (_, i) => qualEntry(id(i + 1), i + 1)),
+      ttPhaseRounds: [
+        // Only p02 and p03 run; p01 and p04 sit out (rank 1 and 4).
+        phaseRound("phase1", 1, "MC1", [
+          { playerId: id(2), timeMs: 70000 },
+          { playerId: id(3), timeMs: 65000 },
+        ], { eliminatedIds: [id(2)] }),
+      ],
+    });
+    const r = replayTTFinals(data)[0];
+    // Non-runners p01, p04 (time 0) come first in input order; among runners,
+    // p03 (65s) before p02 (70s).
+    const display = r.displayRowOrder;
+    // p01 & p04 occupy the first two slots (order between them = input order).
+    expect(new Set(display.slice(0, 2))).toEqual(new Set([id(1), id(4)]));
+    // p03 before p02 among the runners.
+    expect(display.indexOf(id(3))).toBeLessThan(display.indexOf(id(2)));
+  });
+});
+
+// --------------------------------------------------------------------------
+// replayTTFinals — phase order & overflow
+// --------------------------------------------------------------------------
+
+describe("replayTTFinals — ordering and overflow", () => {
+  it("plays phase1 rounds, then phase2, then phase3 regardless of input array order", () => {
+    const mk = (phase: "phase1" | "phase2" | "phase3", rn: number, course: string) =>
+      phaseRound(phase, rn, course, [
+        { playerId: id(1), timeMs: 60000 },
+        { playerId: id(2), timeMs: 61000 },
+      ], { eliminatedIds: [id(2)] });
+    const data = emptyData({
+      ttEntries: universe24(),
+      // Deliberately shuffled input order.
+      ttPhaseRounds: [
+        mk("phase3", 1, "RR"),
+        mk("phase1", 2, "DP1"),
+        mk("phase2", 1, "GV1"),
+        mk("phase1", 1, "MC1"),
+      ],
+    });
+    const rounds = replayTTFinals(data);
+    expect(rounds.map((r) => r.course)).toEqual(["MC1", "DP1", "GV1", "RR"]);
+  });
+
+  it("drops rounds beyond TT_FINALS_MAX_ROUNDS", () => {
+    const many: CdmTTPhaseRound[] = Array.from(
+      { length: TT_FINALS_MAX_ROUNDS + 5 },
+      (_, i) =>
+        phaseRound("phase1", i + 1, "MC1", [
+          { playerId: id(1), timeMs: 60000 },
+          { playerId: id(2), timeMs: 61000 },
+        ], { eliminatedIds: [id(2)] }),
+    );
+    const rounds = replayTTFinals(emptyData({ ttEntries: universe24(), ttPhaseRounds: many }));
+    expect(rounds).toHaveLength(TT_FINALS_MAX_ROUNDS);
+  });
+
+  it("ignores a result for a player outside the 24-player universe", () => {
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        phaseRound("phase1", 1, "MC1", [
+          { playerId: id(17), timeMs: 60000 },
+          { playerId: "ghost", timeMs: 61000 }, // not in universe
+          { playerId: id(18), timeMs: 99000 },
+        ], { eliminatedIds: [id(18)] }),
+      ],
+    });
+    const r = replayTTFinals(data)[0];
+    expect(r.participants.has("ghost")).toBe(false);
+    expect(r.participants.has(id(17))).toBe(true);
+  });
+});
+
+// --------------------------------------------------------------------------
+// replayTTFinals — full three-phase progression
+// --------------------------------------------------------------------------
+
+describe("replayTTFinals — three-phase progression", () => {
+  it("plays phase1, then phase2, then phase3 and carries the ledger across phases", () => {
+    // Minimal-but-valid three-phase run. We only assert the phase ordering and
+    // that the phase-3 entry grant fires when phase-3 begins, since the precise
+    // per-round wear-down is covered by the focused tests above.
+    const elim = (p: number, ...runners: number[]) =>
+      runners.map((n, i) => ({
+        playerId: id(n),
+        timeMs: n === p ? 99000 : 60000 + i * 1000,
+      }));
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        // phase1: ranks 17..24, eliminate the slowest until 4 remain.
+        phaseRound("phase1", 1, "MC1", elim(24, 17, 18, 19, 20, 21, 22, 23, 24), {
+          eliminatedIds: [id(24)],
+        }),
+        // phase2: survivors + ranks 13..16 (model with a single elimination).
+        phaseRound("phase2", 1, "DP1", elim(16, 13, 14, 15, 16, 17, 18, 19, 20), {
+          eliminatedIds: [id(16)],
+        }),
+        // phase3: top 12 + phase2 survivors begin the life system.
+        phaseRound("phase3", 1, "GV1", [
+          { playerId: id(1), timeMs: 60000 },
+          { playerId: id(2), timeMs: 61000 },
+          { playerId: id(3), timeMs: 62000 },
+          { playerId: id(4), timeMs: 63000 },
+        ]),
+      ],
+    });
+    const rounds = replayTTFinals(data);
+    expect(rounds.map((r) => r.course)).toEqual(["MC1", "DP1", "GV1"]);
+    // Phase-3 round grants the +2 entry top-up to its runners.
+    expect(rounds[2].gains.get(id(1))).toBe(2);
+    // Phase-1 / phase-2 rounds never grant lives.
+    expect(rounds[0].gains.size).toBe(0);
+    expect(rounds[1].gains.size).toBe(0);
+  });
+});
+
+// --------------------------------------------------------------------------
+// replayTTFinals — sudden-death outcomes (folded into the parent round)
+// --------------------------------------------------------------------------
+
+describe("replayTTFinals — sudden-death resolution", () => {
+  // CdmTournamentData has no sudden-death field (the export include does not
+  // fetch TTPhaseSuddenDeathRound). This is by design: submitSuddenDeathResults
+  // writes the resolved eliminatedIds / livesReset back onto the PARENT
+  // TTPhaseRound (finals-phase-manager.ts:1666-1673), so the parent round
+  // already carries the final outcome and the replay reconstructs it without a
+  // separate SD round. A standalone SD ledger row would double-count the life
+  // change. These tests pin that the parent-round outcome drives the ledger.
+
+  it("phase1: uses the parent round's resolved eliminatedIds even when the stored times tie", () => {
+    // Two players tie for slowest; a sudden death resolved p18 as the loser.
+    // The parent round's results keep the original (tied) times, but its
+    // eliminatedIds was set to the SD loser. The replay must mark p18, not p17.
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        phaseRound("phase1", 1, "MC1", [
+          { playerId: id(17), timeMs: 70000 }, // tie
+          { playerId: id(18), timeMs: 70000 }, // tie → lost the sudden death
+          { playerId: id(19), timeMs: 60000 },
+          { playerId: id(20), timeMs: 61000 },
+        ], { eliminatedIds: [id(18)] }),
+      ],
+    });
+    const r = replayTTFinals(data)[0];
+    expect(r.lostLife).toEqual(new Set([id(18)]));
+    expect(r.livesAfter.get(id(18))).toBe(0);
+    expect(r.livesAfter.get(id(17))).toBe(1);
+  });
+
+  it("phase3: honours a livesReset that a sudden death produced on the parent round", () => {
+    // Wear two players to their last life, then a tie-broken round eliminates
+    // both (count hits threshold 2) and the parent round records livesReset.
+    const fourRunners = (slowA: number, slowB: number) => [
+      { playerId: id(1), timeMs: 60000 },
+      { playerId: id(2), timeMs: 61000 },
+      { playerId: id(slowA), timeMs: 70000 },
+      { playerId: id(slowB), timeMs: 70000 }, // tie resolved via sudden death
+    ];
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        phaseRound("phase3", 1, "MC1", fourRunners(3, 4)),
+        phaseRound("phase3", 2, "DP1", fourRunners(3, 4)),
+        phaseRound("phase3", 3, "GV1", fourRunners(3, 4), {
+          eliminatedIds: [id(3), id(4)],
+          livesReset: true,
+        }),
+      ],
+    });
+    const r3 = replayTTFinals(data)[2];
+    expect(r3.livesAfter.get(id(1))).toBe(3);
+    expect(r3.livesAfter.get(id(2))).toBe(3);
+    expect(r3.livesAfter.get(id(3))).toBe(0);
+    expect(r3.livesAfter.get(id(4))).toBe(0);
+  });
+});
+
+// --------------------------------------------------------------------------
+// buildTTFinalsWrites — no-data clearing path
+// --------------------------------------------------------------------------
+
+describe("buildTTFinalsWrites — no TT finals data", () => {
+  it("clears every input cell of all 40 round blocks (template carries CDM 2025 data)", () => {
+    const writes = buildTTFinalsWrites(emptyData());
+    const map = indexWrites(writes, "TT Finals");
+
+    // Round 1: Left C, Gain D, Time E rows 3..26; display Lost K rows 3..26;
+    // header at G1 cleared.
+    for (let row = 3; row <= 26; row++) {
+      expectClear(map, `C${row}`);
+      expectClear(map, `D${row}`);
+      expectClear(map, `E${row}`);
+      expectClear(map, `K${row}`);
+    }
+    expectClear(map, "G1"); // round-1 display header
+    // Round 40: Gain SQ, Time SR, display Lost SX rows 3..26; Left SP is a
+    // formula and must NOT be cleared (Left typed only in round 1).
+    for (let row = 3; row <= 26; row++) {
+      expectClear(map, `SQ${row}`);
+      expectClear(map, `SR${row}`);
+      expectClear(map, `SX${row}`);
+    }
+    expectClear(map, "ST1"); // round-40 display header
+  });
+
+  it("does NOT clear the Left column for rounds >= 2 (it is a spill formula)", () => {
+    const writes = buildTTFinalsWrites(emptyData());
+    const map = indexWrites(writes, "TT Finals");
+    // r=2 Left is column P → must be untouched.
+    for (let row = 3; row <= 26; row++) {
+      expectUntouched(map, `P${row}`);
+    }
+  });
+
+  it("never writes to the final standings block TA..TD", () => {
+    const writes = buildTTFinalsWrites(emptyData());
+    for (const w of writes) {
+      expect(w.ref).not.toMatch(/^T[A-D]\d+$/);
+    }
+  });
+});
+
+// --------------------------------------------------------------------------
+// buildTTFinalsWrites — data path
+// --------------------------------------------------------------------------
+
+describe("buildTTFinalsWrites — round 1 (phase1, 8 runners)", () => {
+  function buildRound1Map(): Map<string, CdmCellWrite> {
+    const runners = [17, 18, 19, 20, 21, 22, 23, 24];
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        phaseRound(
+          "phase1",
+          1,
+          "MC1",
+          runners.map((n, i) => ({ playerId: id(n), timeMs: 60000 + i * 1000 })),
+          { eliminatedIds: [id(24)] },
+        ),
+      ],
+    });
+    return indexWrites(buildTTFinalsWrites(data), "TT Finals");
+  }
+
+  it("writes the round header 'Round 1 - <full course name>' at G1", () => {
+    expectString(buildRound1Map(), "G1", `Round 1 - ${CDM_COURSE_NAMES["MC1"]}`);
+  });
+
+  it("writes Left=1 for every universe row in round 1 (C3..C26)", () => {
+    const map = buildRound1Map();
+    for (let row = 3; row <= 26; row++) {
+      expectNumber(map, `C${row}`, 1);
+    }
+  });
+
+  it("writes each runner's time (MSSCC) and 0 for non-runners in the Time column", () => {
+    // Round-1 input row order is rank 1..24, so row = 3 + (rank-1).
+    // p17 (rank 17) → row 19, time 60000ms → msToCdmTime.
+    const map = buildRound1Map();
+    expectNumber(map, "E19", msToCdmTime(60000)); // p17, first runner
+    expectNumber(map, "E26", msToCdmTime(60000 + 7 * 1000)); // p24, slowest runner
+    // A non-runner (rank 1 → row 3) gets Time 0.
+    expectNumber(map, "E3", 0);
+  });
+
+  it("clears the Gain column for round 1 (no phase-3 entry / reset here)", () => {
+    const map = buildRound1Map();
+    for (let row = 3; row <= 26; row++) {
+      expectClear(map, `D${row}`);
+    }
+  });
+
+  it("writes Lost=1 on the eliminated player's display row and clears the rest", () => {
+    // p24 (slowest) lost a life. Display order sorts by time ASC with non-
+    // runners first; p24 is the slowest runner → last display row = K26.
+    const map = buildRound1Map();
+    expectNumber(map, "K26", 1);
+    expectClear(map, "K3");
+  });
+});
+
+describe("buildTTFinalsWrites — runner with a null time writes 0", () => {
+  it("encodes a present-but-null runner time as 0 in the Time column", () => {
+    // A runner present in the round but with no recorded time should write 0
+    // (matching how the replay sorts a null time with the non-runners). Such
+    // data should not arise from submitRoundResults, but the writer is defensive.
+    const data = emptyData({
+      ttEntries: Array.from({ length: 4 }, (_, i) => qualEntry(id(i + 1), i + 1)),
+      ttPhaseRounds: [
+        {
+          phase: "phase1",
+          roundNumber: 1,
+          course: "MC1",
+          results: [
+            { playerId: id(1), timeMs: 60000 },
+            { playerId: id(2), timeMs: null }, // runner, no time
+            { playerId: id(3), timeMs: 62000 },
+            { playerId: id(4), timeMs: 99000 },
+          ],
+          eliminatedIds: [id(4)],
+          livesReset: false,
+        } as CdmTTPhaseRound,
+      ],
+    });
+    const map = indexWrites(buildTTFinalsWrites(data), "TT Finals");
+    // p02 (rank 2 → input row 4) has a null time → Time cell E4 = 0.
+    expectNumber(map, "E4", 0);
+    // A real runner still gets its encoded time (p03 rank 3 → row 5).
+    expectNumber(map, "E5", msToCdmTime(62000));
+  });
+});
+
+describe("buildTTFinalsWrites — phase-3 entry round writes the +2 Gain", () => {
+  it("emits Gain=2 on each phase-3 entrant row and the round's times", () => {
+    // Single phase-3 round as the only round → it is sheet round 1 (columns
+    // C/D/E). The +2 entry grant lands in the Gain column.
+    const data = emptyData({
+      ttEntries: Array.from({ length: 4 }, (_, i) => qualEntry(id(i + 1), i + 1)),
+      ttPhaseRounds: [
+        phaseRound("phase3", 1, "MC1", [
+          { playerId: id(1), timeMs: 60000 },
+          { playerId: id(2), timeMs: 61000 },
+          { playerId: id(3), timeMs: 62000 },
+          { playerId: id(4), timeMs: 63000 },
+        ]),
+      ],
+    });
+    const map = indexWrites(buildTTFinalsWrites(data), "TT Finals");
+    // Input rows: ranks 1..4 → rows 3..6. All four get Gain +2.
+    for (let row = 3; row <= 6; row++) {
+      expectNumber(map, `D${row}`, 2);
+    }
+    // Rows 7..26 have no runner and no gain → Gain cleared.
+    expectClear(map, "D7");
+  });
+});
+
+describe("buildTTFinalsWrites — second round uses the r=2 column block", () => {
+  it("writes round 2 Time into column R and the header at T1, leaving Left (P) untouched", () => {
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        phaseRound("phase1", 1, "MC1", [
+          { playerId: id(17), timeMs: 60000 },
+          { playerId: id(18), timeMs: 61000 },
+          { playerId: id(19), timeMs: 62000 },
+          { playerId: id(20), timeMs: 99000 },
+        ], { eliminatedIds: [id(20)] }),
+        phaseRound("phase1", 2, "DP1", [
+          { playerId: id(17), timeMs: 60000 },
+          { playerId: id(18), timeMs: 61000 },
+          { playerId: id(19), timeMs: 62000 },
+        ], { eliminatedIds: [id(19)] }),
+      ],
+    });
+    const map = indexWrites(buildTTFinalsWrites(data), "TT Finals");
+    expectString(map, "T1", `Round 2 - ${CDM_COURSE_NAMES["DP1"]}`);
+    // Some R-column cell carries a written time; Left column P is never written.
+    let rWritten = false;
+    for (let row = 3; row <= 26; row++) {
+      const w = map.get(`R${row}`);
+      if (w && w.op === "number" && w.value > 0) rWritten = true;
+      expectUntouched(map, `P${row}`); // Left is a formula for r>=2
+    }
+    expect(rWritten).toBe(true);
+  });
+});
+
+describe("buildTTFinalsWrites — unused trailing rounds", () => {
+  it("clears the input cells of round blocks that have no data", () => {
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        phaseRound("phase1", 1, "MC1", [
+          { playerId: id(17), timeMs: 60000 },
+          { playerId: id(18), timeMs: 99000 },
+        ], { eliminatedIds: [id(18)] }),
+      ],
+    });
+    const map = indexWrites(buildTTFinalsWrites(data), "TT Finals");
+    // Round 2 (columns Q Gain, R Time, X Lost) is unused → cleared.
+    for (let row = 3; row <= 26; row++) {
+      expectClear(map, `R${row}`);
+      expectClear(map, `Q${row}`);
+      expectClear(map, `X${row}`);
+    }
+  });
+});
+
+// --------------------------------------------------------------------------
+// buildTTFinalsWrites — structural guarantees
+// --------------------------------------------------------------------------
+
+describe("buildTTFinalsWrites — structural", () => {
+  it("emits one op per cell (no duplicate refs)", () => {
+    const data = emptyData({
+      ttEntries: universe24(),
+      ttPhaseRounds: [
+        phaseRound("phase1", 1, "MC1", [
+          { playerId: id(17), timeMs: 60000 },
+          { playerId: id(18), timeMs: 99000 },
+        ], { eliminatedIds: [id(18)] }),
+      ],
+    });
+    // indexWrites throws on a duplicate ref.
+    expect(() => indexWrites(buildTTFinalsWrites(data), "TT Finals")).not.toThrow();
+  });
+
+  it("only writes to the 'TT Finals' sheet", () => {
+    const writes = buildTTFinalsWrites(emptyData());
+    for (const w of writes) expect(w.sheet).toBe("TT Finals");
+  });
+
+  it("confirms the data-row span matches TT_FINALS_FIRST_DATA_ROW..+23", () => {
+    // Guards the constant wiring: 24 finalists, rows 3..26.
+    expect(TT_FINALS_FIRST_DATA_ROW).toBe(3);
+    expect(TT_FINALS_MAX_FINALISTS).toBe(24);
+  });
+});
+
+// --------------------------------------------------------------------------
+// Type-shape guard for the replay round (compile-time + a trivial runtime use)
+// --------------------------------------------------------------------------
+
+describe("TTFinalsReplayRound shape", () => {
+  it("exposes the fields the writer consumes", () => {
+    const round: TTFinalsReplayRound = {
+      course: "MC1",
+      participants: new Map(),
+      lostLife: new Set(),
+      gains: new Map(),
+      inputRowOrder: [],
+      displayRowOrder: [],
+      livesAfter: new Map(),
+    };
+    expect(round.course).toBe("MC1");
+  });
+});

--- a/smkc-score-app/__tests__/lib/cdm-export/fill/tt-qualifications.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/fill/tt-qualifications.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for the TT Qualifications fill map (lap-time inputs only).
+ *
+ * Ground truth: /tmp/cdm-analysis/sheet2025/sheet_TT_Qualifications.txt
+ *   - Header G1..Z1 = the 20 CDM_COURSES in order (MC1..RR).
+ *   - A2/B2/C2/E2/F2 are dynamic-array formulas (the # / nickname / seeding
+ *     spills) and AA2.. are the score conversions — none are inputs.
+ *   - G2 = 11034, H2 = 13948 … are the raw MSSCC time integers we write.
+ *   - Row r hosts the player at position (r-2) of SORT(FILTER(Registration
+ *     [Nickname], TT="Yes")), i.e. nicknames case-insensitive ascending.
+ *
+ * The fill map therefore only writes G..Z (cols 7..26) for rows 2..48 and
+ * clears the unused course cells; E/F/AA+ must never be touched.
+ */
+
+import { buildTTQualificationWrites } from "@/lib/cdm-export/fill/tt-qualifications";
+import { CDM_COURSES } from "@/lib/cdm-export/cdm-constants";
+import type {
+  CdmTTEntry,
+  CdmPlayer,
+  CdmTournamentData,
+} from "@/lib/cdm-export/types";
+import {
+  indexWrites,
+  expectNumber,
+  expectClear,
+  expectUntouched,
+  writtenRefs,
+} from "./write-helpers";
+
+const SHEET = "TT Qualifications" as const;
+
+function player(id: string, nickname: string, name = nickname): CdmPlayer {
+  return { id, name, nickname };
+}
+
+function ttEntry(
+  p: CdmPlayer,
+  stage: string,
+  times: Record<string, string> | null = null,
+): CdmTTEntry {
+  return {
+    player: p,
+    playerId: p.id,
+    stage,
+    seeding: null,
+    lives: 3,
+    eliminated: false,
+    times,
+  };
+}
+
+function emptyData(over: Partial<CdmTournamentData> = {}): CdmTournamentData {
+  return {
+    name: "T",
+    date: new Date("2025-01-01"),
+    bmQualifications: [],
+    mrQualifications: [],
+    gpQualifications: [],
+    bmMatches: [],
+    mrMatches: [],
+    gpMatches: [],
+    ttEntries: [],
+    ttPhaseRounds: [],
+    ...over,
+  };
+}
+
+/** Column letter for the i-th course (0-based): G=7, H=8, …, Z=26. */
+function courseCol(i: number): string {
+  return String.fromCharCode("G".charCodeAt(0) + i);
+}
+
+describe("buildTTQualificationWrites — row placement", () => {
+  it("places players on rows 2.. by nickname case-insensitive ascending", () => {
+    const zoe = player("p1", "zoe");
+    const alex = player("p2", "Alex");
+    const data = emptyData({
+      ttEntries: [
+        ttEntry(zoe, "qualification", { MC1: "1:10.34" }),
+        ttEntry(alex, "qualification", { MC1: "0:59.79" }),
+      ],
+    });
+    const map = indexWrites(buildTTQualificationWrites(data), SHEET);
+    // "Alex" < "zoe" case-insensitively -> Alex on row 2, zoe on row 3.
+    expectNumber(map, "G2", 5979); // Alex MC1 = 0:59.79 -> 5979
+    expectNumber(map, "G3", 11034); // zoe MC1 = 1:10.34 -> 11034
+  });
+
+  it("only considers stage=qualification entries (ignores phase1/2/3)", () => {
+    const a = player("p1", "Aaa");
+    const b = player("p2", "Bbb");
+    const data = emptyData({
+      ttEntries: [
+        ttEntry(a, "qualification", { MC1: "0:10.00" }),
+        ttEntry(b, "phase1", { MC1: "0:10.00" }), // not a qualification row
+      ],
+    });
+    const writes = buildTTQualificationWrites(data);
+    const map = indexWrites(writes, SHEET);
+    // a's qualification time written on row 2; b never appears as a data value.
+    expectNumber(map, "G2", 1000); // 0:10.00 -> 10s = 1000 centiseconds encoded
+    // Only one player's worth of times: G3 must be a *clear* (spare row), not a value.
+    expectClear(map, "G3");
+  });
+});
+
+describe("buildTTQualificationWrites — course columns G..Z", () => {
+  it("writes each course time in CDM_COURSES column order", () => {
+    const a = player("p1", "Aaa");
+    // Provide a distinct time per course so each column is checkable.
+    // 0:10.cc -> 10s + cc centiseconds = 1000 + cc encoded (minutes=0).
+    const times: Record<string, string> = {};
+    CDM_COURSES.forEach((c, i) => {
+      const cc = String(i).padStart(2, "0");
+      times[c] = `0:10.${cc}`;
+    });
+    const data = emptyData({ ttEntries: [ttEntry(a, "qualification", times)] });
+    const map = indexWrites(buildTTQualificationWrites(data), SHEET);
+    CDM_COURSES.forEach((c, i) => {
+      expectNumber(map, `${courseCol(i)}2`, 1000 + i);
+    });
+  });
+
+  it("clears a course cell when that course time is missing or empty", () => {
+    const a = player("p1", "Aaa");
+    const data = emptyData({
+      ttEntries: [ttEntry(a, "qualification", { MC1: "0:10.00", DP1: "" })],
+    });
+    const map = indexWrites(buildTTQualificationWrites(data), SHEET);
+    expectNumber(map, "G2", 1000); // MC1 present
+    expectClear(map, "H2"); // DP1 empty string -> clear, not 0
+    expectClear(map, "I2"); // GV1 absent key -> clear
+  });
+
+  it("clears every course column when the entry has no times object", () => {
+    const a = player("p1", "Aaa");
+    const data = emptyData({ ttEntries: [ttEntry(a, "qualification", null)] });
+    const map = indexWrites(buildTTQualificationWrites(data), SHEET);
+    for (let i = 0; i < CDM_COURSES.length; i++) {
+      expectClear(map, `${courseCol(i)}2`);
+    }
+  });
+});
+
+describe("buildTTQualificationWrites — formula cells and bounds", () => {
+  it("never writes the formula columns A..F or AA and beyond", () => {
+    const a = player("p1", "Aaa");
+    const data = emptyData({
+      ttEntries: [ttEntry(a, "qualification", { MC1: "1:00.00" })],
+    });
+    const map = indexWrites(buildTTQualificationWrites(data), SHEET);
+    for (const ref of ["A2", "B2", "C2", "E2", "F2", "AA2", "AB2"]) {
+      expectUntouched(map, ref);
+    }
+  });
+
+  it("clears spare rows' course cells up to row 48 but never row 49", () => {
+    const a = player("p1", "Aaa");
+    const data = emptyData({
+      ttEntries: [ttEntry(a, "qualification", { MC1: "1:00.00" })],
+    });
+    const writes = buildTTQualificationWrites(data);
+    const map = indexWrites(writes, SHEET);
+    // Spare rows 3..48 have their G..Z cleared.
+    expectClear(map, "G3");
+    expectClear(map, "Z48");
+    expectUntouched(map, "G49"); // outside the 47-row table
+    // No write should reference a row > 48.
+    for (const ref of writtenRefs(writes, SHEET)) {
+      const row = Number(ref.replace(/[A-Z]/g, ""));
+      expect(row).toBeLessThanOrEqual(48);
+    }
+  });
+
+  it("truncates to 47 players and never writes row 49", () => {
+    const players = Array.from({ length: 50 }, (_, i) =>
+      // zero-pad nickname so case-insensitive sort is the numeric order
+      player(`p${i}`, `nick${String(i).padStart(3, "0")}`),
+    );
+    const data = emptyData({
+      ttEntries: players.map((p) => ttEntry(p, "qualification", { MC1: "0:10.00" })),
+    });
+    const writes = buildTTQualificationWrites(data);
+    const map = indexWrites(writes, SHEET);
+    expectNumber(map, "G2", 1000); // first player
+    expectNumber(map, "G48", 1000); // 47th player on row 48
+    expectUntouched(map, "G49"); // 48th+ dropped
+  });
+
+  it("returns only clears (no values) when there are no TT qualification entries", () => {
+    const data = emptyData();
+    const writes = buildTTQualificationWrites(data);
+    const map = indexWrites(writes, SHEET);
+    // Every emitted op must be a clearValue (spare-row cleanup only).
+    for (const w of writes) expect(w.op).toBe("clearValue");
+    expectClear(map, "G2");
+    expectClear(map, "Z48");
+  });
+});

--- a/smkc-score-app/__tests__/lib/cdm-export/fill/write-helpers.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/fill/write-helpers.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared assertion helpers for CDM fill-map tests.
+ *
+ * Each fill function returns a flat CdmCellWrite[] that a downstream XML patcher
+ * applies in array order (last write wins per ref). These helpers let tests
+ * reason about the *effective* state per cell, and assert that the fill map
+ * never emits a duplicate op for the same cell (clear-then-write is collapsed
+ * by the fill functions themselves to a single op per ref).
+ */
+
+import type { CdmCellWrite, CdmSheetName } from "@/lib/cdm-export/types";
+
+/** Build a Map ref -> op for a single sheet, asserting no duplicate refs. */
+export function indexWrites(
+  writes: CdmCellWrite[],
+  sheet: CdmSheetName,
+): Map<string, CdmCellWrite> {
+  const map = new Map<string, CdmCellWrite>();
+  for (const w of writes) {
+    if (w.sheet !== sheet) continue;
+    if (map.has(w.ref)) {
+      throw new Error(
+        `duplicate write for ${sheet}!${w.ref}: fill maps must emit one op per cell`,
+      );
+    }
+    map.set(w.ref, w);
+  }
+  return map;
+}
+
+/** Assert a cell carries the given inline-string value. */
+export function expectString(
+  map: Map<string, CdmCellWrite>,
+  ref: string,
+  value: string,
+): void {
+  const w = map.get(ref);
+  expect(w).toBeDefined();
+  expect(w).toMatchObject({ op: "inlineString", value });
+}
+
+/** Assert a cell carries the given numeric value. */
+export function expectNumber(
+  map: Map<string, CdmCellWrite>,
+  ref: string,
+  value: number,
+): void {
+  const w = map.get(ref);
+  expect(w).toBeDefined();
+  expect(w).toMatchObject({ op: "number", value });
+}
+
+/** Assert a cell is cleared (value dropped, formula/style kept). */
+export function expectClear(map: Map<string, CdmCellWrite>, ref: string): void {
+  const w = map.get(ref);
+  expect(w).toBeDefined();
+  expect(w?.op).toBe("clearValue");
+}
+
+/** Assert no write at all targets a given cell. */
+export function expectUntouched(
+  map: Map<string, CdmCellWrite>,
+  ref: string,
+): void {
+  expect(map.has(ref)).toBe(false);
+}
+
+/** Collect every ref written on a sheet (for "nothing outside set X" checks). */
+export function writtenRefs(
+  writes: CdmCellWrite[],
+  sheet: CdmSheetName,
+): Set<string> {
+  return new Set(writes.filter((w) => w.sheet === sheet).map((w) => w.ref));
+}

--- a/smkc-score-app/__tests__/lib/cdm-export/index.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/index.test.ts
@@ -1,0 +1,231 @@
+/**
+ * generateCdmWorkbook integration tests (t-wada TDD).
+ *
+ * generateCdmWorkbook is the single public entry point of the CDM exporter: it
+ * concatenates every fill builder's writes (main-hub → tt-qualifications →
+ * qualifications bm/mr/gp → finals bm/mr/gp → tt-finals) and patches the real
+ * template once via patchCdmWorkbook. These tests run against the REAL
+ * public/templates/cdm-2025-template.xlsm read from disk, because the whole
+ * point of the rewrite is byte-level fidelity to that workbook — the assertions
+ * below are the regression guards the old SheetJS exporter could not satisfy:
+ *
+ *  (a) the input cells the builders own are patched to the expected XML
+ *      (Main Hub player rows, TT Qualifications times, BM Finals seed/score),
+ *  (b) xl/tables/table1.xml, xl/richData/rdrichvalue.xml and xl/metadata.xml are
+ *      byte-identical to the template (the parts the old exporter dropped),
+ *  (c) xl/calcChain.xml is gone and xl/workbook.xml carries fullCalcOnLoad.
+ *
+ * Two fixtures exercise the two realistic shapes: an 8-player single-round
+ * tournament (BM qualification + finals winners_qf, the degraded-8 path) and a
+ * 24-player playoff tournament (faithful 24 finals with typed seed cells).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+import { unzipSync, strFromU8 } from "fflate";
+import { generateCdmWorkbook } from "@/lib/cdm-export";
+import type {
+  CdmMatch,
+  CdmModeQualification,
+  CdmTournamentData,
+  CdmTTEntry,
+} from "@/lib/cdm-export/types";
+
+const TEMPLATE_PATH = join(
+  process.cwd(),
+  "public",
+  "templates",
+  "cdm-2025-template.xlsm",
+);
+
+function loadTemplate(): Uint8Array {
+  return new Uint8Array(readFileSync(TEMPLATE_PATH));
+}
+
+function parts(bytes: Uint8Array): Record<string, Uint8Array> {
+  return unzipSync(bytes);
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/** Sheet name → part path resolution mirrors xlsx-zip-patcher (used for reads). */
+const SHEET_PATHS: Record<string, string> = {
+  "Main Hub": "xl/worksheets/sheet1.xml",
+  "TT Qualifications": "xl/worksheets/sheet3.xml",
+  "BM Finals": "xl/worksheets/sheet7.xml",
+};
+
+function readSheet(out: Uint8Array, sheetName: string): string {
+  return strFromU8(parts(out)[SHEET_PATHS[sheetName]]);
+}
+
+const player = (id: string, name: string, nickname: string): CdmTTEntry["player"] => ({
+  id,
+  name,
+  nickname,
+});
+
+/**
+ * Minimal 8-player fixture: 8 BM qualifiers (groups A/B) plus an 8-player
+ * winners_qf finals round. Exercises the Main Hub player rows, the BM
+ * qualification block ordering and the degraded-8 finals overwrite path.
+ */
+function eightPlayerFixture(): CdmTournamentData {
+  const names = ["Alice", "Bob", "Cara", "Dan", "Eve", "Finn", "Gus", "Hana"];
+  const bmQualifications: CdmModeQualification[] = names.map((n, i) => ({
+    player: player(`p${i + 1}`, n, n.toUpperCase()),
+    seeding: i + 1,
+    group: i % 2 === 0 ? "A" : "B",
+    points: 0,
+    score: 100 - i,
+  }));
+  const bmMatches: CdmMatch[] = [
+    {
+      matchNumber: 13,
+      stage: "finals",
+      round: "winners_qf",
+      player1: player("p1", "Alice", "ALICE"),
+      player2: player("p2", "Bob", "BOB"),
+      score1: 5,
+      score2: 3,
+      completed: true,
+    },
+  ];
+  return {
+    name: "Eight Player CDM",
+    date: new Date("2025-06-01"),
+    bmQualifications,
+    mrQualifications: [],
+    gpQualifications: [],
+    bmMatches,
+    mrMatches: [],
+    gpMatches: [],
+    ttEntries: [],
+    ttPhaseRounds: [],
+  };
+}
+
+/**
+ * 24-player playoff fixture: a single TT qualifier with a recorded time plus a
+ * BM playoff_r1 match. The playoff presence selects the faithful-24 finals
+ * path, so BM Finals seed cell E5 gets a typed B-position and H5 gets a score.
+ */
+function twentyFourPlayoffFixture(): CdmTournamentData {
+  const ttEntries: CdmTTEntry[] = [
+    {
+      player: player("t1", "Tina", "TINA"),
+      playerId: "t1",
+      stage: "qualification",
+      seeding: 1,
+      lives: 3,
+      eliminated: false,
+      times: { MC1: "1:10.34" },
+      totalTime: 70340,
+      rank: 1,
+    },
+  ];
+  // generatePlayoffStructure(12) playoff_r1[0] has player1Seed=11, player2Seed=10
+  // (verified against double-elimination.ts), so slot1 -> B-position 12+11=23 and
+  // slot2 -> B-position 12+10=22. The exporter types those B-positions into the
+  // Barrage-1 block (D column, +1 seed offset => E5/E6).
+  const bmMatches: CdmMatch[] = [
+    {
+      matchNumber: 1,
+      stage: "playoff",
+      round: "playoff_r1",
+      player1: player("p1", "Alice", "ALICE"),
+      player2: player("p2", "Bob", "BOB"),
+      score1: 4,
+      score2: 2,
+      completed: true,
+    },
+  ];
+  return {
+    name: "Playoff CDM",
+    date: new Date("2025-06-01"),
+    bmQualifications: [],
+    mrQualifications: [],
+    gpQualifications: [],
+    bmMatches,
+    mrMatches: [],
+    gpMatches: [],
+    ttEntries,
+    ttPhaseRounds: [],
+  };
+}
+
+describe("generateCdmWorkbook — untouched-part fidelity", () => {
+  const original = loadTemplate();
+  const originalParts = parts(original);
+  const out = generateCdmWorkbook(loadTemplate(), eightPlayerFixture());
+  const outParts = parts(out);
+
+  it("keeps xl/tables/table1.xml byte-identical to the template", () => {
+    expect(outParts["xl/tables/table1.xml"]).toBeDefined();
+    expect(
+      bytesEqual(outParts["xl/tables/table1.xml"], originalParts["xl/tables/table1.xml"]),
+    ).toBe(true);
+  });
+
+  it("keeps xl/richData/rdrichvalue.xml byte-identical to the template", () => {
+    expect(outParts["xl/richData/rdrichvalue.xml"]).toBeDefined();
+    expect(
+      bytesEqual(
+        outParts["xl/richData/rdrichvalue.xml"],
+        originalParts["xl/richData/rdrichvalue.xml"],
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps xl/metadata.xml byte-identical to the template", () => {
+    expect(outParts["xl/metadata.xml"]).toBeDefined();
+    expect(bytesEqual(outParts["xl/metadata.xml"], originalParts["xl/metadata.xml"])).toBe(true);
+  });
+
+  it("removes xl/calcChain.xml and adds fullCalcOnLoad to workbook.xml", () => {
+    expect(originalParts["xl/calcChain.xml"]).toBeDefined();
+    expect(outParts["xl/calcChain.xml"]).toBeUndefined();
+    const wb = strFromU8(outParts["xl/workbook.xml"]);
+    expect(wb).toContain('fullCalcOnLoad="1"');
+  });
+});
+
+describe("generateCdmWorkbook — patched input cells (8-player)", () => {
+  const out = generateCdmWorkbook(loadTemplate(), eightPlayerFixture());
+  const mainHub = readSheet(out, "Main Hub");
+
+  it("writes the Main Hub player names in case-insensitive name order", () => {
+    // Universe is sorted by name asc: Alice .. Hana -> rows 2..9.
+    expect(mainHub).toContain('<c r="B2" s="2" t="inlineStr"><is><t>Alice</t></is></c>');
+    expect(mainHub).toContain('<c r="B9" s="2" t="inlineStr"><is><t>Hana</t></is></c>');
+  });
+
+  it("leaves Main Hub row 62 unwritten (template has no B62; stays absent)", () => {
+    // The fixed 60-row table ends at row 61; the exporter must never address
+    // row 62, so the absent template cell stays absent in the output.
+    expect(mainHub).not.toContain('r="B62"');
+  });
+});
+
+describe("generateCdmWorkbook — patched input cells (24-player playoff)", () => {
+  const out = generateCdmWorkbook(loadTemplate(), twentyFourPlayoffFixture());
+  const ttQual = readSheet(out, "TT Qualifications");
+  const bmFinals = readSheet(out, "BM Finals");
+
+  it("writes the TT Qualifications MC1 time as a CDM MSSCC integer", () => {
+    // 1:10.34 -> 1*10000 + 10*100 + 34 = 11034, on the single qualifier's row 2.
+    expect(ttQual).toContain('<c r="G2" s="45"><v>11034</v></c>');
+  });
+
+  it("writes the BM Finals playoff seed cell and score on the faithful-24 path", () => {
+    // playoff_r1[0] slot1 -> B-position 23 typed into E5; Alice's score 4 into H5.
+    // slot2 -> B-position 22 into E6; Bob's score 2 into H6.
+    expect(bmFinals).toContain('<c r="E5" s="27"><v>23</v></c>');
+    expect(bmFinals).toContain('<c r="E6" s="27"><v>22</v></c>');
+    expect(bmFinals).toContain('<c r="H5" s="3"><v>4</v></c>');
+    expect(bmFinals).toContain('<c r="H6" s="3"><v>2</v></c>');
+  });
+});

--- a/smkc-score-app/__tests__/lib/cdm-export/sheet-xml-patcher.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/sheet-xml-patcher.test.ts
@@ -1,0 +1,299 @@
+/**
+ * SheetXmlPatcher unit tests (t-wada TDD).
+ *
+ * These tests pin the precise, byte-stable behaviour the CDM "ZIP surgery"
+ * exporter relies on: only the touched <c>/<row> regions may change, every
+ * other byte of the worksheet XML must be reproduced verbatim. The fixtures
+ * mirror the real cell grammar found in
+ * public/templates/cdm-2025-template.xlsm:
+ *   - shared-string cells   <c r=".." s=".." t="s"><v>idx</v></c>
+ *   - plain number cells     <c r=".." s=".."><v>38</v></c>
+ *   - formula cells          <c r=".." s=".."><f>ROW()-1</f><v>1</v></c>
+ *   - array-formula cells    <c r=".." cm="1" vm="1"><f t="array" ref="..">..</f><v>..</v></c>
+ *   - self-closing shells    <c r=".." s=".."/>
+ *   - self-closing rows      <row r=".." spans=".." ht=".."/>
+ * The compact form (no inter-element whitespace) matches Excel's output.
+ */
+import { SheetXmlPatcher } from "@/lib/cdm-export/sheet-xml-patcher";
+
+/**
+ * Minimal but representative worksheet skeleton. It carries the worksheet
+ * envelope (so serialize() must reproduce the prolog/sheetPr/dimension and the
+ * trailing pageMargins exactly) plus a sheetData with a mix of cell shapes.
+ */
+const FIXTURE_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+  '<dimension ref="A1:F3"/>' +
+  "<sheetData>" +
+  // Row 2: A2 formula cell, B2 shared string, C2 plain number, D2 array formula
+  '<row r="2" spans="1:6" ht="15" customHeight="1">' +
+  '<c r="A2" s="40"><f>ROW()-1</f><v>1</v></c>' +
+  '<c r="B2" s="2" t="s"><v>13</v></c>' +
+  '<c r="C2" s="4"><v>38</v></c>' +
+  '<c r="D2" s="15" cm="1" vm="1"><f t="array" ref="D2:D5">UNIQUE(X)</f><v>#VALUE!</v></c>' +
+  "</row>" +
+  // Row 4: sparse columns B4 (number) and E4 (self-closing shell) — gap at C/D
+  '<row r="4" spans="1:6">' +
+  '<c r="B4" s="2"><v>7</v></c>' +
+  '<c r="E4" s="23"/>' +
+  "</row>" +
+  // Row 6: self-closing empty row that must be expanded if written to
+  '<row r="6" spans="1:6" ht="15" customHeight="1"/>' +
+  "</sheetData>" +
+  '<pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" footer="0.3"/>' +
+  "</worksheet>";
+
+describe("SheetXmlPatcher — byte stability", () => {
+  it("serialize() returns the exact input when no ops are applied", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    expect(patcher.serialize()).toBe(FIXTURE_XML);
+  });
+
+  it("leaves untouched cells and the envelope byte-identical after one edit", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("C2", { op: "number", value: 99 });
+    const out = patcher.serialize();
+    // Envelope preserved verbatim.
+    expect(out.startsWith('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>')).toBe(true);
+    expect(out).toContain(
+      '<pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" footer="0.3"/>'
+    );
+    // Neighbours in the same row untouched, byte for byte.
+    expect(out).toContain('<c r="B2" s="2" t="s"><v>13</v></c>');
+    expect(out).toContain('<c r="A2" s="40"><f>ROW()-1</f><v>1</v></c>');
+    // Only the target changed.
+    expect(out).toContain('<c r="C2" s="4"><v>99</v></c>');
+  });
+});
+
+describe("SheetXmlPatcher — number op", () => {
+  it("writes <v> and preserves the existing style, removing any t attribute", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("B2", { op: "number", value: 24 }); // B2 was a shared string
+    const out = patcher.serialize();
+    // t="s" must be gone; style kept; numeric value written.
+    expect(out).toContain('<c r="B2" s="2"><v>24</v></c>');
+    expect(out).not.toContain('<c r="B2" s="2" t="s">');
+  });
+
+  it("formats numbers in plain decimal (never scientific notation)", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("C2", { op: "number", value: 11034 });
+    expect(patcher.serialize()).toContain('<c r="C2" s="4"><v>11034</v></c>');
+
+    const p2 = new SheetXmlPatcher(FIXTURE_XML);
+    p2.apply("C2", { op: "number", value: 0.0000001 });
+    // 1e-7 must NOT serialize as "1e-7".
+    expect(p2.serialize()).toContain("<v>0.0000001</v>");
+    expect(p2.serialize()).not.toContain("e-");
+  });
+
+  it("rejects non-finite numbers", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    expect(() => patcher.apply("C2", { op: "number", value: NaN })).toThrow();
+    expect(() => patcher.apply("C2", { op: "number", value: Infinity })).toThrow();
+  });
+
+  it("throws (with the ref) when the target holds a formula", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    expect(() => patcher.apply("A2", { op: "number", value: 5 })).toThrow(/A2/);
+    expect(() => patcher.apply("D2", { op: "number", value: 5 })).toThrow(/D2/);
+  });
+
+  it("drops vm and cm when writing a value", () => {
+    // A non-formula cell carrying vm/cm (rich-value marker). number write must
+    // remove those markers so the rich value index is not reused incorrectly.
+    const xml =
+      "<worksheet><sheetData>" +
+      '<row r="3" spans="1:4"><c r="D3" s="41" t="e" vm="2"><v>#VALUE!</v></c></row>' +
+      "</sheetData></worksheet>";
+    const patcher = new SheetXmlPatcher(xml);
+    patcher.apply("D3", { op: "number", value: 8 });
+    const out = patcher.serialize();
+    expect(out).toContain('<c r="D3" s="41"><v>8</v></c>');
+    expect(out).not.toContain("vm=");
+    expect(out).not.toContain("#VALUE!");
+  });
+});
+
+describe("SheetXmlPatcher — inlineString op", () => {
+  it("writes t=\"inlineStr\" with an <is><t> body, preserving style", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("B2", { op: "inlineString", value: "Mario" });
+    expect(patcher.serialize()).toContain(
+      '<c r="B2" s="2" t="inlineStr"><is><t>Mario</t></is></c>'
+    );
+  });
+
+  it("XML-escapes &, <, >, \" and ' in the string body", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("B2", { op: "inlineString", value: `a&b<c>d"e'f` });
+    expect(patcher.serialize()).toContain(
+      "<is><t>a&amp;b&lt;c&gt;d&quot;e&apos;f</t></is>"
+    );
+  });
+
+  it("adds xml:space=\"preserve\" when the value has leading/trailing whitespace", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("B2", { op: "inlineString", value: "  pad  " });
+    expect(patcher.serialize()).toContain(
+      '<is><t xml:space="preserve">  pad  </t></is>'
+    );
+    // No-space value must NOT get the attribute.
+    const p2 = new SheetXmlPatcher(FIXTURE_XML);
+    p2.apply("B2", { op: "inlineString", value: "tight" });
+    expect(p2.serialize()).toContain("<is><t>tight</t></is>");
+    expect(p2.serialize()).not.toContain("xml:space");
+  });
+
+  it("throws on a formula cell", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    expect(() => patcher.apply("A2", { op: "inlineString", value: "x" })).toThrow(/A2/);
+  });
+});
+
+describe("SheetXmlPatcher — clearValue op", () => {
+  it("drops <v> but keeps the formula, style and attributes", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("A2", { op: "clearValue" });
+    // Formula + style survive; cached <v> removed.
+    expect(patcher.serialize()).toContain('<c r="A2" s="40"><f>ROW()-1</f></c>');
+  });
+
+  it("drops <is> for an inline-string cell while keeping the shell", () => {
+    const xml =
+      "<worksheet><sheetData>" +
+      '<row r="2" spans="1:2"><c r="A2" s="5" t="inlineStr"><is><t>hi</t></is></c></row>' +
+      "</sheetData></worksheet>";
+    const patcher = new SheetXmlPatcher(xml);
+    patcher.apply("A2", { op: "clearValue" });
+    // Value content gone; styled shell remains. (t may stay; the cell is empty.)
+    const out = patcher.serialize();
+    expect(out).not.toContain("<is>");
+    expect(out).not.toContain("hi");
+    expect(out).toContain('r="A2"');
+  });
+
+  it("is a no-op when the cell does not exist", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("Z99", { op: "clearValue" });
+    expect(patcher.serialize()).toBe(FIXTURE_XML);
+  });
+});
+
+describe("SheetXmlPatcher — overwrite ops (degraded modes)", () => {
+  it("overwriteNumber replaces value AND removes the formula", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("A2", { op: "overwriteNumber", value: 42 });
+    expect(patcher.serialize()).toContain('<c r="A2" s="40"><v>42</v></c>');
+    expect(patcher.serialize()).not.toContain("ROW()-1");
+  });
+
+  it("overwriteString replaces a formula cell with an inline string", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("A2", { op: "overwriteString", value: "Winner" });
+    const out = patcher.serialize();
+    expect(out).toContain('<c r="A2" s="40" t="inlineStr"><is><t>Winner</t></is></c>');
+    expect(out).not.toContain("ROW()-1");
+  });
+});
+
+describe("SheetXmlPatcher — strip op", () => {
+  it("removes <f>/<v>/t/cm/vm and keeps only the styled shell", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("D2", { op: "strip" }); // array-formula cell with cm/vm
+    const out = patcher.serialize();
+    expect(out).toContain('<c r="D2" s="15"/>');
+    expect(out).not.toContain("UNIQUE(X)");
+    expect(out).not.toContain("cm=");
+    expect(out).not.toContain("vm=");
+  });
+
+  it("is a no-op when the cell does not exist", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("Z1", { op: "strip" });
+    expect(patcher.serialize()).toBe(FIXTURE_XML);
+  });
+});
+
+describe("SheetXmlPatcher — cell insertion", () => {
+  it("inserts a missing cell in A1 column order within an existing row", () => {
+    // Row 4 has B4 then E4; inserting C4 must land between them.
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("C4", { op: "number", value: 5 });
+    const out = patcher.serialize();
+    const b = out.indexOf('r="B4"');
+    const c = out.indexOf('r="C4"');
+    const e = out.indexOf('r="E4"');
+    expect(b).toBeGreaterThan(-1);
+    expect(c).toBeGreaterThan(b);
+    expect(e).toBeGreaterThan(c);
+    expect(out).toContain('<c r="C4"><v>5</v></c>');
+  });
+
+  it("appends a cell after the last cell when its column is highest", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("F4", { op: "inlineString", value: "tail" });
+    const out = patcher.serialize();
+    const e = out.indexOf('r="E4"');
+    const f = out.indexOf('r="F4"');
+    expect(f).toBeGreaterThan(e);
+  });
+
+  it("inserts a missing row in row order, preserving sibling rows", () => {
+    // Insert row 3 between rows 2 and 4.
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("A3", { op: "number", value: 1 });
+    const out = patcher.serialize();
+    const r2 = out.indexOf('<row r="2"');
+    const r3 = out.indexOf('<row r="3"');
+    const r4 = out.indexOf('<row r="4"');
+    expect(r3).toBeGreaterThan(r2);
+    expect(r4).toBeGreaterThan(r3);
+    expect(out).toContain('<row r="3"><c r="A3"><v>1</v></c></row>');
+  });
+
+  it("expands a self-closing row when a cell is written into it", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("B6", { op: "number", value: 3 });
+    const out = patcher.serialize();
+    // Original row attributes (spans/ht/customHeight) must be preserved.
+    expect(out).toContain(
+      '<row r="6" spans="1:6" ht="15" customHeight="1"><c r="B6"><v>3</v></c></row>'
+    );
+    expect(out).not.toContain('<row r="6" spans="1:6" ht="15" customHeight="1"/>');
+  });
+
+  it("appends a brand-new row beyond the last existing row", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("A9", { op: "number", value: 7 });
+    const out = patcher.serialize();
+    const r6 = out.indexOf('<row r="6"');
+    const r9 = out.indexOf('<row r="9"');
+    expect(r9).toBeGreaterThan(r6);
+    expect(out).toContain('<row r="9"><c r="A9"><v>7</v></c></row>');
+  });
+});
+
+describe("SheetXmlPatcher — ordering and idempotency", () => {
+  it("applies multiple ops to the same ref last-write-wins", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("C2", { op: "number", value: 1 });
+    patcher.apply("C2", { op: "number", value: 2 });
+    patcher.apply("C2", { op: "inlineString", value: "final" });
+    const out = patcher.serialize();
+    // Only the final inline-string write survives in C2; no stale numeric cache.
+    expect(out).toContain('<c r="C2" s="4" t="inlineStr"><is><t>final</t></is></c>');
+    expect(out).not.toContain('<c r="C2" s="4"><v>1</v></c>');
+    expect(out).not.toContain('<c r="C2" s="4"><v>2</v></c>');
+  });
+
+  it("serialize() is stable across repeated calls", () => {
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("C2", { op: "number", value: 5 });
+    const a = patcher.serialize();
+    const b = patcher.serialize();
+    expect(a).toBe(b);
+  });
+});

--- a/smkc-score-app/__tests__/lib/cdm-export/xlsx-zip-patcher.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/xlsx-zip-patcher.test.ts
@@ -1,0 +1,215 @@
+/**
+ * patchCdmWorkbook integration tests (t-wada TDD).
+ *
+ * These run against the REAL template public/templates/cdm-2025-template.xlsm,
+ * read from disk with fs, because the whole point of the rewrite is byte-level
+ * fidelity to that workbook. The old SheetJS exporter silently dropped
+ * xl/tables/* and xl/richData/* and corrupted the dynamic-array formula web;
+ * the assertions below are the regression guards that lock that out:
+ *
+ *  - a no-op patch changes ONLY xl/workbook.xml (calcPr), [Content_Types].xml
+ *    (calcChain Override removed) and xl/_rels/workbook.xml.rels (calcChain
+ *    Relationship removed); every other part is byte-identical.
+ *  - xl/calcChain.xml is gone (Excel rebuilds it from fullCalcOnLoad).
+ *  - tables/table1.xml and richData/rdrichvalue.xml survive untouched.
+ *  - real input cells (Main Hub) accept inlineString / number / clearValue and
+ *    neighbouring bytes are unchanged.
+ *  - writing a number over an ARRAY-formula cell (Overall Ranking B2) throws.
+ *  - a perf smoke test applies 20k ops to a real sheet within a few seconds.
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+import { unzipSync, strFromU8 } from "fflate";
+import { patchCdmWorkbook } from "@/lib/cdm-export/xlsx-zip-patcher";
+import type { CdmCellWrite } from "@/lib/cdm-export/types";
+
+const TEMPLATE_PATH = join(
+  process.cwd(),
+  "public",
+  "templates",
+  "cdm-2025-template.xlsm"
+);
+
+function loadTemplate(): Uint8Array {
+  return new Uint8Array(readFileSync(TEMPLATE_PATH));
+}
+
+/** Unzip helper returning the raw byte map. */
+function parts(bytes: Uint8Array): Record<string, Uint8Array> {
+  return unzipSync(bytes);
+}
+
+/** Byte-equality helper for two Uint8Arrays. */
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+describe("patchCdmWorkbook — no-op pass-through fidelity", () => {
+  const original = loadTemplate();
+  const originalParts = parts(original);
+  const out = patchCdmWorkbook(loadTemplate(), []);
+  const outParts = parts(out);
+
+  it("preserves every part except workbook.xml, content types and workbook rels", () => {
+    const allowedToDiffer = new Set([
+      "xl/workbook.xml",
+      "[Content_Types].xml",
+      "xl/_rels/workbook.xml.rels",
+    ]);
+    const removed = new Set(["xl/calcChain.xml"]);
+
+    for (const path of Object.keys(originalParts)) {
+      if (removed.has(path)) continue; // expected to be gone
+      if (allowedToDiffer.has(path)) continue; // checked individually below
+      expect(outParts[path]).toBeDefined();
+      expect(bytesEqual(outParts[path], originalParts[path])).toBe(true);
+    }
+  });
+
+  it("removes xl/calcChain.xml", () => {
+    expect(originalParts["xl/calcChain.xml"]).toBeDefined();
+    expect(outParts["xl/calcChain.xml"]).toBeUndefined();
+  });
+
+  it("keeps tables and richData parts that the old exporter destroyed", () => {
+    expect(outParts["xl/tables/table1.xml"]).toBeDefined();
+    expect(bytesEqual(outParts["xl/tables/table1.xml"], originalParts["xl/tables/table1.xml"])).toBe(true);
+    expect(outParts["xl/richData/rdrichvalue.xml"]).toBeDefined();
+    expect(
+      bytesEqual(outParts["xl/richData/rdrichvalue.xml"], originalParts["xl/richData/rdrichvalue.xml"])
+    ).toBe(true);
+  });
+
+  it("keeps all 12 worksheet xml parts byte-identical when nothing is written", () => {
+    const sheets = Object.keys(originalParts).filter((p) =>
+      /^xl\/worksheets\/sheet\d+\.xml$/.test(p)
+    );
+    expect(sheets.length).toBe(12);
+    for (const sheet of sheets) {
+      expect(bytesEqual(outParts[sheet], originalParts[sheet])).toBe(true);
+    }
+  });
+
+  it("adds fullCalcOnLoad to calcPr in workbook.xml", () => {
+    const wb = strFromU8(outParts["xl/workbook.xml"]);
+    expect(wb).toContain('fullCalcOnLoad="1"');
+    // The original calcId must be preserved.
+    expect(wb).toContain('calcId="191028"');
+  });
+
+  it("removes the calcChain Override from [Content_Types].xml", () => {
+    const ct = strFromU8(outParts["[Content_Types].xml"]);
+    expect(ct).not.toContain("calcChain.xml");
+  });
+
+  it("removes the calcChain Relationship from workbook.xml.rels", () => {
+    const rels = strFromU8(outParts["xl/_rels/workbook.xml.rels"]);
+    expect(rels).not.toContain("calcChain.xml");
+  });
+
+  it("preserves the zip entry order (minus calcChain)", () => {
+    const expectedOrder = Object.keys(originalParts).filter(
+      (p) => p !== "xl/calcChain.xml"
+    );
+    const actualOrder = Object.keys(outParts);
+    expect(actualOrder).toEqual(expectedOrder);
+  });
+});
+
+describe("patchCdmWorkbook — real cell writes", () => {
+  function readSheet(out: Uint8Array, sheetPath: string): string {
+    return strFromU8(parts(out)[sheetPath]);
+  }
+
+  it("writes inlineString, number and clearValue into Main Hub input cells", () => {
+    const writes: CdmCellWrite[] = [
+      { sheet: "Main Hub", ref: "B2", op: "inlineString", value: "Mario Kart" },
+      { sheet: "Main Hub", ref: "O3", op: "number", value: 16 },
+      { sheet: "Main Hub", ref: "E2", op: "clearValue" },
+    ];
+    const out = patchCdmWorkbook(loadTemplate(), writes);
+    const sheet1 = readSheet(out, "xl/worksheets/sheet1.xml");
+
+    // B2 became an inline string (was a shared-string cell t="s").
+    expect(sheet1).toContain('<c r="B2" s="2" t="inlineStr"><is><t>Mario Kart</t></is></c>');
+    // O3 set to 16 (was <c r="O3" s="3"><v>24</v></c>).
+    expect(sheet1).toContain('<c r="O3" s="3"><v>16</v></c>');
+    // E2 value cleared (was <c r="E2" s="4"><v>38</v></c>) — keeps styled shell.
+    expect(sheet1).toContain('<c r="E2" s="4"/>');
+  });
+
+  it("leaves the byte slice of an untouched neighbour cell unchanged", () => {
+    const writes: CdmCellWrite[] = [
+      { sheet: "Main Hub", ref: "C2", op: "inlineString", value: "Nick" },
+    ];
+    const out = patchCdmWorkbook(loadTemplate(), writes);
+    const sheet1 = readSheet(out, "xl/worksheets/sheet1.xml");
+    // B2 (the immediate left neighbour) must be reproduced exactly.
+    expect(sheet1).toContain('<c r="B2" s="2" t="s"><v>13</v></c>');
+    // A2's formula cell is untouched too.
+    expect(sheet1).toContain('<c r="A2" s="40"><f>ROW()-1</f><v>1</v></c>');
+  });
+
+  it("throws when a number is written over an ARRAY-formula cell (Overall Ranking B2)", () => {
+    const writes: CdmCellWrite[] = [
+      { sheet: "Overall Ranking", ref: "B2", op: "number", value: 1 },
+    ];
+    expect(() => patchCdmWorkbook(loadTemplate(), writes)).toThrow(/B2/);
+  });
+
+  it("strip removes the <f> from a formula cell", () => {
+    const writes: CdmCellWrite[] = [
+      { sheet: "Overall Ranking", ref: "B2", op: "strip" },
+    ];
+    const out = patchCdmWorkbook(loadTemplate(), writes);
+    const sheet12 = readSheet(out, "xl/worksheets/sheet12.xml");
+    // The B2 array formula text must be gone; a styled shell remains.
+    expect(sheet12).not.toContain("_xlfn._xlws.SORT(_xlfn.UNIQUE(Registration[Nickname]))");
+    expect(sheet12).toContain('<c r="B2" s="32"/>');
+  });
+
+  it("throws on an unknown sheet name", () => {
+    const writes = [
+      { sheet: "Nonexistent Sheet", ref: "A1", op: "number", value: 1 },
+    ] as unknown as CdmCellWrite[];
+    expect(() => patchCdmWorkbook(loadTemplate(), writes)).toThrow();
+  });
+
+  it("produces a workbook that fflate can re-open (round-trips)", () => {
+    const writes: CdmCellWrite[] = [
+      { sheet: "Main Hub", ref: "B2", op: "inlineString", value: "X" },
+    ];
+    const out = patchCdmWorkbook(loadTemplate(), writes);
+    expect(() => unzipSync(out)).not.toThrow();
+  });
+});
+
+describe("patchCdmWorkbook — performance smoke", () => {
+  it("applies 20k ops to a real sheet within a few seconds", () => {
+    // BM Qualifications (sheet6) is large (456 KB). Hammer its input columns.
+    const writes: CdmCellWrite[] = [];
+    for (let i = 0; i < 20000; i++) {
+      // Spread writes across rows 2..481 and a handful of columns to exercise
+      // both row indexing and cell insertion/parsing paths.
+      const row = 2 + (i % 480);
+      const cols = ["S", "T", "U", "V", "W"];
+      const col = cols[i % cols.length];
+      writes.push({
+        sheet: "BM Qualifications",
+        ref: `${col}${row}`,
+        op: "number",
+        value: i % 5,
+      });
+    }
+    const start = Date.now();
+    const out = patchCdmWorkbook(loadTemplate(), writes);
+    const elapsed = Date.now() - start;
+    expect(out.length).toBeGreaterThan(0);
+    // Generous ceiling for CI; the design target is < 2s.
+    expect(elapsed).toBeLessThan(5000);
+  });
+});

--- a/smkc-score-app/docs/cdm-export-design.md
+++ b/smkc-score-app/docs/cdm-export-design.md
@@ -1,0 +1,272 @@
+# CDM 試合結果シート生成 — 設計書
+
+対象: `GET /api/tournaments/[id]/export?format=cdm`（admin専用）の全面再設計。
+テンプレート: `public/templates/cdm-2025-template.xlsm`（CDM 2025 実イベントの完成ワークブックと同一内容）。
+
+## 1. 背景と根拠
+
+CDM ワークブックは **VBAマクロなし**・**Excel 動的配列数式駆動**である。
+順位表（SUMIF/SORTBY）・決勝ブラケット進行（`IF(COUNTA(scores)<2,"Winner of X",INDEX(SORTBY(...)))`）・
+総合ランキング（全シートへのXLOOKUP）はすべて数式が自動計算し、人間が入力するのは
+**試合スコア・シード番号・タイムのみ**。
+
+旧実装（@e965/xlsx で read→write）は実測で以下が確認された:
+
+1. `xl/tables/*.xml`（Registration / Tracks / Cups）と `xl/richData/*`（国旗画像）が
+   **write時に欠落** → 全シートの `Registration[...]` 構造化参照が `#NAME?` となり数式網が全壊。
+2. スピル範囲（例: BM Qualifications `E2:Q47` のアンカー配下）へ静的値を書くため、
+   Excel で開くと `#SPILL!` エラー。
+3. TT タイムをミリ秒整数で書いていたが、シートの期待形式は `M*10000+SS*100+CC`
+   （例 1:10.34 → `11034`）。
+4. 決勝シートのシード番号セル（数値）へニックネーム文字列を書き込み → `XLOOKUP` が `#N/A`。
+
+よって方式を **「ZIP外科手術によるテンプレート充填」** に置き換える。
+入力セルのみを書き換え、その他のパート（tables/richData/styles/metadata/printerSettings/
+customXml/media/sharedStrings…）は **1バイトも変更せず素通し** する。
+
+## 2. アーキテクチャ
+
+```
+loadCDMTemplate (ASSETS fetch, 現行どおり)
+  → unzipSync (fflate)                     … Map<path, Uint8Array>
+  → 書込対象シートの xl/worksheets/sheetN.xml を SheetXmlPatcher で精密パッチ
+  → xl/workbook.xml の <calcPr> に fullCalcOnLoad="1" を付与
+  → xl/calcChain.xml を削除（rels と [Content_Types].xml からも除去。Excelが再構築する）
+  → zipSync → NextResponse
+```
+
+- シート名→`sheetN.xml` の解決は `xl/workbook.xml`（`<sheet name= r:id=>`）と
+  `xl/_rels/workbook.xml.rels` を解析して行う（番号ハードコード禁止）。
+- 文字列セルは `t="inlineStr"` で書く（sharedStrings.xml 非接触）。XML エスケープ必須。
+  ユーザー由来文字列（ニックネーム等）は常に inlineStr であり数式注入は構造上不可能。
+- 既存セルの上書きは `s=`(style) 属性を保持。値クリアは `<v>`/`<is>` のみ除去し
+  セル・数式・スタイルは残す。数式セルへの値書込は明示 API（縮退モード専用）でのみ許可。
+- 依存追加: `fflate`。`@e965/xlsx` は**エクスポータからは完全に除去**したが、依存自体は残す:
+  E2E ランナー（e2e/tc-all.js TC-816A）が生成済みワークブックの**読み取り側**検証に
+  `XLSX.read` を使う（読みは安全。壊れていたのは write 側のみ）。
+
+### モジュール構成（src/lib/cdm-export/）
+
+```
+types.ts              共有型（CellWrite ほか）※設計時に確定済み
+cdm-constants.ts      コース表・シート名・座標定数 ※設計時に確定済み
+xlsx-zip-patcher.ts   zip入出力・パート素通し・calcChain除去・calcPr付与・シート解決
+sheet-xml-patcher.ts  sheetData の <row>/<c> 精密パッチ（挿入は行/セル順序維持）
+time-format.ts        "M:SS.cc" ⇔ MSSHH整数（centisecond, 半上げ丸め）
+fill/main-hub.ts      Main Hub 充填
+fill/tt-qualifications.ts
+fill/qualifications.ts  BM/MR/GP 共通（モードパラメタ化）
+fill/finals.ts          BM/MR/GP 決勝 + slot-semantics
+fill/tt-finals.ts       TT 決勝（ライフ再生 replay 含む）
+index.ts              generateCdmWorkbook(templateBuffer, tournamentData) → Uint8Array
+```
+
+route.ts は CSV パスを温存し、CDM パスのみ `generateCdmWorkbook` を呼ぶ薄い層にする。
+
+## 3. セル契約（fill map）
+
+座標はすべてテンプレート実物のダンプから検証済み。**ここに書かれていないセルには一切書かない。**
+
+### 3.1 Main Hub（Registration テーブル A1:L61）
+
+| 列 | 内容 | 備考 |
+|----|------|------|
+| B,C | name, nickname | rows 2..61（最大60人、超過は切捨て+log） |
+| D | country（プレーンテキスト） | 元はリッチバリュー画像。テキスト化で国旗表示は劣化（許容・後述） |
+| E..H | TT/BM/MR/GP Order = **合成順序** | 下記 3.1.1 |
+| I..L | "Yes"/"No"（モード参加） | TT=TTEntry(qualification)有無、他=Qualification有無 |
+| O3..R3 | Qualifying 人数 | TT=**min(24, TT予選人数)**（O3 は TT Finals の名簿スピル長。replay のユニバースと一致必須。予選ゼロ時のみ distinct phase 選手数へフォールバック）、BM/MR/GP=ブラケット規模(24/16/8) |
+| O4..R4 | グループ数 | TT=0、他=予選の distinct group 数 |
+
+- A列（`=ROW()-1`）、N2:R2（COUNTIF）、T/U（集計スピル）は**非接触**。
+- 余剰行（プレイヤー数+2 .. 61）は B..L の値をクリア。
+- 行順は **name（B列）の大小無視昇順**（CDM 2025 実データと同じ。機能には無関係で
+  FILTER/SORT が再導出する）。
+
+#### 3.1.1 合成順序（重要）
+
+シートは Main Hub の Order 値から
+`グループg = {gi+1, gi+1+G, gi+1+2G, ...}`（G=グループ数, gi=0始まりグループ添字）という
+**インターリーブでグループを導出**する。アプリのグループ割当（蛇行スネーク）とは異なるため、
+アプリの実グループ構成を再現するよう Order を合成する:
+
+```
+グループ g(添字gi) 内でアプリ seeding 昇順 k番目(0始まり) の選手
+  → Order = gi + 1 + k*G
+```
+
+これによりシート導出グループ == アプリ実グループとなる。TT はグループなしのため
+seeding（なければ予選順位）をそのまま 1..N で振る。
+制約: シート数式は均等グループ（P2/P4 が整数）を前提とする。不均等時は log 警告のうえ続行。
+
+### 3.2 TT Qualifications
+
+- 書込は **G..Z（20コース、`CDM_COURSES` 順）× rows 2..48** のタイムのみ。
+- 行は `F2# = SORT(FILTER(Registration[Nickname], TT="Yes"))` のスピル順 =
+  **ニックネームの大文字小文字無視・昇順**を JS 側で再現して割当てる
+  （Excel SORT は case-insensitive・安定。非ASCII勢の照合差異は既知の限界として log）。
+- タイム形式: `"M:SS.cc"` → 整数 `M*10000 + SS*100 + CC`（ms→centisecond は半上げ）。
+- 欠測コースはセル値クリア（シート数式上 0 扱いになり、**全タイム入力完了までシート側
+  TTポイントはアプリと一致しない**。テンプレート設計由来の既知の限界として文書化）。
+- E,F（#・名前）、AA..CR（換算・ランク・ポイント・最終順位）は全て数式 → **非接触**。
+
+### 3.3 BM/MR/GP Qualifications（共通レイアウト）
+
+- 順位表 E..Q、ソート済み順位 AF..AI/AJ..AM/AG..AJ、出場順 AK..AL 等は全て数式 → **非接触**。
+- 試合領域は **選手ブロック制**: データ行 2..16、ヘッダ行17、以降ストライド16（最大48ブロック）。
+  ブロック順 = シートの G2# スピル順 = **グループA選手（合成Order昇順）→ B → C…**。
+  各試合は**両選手のブロックに1行ずつ（計2回）**現れる。
+- ブロック内行（オーナー視点・roundNumber, matchNumber 昇順）:
+
+| 列 | 内容 |
+|----|------|
+| S | matchNumber |
+| T | tvNumber（null はクリア） |
+| U | オーナーの side（player1Side/player2Side） |
+| V | オーナーのニックネーム |
+| W | オーナーのスコア（BM/MR: ラウンド取得数 0..4、GP: ドライバーポイント 0..45） |
+| Z | 相手ニックネーム（BYE は `Break`） |
+| AA | 相手の side |
+| Y | **GPのみ**相手ポイントを書く（BM/MR は `=4-W` 数式のため非接触） |
+| AB..AE | **MRのみ** assignedCourses 略称4つ / **GPのみ** AB=cup名 |
+
+- X(`-`)・AB..AD(BM)/AF..AH(MR)/AC..AE(GP) の W/T/L 判定数式は非接触。
+- 未完了試合はスコアセルをクリア（数式が空欄を無害に処理する）。
+- BYE: BM/MR は W=4（自動完了）、GP は実入力ポイント。
+- 余剰行・余剰ブロックは入力セル（S,T,U,V,W,Z,AA + GP:Y + MR:AB..AE）をクリア。
+
+### 3.4 BM/MR/GP Finals（24人 CDM レイアウト）
+
+ブロック列: Barrage1=D(4), Barrage2=K(11), Top16=R(18), UBQ=Y(25), UBS=AF(32),
+UBF=AM(39), GF1=AT(46), GF2=BA(53)。下段 LB は R/Y/AF/AM/AT/BA の rows 41..54。
+ブロック内オフセット: +0=ラベル/試合番号, +1=シード#, +2=名前, +3=国旗, +4=スコア。
+
+**B3:B26 = シードリスト（B-position 順のニックネーム）**:
+- 24人（16+playoff）: B-pos 1..12 = 直行勢（upper seed `[1,2,…,9,11,13,15]` の順）、
+  B-pos 13..24 = playoff seed 1..12（= 予選13..24位相当）。
+- 16人: B-pos = upper seed 1..16。8人: 1..8。
+- 各シードの実選手は決勝試合レコードと `generateBracketStructure`/`generatePlayoffStructure`
+  の構造シードを matchNumber で突合して復元する（DB に seed 列は無い）。
+- **モード差（実テンプレート検証・統合時に確定）**: BM/MR の B3:B26 は型付き共有文字列入力だが、
+  **GP の B3 は配列スピル数式** `=XLOOKUP(ANCHORARRAY(A3),'GP Qualifications'!AL:AL,'GP Qualifications'!AM:AM)`
+  （`ref="B3:B26"`）であり、B4:B26 はそのスピルセル。よって **GP では B3:B26 を一切書かない・クリアしない**
+  （書けば B3 で数式上書き例外、B4:B26 で #SPILL!）。GP のシードリストは GP Qualifications シートから
+  数式で導出される（型付きシードセル E5 等とスコアセルは GP でも従来どおり書く）。
+  実装は `fill/finals.ts` の `seedListIsFormula(mode)` で分岐する。
+
+**書込セル（faithful モード = 16+playoff）**:
+- 型付きシードセルのみ書く:
+  - playoff_r1[k]: E{row},E{row+1}（rows 5/13/21/29）
+  - playoff_r2[k]: L{row} のみ（slot2 は `Winner of B1,k` 数式 → 非接触）
+  - winners_r1: idx 0,2,4,6 は S{row} のみ（slot2 は `Winner of B2,k` 数式）、
+    idx 1,3,5,7 は S{row},S{row+1}
+- スコアは **同一性解決**で書く（3.4.1）。
+- 名前列（F/M/T/AA/AH/AO/AV/BC）・進出数式・最終順位ブロック（BG/BH/BI）・
+  "First to"・Arena ヘッダ・B32/B33 は非接触。
+- TV 番号はテンプレートに該当セルが無いため**書かない**。
+- GF reset 不要時はスコアをクリアするだけ（数式が空欄処理）。
+
+#### 3.4.1 スロット意味論と同一性解決スコア
+
+テンプレート数式が定めるスロット帰属（検証済み）:
+
+| round[idx] | slot1 | slot2 |
+|---|---|---|
+| playoff_r1[k] | typed seed | typed seed |
+| playoff_r2[k] | typed seed (bye) | winnerOf playoff_r1[k] |
+| winners_r1[2k] | typed seed | winnerOf playoff_r2[k] |
+| winners_r1[2k+1] | typed seed | typed seed |
+| winners_qf[k] | winnerOf winners_r1[2k] | winnerOf winners_r1[2k+1] |
+| winners_sf[k] | winnerOf winners_qf[2k] | winnerOf winners_qf[2k+1] |
+| winners_final | winnerOf winners_sf[0] | winnerOf winners_sf[1] |
+| losers_r1[k] | loserOf winners_r1[2k] | loserOf winners_r1[2k+1] |
+| losers_r2[k] | loserOf winners_qf[3-k] | winnerOf losers_r1[k] |
+| losers_r3[k] | winnerOf losers_r2[2k] | winnerOf losers_r2[2k+1] |
+| losers_r4[k] | loserOf winners_sf[k] | winnerOf losers_r3[k] |
+| losers_sf | winnerOf losers_r4[0] | winnerOf losers_r4[1] |
+| losers_final | **loserOf winners_final** | winnerOf losers_sf |
+| grand_final | winnerOf winners_final | winnerOf losers_final |
+| grand_final_reset | winnerOf grand_final | loserOf grand_final |
+
+アプリの p1/p2 とスロット順は **losers_final で反転**している（他は一致を検証済み）。
+よってスコアは「スロット意味論を解決した期待選手の実スコア」を書く。
+期待選手と実レコードが一致しない場合（手動運用等）は p1/p2 順にフォールバックし `logger.warn`。
+
+**縮退モード**:
+- 16人（playoff 無し）: winners_r1 idx0,2,4,6 の slot2（S/T セル）を**値で上書き**
+  （数式除去）。Barrage ブロックの入力/数式セルを除去。
+- 8人: winners_qf 以降へ同様にマップし、UBQ/LB 各スロットの**名前セルを解決済み値で上書き**。
+  未使用ブロック（Barrage/Top16/losers_r1,r2 の余剰スロット/losers_r4 等）は値・数式とも除去。
+  log で縮退を明示。
+
+### 3.5 TT Finals
+
+ラウンドブロック: r=1..40、入力ブロック先頭列 `1+13(r-1)`（A,N,AA,…）、
+表示ブロック先頭列 `7+13(r-1)`（G,T,AG,…）。各ブロック rows 1..26（データ 3..26）。
+
+- アプリの順序: phase1 ラウンド（roundNumber昇順）→ phase2 → phase3 を
+  シート Round 1..40 に順番に割当（40 超過は切捨て+log）。
+  SuddenDeath は**独立ラウンドとして挿入しない**: `submitSuddenDeathResults` が解決後の
+  `eliminatedIds`/`livesReset` を親 `TTPhaseRound` に書き戻すため（finals-phase-manager.ts）、
+  親ラウンドだけでライフ台帳が完結する。別行にすると二重計上になる（実装時に確定した仕様）。
+- 行 = 選手。Round1 入力ブロックの行順 = B3# = **予選最終順位 1..24**（アプリの予選順位で再現）。
+  Round r≥2 の行順 = `SORTBY(前ラウンド表示名, 前ラウンド残ライフ desc)`（安定ソート）を
+  JS 側 replay で正確に再現する。
+- 書込:
+  - 表示ブロック行1: `Round {r} - {コース正式名}`
+  - Round1 入力ブロック C3..C26 = 初期ライフ（全員 1）。E = タイム（MSSHH）、非走者は 0。
+  - Round r≥2: Time 列（+4）に参加者タイム/非走者 0、Gain 列（+3）に
+    ライフ増分（phase3 開始時 +2、リセット時の補充）。Left 列は数式 → 非接触。
+  - 表示ブロック Lost 列（表示先頭+4）: そのラウンドでライフを失った選手の
+    **ソート後表示行**に `1`。
+- ライフ replay: `TTPhaseRound.results/eliminatedIds/livesReset` とフェーズ規則
+  （phase1/2 はライフ1相当・各ラウンド最下位1名脱落、phase3 は初期3・残8/4/2でリセット）
+  から各ラウンドの Lost/Gain/残ライフを純関数で再構築する。
+- 最終順位ブロック（TA..TD）は数式 → **非接触**（Overall Ranking の TT Bonus がここを参照）。
+- 既知の限界: 脱落済み選手の最終ブロック内序列はライフ同値のため概算となる
+  （テンプレート設計由来。確定順位の正はアプリ側）。
+
+### 3.6 書かないシート
+
+**Overall Ranking / TT for Scoub / Parameters は完全に数式駆動のため一切書かない。**
+旧実装の writeOverallRanking は削除し、prisma include から playerScores を外す。
+
+## 4. データ取得
+
+現行 `CDM_EXPORT_INCLUDE` から `playerScores` を除去。追加で必要なもの:
+- 決勝シード復元のための finals/playoff 試合（既に bmMatches 等に含まれる）。
+- TT finals: `ttPhaseRounds`（含まれる）+ SuddenDeath（必要なら追加 include）。
+
+Qualifying 人数（O3..R3）: 決勝データがあればその規模（playoff有=24）、なければ
+`min(24, 予選参加者数)`。グループ数（O4..R4）: 予選 distinct group 数。
+
+## 5. テスト計画（t-wada TDD）
+
+1. **sheet-xml-patcher**: 実テンプレート XML 断片をフィクスチャに、
+   置換/挿入/クリア/属性保持/エスケープ/無操作時の同一性 をユニットテスト。
+2. **fill 各モジュール**: 純関数 `appData → CellWrite[]` を、合成順序・MSSHH 変換・
+   ブロック配置・スロット意味論・TT replay について網羅的にユニットテスト。
+   24人/16人/8人/途中状態/BYE/未完了 のフィクスチャを用意。
+3. **統合**: 実テンプレート（public/templates）に対し generate を実行し、
+   (a) パッチ対象セルの XML 値、(b) **非対象パートのバイト同一性**、
+   (c) tables/richData/metadata の存続 をアサート（旧実装に欠けていた回帰ガード）。
+4. **route**: 認証 401/403、404、テンプレート 503、Content-Type/Disposition は現行テストを継承。
+   CSV テストは無変更。
+5. **E2E**: `e2e/tc-cdm-export.js` 新設 — Phase A データ投入後に
+   `?format=cdm` をバイナリ取得 → fflate で解凍 → tables/richData の存在と
+   Main Hub/スコアセルの値を検証。`tc-all.js` に登録し、`E2E_TEST_CASES.md` に TC を追記。
+6. **手動検証**: 生成物を LibreOffice/Excel で開き #SPILL!/#NAME? が無いことを目視確認
+   （リリース前必須・自動化対象外）。
+
+## 6. 既知の限界（明示的に受け入れるもの）
+
+- 国旗（リッチバリュー画像）: Country をテキスト化するため国旗列は表示劣化する。
+  richData パート自体は素通しで保全（将来 vm 索引の再利用で復元可能）。
+- TT 予選の途中状態はシート側ポイントが暫定値になる（空タイム=0 のテンプレート仕様）。
+- シートの Score 丸め（INT）とアプリ（round）で最大1ポイントの表示差。
+- 8人ブラケットは数式エッジ非互換のため値上書き縮退（Excel 上での再計算連動なし）。
+- ニックネームは DB unique 制約があり、シートのニックネーム・キーの一意性前提と整合。
+- GP 決勝のシードリスト（B3:B26）はエクスポータが書かず GP Qualifications シートの
+  数式スピルから導出されるため、GP Qualifications（AL/AM 列）が未充填だと GP 決勝の
+  シード名が空欄/#N/A になる。BM/MR は型付き入力なので影響しない。確定は §5.6 の
+  LibreOffice 目視確認で担保する。

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -174,6 +174,27 @@ function cdmE2eSeedListSet(sheet) {
 }
 
 /**
+ * Fetch a mode's qualification roster nicknames. The seed-list check needs
+ * this because in the playoff-only mid-state the exporter fills B-positions
+ * 1..12 from the QUALIFICATION standings fallback (design §3.4) — those
+ * players have no finals match record yet, so finals participants alone is
+ * the wrong allowed-universe for B3:B26.
+ */
+async function cdmE2eQualificationNicknames(page, tournamentId, modePath) {
+  const json = await page.evaluate(async (u) => {
+    const r = await fetch(`${u}?ts=${Date.now()}`, { cache: 'no-store' });
+    return r.json().catch(() => ({}));
+  }, `/api/tournaments/${tournamentId}/${modePath}`);
+  const qualifications = json?.data?.qualifications ?? [];
+  const names = new Set();
+  for (const q of qualifications) {
+    const nickname = q?.player?.nickname;
+    if (typeof nickname === 'string' && nickname) names.add(nickname);
+  }
+  return names;
+}
+
+/**
  * Verify the structural parts the OLD SheetJS read→write exporter destroyed:
  * the worksheet tables and the rich-data (flag image) part must survive, and the
  * stale calcChain must be gone so Excel rebuilds it after fullCalcOnLoad. This is
@@ -3598,18 +3619,24 @@ async function main() {
             }
 
             // (b.4) BM/MR seed list (B3:B26) sanity — every name the exporter wrote
-            // there must be one of this mode's finals participants (GP's B column is a
-            // formula spill, intentionally skipped above so `seedList` is empty there).
-            const finalsNicknames = new Set();
+            // there must come from THIS tournament: a finals participant or, for the
+            // playoff-only mid-state, a qualification-roster player (design §3.4 fills
+            // B-positions 1..12 from the qualification standings before winners_r1
+            // exists). The check still catches the real regression — stale CDM 2025
+            // template names ("Geo", "Sami", ...) leaking into the output. (GP's B
+            // column is a formula spill, intentionally skipped above so `seedList`
+            // is empty there.)
+            const allowedSeedNames = await cdmE2eQualificationNicknames(
+              page, exportTid, mode.toLowerCase());
             for (const match of cdmE2eFinalsMatches(state)) {
-              if (match.player1?.nickname) finalsNicknames.add(match.player1.nickname);
-              if (match.player2?.nickname) finalsNicknames.add(match.player2.nickname);
+              if (match.player1?.nickname) allowedSeedNames.add(match.player1.nickname);
+              if (match.player2?.nickname) allowedSeedNames.add(match.player2.nickname);
             }
             for (const seedName of seedList) {
               checked++;
               checkedByMode[mode]++;
-              if (!finalsNicknames.has(seedName)) {
-                failures.push(`${mode} seed list name "${seedName}" is not a finals participant`);
+              if (!allowedSeedNames.has(seedName)) {
+                failures.push(`${mode} seed list name "${seedName}" is not a finals or qualification participant`);
               }
             }
           }

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -11,6 +11,7 @@
 const fs = require('fs');
 const https = require('https');
 const XLSX = require('@e965/xlsx');
+const { unzipSync } = require('fflate');
 const {
   apiActivateTournament,
   apiUpdateTournament,
@@ -91,9 +92,16 @@ const CDM_FINALS_E2E_SLOTS = {
   losers_final: [{ blockStart: 53, row: 47 }],
 };
 
-// Keep this expectation map synchronized with route.ts CDM_FINALS_BRACKET_SLOTS.
-// TC-816A intentionally reads the exported workbook, but it still needs the
-// template's native coordinates to know which cell each round should occupy.
+// Keep this expectation map synchronized with src/lib/cdm-export/cdm-constants.ts
+// FINALS_BRACKET_SLOTS (the production source of truth after the ZIP-surgery
+// rewrite — the old slot table that used to live in the export route was deleted).
+// TC-816A reads the exported workbook, so it still needs the template's native
+// coordinates to know which cell each round should occupy. Block offsets:
+// +1 seed#, +2 name, +4 score (FINALS_BLOCK_{SEED,NAME,SCORE}_OFFSET).
+const CDM_FINALS_BLOCK_SEED_OFFSET = 1;
+const CDM_FINALS_BLOCK_NAME_OFFSET = 2;
+const CDM_FINALS_BLOCK_SCORE_OFFSET = 4;
+
 function cdmE2eSlotRound(match) {
   const round = match?.round || '';
   const bracketPosition = String(match?.bracketPosition || '').toLowerCase();
@@ -103,15 +111,89 @@ function cdmE2eSlotRound(match) {
   return null;
 }
 
-function cdmE2eMatchLabel(match) {
-  const slotRound = cdmE2eSlotRound(match);
-  if (slotRound === 'grand_final_reset') return 'GF Reset';
-  if (slotRound === 'grand_final') return 'GF';
-  return match.bracketPosition || match.round || `M${match.matchNumber}`;
-}
-
 function cdmE2eCell(col, row) {
   return XLSX.utils.encode_cell({ c: col - 1, r: row - 1 });
+}
+
+/**
+ * SheetJS reads a cell as { v, f? }: `v` is the value (or a formula's cached
+ * value), `f` is the formula text when the cell carries one. The rewritten
+ * exporter only writes VALUES into input cells and leaves every template formula
+ * untouched, so a cell with `.f` set was NOT written by the exporter (its `.v` is
+ * just the template's stale cached value and must never be asserted as data).
+ */
+function cdmE2eCellValue(sheet, ref) {
+  const cell = sheet?.[ref];
+  if (!cell) return undefined;
+  return cell.v;
+}
+function cdmE2eIsWrittenValue(sheet, ref) {
+  const cell = sheet?.[ref];
+  return Boolean(cell) && cell.f === undefined && cell.v !== undefined && cell.v !== '';
+}
+
+/** Name cell ref (+2) for a slot: slot1 = geometry.row, slot2 = geometry.row + 1. */
+function cdmE2eNameCellRef(slot, slotIndex) {
+  return cdmE2eCell(slot.blockStart + CDM_FINALS_BLOCK_NAME_OFFSET, slot.row + slotIndex);
+}
+/** Score cell ref (+4) for a slot. */
+function cdmE2eScoreCellRef(slot, slotIndex) {
+  return cdmE2eCell(slot.blockStart + CDM_FINALS_BLOCK_SCORE_OFFSET, slot.row + slotIndex);
+}
+/** Seed-number cell ref (+1) for a slot. */
+function cdmE2eSeedCellRef(slot, slotIndex) {
+  return cdmE2eCell(slot.blockStart + CDM_FINALS_BLOCK_SEED_OFFSET, slot.row + slotIndex);
+}
+
+/**
+ * The score a slot should carry for a completed match. BM/MR use score1/score2,
+ * GP uses points1/points2 (FT cups won). slotIndex picks player1 (0) / player2 (1).
+ */
+function cdmE2eMatchScore(match, mode, slotIndex) {
+  if (mode === 'GP') {
+    const value = slotIndex === 0 ? match.points1 : match.points2;
+    return Number.isFinite(value) ? value : null;
+  }
+  const value = slotIndex === 0 ? match.score1 : match.score2;
+  return Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Read the BM/MR seed list (column B, rows 3..26) as a Set of written nicknames.
+ * Empty for GP: GP's B3:B26 is an array-spill formula derived from GP
+ * Qualifications, so the exporter never writes it (the cells hold stale cached
+ * values) — GP seed names must not be asserted from this column (design §3.4).
+ */
+function cdmE2eSeedListSet(sheet) {
+  const names = new Set();
+  for (let row = 3; row <= 26; row++) {
+    const ref = `B${row}`;
+    if (cdmE2eIsWrittenValue(sheet, ref)) names.add(String(sheet[ref].v));
+  }
+  return names;
+}
+
+/**
+ * Verify the structural parts the OLD SheetJS read→write exporter destroyed:
+ * the worksheet tables and the rich-data (flag image) part must survive, and the
+ * stale calcChain must be gone so Excel rebuilds it after fullCalcOnLoad. This is
+ * the root regression guard for the rewrite (design §2 / §5.3).
+ * Returns an array of human-readable failures (empty = OK).
+ */
+function cdmE2eStructuralFailures(zipBytes) {
+  const failures = [];
+  let parts;
+  try {
+    parts = unzipSync(new Uint8Array(zipBytes));
+  } catch (err) {
+    return [`zip could not be decoded: ${err instanceof Error ? err.message : String(err)}`];
+  }
+  if (!parts['xl/tables/table1.xml']) failures.push('xl/tables/table1.xml missing (Registration/Tracks/Cups tables dropped)');
+  if (!parts['xl/richData/rdrichvalue.xml']) failures.push('xl/richData/rdrichvalue.xml missing (flag rich-data dropped)');
+  if (parts['xl/calcChain.xml']) failures.push('xl/calcChain.xml present (stale calc chain not removed)');
+  const workbookXml = parts['xl/workbook.xml'] ? Buffer.from(parts['xl/workbook.xml']).toString('utf8') : '';
+  if (!/fullCalcOnLoad="1"/.test(workbookXml)) failures.push('xl/workbook.xml is missing fullCalcOnLoad="1"');
+  return failures;
 }
 
 const cdmE2eFinalsApi = {
@@ -207,15 +289,6 @@ async function ensureCdmE2eFinalsFixture(page, tournamentId, api = cdmE2eFinalsA
   }
 
   return { modeStates, readinessDetails };
-}
-
-function cdmE2eGpCupResultsSummary(match) {
-  return (match.cupResults || []).map((result, index) => {
-    const cup = typeof result?.cup === 'string' && result.cup ? result.cup : `Cup ${index + 1}`;
-    const points1 = Number.isFinite(result?.points1) ? result.points1 : '';
-    const points2 = Number.isFinite(result?.points2) ? result.points2 : '';
-    return `${cup}: ${points1}-${points2}`;
-  }).join('; ');
 }
 
 function log(tc, s, d = '') {
@@ -3397,7 +3470,36 @@ async function main() {
     }
   }
 
-  // TC-816A: CDM export finals coordinate mapping is covered by the automated E2E runner.
+  // TC-816A: CDM export finals land in the template's native bracket coordinates.
+  //
+  // The exporter was rewritten from SheetJS read→write to ZIP surgery
+  // (src/lib/cdm-export/): it preserves every template formula and writes ONLY
+  // input cells. We assert two contracts against the freshly-exported workbook:
+  //   (a) Structural regression guard — the parts the old exporter destroyed
+  //       (xl/tables/table1.xml, xl/richData/rdrichvalue.xml) survive, the stale
+  //       xl/calcChain.xml is gone, and workbook.xml gained fullCalcOnLoad="1".
+  //   (b) Per-mode finals values — for each slot-mappable finals match we check
+  //       the cells the exporter actually wrote at its native coordinates. We tell
+  //       written values apart from template formulas via SheetJS `.f` (a cell with
+  //       a formula was NOT written by the exporter; its `.v` is only a stale cache):
+  //         · name cell (+2): only when written as a VALUE (the 8-player degenerate
+  //           path value-overwrites resolved nicknames here; the faithful 24-player
+  //           path leaves an XLOOKUP formula, which we skip). When written it must
+  //           equal one of the match's two player nicknames.
+  //         · score cell (+4): completed matches only (else cleared/blank), equal to
+  //           score1/score2 (GP: points1/points2 = FT cups won). The freshly-
+  //           generated fixture usually has no completed finals match yet, so this is
+  //           best-effort. Slot order is p1→slot1 / p2→slot2 except losers_final
+  //           (the exporter reverses it); the faithful path may also place scores by
+  //           identity resolution, so the check accepts {slot1,slot2}=={s1,s2} as a
+  //           set rather than positionally.
+  //         · seed-number cell (+1): the typed B-position the exporter writes at each
+  //           TYPED-seed slot (formula slots are skipped). Asserted as an integer in
+  //           1..24. winners_r1 + Barrage give every mode many of these in the
+  //           faithful path, so all three modes reach ≥1 check even with no scores.
+  //         · BM/MR seed-list (B3:B26) sanity: every nickname the exporter wrote
+  //           there is one of this mode's finals participants. GP's B3:B26 is a
+  //           formula spill (derived from GP Qualifications) we never read.
   {
     const exportTid = sharedFixture?.tournamentId ?? TID;
     if (exportTid) {
@@ -3417,14 +3519,17 @@ async function main() {
         if (exportResp.status !== 200) {
           log('TC-816A', 'FAIL', `CDM export HTTP ${exportResp.status}`);
         } else {
-          const workbook = XLSX.read(Buffer.from(exportResp.bytes), { type: 'buffer' });
-          const failures = [];
+          const structuralFailures = cdmE2eStructuralFailures(exportResp.bytes);
+          // cellFormula:true so SheetJS sets `.f` on formula cells, letting us tell
+          // an exporter-written value apart from a template formula's cached value.
+          const workbook = XLSX.read(Buffer.from(exportResp.bytes), { type: 'buffer', cellFormula: true });
+          const failures = [...structuralFailures];
           let checked = 0;
-          let gpCupResultsChecked = false;
           const checkedByMode = { BM: 0, MR: 0, GP: 0 };
 
           for (const { mode, sheetName, state } of modeStates) {
             const sheet = workbook.Sheets[sheetName];
+            const seedList = mode === 'GP' ? new Set() : cdmE2eSeedListSet(sheet);
             const roundIndexes = new Map();
             for (const match of cdmE2eFinalsMatches(state)) {
               const slotRound = cdmE2eSlotRound(match);
@@ -3432,22 +3537,79 @@ async function main() {
               roundIndexes.set(slotRound, roundIndex + 1);
               const slot = CDM_FINALS_E2E_SLOTS[slotRound]?.[roundIndex];
               if (!slot) continue;
-              const labelCell = cdmE2eCell(slot.blockStart, slot.row);
-              const actual = sheet?.[labelCell]?.v;
-              const expected = cdmE2eMatchLabel(match);
+              const p1Nick = match.player1?.nickname;
+              const p2Nick = match.player2?.nickname;
+              const nicknames = [p1Nick, p2Nick].filter(Boolean);
+
+              // (b.1) Name cells — assert only the slots the exporter wrote as values.
+              for (const slotIndex of [0, 1]) {
+                const nameRef = cdmE2eNameCellRef(slot, slotIndex);
+                if (!cdmE2eIsWrittenValue(sheet, nameRef)) continue; // formula slot → skip.
+                const actualName = String(cdmE2eCellValue(sheet, nameRef));
+                checked++;
+                checkedByMode[mode]++;
+                if (!nicknames.includes(actualName)) {
+                  failures.push(`${mode} ${slotRound} name ${nameRef}: ${actualName} not in [${nicknames.join(', ')}]`);
+                }
+              }
+
+              // (b.2) Score cells — completed matches only (else cleared/blank).
+              if (match.completed) {
+                const expectedScores = [
+                  cdmE2eMatchScore(match, mode, 0),
+                  cdmE2eMatchScore(match, mode, 1),
+                ];
+                if (expectedScores.every((s) => s != null)) {
+                  const actualScores = [0, 1].map((slotIndex) => {
+                    const ref = cdmE2eScoreCellRef(slot, slotIndex);
+                    const v = cdmE2eCellValue(sheet, ref);
+                    return Number.isFinite(v) ? v : null;
+                  });
+                  checked++;
+                  checkedByMode[mode]++;
+                  // Set-equality: tolerates identity resolution / losers_final reversal.
+                  const expSorted = [...expectedScores].sort((a, b) => a - b);
+                  const actSorted = [...actualScores].map((v) => (v == null ? NaN : v)).sort((a, b) => a - b);
+                  const scoreMatch = expSorted.every((s, i) => s === actSorted[i]);
+                  if (!scoreMatch) {
+                    failures.push(`${mode} ${slotRound} score @${slot.blockStart + CDM_FINALS_BLOCK_SCORE_OFFSET},row ${slot.row}: expected {${expSorted.join(',')}}, got {${actualScores.map((v) => v ?? '<blank>').join(',')}}`);
+                  }
+                }
+              }
+
+              // (b.3) Seed-number cells (+1) — the typed B-position the exporter
+              // writes at each slot's native coordinate. Only TYPED-seed slots carry
+              // a written number (others hold a "Winner of N" reverse-lookup formula,
+              // which we skip). winners_r1 + Barrage slots give every mode plenty of
+              // these in the faithful path even before any score is entered, so each
+              // mode reaches ≥1 check. Both modes use this uniformly; GP's seed-NAME
+              // list (B3:B26) is a formula spill we never read, but its seed NUMBERS
+              // are typed the same way as BM/MR.
+              for (const slotIndex of [0, 1]) {
+                const seedRef = cdmE2eSeedCellRef(slot, slotIndex);
+                if (!cdmE2eIsWrittenValue(sheet, seedRef)) continue; // formula slot → skip.
+                const seedVal = cdmE2eCellValue(sheet, seedRef);
+                checked++;
+                checkedByMode[mode]++;
+                if (!Number.isInteger(seedVal) || seedVal < 1 || seedVal > 24) {
+                  failures.push(`${mode} ${slotRound} seed ${seedRef}: expected B-position 1..24, got ${seedVal ?? '<blank>'}`);
+                }
+              }
+            }
+
+            // (b.4) BM/MR seed list (B3:B26) sanity — every name the exporter wrote
+            // there must be one of this mode's finals participants (GP's B column is a
+            // formula spill, intentionally skipped above so `seedList` is empty there).
+            const finalsNicknames = new Set();
+            for (const match of cdmE2eFinalsMatches(state)) {
+              if (match.player1?.nickname) finalsNicknames.add(match.player1.nickname);
+              if (match.player2?.nickname) finalsNicknames.add(match.player2.nickname);
+            }
+            for (const seedName of seedList) {
               checked++;
               checkedByMode[mode]++;
-              if (actual !== expected) {
-                failures.push(`${mode} ${slotRound} ${labelCell}: expected ${expected}, got ${actual ?? '<blank>'}`);
-              }
-              if (mode === 'GP' && Array.isArray(match.cupResults) && match.cupResults.length > 0 && !gpCupResultsChecked) {
-                const summaryCell = cdmE2eCell(slot.blockStart + 5, slot.row);
-                const expectedSummary = cdmE2eGpCupResultsSummary(match);
-                const actualSummary = sheet?.[summaryCell]?.v;
-                gpCupResultsChecked = true;
-                if (actualSummary !== expectedSummary) {
-                  failures.push(`GP cupResults ${summaryCell}: expected ${expectedSummary}, got ${actualSummary ?? '<blank>'}`);
-                }
+              if (!finalsNicknames.has(seedName)) {
+                failures.push(`${mode} seed list name "${seedName}" is not a finals participant`);
               }
             }
           }
@@ -3456,11 +3618,11 @@ async function main() {
             .map(([mode]) => mode);
 
           log('TC-816A',
-            checked > 0 && missingModes.length === 0 && failures.length === 0 ? 'PASS' : 'FAIL',
-            checked === 0 ? `No finals matches available for CDM coordinate verification (${readinessSummary})`
-            : missingModes.length > 0 ? `No finals matches checked for modes: ${missingModes.join(', ')} (${readinessSummary})`
+            structuralFailures.length === 0 && checked > 0 && missingModes.length === 0 && failures.length === 0 ? 'PASS' : 'FAIL',
+            structuralFailures.length > 0 ? `structural: ${structuralFailures.slice(0, 3).join('; ')}`
+            : checked === 0 ? `No finals matches available for CDM coordinate verification (${readinessSummary})`
+            : missingModes.length > 0 ? `No finals cells checked for modes: ${missingModes.join(', ')} (${readinessSummary})`
             : failures.length > 0 ? failures.slice(0, 3).join('; ')
-            : !gpCupResultsChecked ? 'GP cupResults not available; skipped summary-cell check'
             : '');
         }
       } catch (err) {

--- a/smkc-score-app/package-lock.json
+++ b/smkc-score-app/package-lock.json
@@ -25,6 +25,7 @@
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "fflate": "^0.8.3",
         "geist": "^1.5.1",
         "lucide-react": "^0.562.0",
         "next": "^16.2.6",
@@ -11352,6 +11353,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/smkc-score-app/package.json
+++ b/smkc-score-app/package.json
@@ -65,6 +65,7 @@
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "fflate": "^0.8.3",
     "geist": "^1.5.1",
     "lucide-react": "^0.562.0",
     "next": "^16.2.6",

--- a/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
@@ -21,7 +21,6 @@
  */
 import { NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import * as XLSX from "@e965/xlsx";
 import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import prisma from "@/lib/prisma";
 import { formatDate, formatTime } from "@/lib/excel";
@@ -29,65 +28,65 @@ import { createLogger } from "@/lib/logger";
 import { createErrorResponse, handleAuthError, handleAuthzError } from "@/lib/error-handling";
 import { resolveTournamentId } from "@/lib/tournament-identifier";
 import { auth } from "@/lib/auth";
+import { generateCdmWorkbook } from "@/lib/cdm-export";
+import type {
+  CdmMatch,
+  CdmModeQualification,
+  CdmTTEntry,
+  CdmTTPhaseRound,
+  CdmTournamentData,
+} from "@/lib/cdm-export/types";
 
 const CDM_TEMPLATE_PATH = "/templates/cdm-2025-template.xlsm";
 
-type PlayerPublic = {
+/*
+ * Prisma row shapes the CDM mapper reads. These mirror the columns the
+ * CDM_EXPORT_INCLUDE query returns (player projected through PLAYER_PUBLIC_SELECT);
+ * they exist only to give mapToCdmTournamentData a typed input without pulling the
+ * full generated Prisma payload type into this route. Every field below maps 1:1
+ * to a prisma/schema.prisma column (BMQualification/BMMatch/GPMatch/TTEntry/
+ * TTPhaseRound) so the mapping is a pure field projection, not a transformation.
+ */
+type CdmPlayerRow = {
   id: string;
   name: string;
   nickname: string;
   country?: string | null;
 };
 
-type ModeQualification = {
-  player: PlayerPublic;
-  seeding: number | null;
+type CdmQualificationRow = {
+  player: CdmPlayerRow;
   group: string;
-  mp: number;
-  wins: number;
-  ties: number;
-  losses: number;
+  seeding: number | null;
   points: number;
   score: number;
   rankOverride?: number | null;
-  winRounds?: number;
-  lossRounds?: number;
 };
 
-type MatchWithPlayers = {
+type CdmMatchRow = {
   matchNumber: number;
   stage: string;
   round?: string | null;
-  tvNumber?: number | null;
+  bracketPosition?: string | null;
+  isGrandFinal?: boolean;
   roundNumber?: number | null;
+  tvNumber?: number | null;
   isBye?: boolean;
-  player1: PlayerPublic;
-  player1Side?: number;
-  player2: PlayerPublic;
-  player2Side?: number;
-  score1?: number;
-  score2?: number;
-  points1?: number;
-  points2?: number;
+  player1: CdmPlayerRow;
+  player2: CdmPlayerRow;
+  player1Side?: number | null;
+  player2Side?: number | null;
+  score1?: number | null;
+  score2?: number | null;
+  points1?: number | null;
+  points2?: number | null;
   completed: boolean;
   assignedCourses?: unknown;
   cup?: string | null;
-  cupResults?: unknown;
-  bracketPosition?: string | null;
-  isGrandFinal?: boolean;
 };
 
-type TTPhaseRoundExport = {
-  phase: string;
-  roundNumber: number;
-  course: string;
-  results: unknown;
-  eliminatedIds?: unknown;
-  livesReset: boolean;
-};
-
-type TTEntryExport = {
-  player: PlayerPublic;
+type CdmTtEntryRow = {
+  player: CdmPlayerRow;
   playerId: string;
   stage: string;
   seeding: number | null;
@@ -96,26 +95,30 @@ type TTEntryExport = {
   times?: unknown;
   totalTime?: number | null;
   qualificationPoints?: number | null;
+  rank?: number | null;
 };
 
-type TournamentPlayerScoreExport = {
-  player: PlayerPublic;
-  taQualificationPoints: number;
-  bmQualificationPoints: number;
-  mrQualificationPoints: number;
-  gpQualificationPoints: number;
-  taFinalsPoints: number;
-  bmFinalsPoints: number;
-  mrFinalsPoints: number;
-  gpFinalsPoints: number;
-  totalPoints: number;
-  overallRank: number | null;
+type CdmTtPhaseRoundRow = {
+  phase: string;
+  roundNumber: number;
+  course: string;
+  results: unknown;
+  eliminatedIds?: unknown;
+  livesReset: boolean;
 };
 
-const CDM_COURSES = [
-  "MC1", "DP1", "GV1", "BC1", "MC2", "CI1", "GV2", "DP2", "BC2", "MC3",
-  "KB1", "CI2", "VL1", "BC3", "MC4", "DP3", "KB2", "GV3", "VL2", "RR",
-] as const;
+type CdmTournamentRow = {
+  name: string;
+  date: Date;
+  bmQualifications: CdmQualificationRow[];
+  mrQualifications: CdmQualificationRow[];
+  gpQualifications: CdmQualificationRow[];
+  bmMatches: CdmMatchRow[];
+  mrMatches: CdmMatchRow[];
+  gpMatches: CdmMatchRow[];
+  ttEntries: CdmTtEntryRow[];
+  ttPhaseRounds: CdmTtPhaseRoundRow[];
+};
 
 const BASE_EXPORT_INCLUDE = {
   bmQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
@@ -125,139 +128,19 @@ const BASE_EXPORT_INCLUDE = {
   ttEntries: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
 };
 
+/*
+ * The CDM workbook is formula-driven: standings, bracket advancement and the
+ * Overall Ranking sheet are all computed by Excel dynamic-array formulas from a
+ * small set of input cells, so the exporter never writes the Overall Ranking
+ * sheet and therefore does NOT need playerScores (design §3.6). We add only the
+ * MR/GP qualification seeds and the TT phase rounds the workbook sheets read.
+ */
 const CDM_EXPORT_INCLUDE = {
   ...BASE_EXPORT_INCLUDE,
   mrQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
   gpQualifications: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
   ttPhaseRounds: true,
-  playerScores: { include: { player: { select: PLAYER_PUBLIC_SELECT } } },
 };
-
-/*
- * CDM 2025 workbook template coordinates. These constants are fixed template
- * ranges, not business limits; writing past them risks overwriting formula
- * regions and hidden helper cells in the macro workbook.
- */
-// Main Hub player table is bounded by explicit template anchors and a fixed
-// capacity. Keep both anchor and capacity in constants so range updates stay
-// synchronized in code.
-const CDM_PLAYER_HUB_FIRST_ROW = 2;
-const CDM_PLAYER_HUB_ROW_SPAN = 60;
-const CDM_PLAYER_HUB_LAST_ROW = CDM_PLAYER_HUB_FIRST_ROW + CDM_PLAYER_HUB_ROW_SPAN - 1;
-const CDM_PLAYER_HUB_MAX_PLAYERS = CDM_PLAYER_HUB_ROW_SPAN;
-// TT Qualifications uses the same rows as Main Hub, but keep aliases so
-// writeTTQualifications keeps sheet-level readability.
-const CDM_TT_QUAL_FIRST_ROW = CDM_PLAYER_HUB_FIRST_ROW;
-const CDM_TT_QUAL_MAX_PLAYERS = CDM_PLAYER_HUB_MAX_PLAYERS;
-// Qualification sheets reserve CDM_QUALIFICATION_MAX_ROWS rows starting at
-// CDM_QUALIFICATION_FIRST_ROW (header row is above the data block).
-const CDM_QUALIFICATION_FIRST_ROW = 2;
-const CDM_QUALIFICATION_MAX_ROWS = 767;
-// Finals players list occupies fixed rows for A1-style standings blocks in each finals sheet.
-const CDM_FINALS_PLAYER_FIRST_ROW = 3;
-const CDM_FINALS_MAX_PLAYERS = 52;
-const CDM_FINALS_BLOCK_START_COLUMNS = [4, 11, 18, 25, 32, 39, 46, 53, 60, 67, 74, 81, 88, 95, 102];
-const CDM_FINALS_BLOCK_END_OFFSET = 6;
-const CDM_FINALS_LAST_COLUMN = 107;
-const CDM_FINALS_MATCH_FIRST_ROW = 5;
-const CDM_FINALS_PAIR_ROWS = [5, 13, 21, 29, 37, 45];
-// CDM Finals sheets are laid out as fixed bracket regions, not as a dense
-// table. Map the app's canonical round ids to the template's native block and
-// top-row coordinates so exports preserve the bracket shape operators expect.
-const CDM_FINALS_BRACKET_SLOTS: Record<string, Array<{ blockStart: number; row: number }>> = {
-  playoff_r1: [5, 13, 21, 29].map((row) => ({ blockStart: 4, row })),
-  playoff_r2: [5, 13, 21, 29].map((row) => ({ blockStart: 11, row })),
-  winners_r1: [5, 9, 13, 17, 21, 25, 29, 33].map((row) => ({ blockStart: 18, row })),
-  winners_qf: [7, 15, 23, 31].map((row) => ({ blockStart: 25, row })),
-  winners_sf: [11, 27].map((row) => ({ blockStart: 32, row })),
-  winners_final: [{ blockStart: 39, row: 19 }],
-  grand_final: [{ blockStart: 46, row: 19 }],
-  grand_final_reset: [{ blockStart: 53, row: 19 }],
-  losers_r1: [41, 45, 49, 53].map((row) => ({ blockStart: 18, row })),
-  losers_r2: [41, 45, 49, 53].map((row) => ({ blockStart: 25, row })),
-  losers_r3: [43, 51].map((row) => ({ blockStart: 32, row })),
-  losers_r4: [43, 51].map((row) => ({ blockStart: 39, row })),
-  losers_sf: [{ blockStart: 46, row: 47 }],
-  losers_final: [{ blockStart: 53, row: 47 }],
-};
-const CDM_TT_FINALIST_FIRST_ROW = 3;
-const CDM_TT_FINALIST_MAX_ROWS = 24;
-// TT rounds are rendered into fixed block starts; each block maps to one
-// logical section defined by CDM_TT_ROUND_START_COLUMNS.
-const CDM_TT_ROUND_START_COLUMNS = [7, 20, 33, 46, 59, 72, 85, 98];
-const CDM_TT_ROUND_BLOCK_END_OFFSET = 5;
-const CDM_TT_ROUND_LAST_COLUMN = 524;
-const CDM_TT_ROUND_FIRST_ROW = 1;
-const CDM_TT_ROUND_LAST_ROW = 26;
-// TT rounds keep at most CDM_TT_ROUND_MAX_RESULTS rows per block within
-// rows CDM_TT_ROUND_FIRST_ROW..CDM_TT_ROUND_LAST_ROW (with 2 header rows),
-// so values beyond this cap are intentionally dropped.
-const CDM_TT_ROUND_MAX_RESULTS = 24;
-const CDM_OVERALL_FIRST_ROW = 2;
-const CDM_OVERALL_MAX_ROWS = 64;
-
-// Older generators and manual fixtures can still store grand finals as
-// round="gf" with bracketPosition="gf"; normalize those aliases before slot
-// lookup so legacy rows land in the same native CDM bracket cell as current
-// round="grand_final" rows.
-function cdmFinalsSlotRound(match: MatchWithPlayers): string | null {
-  const round = match.round ?? "";
-  const bracketPosition = (match.bracketPosition ?? "").toLowerCase();
-  if (round in CDM_FINALS_BRACKET_SLOTS) return round;
-  if (bracketPosition.includes("reset")) return "grand_final_reset";
-  if (round === "gf" || bracketPosition === "gf" || match.isGrandFinal) return "grand_final";
-  return null;
-}
-
-function setCell(ws: XLSX.WorkSheet, address: string, value: unknown) {
-  if (value === null || value === undefined) {
-    delete ws[address];
-    return;
-  }
-  if (typeof value === "number") {
-    ws[address] = { ...(ws[address] ?? {}), t: "n", v: value };
-    return;
-  }
-  ws[address] = { ...(ws[address] ?? {}), t: "s", v: String(value) };
-}
-
-function toColumn(column: number): string {
-  let result = "";
-  while (column > 0) {
-    const rem = (column - 1) % 26;
-    result = String.fromCharCode(65 + rem) + result;
-    column = Math.floor((column - 1) / 26);
-  }
-  return result;
-}
-
-function parseTimeMs(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  const match = trimmed.match(/^(?:(\d+):)?(\d+)(?:[.:](\d{1,3}))?$/);
-  if (!match) return null;
-  const minutes = Number(match[1] ?? 0);
-  const seconds = Number(match[2]);
-  const ms = Number((match[3] ?? "0").padEnd(3, "0").slice(0, 3));
-  return minutes * 60_000 + seconds * 1_000 + ms;
-}
-
-function normalizeJsonRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
-}
-
-function sortQualifications<T extends ModeQualification>(items: T[]): T[] {
-  return [...items].sort((a, b) =>
-    a.group.localeCompare(b.group) ||
-    (a.rankOverride ?? Number.MAX_SAFE_INTEGER) - (b.rankOverride ?? Number.MAX_SAFE_INTEGER) ||
-    b.score - a.score ||
-    b.points - a.points ||
-    (a.seeding ?? Number.MAX_SAFE_INTEGER) - (b.seeding ?? Number.MAX_SAFE_INTEGER) ||
-    a.player.nickname.localeCompare(b.player.nickname)
-  );
-}
 
 async function loadCDMTemplate(request: Request): Promise<
   | { ok: true; buffer: ArrayBuffer }
@@ -289,422 +172,98 @@ async function loadCDMTemplate(request: Request): Promise<
   return { ok: false, status: response.status, source: "fetch" };
 }
 
-function writePlayerHub(
-  workbook: XLSX.WorkBook,
-  players: PlayerPublic[],
-  seedByMode: Record<"tt" | "bm" | "mr" | "gp", Map<string, number | null>>
-) {
-  const ws = workbook.Sheets["Main Hub"];
-  if (!ws) return;
-
-  for (let row = CDM_PLAYER_HUB_FIRST_ROW; row <= CDM_PLAYER_HUB_LAST_ROW; row++) {
-    for (const col of ["B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"]) {
-      setCell(ws, `${col}${row}`, "");
-    }
-  }
-
-  players.slice(0, CDM_PLAYER_HUB_MAX_PLAYERS).forEach((player, index) => {
-    const row = index + CDM_PLAYER_HUB_FIRST_ROW;
-    setCell(ws, `B${row}`, player.name);
-    setCell(ws, `C${row}`, player.nickname);
-    setCell(ws, `D${row}`, player.country ?? "");
-    setCell(ws, `E${row}`, seedByMode.tt.get(player.id) ?? "");
-    setCell(ws, `F${row}`, seedByMode.bm.get(player.id) ?? "");
-    setCell(ws, `G${row}`, seedByMode.mr.get(player.id) ?? "");
-    setCell(ws, `H${row}`, seedByMode.gp.get(player.id) ?? "");
-    setCell(ws, `I${row}`, seedByMode.tt.has(player.id) ? "Yes" : "No");
-    setCell(ws, `J${row}`, seedByMode.bm.has(player.id) ? "Yes" : "No");
-    setCell(ws, `K${row}`, seedByMode.mr.has(player.id) ? "Yes" : "No");
-    setCell(ws, `L${row}`, seedByMode.gp.has(player.id) ? "Yes" : "No");
-  });
-}
-
-function writeTTQualifications(workbook: XLSX.WorkBook, entries: TTEntryExport[]) {
-  const ws = workbook.Sheets["TT Qualifications"];
-  if (!ws) return;
-
-  for (let row = CDM_TT_QUAL_FIRST_ROW; row < CDM_TT_QUAL_FIRST_ROW + CDM_TT_QUAL_MAX_PLAYERS; row++) {
-    for (let col = 5; col <= 26; col++) {
-      setCell(ws, `${toColumn(col)}${row}`, "");
-    }
-  }
-
-  const qualificationEntries = entries
-    .filter((entry) => entry.stage === "qualification")
-    .sort((a, b) => (a.seeding ?? Number.MAX_SAFE_INTEGER) - (b.seeding ?? Number.MAX_SAFE_INTEGER));
-
-  qualificationEntries.slice(0, CDM_TT_QUAL_MAX_PLAYERS).forEach((entry, index) => {
-    const row = index + CDM_TT_QUAL_FIRST_ROW;
-    setCell(ws, `E${row}`, index + 1);
-    setCell(ws, `F${row}`, entry.player.nickname);
-    const times = normalizeJsonRecord(entry.times);
-    CDM_COURSES.forEach((course, courseIndex) => {
-      setCell(ws, `${toColumn(7 + courseIndex)}${row}`, parseTimeMs(times[course]));
-    });
-  });
-}
-
-function writeQualificationSheet(
-  workbook: XLSX.WorkBook,
-  sheetName: string,
-  qualifications: ModeQualification[],
-  matches: MatchWithPlayers[],
-  mode: "bm" | "mr" | "gp"
-) {
-  const ws = workbook.Sheets[sheetName];
-  if (!ws) return;
-
-  for (let row = CDM_QUALIFICATION_FIRST_ROW; row < CDM_QUALIFICATION_FIRST_ROW + CDM_QUALIFICATION_MAX_ROWS; row++) {
-    for (const col of ["E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q"]) {
-      setCell(ws, `${col}${row}`, "");
-    }
-    for (let col = 19; col <= 31; col++) {
-      setCell(ws, `${toColumn(col)}${row}`, "");
-    }
-  }
-
-  sortQualifications(qualifications).slice(0, CDM_QUALIFICATION_MAX_ROWS).forEach((qualification, index) => {
-    const row = index + CDM_QUALIFICATION_FIRST_ROW;
-    setCell(ws, `E${row}`, qualification.group);
-    setCell(ws, `F${row}`, qualification.seeding ?? "");
-    setCell(ws, `G${row}`, qualification.player.nickname);
-    setCell(ws, `H${row}`, qualification.player.country ?? "");
-    setCell(ws, `I${row}`, qualification.mp);
-    setCell(ws, `J${row}`, qualification.wins);
-    setCell(ws, `K${row}`, qualification.ties);
-    setCell(ws, `L${row}`, qualification.losses);
-    if (mode === "gp") {
-      setCell(ws, `M${row}`, qualification.points);
-      setCell(ws, `N${row}`, "");
-      setCell(ws, `O${row}`, qualification.points);
-    } else {
-      setCell(ws, `M${row}`, qualification.winRounds ?? 0);
-      setCell(ws, `N${row}`, qualification.lossRounds ?? 0);
-      setCell(ws, `O${row}`, qualification.points);
-    }
-    setCell(ws, `P${row}`, 0);
-    setCell(ws, `Q${row}`, qualification.score);
-  });
-
-  matches
-    .filter((match) => match.stage === "qualification")
-    .sort((a, b) => (a.roundNumber ?? 0) - (b.roundNumber ?? 0) || a.matchNumber - b.matchNumber)
-    .slice(0, CDM_QUALIFICATION_MAX_ROWS)
-    .forEach((match, index) => {
-      const row = index + CDM_QUALIFICATION_FIRST_ROW;
-      setCell(ws, `S${row}`, match.matchNumber);
-      setCell(ws, `T${row}`, match.tvNumber ?? "");
-      setCell(ws, `U${row}`, match.player1Side ?? 1);
-      setCell(ws, `V${row}`, match.player1.nickname);
-      setCell(ws, `W${row}`, mode === "gp" ? match.points1 ?? 0 : match.score1 ?? 0);
-      setCell(ws, `X${row}`, "-");
-      setCell(ws, `Y${row}`, mode === "gp" ? match.points2 ?? 0 : match.score2 ?? 0);
-      setCell(ws, `Z${row}`, match.isBye ? "Break" : match.player2.nickname);
-      setCell(ws, `AA${row}`, match.player2Side ?? 2);
-      if (mode === "mr") {
-        const courses = Array.isArray(match.assignedCourses) ? match.assignedCourses : [];
-        for (let courseIndex = 0; courseIndex < 4; courseIndex++) {
-          setCell(ws, `${toColumn(28 + courseIndex)}${row}`, courses[courseIndex] ?? "");
-        }
-      }
-      if (mode === "gp") {
-        setCell(ws, `AB${row}`, match.cup ?? "");
-      }
-    });
-}
-
-function uniquePlayersFromMatches(matches: MatchWithPlayers[]): PlayerPublic[] {
-  const players = new Map<string, PlayerPublic>();
-  matches.forEach((match) => {
-    players.set(match.player1.id, match.player1);
-    players.set(match.player2.id, match.player2);
-  });
-  return [...players.values()].sort((a, b) => a.nickname.localeCompare(b.nickname));
-}
-
-// The end column and row are inclusive because XLSX cells are addressed one by
-// one here; callers that derive an end column from a start column must pass an
-// explicit end offset, not a count/width, to avoid off-by-one mistakes.
-function clearRange(ws: XLSX.WorkSheet, startCol: number, endCol: number, startRow: number, endRow: number) {
-  for (let row = startRow; row <= endRow; row++) {
-    for (let col = startCol; col <= endCol; col++) {
-      setCell(ws, `${toColumn(col)}${row}`, "");
-    }
-  }
-}
-
-function gpCupResultsSummary(match: MatchWithPlayers): string {
-  if (!Array.isArray(match.cupResults) || match.cupResults.length === 0) {
-    return match.cup ?? "";
-  }
-
-  return match.cupResults.map((result, index) => {
-    const record = result && typeof result === "object" ? result as Record<string, unknown> : {};
-    const cup = typeof record.cup === "string" && record.cup.trim() ? record.cup : `Cup ${index + 1}`;
-    const points1 = typeof record.points1 === "number" && Number.isFinite(record.points1) ? record.points1 : "";
-    const points2 = typeof record.points2 === "number" && Number.isFinite(record.points2) ? record.points2 : "";
-    return `${cup}: ${points1}-${points2}`;
-  }).join("; ");
-}
-
-function cdmFinalsSlotForMatch(
-  match: MatchWithPlayers,
-  roundIndex: number,
-  fallbackIndex: number
-): { blockStart: number; row: number; isFallback: boolean } | null {
-  const slotRound = cdmFinalsSlotRound(match);
-  const slots = slotRound ? CDM_FINALS_BRACKET_SLOTS[slotRound] : undefined;
-  if (slots?.[roundIndex]) {
-    return { ...slots[roundIndex], isFallback: false };
-  }
-
-  const fallbackBlockStart = CDM_FINALS_BLOCK_START_COLUMNS[Math.floor(fallbackIndex / CDM_FINALS_PAIR_ROWS.length)];
-  const fallbackRow = CDM_FINALS_PAIR_ROWS[fallbackIndex % CDM_FINALS_PAIR_ROWS.length];
-  return fallbackBlockStart && fallbackRow ? { blockStart: fallbackBlockStart, row: fallbackRow, isFallback: true } : null;
-}
-
-function cdmFinalsMatchLabel(match: MatchWithPlayers): string {
-  const slotRound = cdmFinalsSlotRound(match);
-  if (slotRound === "grand_final_reset") return "GF Reset";
-  if (slotRound === "grand_final") return "GF";
-  return match.bracketPosition || match.round || `M${match.matchNumber}`;
-}
-
-function writeMatchFinalsSheet(
-  workbook: XLSX.WorkBook,
-  sheetName: string,
-  qualifications: ModeQualification[],
-  matches: MatchWithPlayers[],
-  mode: "bm" | "mr" | "gp"
-) {
-  const ws = workbook.Sheets[sheetName];
-  if (!ws) return;
-
-  const finalsMatches = matches
-    .filter((match) =>
-      match.stage === "playoff" ||
-      match.stage === "finals" ||
-      match.stage === "grand_final"
-    )
-    .sort((a, b) =>
-      (a.round ?? "").localeCompare(b.round ?? "") ||
-      a.matchNumber - b.matchNumber
-    );
-
-  const qualifiedPlayers = finalsMatches.length > 0
-    ? uniquePlayersFromMatches(finalsMatches)
-    : sortQualifications(qualifications).slice(0, 24).map((qualification) => qualification.player);
-
-  clearRange(ws, 1, 2, CDM_FINALS_PLAYER_FIRST_ROW, CDM_FINALS_PLAYER_FIRST_ROW + CDM_FINALS_MAX_PLAYERS - 1);
-  qualifiedPlayers.slice(0, CDM_FINALS_MAX_PLAYERS).forEach((player, index) => {
-    const row = index + CDM_FINALS_PLAYER_FIRST_ROW;
-    setCell(ws, `A${row}`, index + 1);
-    setCell(ws, `B${row}`, player.nickname);
-  });
-
-  CDM_FINALS_BLOCK_START_COLUMNS.forEach((start) =>
-    clearRange(
-      ws,
-      start,
-      Math.min(start + CDM_FINALS_BLOCK_END_OFFSET, CDM_FINALS_LAST_COLUMN),
-      CDM_FINALS_MATCH_FIRST_ROW,
-      CDM_FINALS_PLAYER_FIRST_ROW + CDM_FINALS_MAX_PLAYERS - 1
-    )
-  );
-
-  const roundIndexes = new Map<string, number>();
-  let fallbackIndex = 0;
-  finalsMatches.forEach((match) => {
-    const roundKey = match.round ?? "";
-    const roundIndex = roundIndexes.get(roundKey) ?? 0;
-    roundIndexes.set(roundKey, roundIndex + 1);
-    const slot = cdmFinalsSlotForMatch(match, roundIndex, fallbackIndex);
-    if (!slot) return;
-    if (slot.isFallback) fallbackIndex++;
-
-    const { blockStart, row } = slot;
-    const p1Score = mode === "gp" ? match.points1 ?? 0 : match.score1 ?? 0;
-    const p2Score = mode === "gp" ? match.points2 ?? 0 : match.score2 ?? 0;
-    const label = cdmFinalsMatchLabel(match);
-
-    setCell(ws, `${toColumn(blockStart)}${row}`, label);
-    setCell(ws, `${toColumn(blockStart + 1)}${row}`, match.player1.nickname);
-    setCell(ws, `${toColumn(blockStart + 2)}${row}`, match.player1.name);
-    setCell(ws, `${toColumn(blockStart + 4)}${row}`, p1Score);
-    setCell(ws, `${toColumn(blockStart + 1)}${row + 1}`, match.player2.nickname);
-    setCell(ws, `${toColumn(blockStart + 2)}${row + 1}`, match.player2.name);
-    setCell(ws, `${toColumn(blockStart + 4)}${row + 1}`, p2Score);
-
-    if (mode === "gp") {
-      // GP finals store FT progress in points1/points2 and the actual
-      // per-cup driver points in cupResults; export the cup summary so CDM
-      // audits do not lose the played-cup score detail.
-      setCell(ws, `${toColumn(blockStart + 5)}${row}`, gpCupResultsSummary(match));
-    }
-    if (match.tvNumber) {
-      setCell(ws, `${toColumn(blockStart + 6)}${row}`, `TV ${match.tvNumber}`);
-    }
-  });
-}
-
-function writeTTFinals(workbook: XLSX.WorkBook, entries: TTEntryExport[], rounds: TTPhaseRoundExport[]) {
-  const ws = workbook.Sheets["TT Finals"];
-  if (!ws) return;
-
-  const phaseEntries = new Map<string, TTEntryExport[]>();
-  entries
-    .filter((entry) => entry.stage === "phase1" || entry.stage === "phase2" || entry.stage === "phase3")
-    .forEach((entry) => {
-      const bucket = phaseEntries.get(entry.stage) ?? [];
-      bucket.push(entry);
-      phaseEntries.set(entry.stage, bucket);
-    });
-
-  const allFinalists = [...phaseEntries.values()]
-    .flat()
-    .sort((a, b) =>
-      a.stage.localeCompare(b.stage) ||
-      Number(a.eliminated) - Number(b.eliminated) ||
-      b.lives - a.lives ||
-      (a.totalTime ?? Number.MAX_SAFE_INTEGER) - (b.totalTime ?? Number.MAX_SAFE_INTEGER)
-    );
-
-  clearRange(ws, 1, 5, CDM_TT_FINALIST_FIRST_ROW, CDM_TT_FINALIST_FIRST_ROW + CDM_TT_FINALIST_MAX_ROWS - 1);
-  allFinalists.slice(0, CDM_TT_FINALIST_MAX_ROWS).forEach((entry, index) => {
-    const row = index + CDM_TT_FINALIST_FIRST_ROW;
-    setCell(ws, `A${row}`, index + 1);
-    setCell(ws, `B${row}`, entry.player.nickname);
-    setCell(ws, `C${row}`, entry.eliminated ? 0 : 1);
-    setCell(ws, `D${row}`, entry.stage);
-    setCell(ws, `E${row}`, entry.totalTime ?? "");
-  });
-
-  CDM_TT_ROUND_START_COLUMNS.forEach((start) =>
-    clearRange(
-      ws,
-      start,
-      Math.min(start + CDM_TT_ROUND_BLOCK_END_OFFSET, CDM_TT_ROUND_LAST_COLUMN),
-      CDM_TT_ROUND_FIRST_ROW,
-      CDM_TT_ROUND_LAST_ROW
-    )
-  );
-
-  rounds
-    .filter((round) => round.phase === "phase1" || round.phase === "phase2" || round.phase === "phase3")
-    .sort((a, b) => a.phase.localeCompare(b.phase) || a.roundNumber - b.roundNumber)
-    .slice(0, CDM_TT_ROUND_START_COLUMNS.length)
-    .forEach((round, index) => {
-      const start = CDM_TT_ROUND_START_COLUMNS[index];
-      const results = Array.isArray(round.results) ? round.results as Array<{ playerId?: string; timeMs?: number; isRetry?: boolean }> : [];
-      const entriesById = new Map(entries.map((entry) => [entry.playerId, entry]));
-
-      setCell(ws, `${toColumn(start)}1`, `${round.phase} Round ${round.roundNumber} - ${round.course}`);
-      setCell(ws, `${toColumn(start)}2`, "#");
-      setCell(ws, `${toColumn(start + 1)}2`, "Name");
-      setCell(ws, `${toColumn(start + 3)}2`, "Time");
-      setCell(ws, `${toColumn(start + 4)}2`, "Lost");
-      setCell(ws, `${toColumn(start + 5)}2`, "Left");
-
-      results.slice(0, CDM_TT_ROUND_MAX_RESULTS).forEach((result, resultIndex) => {
-        const row = resultIndex + CDM_TT_FINALIST_FIRST_ROW;
-        const entry = result.playerId ? entriesById.get(result.playerId) : null;
-        setCell(ws, `${toColumn(start)}${row}`, resultIndex + 1);
-        setCell(ws, `${toColumn(start + 1)}${row}`, entry?.player.nickname ?? result.playerId ?? "");
-        setCell(ws, `${toColumn(start + 3)}${row}`, result.timeMs ?? "");
-        setCell(ws, `${toColumn(start + 4)}${row}`, result.isRetry ? "Retry" : "");
-        setCell(ws, `${toColumn(start + 5)}${row}`, entry?.lives ?? "");
-      });
-    });
-}
-
-function writeOverallRanking(workbook: XLSX.WorkBook, scores: TournamentPlayerScoreExport[]) {
-  const ws = workbook.Sheets["Overall Ranking"];
-  if (!ws) return;
-
-  clearRange(ws, 1, 24, CDM_OVERALL_FIRST_ROW, CDM_OVERALL_FIRST_ROW + CDM_OVERALL_MAX_ROWS - 1);
-  scores
-    .slice()
-    .sort((a, b) => (a.overallRank ?? Number.MAX_SAFE_INTEGER) - (b.overallRank ?? Number.MAX_SAFE_INTEGER) || b.totalPoints - a.totalPoints)
-    .slice(0, CDM_OVERALL_MAX_ROWS)
-    .forEach((score, index) => {
-      const row = index + CDM_OVERALL_FIRST_ROW;
-      const rank = score.overallRank ?? index + 1;
-      setCell(ws, `A${row}`, rank);
-      setCell(ws, `B${row}`, score.player.nickname);
-      setCell(ws, `D${row}`, score.taQualificationPoints);
-      setCell(ws, `E${row}`, score.taFinalsPoints);
-      setCell(ws, `F${row}`, score.taQualificationPoints + score.taFinalsPoints);
-      setCell(ws, `H${row}`, score.bmQualificationPoints);
-      setCell(ws, `I${row}`, score.bmFinalsPoints);
-      setCell(ws, `J${row}`, score.bmQualificationPoints + score.bmFinalsPoints);
-      setCell(ws, `L${row}`, score.mrQualificationPoints);
-      setCell(ws, `M${row}`, score.mrFinalsPoints);
-      setCell(ws, `N${row}`, score.mrQualificationPoints + score.mrFinalsPoints);
-      setCell(ws, `P${row}`, score.gpQualificationPoints);
-      setCell(ws, `Q${row}`, score.gpFinalsPoints);
-      setCell(ws, `R${row}`, score.gpQualificationPoints + score.gpFinalsPoints);
-      setCell(ws, `T${row}`, score.totalPoints);
-      setCell(ws, `V${row}`, rank);
-      setCell(ws, `W${row}`, score.player.nickname);
-      setCell(ws, `X${row}`, score.totalPoints);
-    });
-}
-
-function createCDMWorkbook(templateData: ArrayBuffer, tournament: {
-  name: string;
-  date: Date;
-  bmQualifications: ModeQualification[];
-  mrQualifications: ModeQualification[];
-  gpQualifications: ModeQualification[];
-  bmMatches: MatchWithPlayers[];
-  mrMatches: MatchWithPlayers[];
-  gpMatches: MatchWithPlayers[];
-  ttEntries: TTEntryExport[];
-  ttPhaseRounds: TTPhaseRoundExport[];
-  playerScores: TournamentPlayerScoreExport[];
-}) {
-  const workbook = XLSX.read(templateData, { bookVBA: true, cellStyles: true });
-  const playersById = new Map<string, PlayerPublic>();
-  const seedByMode = {
-    tt: new Map<string, number | null>(),
-    bm: new Map<string, number | null>(),
-    mr: new Map<string, number | null>(),
-    gp: new Map<string, number | null>(),
+/*
+ * Map the Prisma export query result into the CdmTournamentData the generator
+ * consumes. This is a pure field projection (no business logic): each property
+ * lines up with a prisma/schema.prisma column. BM/MR matches carry round-win
+ * scores (score1/score2); GP matches carry driver points (points1/points2); the
+ * generator's fill maps pick the right pair per mode. Player objects come from
+ * PLAYER_PUBLIC_SELECT, so password is never present here. The Overall Ranking
+ * sheet is formula-driven, hence no playerScores mapping (design §3.6).
+ */
+function mapPlayer(player: CdmPlayerRow): CdmTournamentData["bmQualifications"][number]["player"] {
+  return {
+    id: player.id,
+    name: player.name,
+    nickname: player.nickname,
+    country: player.country ?? null,
   };
+}
 
-  const rememberPlayer = (player: PlayerPublic) => playersById.set(player.id, player);
-  tournament.ttEntries.forEach((entry) => {
-    rememberPlayer(entry.player);
-    if (entry.stage === "qualification") seedByMode.tt.set(entry.player.id, entry.seeding);
-  });
-  tournament.bmQualifications.forEach((qualification) => {
-    rememberPlayer(qualification.player);
-    seedByMode.bm.set(qualification.player.id, qualification.seeding);
-  });
-  tournament.mrQualifications.forEach((qualification) => {
-    rememberPlayer(qualification.player);
-    seedByMode.mr.set(qualification.player.id, qualification.seeding);
-  });
-  tournament.gpQualifications.forEach((qualification) => {
-    rememberPlayer(qualification.player);
-    seedByMode.gp.set(qualification.player.id, qualification.seeding);
-  });
+function mapQualification(q: CdmQualificationRow): CdmModeQualification {
+  return {
+    player: mapPlayer(q.player),
+    seeding: q.seeding,
+    group: q.group,
+    rankOverride: q.rankOverride ?? null,
+    points: q.points,
+    score: q.score,
+  };
+}
 
-  const players = [...playersById.values()].sort((a, b) => a.nickname.localeCompare(b.nickname));
-  writePlayerHub(workbook, players, seedByMode);
-  writeTTQualifications(workbook, tournament.ttEntries);
-  writeQualificationSheet(workbook, "BM Qualifications", tournament.bmQualifications, tournament.bmMatches, "bm");
-  writeQualificationSheet(workbook, "MR Qualifications", tournament.mrQualifications, tournament.mrMatches, "mr");
-  writeQualificationSheet(workbook, "GP Qualifications", tournament.gpQualifications, tournament.gpMatches, "gp");
-  writeMatchFinalsSheet(workbook, "BM Finals", tournament.bmQualifications, tournament.bmMatches, "bm");
-  writeMatchFinalsSheet(workbook, "MR Finals", tournament.mrQualifications, tournament.mrMatches, "mr");
-  writeMatchFinalsSheet(workbook, "GP Finals", tournament.gpQualifications, tournament.gpMatches, "gp");
-  writeTTFinals(workbook, tournament.ttEntries, tournament.ttPhaseRounds);
-  writeOverallRanking(workbook, tournament.playerScores);
+function mapMatch(match: CdmMatchRow): CdmMatch {
+  return {
+    matchNumber: match.matchNumber,
+    stage: match.stage,
+    round: match.round ?? null,
+    bracketPosition: match.bracketPosition ?? null,
+    isGrandFinal: match.isGrandFinal ?? false,
+    roundNumber: match.roundNumber ?? null,
+    tvNumber: match.tvNumber ?? null,
+    isBye: match.isBye ?? false,
+    player1: mapPlayer(match.player1),
+    player2: mapPlayer(match.player2),
+    player1Side: match.player1Side ?? null,
+    player2Side: match.player2Side ?? null,
+    score1: match.score1 ?? null,
+    score2: match.score2 ?? null,
+    points1: match.points1 ?? null,
+    points2: match.points2 ?? null,
+    completed: match.completed,
+    assignedCourses: match.assignedCourses,
+    cup: match.cup ?? null,
+  };
+}
 
-  workbook.Workbook = workbook.Workbook ?? {};
-  (workbook.Workbook as XLSX.WorkBook["Workbook"] & { CalcPr?: { fullCalcOnLoad: string } }).CalcPr = { fullCalcOnLoad: "1" };
-  return XLSX.write(workbook, { type: "buffer", bookType: "xlsm", bookVBA: true, cellStyles: true });
+function mapTtEntry(entry: CdmTtEntryRow): CdmTTEntry {
+  return {
+    player: mapPlayer(entry.player),
+    playerId: entry.playerId,
+    stage: entry.stage,
+    seeding: entry.seeding,
+    lives: entry.lives,
+    eliminated: entry.eliminated,
+    times: entry.times,
+    totalTime: entry.totalTime ?? null,
+    qualificationPoints: entry.qualificationPoints ?? null,
+    rank: entry.rank ?? null,
+  };
+}
+
+function mapTtPhaseRound(round: CdmTtPhaseRoundRow): CdmTTPhaseRound {
+  return {
+    phase: round.phase,
+    roundNumber: round.roundNumber,
+    course: round.course,
+    results: round.results,
+    eliminatedIds: round.eliminatedIds,
+    livesReset: round.livesReset,
+  };
+}
+
+function mapToCdmTournamentData(tournament: CdmTournamentRow): CdmTournamentData {
+  return {
+    name: tournament.name,
+    date: tournament.date,
+    bmQualifications: tournament.bmQualifications.map(mapQualification),
+    mrQualifications: tournament.mrQualifications.map(mapQualification),
+    gpQualifications: tournament.gpQualifications.map(mapQualification),
+    bmMatches: tournament.bmMatches.map(mapMatch),
+    mrMatches: tournament.mrMatches.map(mapMatch),
+    gpMatches: tournament.gpMatches.map(mapMatch),
+    ttEntries: tournament.ttEntries.map(mapTtEntry),
+    ttPhaseRounds: tournament.ttPhaseRounds.map(mapTtPhaseRound),
+  };
 }
 
 export async function GET(
@@ -747,10 +306,20 @@ export async function GET(
         return createErrorResponse("Failed to load CDM export template", 503, "SERVICE_UNAVAILABLE");
       }
 
-      const workbookBuffer = createCDMWorkbook(template.buffer, tournament);
+      // The Prisma payload (player columns projected via PLAYER_PUBLIC_SELECT)
+      // is structurally a CdmTournamentRow; cast through unknown because the
+      // generated Prisma include type is wider/looser than our read-only shape.
+      const cdmData = mapToCdmTournamentData(tournament as unknown as CdmTournamentRow);
+      // generateCdmWorkbook returns a Uint8Array over the zip's backing buffer.
+      // Re-wrap it so the response body is a Uint8Array<ArrayBuffer> (BodyInit);
+      // the patcher's declared return widens to ArrayBufferLike, which NextResponse
+      // does not accept directly. The copy is one-time and admin-only.
+      const workbookBytes = new Uint8Array(
+        generateCdmWorkbook(new Uint8Array(template.buffer), cdmData),
+      );
       const filename = `${tournament.name.replace(/[^a-zA-Z0-9]/g, "_")}-cdm-${formatDate(new Date(tournament.date))}.xlsm`;
 
-      return new NextResponse(new Uint8Array(workbookBuffer), {
+      return new NextResponse(workbookBytes, {
         headers: {
           "Content-Type": "application/vnd.ms-excel.sheet.macroEnabled.12",
           "Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(filename)}; filename="${filename}"`,

--- a/smkc-score-app/src/lib/cdm-export/cdm-constants.ts
+++ b/smkc-score-app/src/lib/cdm-export/cdm-constants.ts
@@ -1,0 +1,185 @@
+/**
+ * CDM workbook export — template coordinates and lookup tables.
+ *
+ * Every constant below was verified against a full cell dump of
+ * public/templates/cdm-2025-template.xlsm (the workbook used at CDM 2025).
+ * The template is formula-driven; these constants describe ONLY the regions
+ * the workbook treats as human inputs, plus the geometry needed to clear
+ * leftover data. Do not invent coordinates that are not documented in
+ * docs/cdm-export-design.md — writing anywhere else risks destroying the
+ * dynamic-array spill ranges that compute standings and brackets.
+ */
+
+import type { CdmSheetName, CdmVersusMode } from "./types";
+
+/**
+ * The 20 SMK courses in the exact column order of the TT Qualifications
+ * sheet (G1..Z1 headers) and of TTEntry.times keys.
+ */
+export const CDM_COURSES = [
+  "MC1", "DP1", "GV1", "BC1", "MC2", "CI1", "GV2", "DP2", "BC2", "MC3",
+  "KB1", "CI2", "VL1", "BC3", "MC4", "DP3", "KB2", "GV3", "VL2", "RR",
+] as const;
+
+/** Course abbreviation → full display name (Parameters!C2:D21 "Tracks" table). */
+export const CDM_COURSE_NAMES: Record<string, string> = {
+  MC1: "Mario Circuit 1", DP1: "Donut Plains 1", GV1: "Ghost Valley 1",
+  BC1: "Bowser Castle 1", MC2: "Mario Circuit 2", CI1: "Choco Island 1",
+  GV2: "Ghost Valley 2", DP2: "Donut Plains 2", BC2: "Bowser Castle 2",
+  MC3: "Mario Circuit 3", KB1: "Koopa Beach 1", CI2: "Choco Island 2",
+  VL1: "Vanilla Lake 1", BC3: "Bowser Castle 3", MC4: "Mario Circuit 4",
+  DP3: "Donut Plains 3", KB2: "Koopa Beach 2", GV3: "Ghost Valley 3",
+  VL2: "Vanilla Lake 2", RR: "Rainbow Road",
+};
+
+export const CDM_QUALIFICATION_SHEETS: Record<CdmVersusMode, CdmSheetName> = {
+  bm: "BM Qualifications",
+  mr: "MR Qualifications",
+  gp: "GP Qualifications",
+};
+
+export const CDM_FINALS_SHEETS: Record<CdmVersusMode, CdmSheetName> = {
+  bm: "BM Finals",
+  mr: "MR Finals",
+  gp: "GP Finals",
+};
+
+/* ------------------------------------------------------------------ *
+ * Main Hub — Registration table A1:L61 (60 player rows) plus the
+ * "Qualifying" / "Groups" count inputs at O3:R3 / O4:R4.
+ * Column A (=ROW()-1), N2:R2 (COUNTIF) and T/U spills are formulas.
+ * ------------------------------------------------------------------ */
+export const MAIN_HUB_FIRST_PLAYER_ROW = 2;
+export const MAIN_HUB_MAX_PLAYERS = 60;
+export const MAIN_HUB_LAST_PLAYER_ROW =
+  MAIN_HUB_FIRST_PLAYER_ROW + MAIN_HUB_MAX_PLAYERS - 1; // 61
+/** Mode column order for Order (E..H) and participation Yes/No (I..L). */
+export const MAIN_HUB_MODE_ORDER = ["tt", "bm", "mr", "gp"] as const;
+export const MAIN_HUB_QUALIFYING_ROW = 3; // O3..R3
+export const MAIN_HUB_GROUPS_ROW = 4; // O4..R4
+/** O..R column letters indexed like MAIN_HUB_MODE_ORDER. */
+export const MAIN_HUB_COUNT_COLUMNS = ["O", "P", "Q", "R"] as const;
+
+/* ------------------------------------------------------------------ *
+ * TT Qualifications — time inputs only.
+ * Row r hosts the player at position (r-2) of the sheet's
+ * SORT(FILTER(Registration[Nickname], TT="Yes")) spill, i.e. nicknames in
+ * case-insensitive ascending order. Columns G..Z = CDM_COURSES order.
+ * Times are integers M*10000 + SS*100 + CC (e.g. 1:10.34 → 11034).
+ * ------------------------------------------------------------------ */
+export const TT_QUAL_FIRST_ROW = 2;
+export const TT_QUAL_MAX_PLAYERS = 47; // template rows 2..48
+export const TT_QUAL_FIRST_TIME_COLUMN = 7; // G
+export const TT_QUAL_LAST_TIME_COLUMN = 26; // Z
+
+/* ------------------------------------------------------------------ *
+ * BM/MR/GP Qualifications — per-player match blocks.
+ * Block 0 data rows 2..16, header row 17, then stride 16 (max 48 blocks).
+ * Block order equals the sheet's G2# spill: group A players in synthesized
+ * order, then group B, ... Each match appears once in each player's block.
+ * Input columns: S,T,U,V,W,Z,AA (+ Y for GP; AB..AE MR courses; AB GP cup).
+ * X ('-'), Y (BM/MR formula =4-W) and the W/T/L formula columns are not inputs.
+ * ------------------------------------------------------------------ */
+export const QUAL_BLOCK_FIRST_DATA_ROW = 2;
+export const QUAL_BLOCK_STRIDE = 16;
+export const QUAL_BLOCK_DATA_ROWS = 15;
+export const QUAL_BLOCK_MAX_BLOCKS = 48;
+export const QUAL_MATCH_COLUMNS = {
+  matchNumber: "S",
+  tvNumber: "T",
+  ownerSide: "U",
+  ownerNickname: "V",
+  ownerScore: "W",
+  opponentScore: "Y", // GP only — BM/MR keep the template formula =4-W
+  opponentNickname: "Z",
+  opponentSide: "AA",
+  /** MR: assignedCourses[0..3] → AB..AE. GP: cup name → AB. */
+  extraFirstColumn: "AB",
+} as const;
+
+/* ------------------------------------------------------------------ *
+ * BM/MR/GP Finals — fixed 24-player CDM bracket geometry.
+ * A block holds one match in two consecutive rows; columns within a block:
+ * +0 label/match#, +1 seed#, +2 name, +3 flag, +4 score.
+ * Only the seed cells listed as "typed" in the design doc and the score
+ * cells are inputs; name/advancement cells are formulas.
+ * ------------------------------------------------------------------ */
+export const FINALS_SEED_LIST_COLUMN = "B"; // B3:B26 qualified nicknames
+export const FINALS_SEED_LIST_FIRST_ROW = 3;
+export const FINALS_SEED_LIST_MAX_ROWS = 24; // rows 3..26
+/**
+ * Upper-bracket B-positions of the 12 direct qualifiers, in seed order.
+ * generateBracketStructure(16) pairs [1,16],[8,9],[5,12],[4,13],[3,14],
+ * [6,11],[7,10],[2,15]; playoff winners occupy upper seeds 16/12/14/10,
+ * so direct players hold upper seeds 1..9,11,13,15 → B-positions 1..12.
+ */
+export const FINALS_DIRECT_UPPER_SEEDS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 13, 15] as const;
+/** Playoff seed p (1..12) sits at B-position 12 + p (rows 15..26). */
+export const FINALS_PLAYOFF_B_POSITION_OFFSET = 12;
+
+export interface FinalsSlotGeometry {
+  /** 1-based column of the block's label column (+0 offset). */
+  blockStart: number;
+  /** Row of the match's first (slot1) row; slot2 is row + 1. */
+  row: number;
+}
+
+/**
+ * Verified block geometry per app round id, in app match order
+ * (k-th match of a round → k-th entry). Upper rows hold the winners path,
+ * rows 41..54 the losers path of the same column blocks.
+ */
+export const FINALS_BRACKET_SLOTS: Record<string, FinalsSlotGeometry[]> = {
+  playoff_r1: [5, 13, 21, 29].map((row) => ({ blockStart: 4, row })), // D "Barrage 1"
+  playoff_r2: [5, 13, 21, 29].map((row) => ({ blockStart: 11, row })), // K "Barrage 2"
+  winners_r1: [5, 9, 13, 17, 21, 25, 29, 33].map((row) => ({ blockStart: 18, row })), // R "Top 16"
+  winners_qf: [7, 15, 23, 31].map((row) => ({ blockStart: 25, row })), // Y
+  winners_sf: [11, 27].map((row) => ({ blockStart: 32, row })), // AF
+  winners_final: [{ blockStart: 39, row: 19 }], // AM
+  grand_final: [{ blockStart: 46, row: 19 }], // AT
+  grand_final_reset: [{ blockStart: 53, row: 19 }], // BA
+  losers_r1: [41, 45, 49, 53].map((row) => ({ blockStart: 18, row })),
+  losers_r2: [41, 45, 49, 53].map((row) => ({ blockStart: 25, row })),
+  losers_r3: [43, 51].map((row) => ({ blockStart: 32, row })),
+  losers_r4: [43, 51].map((row) => ({ blockStart: 39, row })),
+  losers_sf: [{ blockStart: 46, row: 47 }],
+  losers_final: [{ blockStart: 53, row: 47 }],
+};
+
+export const FINALS_BLOCK_SEED_OFFSET = 1;
+export const FINALS_BLOCK_NAME_OFFSET = 2;
+export const FINALS_BLOCK_SCORE_OFFSET = 4;
+
+/* ------------------------------------------------------------------ *
+ * TT Finals — 40 pre-built round blocks, stride 13 columns.
+ * Round r (1-based): input block first column 1 + 13(r-1) (A, N, AA, ...),
+ * display block first column 7 + 13(r-1) (G, T, AG, ...).
+ * Input block columns: +0 #(formula), +1 name(formula), +2 Left
+ * (typed only in round 1), +3 Gain (typed), +4 Time (typed, MSSHH; 0 = sat out).
+ * Display block columns: +0 #, +1 name, +2 flag, +3 time, +4 Lost (typed 1),
+ * +5 Left — all formulas except Lost.
+ * Rows 3..26 hold up to 24 finalists; the final standings block TA..TD is
+ * pure formulas and must never be written.
+ * ------------------------------------------------------------------ */
+export const TT_FINALS_MAX_ROUNDS = 40;
+export const TT_FINALS_ROUND_STRIDE = 13;
+export const TT_FINALS_INPUT_FIRST_COLUMN = 1; // A
+export const TT_FINALS_DISPLAY_FIRST_COLUMN = 7; // G
+export const TT_FINALS_FIRST_DATA_ROW = 3;
+export const TT_FINALS_MAX_FINALISTS = 24; // rows 3..26
+export const TT_FINALS_INPUT_LEFT_OFFSET = 2;
+export const TT_FINALS_INPUT_GAIN_OFFSET = 3;
+export const TT_FINALS_INPUT_TIME_OFFSET = 4;
+export const TT_FINALS_DISPLAY_LOST_OFFSET = 4;
+
+/** Convert a 1-based column number to its A1 letters (1→A, 27→AA). */
+export function toColumnLetters(column: number): string {
+  let result = "";
+  let n = column;
+  while (n > 0) {
+    const rem = (n - 1) % 26;
+    result = String.fromCharCode(65 + rem) + result;
+    n = Math.floor((n - 1) / 26);
+  }
+  return result;
+}

--- a/smkc-score-app/src/lib/cdm-export/fill/finals-slot-semantics.ts
+++ b/smkc-score-app/src/lib/cdm-export/fill/finals-slot-semantics.ts
@@ -1,0 +1,189 @@
+/**
+ * CDM finals — slot-semantics table (machine-readable form of design §3.4.1).
+ *
+ * The 24-player BM/MR/GP Finals sheet is a formula-driven double-elimination
+ * bracket. Every match block holds two stacked rows ("slots"); each slot's
+ * NAME cell is either:
+ *
+ *   - a *typed seed* — the template stores a literal B-position number in the
+ *     seed cell (offset +1) and an XLOOKUP-on-A:A formula in the name cell. We
+ *     model this as { kind: "seed" }. The fill map writes the B-position number.
+ *
+ *   - an *advancement formula* — the template name cell holds
+ *     `IF(COUNTA(scores)<2,"Winner of N",INDEX(SORTBY(prevNames,prevScores,±1),1))`
+ *     i.e. the winner (descending sort) or loser (ascending sort) of an upstream
+ *     match N. We model this as { kind: "winnerOf"|"loserOf", round, index }
+ *     using *round-local* indices (0-based, app match order), NOT the template's
+ *     absolute match numbers. The fill map writes nothing here in faithful mode.
+ *
+ * Each formula below is transcribed from the verified template dump
+ * /tmp/cdm-analysis/sheet2025/sheet_BM_Finals.txt (MR/GP share the layout). The
+ * template's absolute match numbers map to round-local indices as:
+ *   Top16 (winners_r1)      = matches 1..8   -> idx 0..7
+ *   UBQ   (winners_qf)      = matches 13..16 -> idx 0..3
+ *   UBS   (winners_sf)      = matches 23,24  -> idx 0,1
+ *   UBF   (winners_final)   = match 28       -> idx 0
+ *   GF1   (grand_final)     = match 30       -> idx 0
+ *   GF2   (grand_final_reset)= match 31      -> idx 0
+ *   LBR1  (losers_r1)       = matches 9..12  -> idx 0..3 (rows 41,45,49,53)
+ *   LBR2  (losers_r2)       = matches 17..20 -> idx 0..3 (rows 41,45,49,53)
+ *   LB1/8 (losers_r3)       = matches 21,22  -> idx 0,1
+ *   LBQ   (losers_r4)       = matches 25,26  -> idx 0,1
+ *   LBSF  (losers_sf)       = match 27       -> idx 0
+ *   LBF   (losers_final)    = match 29       -> idx 0
+ *   B1/B2 (playoff_r1/r2)   = "B1,k"/"B2,k"  -> idx k-1
+ *
+ * This table is the single source of truth that ties the app's bracket rounds to
+ * the template's formula web; a regression test (finals-slot-semantics.test.ts)
+ * pins every entry to its template formula so an edit cannot silently desync it.
+ */
+
+/** A reference to the winner/loser of another bracket match (round-local index). */
+export interface FinalsSlotRef {
+  kind: "winnerOf" | "loserOf";
+  /** App round id (key of FINALS_SLOT_SEMANTICS). */
+  round: string;
+  /** 0-based match index within that round (app match order). */
+  index: number;
+}
+
+/** One match slot: either a typed seed cell or an advancement reference. */
+export type FinalsSlotSemantics = { kind: "seed" } | FinalsSlotRef;
+
+/** A match is a [slot1, slot2] pair (app player1 side, player2 side). */
+type FinalsMatchSlots = readonly [FinalsSlotSemantics, FinalsSlotSemantics];
+
+const seed: FinalsSlotSemantics = { kind: "seed" };
+const winnerOf = (round: string, index: number): FinalsSlotRef => ({
+  kind: "winnerOf",
+  round,
+  index,
+});
+const loserOf = (round: string, index: number): FinalsSlotRef => ({
+  kind: "loserOf",
+  round,
+  index,
+});
+
+/**
+ * Per-round slot semantics, indexed by round id then by match index. Verified
+ * cell-by-cell against the BM Finals template dump (citations per round).
+ */
+export const FINALS_SLOT_SEMANTICS: Record<
+  string,
+  readonly FinalsMatchSlots[]
+> = {
+  // Barrage 1 (D block). E5/E6, E13/E14, … are literal seed values -> both typed.
+  playoff_r1: [
+    [seed, seed],
+    [seed, seed],
+    [seed, seed],
+    [seed, seed],
+  ],
+  // Barrage 2 (K block). L5/L13/L21/L29 are literal seed values (the BYE seed);
+  // M6 = IF(COUNTA(H5:H6)<2,"Winner of B1,1",…) -> slot2 = winner of playoff_r1[k].
+  playoff_r2: [
+    [seed, winnerOf("playoff_r1", 0)],
+    [seed, winnerOf("playoff_r1", 1)],
+    [seed, winnerOf("playoff_r1", 2)],
+    [seed, winnerOf("playoff_r1", 3)],
+  ],
+  // Top 16 (R block). Even matches (idx 0,2,4,6): S5/S13/S21/S29 are literal seed
+  // values (slot1 typed); T6/T14/… = IF(COUNTA(O…)<2,"Winner of B2,k",…) ->
+  // slot2 = winner of playoff_r2[k]. Odd matches (idx 1,3,5,7): S9/S10,… both
+  // literal seed values -> both typed.
+  winners_r1: [
+    [seed, winnerOf("playoff_r2", 0)], // R5/R6  (Top16 m1)  T6  "Winner of B2,1"
+    [seed, seed], // R9/R10  (Top16 m2)
+    [seed, winnerOf("playoff_r2", 1)], // R13/R14 (Top16 m3) T14 "Winner of B2,2"
+    [seed, seed], // R17/R18 (Top16 m4)
+    [seed, winnerOf("playoff_r2", 2)], // R21/R22 (Top16 m5) T22 "Winner of B2,3"
+    [seed, seed], // R25/R26 (Top16 m6)
+    [seed, winnerOf("playoff_r2", 3)], // R29/R30 (Top16 m7) T30 "Winner of B2,4"
+    [seed, seed], // R33/R34 (Top16 m8)
+  ],
+  // Upper Bracket Quarters (Y block). AA7="Winner of 1", AA8="Winner of 2" ->
+  // each qf[k] = winners of winners_r1[2k] and winners_r1[2k+1].
+  winners_qf: [
+    [winnerOf("winners_r1", 0), winnerOf("winners_r1", 1)], // AA7/AA8
+    [winnerOf("winners_r1", 2), winnerOf("winners_r1", 3)], // AA15/AA16
+    [winnerOf("winners_r1", 4), winnerOf("winners_r1", 5)], // AA23/AA24
+    [winnerOf("winners_r1", 6), winnerOf("winners_r1", 7)], // AA31/AA32
+  ],
+  // Upper Bracket Semi (AF block). AH11="Winner of 13"(qf m1=idx0),
+  // AH12="Winner of 14"(idx1); AH27="Winner of 15"(idx2),AH28="Winner of 16"(idx3).
+  winners_sf: [
+    [winnerOf("winners_qf", 0), winnerOf("winners_qf", 1)], // AH11/AH12
+    [winnerOf("winners_qf", 2), winnerOf("winners_qf", 3)], // AH27/AH28
+  ],
+  // Upper Bracket Final (AM block). AO19="Winner of 23"(sf m23=idx0),
+  // AO20="Winner of 24"(idx1).
+  winners_final: [[winnerOf("winners_sf", 0), winnerOf("winners_sf", 1)]],
+  // Lower Bracket Round 1 (R block rows 41..54). T41="Loser of 1",T42="Loser of 2"
+  // -> losers of winners_r1[2k], winners_r1[2k+1].
+  losers_r1: [
+    [loserOf("winners_r1", 0), loserOf("winners_r1", 1)], // T41/T42
+    [loserOf("winners_r1", 2), loserOf("winners_r1", 3)], // T45/T46
+    [loserOf("winners_r1", 4), loserOf("winners_r1", 5)], // T49/T50
+    [loserOf("winners_r1", 6), loserOf("winners_r1", 7)], // T53/T54
+  ],
+  // Lower Bracket Round 2 (Y block rows 41..54). slot1 = loser of winners_qf in
+  // *reverse* visual order: AA41="Loser of 16"(qf idx3), AA45="Loser of 15"
+  // (idx2), AA49="Loser of 14"(idx1), AA53="Loser of 13"(idx0) -> loserOf qf[3-k].
+  // slot2: AA42="Winner of 9"(losers_r1 idx0) -> winnerOf losers_r1[k].
+  losers_r2: [
+    [loserOf("winners_qf", 3), winnerOf("losers_r1", 0)], // AA41/AA42
+    [loserOf("winners_qf", 2), winnerOf("losers_r1", 1)], // AA45/AA46
+    [loserOf("winners_qf", 1), winnerOf("losers_r1", 2)], // AA49/AA50
+    [loserOf("winners_qf", 0), winnerOf("losers_r1", 3)], // AA53/AA54
+  ],
+  // Lower Bracket 1/8s (AF block rows 43,51). AH43="Winner of 20"(losers_r2 idx0),
+  // AH44="Winner of 19"(idx1); AH51="Winner of 18"(idx2),AH52="Winner of 17"(idx3).
+  losers_r3: [
+    [winnerOf("losers_r2", 0), winnerOf("losers_r2", 1)], // AH43/AH44
+    [winnerOf("losers_r2", 2), winnerOf("losers_r2", 3)], // AH51/AH52
+  ],
+  // Lower Bracket Quarters (AM block rows 43,51). AO43="Loser of 23"(winners_sf
+  // idx0), AO44="Winner of 22"(losers_r3 idx0); AO51="Loser of 24"(sf idx1),
+  // AO52="Winner of 21"(losers_r3 idx1).
+  losers_r4: [
+    [loserOf("winners_sf", 0), winnerOf("losers_r3", 0)], // AO43/AO44
+    [loserOf("winners_sf", 1), winnerOf("losers_r3", 1)], // AO51/AO52
+  ],
+  // Lower Bracket Semi (AT block row 47). AV47="Winner of 25"(losers_r4 idx0),
+  // AV48="Winner of 26"(idx1).
+  losers_sf: [[winnerOf("losers_r4", 0), winnerOf("losers_r4", 1)]],
+  // Lower Bracket Final (BA block row 47). BC47="Loser of 28"(winners_final idx0),
+  // BC48="Winner of 27"(losers_sf idx0). NOTE: slot1/slot2 are REVERSED vs the
+  // app, which seeds the losers_sf winner as player1 (see double-elimination.ts
+  // losers_final position:2). The fill map accounts for this when writing scores.
+  losers_final: [[loserOf("winners_final", 0), winnerOf("losers_sf", 0)]],
+  // Grand Final 1 (AT block row 19). AV19="Winner of 28"(winners_final idx0),
+  // AV20="Winner of 29"(losers_final idx0).
+  grand_final: [[winnerOf("winners_final", 0), winnerOf("losers_final", 0)]],
+  // Grand Final 2 / reset (BA block row 19). BC19="Winner of 30"(grand_final
+  // idx0); BC20 sorts ascending -> the LOSER of grand_final[0].
+  grand_final_reset: [[winnerOf("grand_final", 0), loserOf("grand_final", 0)]],
+};
+
+/**
+ * Look up the semantics of a single slot. Returns null for an unknown round or an
+ * out-of-range match index, so callers can skip gracefully (with a warning) when
+ * an app match cannot be placed.
+ *
+ * @param round      app round id
+ * @param matchIndex 0-based match index within the round
+ * @param slotIndex  0 (player1 side) or 1 (player2 side)
+ */
+export function getSlotSemantics(
+  round: string,
+  matchIndex: number,
+  slotIndex: number,
+): FinalsSlotSemantics | null {
+  const matches = FINALS_SLOT_SEMANTICS[round];
+  if (!matches) return null;
+  const slots = matches[matchIndex];
+  if (!slots) return null;
+  const slot = slots[slotIndex];
+  return slot ?? null;
+}

--- a/smkc-score-app/src/lib/cdm-export/fill/finals.ts
+++ b/smkc-score-app/src/lib/cdm-export/fill/finals.ts
@@ -1,0 +1,1003 @@
+/**
+ * CDM BM/MR/GP Finals fill map — pure function `CdmTournamentData -> CdmCellWrite[]`.
+ *
+ * The Finals sheet (BM/MR/GP share one layout) is a formula-driven 24-player
+ * double-elimination bracket. The workbook computes every name and advancement
+ * itself from a small set of human inputs:
+ *   - B3:B26  — the seed list (nickname per B-position).
+ *   - typed seed cells (offset +1 in each match block) — a B-position number.
+ *   - score cells (offset +4) — the two players' scores for that match.
+ * Everything else (name XLOOKUPs, "Winner of N" advancement, final standings) is
+ * a formula the export must NOT touch on the faithful path. See
+ * docs/cdm-export-design.md §3.4 and finals-slot-semantics.ts.
+ *
+ * The DB stores no seed column, so we reconstruct each slot's B-position by
+ * matching the app finals/playoff match records (by matchNumber) against the
+ * canonical structures from double-elimination.ts (imported, never modified):
+ *   - generateBracketStructure(16) → winners_r1 player1Seed/player2Seed (upper
+ *     seeds); a direct qualifier at upper seed u sits at B-position
+ *     FINALS_DIRECT_UPPER_SEEDS.indexOf(u)+1 (1..12).
+ *   - generatePlayoffStructure(12) → playoff seed p sits at B-position
+ *     FINALS_PLAYOFF_B_POSITION_OFFSET + p (13..24).
+ *   - generateBracketStructure(8) → 8-player upper seeds map directly to B 1..8.
+ *
+ * Bracket size (from which rounds exist) selects the mode:
+ *   - faithful (24): any stage="playoff" match present. Only typed seed cells +
+ *     score cells written; advancement formulas preserved.
+ *   - playoff-only (24, partial): playoff matches but no winners_r1 yet. Same as
+ *     faithful for the playoff blocks; B-positions 13..24 from the playoff, 1..12
+ *     from a qualification-rank fallback.
+ *   - degraded 16 (no playoff, has winners_r1): the Top16 "Winner of B2,k" slots
+ *     and the Barrage blocks have no data, so their formulas are value-overwritten
+ *     / stripped; the rest stays formula-driven.
+ *   - degraded 8 (winners_qf is the first round): the template's 24-player
+ *     advancement cannot represent an 8-player bracket, so every used slot's NAME
+ *     and SCORE is value-overwritten and all unused regions are stripped. A
+ *     warning is logged because Excel will no longer recompute this bracket.
+ *   - no matches: every input cell is cleared so the template renders a blank
+ *     bracket (its formulas already handle empty inputs).
+ */
+
+import { createLogger } from "@/lib/logger";
+import {
+  generateBracketStructure,
+  generatePlayoffStructure,
+} from "@/lib/double-elimination";
+import type { BracketMatch } from "@/types/bracket";
+import {
+  FINALS_BRACKET_SLOTS,
+  FINALS_BLOCK_SEED_OFFSET,
+  FINALS_BLOCK_NAME_OFFSET,
+  FINALS_BLOCK_SCORE_OFFSET,
+  FINALS_DIRECT_UPPER_SEEDS,
+  FINALS_PLAYOFF_B_POSITION_OFFSET,
+  FINALS_SEED_LIST_COLUMN,
+  FINALS_SEED_LIST_FIRST_ROW,
+  FINALS_SEED_LIST_MAX_ROWS,
+  CDM_FINALS_SHEETS,
+  toColumnLetters,
+} from "../cdm-constants";
+import type {
+  CdmCellWrite,
+  CdmMatch,
+  CdmModeQualification,
+  CdmPlayer,
+  CdmSheetName,
+  CdmTournamentData,
+  CdmVersusMode,
+} from "../types";
+import { getSlotSemantics, type FinalsSlotSemantics } from "./finals-slot-semantics";
+
+const logger = createLogger("cdm-export");
+
+const FULL_SEED_COUNT = 24;
+const SIXTEEN = 16;
+const EIGHT = 8;
+
+/**
+ * Accumulates one-op-per-cell writes for a single sheet (last write wins per ref,
+ * insertion order preserved). Mirrors SheetWriteBuilder from sheet-player-order.ts
+ * but adds the overwrite/strip ops the degraded bracket modes need (that builder
+ * is shared and must not be modified). The clear-then-write collapse keeps the
+ * emitted array free of duplicate refs, which the test helpers assert.
+ */
+class FinalsWriteBuilder {
+  private readonly ops = new Map<string, CdmCellWrite>();
+
+  constructor(private readonly sheet: CdmSheetName) {}
+
+  /** Set a numeric value on a non-formula cell (typed seed / score). */
+  setNumber(ref: string, value: number): void {
+    this.ops.set(ref, { sheet: this.sheet, ref, op: "number", value });
+  }
+
+  /** Set an inline string on a non-formula cell. */
+  setString(ref: string, value: string): void {
+    this.ops.set(ref, { sheet: this.sheet, ref, op: "inlineString", value });
+  }
+
+  /** Drop the cached value but keep the cell, style and any formula. */
+  clear(ref: string): void {
+    this.ops.set(ref, { sheet: this.sheet, ref, op: "clearValue" });
+  }
+
+  /** Replace value AND remove any formula (degraded modes only). */
+  overwriteNumber(ref: string, value: number): void {
+    this.ops.set(ref, { sheet: this.sheet, ref, op: "overwriteNumber", value });
+  }
+
+  /** Replace value AND remove any formula with an inline string (degraded only). */
+  overwriteString(ref: string, value: string): void {
+    this.ops.set(ref, { sheet: this.sheet, ref, op: "overwriteString", value });
+  }
+
+  /** Remove value and formula but keep the styled cell shell. */
+  strip(ref: string): void {
+    this.ops.set(ref, { sheet: this.sheet, ref, op: "strip" });
+  }
+
+  /** Set a number or, when null/undefined, clear the cell. */
+  setNumberOrClear(ref: string, value: number | null | undefined): void {
+    if (value == null) this.clear(ref);
+    else this.setNumber(ref, value);
+  }
+
+  build(): CdmCellWrite[] {
+    return [...this.ops.values()];
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Geometry helpers — translate (round, matchIndex, slotIndex) into the
+ * A1 cell references of the seed / name / score cells of that slot.
+ * ------------------------------------------------------------------ */
+
+interface SlotCells {
+  seedRef: string;
+  nameRef: string;
+  scoreRef: string;
+}
+
+/** A1 refs for the seed/name/score cells of a slot, or null if no such slot. */
+function slotCells(
+  round: string,
+  matchIndex: number,
+  slotIndex: number,
+): SlotCells | null {
+  const geometries = FINALS_BRACKET_SLOTS[round];
+  if (!geometries) return null;
+  const geometry = geometries[matchIndex];
+  if (!geometry) return null;
+  const row = geometry.row + slotIndex; // slot1 = row, slot2 = row + 1
+  return {
+    seedRef: `${toColumnLetters(geometry.blockStart + FINALS_BLOCK_SEED_OFFSET)}${row}`,
+    nameRef: `${toColumnLetters(geometry.blockStart + FINALS_BLOCK_NAME_OFFSET)}${row}`,
+    scoreRef: `${toColumnLetters(geometry.blockStart + FINALS_BLOCK_SCORE_OFFSET)}${row}`,
+  };
+}
+
+/** True if the template stores a typed seed value (not a formula) in this slot. */
+function isTypedSeedSlot(round: string, matchIndex: number, slotIndex: number): boolean {
+  return getSlotSemantics(round, matchIndex, slotIndex)?.kind === "seed";
+}
+
+/**
+ * Empty an unused slot per the per-cell rule (design §3.4.1): formula cells are
+ * stripped (value + formula removed, styled shell kept) and typed input cells are
+ * cleared (value dropped, cell/style kept). The seed cell is a typed value only
+ * for "seed" slots; the name cell is always a formula; the score cell is always a
+ * typed input.
+ */
+function emptyUnusedSlot(
+  builder: FinalsWriteBuilder,
+  round: string,
+  matchIndex: number,
+  slotIndex: number,
+): void {
+  const cells = slotCells(round, matchIndex, slotIndex);
+  if (!cells) return;
+  if (isTypedSeedSlot(round, matchIndex, slotIndex)) builder.clear(cells.seedRef);
+  else builder.strip(cells.seedRef); // reverse-lookup formula in formula slots.
+  builder.strip(cells.nameRef); // name is always an XLOOKUP formula.
+  builder.clear(cells.scoreRef); // score is always a typed input.
+}
+
+/* ------------------------------------------------------------------ *
+ * App match access — group a mode's matches by round, in app match order.
+ * ------------------------------------------------------------------ */
+
+/** Matches of one round, sorted by matchNumber so index 0,1,… is app order. */
+function matchesByRound(matches: CdmMatch[]): Map<string, CdmMatch[]> {
+  const byRound = new Map<string, CdmMatch[]>();
+  for (const match of matches) {
+    const round = normalizeRound(match);
+    if (!round) continue;
+    const list = byRound.get(round) ?? [];
+    list.push(match);
+    byRound.set(round, list);
+  }
+  for (const list of byRound.values()) {
+    list.sort((a, b) => a.matchNumber - b.matchNumber);
+  }
+  return byRound;
+}
+
+/**
+ * Normalize a match to a slot-semantics round id. Mirrors the export route's
+ * cdmFinalsSlotRound so the fill map and the (legacy) inline generator agree:
+ *   1. a round already in the bracket geometry wins outright;
+ *   2. else a bracketPosition containing "reset" -> grand_final_reset;
+ *   3. else round/bracketPosition "gf" or isGrandFinal -> grand_final;
+ *   4. else null (unmapped — the caller skips it rather than guessing).
+ * Older generators / manual fixtures can store grand finals as round="gf" with
+ * bracketPosition="gf" or only flag the reset via bracketPosition, so those
+ * aliases are normalized before any geometry lookup.
+ */
+function normalizeRound(match: CdmMatch): string | null {
+  const round = match.round ?? "";
+  const bracketPosition = (match.bracketPosition ?? "").toLowerCase();
+  if (round && FINALS_BRACKET_SLOTS[round]) return round;
+  if (bracketPosition.includes("reset")) return "grand_final_reset";
+  if (round === "gf" || bracketPosition === "gf" || match.isGrandFinal) {
+    return "grand_final";
+  }
+  return null; // unmapped: caller skips (+ warns at the call site if relevant).
+}
+
+/* ------------------------------------------------------------------ *
+ * Score extraction — BM/MR use score1/score2, GP uses points1/points2.
+ * ------------------------------------------------------------------ */
+
+function scoreFor(match: CdmMatch, mode: CdmVersusMode, slotIndex: number): number | null {
+  if (mode === "gp") {
+    const value = slotIndex === 0 ? match.points1 : match.points2;
+    return value ?? null;
+  }
+  const value = slotIndex === 0 ? match.score1 : match.score2;
+  return value ?? null;
+}
+
+/** The winner (or loser) player of a completed match, by comparing its scores. */
+function matchOutcome(
+  match: CdmMatch | undefined,
+  mode: CdmVersusMode,
+  want: "winner" | "loser",
+): CdmPlayer | null {
+  if (!match || !match.completed) return null;
+  const s1 = scoreFor(match, mode, 0);
+  const s2 = scoreFor(match, mode, 1);
+  if (s1 == null || s2 == null || s1 === s2) return null; // undecided / tie
+  const player1Wins = s1 > s2;
+  if (want === "winner") return player1Wins ? match.player1 : match.player2;
+  return player1Wins ? match.player2 : match.player1;
+}
+
+/* ------------------------------------------------------------------ *
+ * B-position reconstruction (faithful 24 + degraded 16/8).
+ *
+ * Produces:
+ *   - bPositionPlayers: B-position -> the player who sits there.
+ *   - seedPlayerBySlot: "round:matchIndex:slotIndex" -> player at that TYPED
+ *     seed slot (used to write the seed-cell B-position and to resolve scores).
+ * ------------------------------------------------------------------ */
+
+interface Reconstruction {
+  bPositionPlayers: Map<number, CdmPlayer>;
+  /** key = `${round}:${matchIndex}:${slotIndex}` */
+  seedBPositionBySlot: Map<string, number>;
+}
+
+function slotKey(round: string, matchIndex: number, slotIndex: number): string {
+  return `${round}:${matchIndex}:${slotIndex}`;
+}
+
+/**
+ * Reconstruct B-positions for the faithful 24-player bracket from the app's
+ * winners_r1 (direct qualifiers) and playoff matches (entrants 13..24), using the
+ * canonical structures to recover each typed slot's structural seed.
+ */
+function reconstruct24(byRound: Map<string, CdmMatch[]>): Reconstruction {
+  const bPositionPlayers = new Map<number, CdmPlayer>();
+  const seedBPositionBySlot = new Map<string, number>();
+
+  const structure16 = generateBracketStructure(SIXTEEN);
+  const r1Structure = structure16.filter((m) => m.round === "winners_r1");
+  const appR1 = byRound.get("winners_r1") ?? [];
+
+  // Direct qualifiers: each TYPED winners_r1 slot maps an upper seed -> B-pos.
+  appR1.forEach((appMatch, matchIndex) => {
+    const struct = r1Structure[matchIndex];
+    if (!struct) return;
+    assignTypedSeed("winners_r1", matchIndex, 0, struct.player1Seed, appMatch.player1, true, bPositionPlayers, seedBPositionBySlot);
+    assignTypedSeed("winners_r1", matchIndex, 1, struct.player2Seed, appMatch.player2, true, bPositionPlayers, seedBPositionBySlot);
+  });
+
+  // Playoff entrants: playoff_r1 both slots + playoff_r2 slot1 (the BYE seed).
+  const playoffStructure = generatePlayoffStructure(12);
+  assignPlayoffSeeds(byRound, playoffStructure, bPositionPlayers, seedBPositionBySlot);
+
+  return { bPositionPlayers, seedBPositionBySlot };
+}
+
+/**
+ * Assign one direct-qualifier typed slot. `upperSeed` is the structural upper
+ * seed (1..16). Only direct seeds (those in FINALS_DIRECT_UPPER_SEEDS) are typed;
+ * playoff-winner seeds (16/12/14/10) are formula slots and are skipped — which
+ * is consistent with the slot-semantics table marking them winnerOf.
+ */
+function assignTypedSeed(
+  round: string,
+  matchIndex: number,
+  slotIndex: number,
+  upperSeed: number | undefined,
+  player: CdmPlayer,
+  asDirect: boolean,
+  bPositionPlayers: Map<number, CdmPlayer>,
+  seedBPositionBySlot: Map<string, number>,
+): void {
+  if (upperSeed == null) return;
+  if (asDirect) {
+    const directIndex = FINALS_DIRECT_UPPER_SEEDS.indexOf(
+      upperSeed as (typeof FINALS_DIRECT_UPPER_SEEDS)[number],
+    );
+    if (directIndex < 0) return; // playoff-winner slot -> formula, not typed.
+    const bPos = directIndex + 1; // B-positions 1..12.
+    bPositionPlayers.set(bPos, player);
+    seedBPositionBySlot.set(slotKey(round, matchIndex, slotIndex), bPos);
+  }
+}
+
+/**
+ * Assign the 12 playoff entrants to B-positions 13..24 from the playoff structure.
+ * playoff_r1[k] slot1/slot2 = structural player1Seed/player2Seed; playoff_r2[k]
+ * slot1 = structural BYE seed (player1Seed). B-pos = OFFSET + structural seed.
+ */
+function assignPlayoffSeeds(
+  byRound: Map<string, CdmMatch[]>,
+  playoffStructure: BracketMatch[],
+  bPositionPlayers: Map<number, CdmPlayer>,
+  seedBPositionBySlot: Map<string, number>,
+): void {
+  const r1Structure = playoffStructure.filter((m) => m.round === "playoff_r1");
+  const r2Structure = playoffStructure.filter((m) => m.round === "playoff_r2");
+  const appR1 = byRound.get("playoff_r1") ?? [];
+  const appR2 = byRound.get("playoff_r2") ?? [];
+
+  const place = (
+    round: string,
+    matchIndex: number,
+    slotIndex: number,
+    structuralSeed: number | undefined,
+    player: CdmPlayer | undefined,
+  ) => {
+    if (structuralSeed == null || !player) return;
+    const bPos = FINALS_PLAYOFF_B_POSITION_OFFSET + structuralSeed; // 13..24
+    bPositionPlayers.set(bPos, player);
+    seedBPositionBySlot.set(slotKey(round, matchIndex, slotIndex), bPos);
+  };
+
+  appR1.forEach((appMatch, matchIndex) => {
+    const struct = r1Structure[matchIndex];
+    if (!struct) return;
+    place("playoff_r1", matchIndex, 0, struct.player1Seed, appMatch.player1);
+    place("playoff_r1", matchIndex, 1, struct.player2Seed, appMatch.player2);
+  });
+  appR2.forEach((appMatch, matchIndex) => {
+    const struct = r2Structure[matchIndex];
+    if (!struct) return;
+    // Only slot1 (the BYE seed) is typed; slot2 is a "Winner of B1,k" formula.
+    place("playoff_r2", matchIndex, 0, struct.player1Seed, appMatch.player1);
+  });
+}
+
+/* ------------------------------------------------------------------ *
+ * Seed-list writing (B3:B26): nickname per B-position, blanks cleared.
+ *
+ * IMPORTANT per-mode difference (verified against the real template dump):
+ *   - BM Finals / MR Finals B3:B26 are TYPED shared-string inputs.
+ *   - GP Finals B3 is an ARRAY-SPILL formula
+ *       =XLOOKUP(ANCHORARRAY(A3),'GP Qualifications'!AL:AL,'GP Qualifications'!AM:AM)
+ *     with ref="B3:B26", so B4:B26 are spill cells (cached values, no own <f>).
+ * Writing or clearing the GP seed list would either overwrite the B3 formula
+ * (SheetXmlPatcher throws) or land a static value inside the spill range
+ * (#SPILL! in Excel). GP therefore derives its seed list from GP Qualifications
+ * by formula and we must leave B3:B26 entirely untouched on the GP sheet.
+ * (Discovered during route integration; the prior unit fixtures never exercised
+ * the GP seed list against the real template.)
+ * ------------------------------------------------------------------ */
+
+/** True when the mode's B3:B26 seed list is a formula spill (GP only). */
+function seedListIsFormula(mode: CdmVersusMode): boolean {
+  return mode === "gp";
+}
+
+function writeSeedList(
+  builder: FinalsWriteBuilder,
+  bPositionPlayers: Map<number, CdmPlayer>,
+  seedCount: number,
+  mode: CdmVersusMode,
+): void {
+  // GP's seed list is a formula spill — never write/clear it (see header note).
+  if (seedListIsFormula(mode)) return;
+  for (let p = 1; p <= FINALS_SEED_LIST_MAX_ROWS; p++) {
+    const row = FINALS_SEED_LIST_FIRST_ROW + (p - 1);
+    const ref = `${FINALS_SEED_LIST_COLUMN}${row}`;
+    const player = p <= seedCount ? bPositionPlayers.get(p) : undefined;
+    if (player) builder.setString(ref, player.nickname);
+    else builder.clear(ref); // unused / unresolved -> blank (formulas handle it).
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Score resolution (identity-resolved, all faithful rounds).
+ *
+ * For each app match we resolve the player the template EXPECTS in each slot
+ * (typed seed -> B-position player; winnerOf/loserOf -> the actual outcome of the
+ * feeding app match) and write that player's real score into the slot's score
+ * cell. If the resolved player is not one of the match's two players (manual
+ * operation), we fall back to slot1->player1 / slot2->player2 and warn.
+ * ------------------------------------------------------------------ */
+
+/** Resolve the player a slot's semantics expect (or null if undetermined). */
+function resolveSlotPlayer(
+  semantics: FinalsSlotSemantics,
+  round: string,
+  matchIndex: number,
+  slotIndex: number,
+  byRound: Map<string, CdmMatch[]>,
+  mode: CdmVersusMode,
+  recon: Reconstruction,
+): CdmPlayer | null {
+  if (semantics.kind === "seed") {
+    const bPos = recon.seedBPositionBySlot.get(slotKey(round, matchIndex, slotIndex));
+    if (bPos == null) return null;
+    return recon.bPositionPlayers.get(bPos) ?? null;
+  }
+  const feeder = (byRound.get(semantics.round) ?? [])[semantics.index];
+  return matchOutcome(feeder, mode, semantics.kind === "winnerOf" ? "winner" : "loser");
+}
+
+/**
+ * Write the two score cells of one app match using identity resolution. Score
+ * cells are cleared when the match is not completed or a slot stays undetermined.
+ */
+function writeMatchScores(
+  builder: FinalsWriteBuilder,
+  round: string,
+  matchIndex: number,
+  match: CdmMatch,
+  byRound: Map<string, CdmMatch[]>,
+  mode: CdmVersusMode,
+  recon: Reconstruction,
+): void {
+  const slot0 = slotCells(round, matchIndex, 0);
+  const slot1 = slotCells(round, matchIndex, 1);
+  if (!slot0 || !slot1) {
+    logger.warn("Finals match has no slot geometry; skipping scores", {
+      mode,
+      round,
+      matchIndex,
+    });
+    return;
+  }
+  // Score-cell refs indexed by slot (0/1) for the resolved-mapping write below.
+  const scoreRefs = [slot0.scoreRef, slot1.scoreRef] as const;
+
+  if (!match.completed) {
+    builder.clear(scoreRefs[0]);
+    builder.clear(scoreRefs[1]);
+    return;
+  }
+
+  // Resolve the expected player per slot from the template's semantics.
+  const expected: Array<CdmPlayer | null> = [null, null];
+  for (const slotIndex of [0, 1]) {
+    const semantics = getSlotSemantics(round, matchIndex, slotIndex);
+    expected[slotIndex] = semantics
+      ? resolveSlotPlayer(semantics, round, matchIndex, slotIndex, byRound, mode, recon)
+      : null;
+  }
+
+  // Map each resolved expected player to the match's actual player to read its
+  // score, then write into that slot's score cell. Fall back to positional
+  // (slot==player) mapping when the resolution does not match the record.
+  const byPlayerId = new Map<string, number>(); // playerId -> slotIndex
+  let resolvedBoth = true;
+  for (const slotIndex of [0, 1]) {
+    const player = expected[slotIndex];
+    if (player && (player.id === match.player1.id || player.id === match.player2.id)) {
+      byPlayerId.set(player.id, slotIndex);
+    } else {
+      resolvedBoth = false;
+    }
+  }
+
+  if (resolvedBoth && byPlayerId.size === 2) {
+    // Write each actual player's score into the slot the template expects it.
+    for (const [actualSlot, player] of [
+      [0, match.player1],
+      [1, match.player2],
+    ] as const) {
+      const targetSlot = byPlayerId.get(player.id)!;
+      builder.setNumberOrClear(scoreRefs[targetSlot], scoreFor(match, mode, actualSlot));
+    }
+    return;
+  }
+
+  // Fallback: positional mapping (slot1<-player1, slot2<-player2) + warn.
+  logger.warn("Finals slot resolution disagreed with match record; positional fallback", {
+    mode,
+    round,
+    matchIndex,
+  });
+  builder.setNumberOrClear(scoreRefs[0], scoreFor(match, mode, 0));
+  builder.setNumberOrClear(scoreRefs[1], scoreFor(match, mode, 1));
+}
+
+/* ------------------------------------------------------------------ *
+ * Typed seed-cell writing (faithful 24).
+ * ------------------------------------------------------------------ */
+
+/**
+ * Write the B-position number into every TYPED seed cell (per slot-semantics).
+ * Formula slots are left untouched so the template's advancement keeps working.
+ */
+function writeTypedSeedCells(
+  builder: FinalsWriteBuilder,
+  recon: Reconstruction,
+): void {
+  for (const [key, bPos] of recon.seedBPositionBySlot) {
+    const [round, matchIndexStr, slotIndexStr] = key.split(":");
+    const cells = slotCells(round, Number(matchIndexStr), Number(slotIndexStr));
+    if (cells) builder.setNumber(cells.seedRef, bPos);
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Region clearing — collect every input cell of a set of rounds so unused
+ * regions can be cleared (typed) or stripped (formula) without leftover data.
+ * ------------------------------------------------------------------ */
+
+/** Every app round id the template geometry knows about. */
+const ALL_FINALS_ROUNDS = Object.keys(FINALS_BRACKET_SLOTS);
+
+/** All (seed, name, score) refs of every slot of the listed rounds. */
+function regionCells(rounds: string[]): SlotCells[] {
+  const cells: SlotCells[] = [];
+  for (const round of rounds) {
+    const geometries = FINALS_BRACKET_SLOTS[round] ?? [];
+    geometries.forEach((_, matchIndex) => {
+      for (const slotIndex of [0, 1]) {
+        const c = slotCells(round, matchIndex, slotIndex);
+        if (c) cells.push(c);
+      }
+    });
+  }
+  return cells;
+}
+
+/** Clear every score cell of the listed rounds (typed input cells). */
+function clearAllScores(builder: FinalsWriteBuilder, rounds: string[]): void {
+  for (const c of regionCells(rounds)) builder.clear(c.scoreRef);
+}
+
+/**
+ * Clear the seed cell of every TYPED slot (per the slot-semantics table) across
+ * all rounds, so an unfilled typed seed never keeps stale data. Formula slots are
+ * skipped entirely — faithful mode must never write or clear a formula cell.
+ * Resolved seeds are re-written afterwards (the builder is last-wins per ref).
+ */
+function clearAllTypedSeedCells(builder: FinalsWriteBuilder): void {
+  for (const round of ALL_FINALS_ROUNDS) {
+    const geometries = FINALS_BRACKET_SLOTS[round];
+    geometries.forEach((_, matchIndex) => {
+      for (const slotIndex of [0, 1]) {
+        const semantics = getSlotSemantics(round, matchIndex, slotIndex);
+        if (!semantics || semantics.kind !== "seed") continue; // formula -> skip.
+        const cells = slotCells(round, matchIndex, slotIndex);
+        if (cells) builder.clear(cells.seedRef);
+      }
+    });
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Public entry point.
+ * ------------------------------------------------------------------ */
+
+/**
+ * Build the BM/MR/GP Finals cell writes for one mode. Clears precede writes so a
+ * partially-filled bracket never leaves stale values behind.
+ */
+export function buildFinalsWrites(
+  data: CdmTournamentData,
+  mode: CdmVersusMode,
+): CdmCellWrite[] {
+  const sheet = CDM_FINALS_SHEETS[mode];
+  const builder = new FinalsWriteBuilder(sheet);
+  const matches = matchesForMode(data, mode);
+  const byRound = matchesByRound(matches);
+
+  const hasPlayoff = matches.some((m) => m.stage === "playoff");
+  const hasR1 = byRound.has("winners_r1");
+  const hasQf = byRound.has("winners_qf");
+
+  if (matches.length === 0) {
+    // No finals at all: clear every input cell so the template shows a blank
+    // bracket (its formulas already render empty inputs harmlessly).
+    buildEmptyBracket(builder, mode);
+    return builder.build();
+  }
+
+  if (hasPlayoff || hasR1) {
+    // Faithful 24 (playoff present) or degraded 16 (winners_r1 but no playoff).
+    return buildFaithfulOr16(builder, data, mode, byRound, hasPlayoff);
+  }
+
+  if (hasQf) {
+    // Degraded 8-player bracket (winners_qf is the first round).
+    return build8Player(builder, byRound, mode);
+  }
+
+  // Matches exist but none map to a known bracket round (e.g. only a stray
+  // unmapped match): treat as blank to avoid corrupting the template.
+  logger.warn("Finals matches present but no recognizable bracket rounds; clearing", {
+    mode,
+    count: matches.length,
+  });
+  buildEmptyBracket(builder, mode);
+  return builder.build();
+}
+
+/** Select a mode's match list from the tournament data. */
+function matchesForMode(data: CdmTournamentData, mode: CdmVersusMode): CdmMatch[] {
+  switch (mode) {
+    case "bm":
+      return data.bmMatches;
+    case "mr":
+      return data.mrMatches;
+    case "gp":
+      return data.gpMatches;
+  }
+}
+
+/** Select a mode's qualifications (for the playoff-only B 1..12 fallback). */
+function qualsForMode(data: CdmTournamentData, mode: CdmVersusMode): CdmModeQualification[] {
+  switch (mode) {
+    case "bm":
+      return data.bmQualifications;
+    case "mr":
+      return data.mrQualifications;
+    case "gp":
+      return data.gpQualifications;
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Mode: no finals — clear every input cell (seed list, all seeds, all scores).
+ * ------------------------------------------------------------------ */
+
+function buildEmptyBracket(builder: FinalsWriteBuilder, mode: CdmVersusMode): void {
+  // Seed list B3:B26 — skipped for GP, whose seed list is a formula spill (see
+  // the writeSeedList header note); clearing it would corrupt the spill.
+  if (!seedListIsFormula(mode)) {
+    for (let p = 1; p <= FINALS_SEED_LIST_MAX_ROWS; p++) {
+      builder.clear(`${FINALS_SEED_LIST_COLUMN}${FINALS_SEED_LIST_FIRST_ROW + (p - 1)}`);
+    }
+  }
+  // Clear only the TYPED seed cells and every score cell; leave all formulas
+  // (name XLOOKUPs, advancement, reverse-lookup seed cells) intact so the empty
+  // template recomputes a clean blank bracket from the now-empty seed list.
+  clearAllTypedSeedCells(builder);
+  for (const c of regionCells(ALL_FINALS_ROUNDS)) {
+    builder.clear(c.scoreRef);
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Mode: faithful (24) or degraded 16.
+ * ------------------------------------------------------------------ */
+
+function buildFaithfulOr16(
+  builder: FinalsWriteBuilder,
+  data: CdmTournamentData,
+  mode: CdmVersusMode,
+  byRound: Map<string, CdmMatch[]>,
+  hasPlayoff: boolean,
+): CdmCellWrite[] {
+  if (hasPlayoff) {
+    const recon = byRound.has("winners_r1")
+      ? reconstruct24(byRound)
+      : reconstructPlayoffOnly(byRound, data, mode);
+    // Clear-then-write: clear every typed seed cell and every score cell first so
+    // unfilled inputs never keep stale data, then write the resolved values
+    // (last-wins). Formula cells are never touched.
+    clearAllTypedSeedCells(builder);
+    clearAllScores(builder, ALL_FINALS_ROUNDS);
+    writeTypedSeedCells(builder, recon);
+    writeSeedList(builder, recon.bPositionPlayers, FULL_SEED_COUNT, mode);
+    writeAllScores(builder, byRound, mode, recon);
+    return builder.build();
+  }
+  // Degraded 16-player: no playoff. Reconstruct B 1..16 from winners_r1 directly.
+  return build16Player(builder, byRound, mode);
+}
+
+/**
+ * Playoff-only partial state (entrants seeded, winners_r1 not yet generated).
+ * B-positions 13..24 come from the playoff; 1..12 fall back to qualification rank
+ * (rankOverride asc nulls-last -> score desc -> points desc -> seeding asc ->
+ * nickname asc) so the direct qualifiers still appear in the seed list.
+ */
+function reconstructPlayoffOnly(
+  byRound: Map<string, CdmMatch[]>,
+  data: CdmTournamentData,
+  mode: CdmVersusMode,
+): Reconstruction {
+  const bPositionPlayers = new Map<number, CdmPlayer>();
+  const seedBPositionBySlot = new Map<string, number>();
+  const playoffStructure = generatePlayoffStructure(12);
+  assignPlayoffSeeds(byRound, playoffStructure, bPositionPlayers, seedBPositionBySlot);
+
+  // B 1..12: top-12 qualifiers by the documented tiebreak, excluding anyone who
+  // is already a playoff entrant (they hold B 13..24).
+  const playoffPlayerIds = new Set(
+    [...bPositionPlayers.values()].map((p) => p.id),
+  );
+  const ranked = rankQualifiers(qualsForMode(data, mode)).filter(
+    (q) => !playoffPlayerIds.has(q.player.id),
+  );
+  ranked.slice(0, FINALS_PLAYOFF_B_POSITION_OFFSET).forEach((q, i) => {
+    bPositionPlayers.set(i + 1, q.player); // B 1..12
+  });
+  return { bPositionPlayers, seedBPositionBySlot };
+}
+
+/**
+ * Order qualifiers by the documented qualification-rank tiebreak:
+ *   rankOverride ascending (nulls last) -> score desc -> points desc ->
+ *   seeding asc (nulls last) -> nickname asc.
+ */
+function rankQualifiers(quals: CdmModeQualification[]): CdmModeQualification[] {
+  return [...quals].sort((a, b) => {
+    const ra = a.rankOverride ?? null;
+    const rb = b.rankOverride ?? null;
+    if (ra !== rb) {
+      if (ra == null) return 1;
+      if (rb == null) return -1;
+      return ra - rb;
+    }
+    if (a.score !== b.score) return b.score - a.score; // higher score first
+    if (a.points !== b.points) return b.points - a.points; // higher points first
+    const sa = a.seeding ?? null;
+    const sb = b.seeding ?? null;
+    if (sa !== sb) {
+      if (sa == null) return 1;
+      if (sb == null) return -1;
+      return sa - sb;
+    }
+    return a.player.nickname.localeCompare(b.player.nickname);
+  });
+}
+
+/** Write every resolvable match score across all faithful rounds. */
+function writeAllScores(
+  builder: FinalsWriteBuilder,
+  byRound: Map<string, CdmMatch[]>,
+  mode: CdmVersusMode,
+  recon: Reconstruction,
+): void {
+  for (const [round, list] of byRound) {
+    if (!FINALS_BRACKET_SLOTS[round]) {
+      logger.warn("Finals round has no geometry; skipping", { mode, round });
+      continue;
+    }
+    list.forEach((match, matchIndex) => {
+      if (matchIndex >= FINALS_BRACKET_SLOTS[round].length) {
+        logger.warn("Finals match index exceeds round geometry; skipping", {
+          mode,
+          round,
+          matchIndex,
+        });
+        return;
+      }
+      writeMatchScores(builder, round, matchIndex, match, byRound, mode, recon);
+    });
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * Mode: degraded 16-player (no playoff).
+ *
+ * The Top16 even-match slot2 cells hold "Winner of B2,k" formulas that reference
+ * the (now empty) Barrage blocks. We value-overwrite those cells with the actual
+ * direct qualifier, strip the Barrage blocks, and otherwise behave like faithful
+ * (winners_qf onward stay formula-driven on the winners_r1 winners).
+ * ------------------------------------------------------------------ */
+
+function build16Player(
+  builder: FinalsWriteBuilder,
+  byRound: Map<string, CdmMatch[]>,
+  mode: CdmVersusMode,
+): CdmCellWrite[] {
+  logger.warn("Finals: 16-player bracket (no playoff) — Barrage formulas value-overwritten", {
+    mode,
+  });
+
+  const bPositionPlayers = new Map<number, CdmPlayer>();
+  const seedBPositionBySlot = new Map<string, number>();
+  const structure16 = generateBracketStructure(SIXTEEN);
+  const r1Structure = structure16.filter((m) => m.round === "winners_r1");
+  const appR1 = byRound.get("winners_r1") ?? [];
+
+  // Every winners_r1 slot is a direct qualifier here; B-position = upper seed.
+  appR1.forEach((appMatch, matchIndex) => {
+    const struct = r1Structure[matchIndex];
+    if (!struct) return;
+    for (const [slotIndex, player, upperSeed] of [
+      [0, appMatch.player1, struct.player1Seed],
+      [1, appMatch.player2, struct.player2Seed],
+    ] as const) {
+      if (upperSeed == null) continue;
+      bPositionPlayers.set(upperSeed, player); // B 1..16 = upper seed.
+      seedBPositionBySlot.set(slotKey("winners_r1", matchIndex, slotIndex), upperSeed);
+    }
+  });
+  const recon: Reconstruction = { bPositionPlayers, seedBPositionBySlot };
+
+  // Clear active-round score cells first, then strip the Barrage so the strip
+  // (value+formula removed, shell kept) wins over the clear on the Barrage's own
+  // score cells. The Barrage is entirely unused in a 16-player bracket.
+  clearAllScores(builder, ALL_FINALS_ROUNDS);
+  for (const c of regionCells(["playoff_r1", "playoff_r2"])) {
+    builder.strip(c.seedRef);
+    builder.strip(c.nameRef);
+    builder.strip(c.scoreRef);
+  }
+  writeSeedList(builder, bPositionPlayers, SIXTEEN, mode);
+
+  // Write winners_r1 seed cells. Even-match slot2 was a "Winner of B2,k" formula:
+  // value-overwrite both the seed number and the name (the formula can no longer
+  // resolve without the Barrage). Other typed slots use plain typed writes.
+  appR1.forEach((appMatch, matchIndex) => {
+    const struct = r1Structure[matchIndex];
+    if (!struct) return;
+    for (const slotIndex of [0, 1] as const) {
+      const cells = slotCells("winners_r1", matchIndex, slotIndex);
+      if (!cells) continue;
+      const bPos = seedBPositionBySlot.get(slotKey("winners_r1", matchIndex, slotIndex));
+      if (bPos == null) continue;
+      const player = slotIndex === 0 ? appMatch.player1 : appMatch.player2;
+      const semantics = getSlotSemantics("winners_r1", matchIndex, slotIndex);
+      if (semantics && semantics.kind !== "seed") {
+        // Former "Winner of B2,k" slot -> value-overwrite seed + name.
+        builder.overwriteNumber(cells.seedRef, bPos);
+        builder.overwriteString(cells.nameRef, player.nickname);
+      } else {
+        builder.setNumber(cells.seedRef, bPos); // genuinely typed slot.
+      }
+    }
+  });
+
+  writeAllScores(builder, byRound, mode, recon);
+  return builder.build();
+}
+
+/* ------------------------------------------------------------------ *
+ * Mode: degraded 8-player.
+ *
+ * The template's 24-player advancement cannot represent an 8-player bracket, so
+ * we value-overwrite every used slot's NAME and SCORE (resolved straight from the
+ * app match records) and strip every unused region. Excel will no longer
+ * recompute this bracket — a documented limitation (design §6).
+ *
+ * Round -> template geometry mapping (8-player app, generateBracketStructure(8)):
+ *   winners_qf[0..3]   -> winners_qf rows 7,15,23,31
+ *   winners_sf[0,1]    -> winners_sf rows 11,27
+ *   winners_final[0]   -> winners_final row 19
+ *   losers_r1[0,1]     -> losers_r1 rows 41,45   (rows 49,53 unused)
+ *   losers_r2[0,1]     -> losers_r2 rows 41,45   (rows 49,53 unused)
+ *   losers_r3[0,1]     -> losers_r3 rows 43,51
+ *   losers_sf[0]       -> losers_sf row 47
+ *   losers_final[0]    -> losers_final row 47
+ *   grand_final[0]     -> grand_final row 19
+ *   grand_final_reset  -> grand_final_reset row 19
+ * Unused: Barrage (playoff_*), Top16 (winners_r1), losers_r4, the extra
+ * losers_r1/losers_r2 slots at rows 49/53.
+ * ------------------------------------------------------------------ */
+
+/** Rounds an 8-player bracket actually uses (others are stripped wholesale). */
+const EIGHT_PLAYER_ROUNDS = [
+  "winners_qf",
+  "winners_sf",
+  "winners_final",
+  "losers_r1",
+  "losers_r2",
+  "losers_r3",
+  "losers_sf",
+  "losers_final",
+  "grand_final",
+  "grand_final_reset",
+] as const;
+
+/** How many matches an 8-player bracket has per round (extras are stripped). */
+const EIGHT_PLAYER_ROUND_SIZES: Record<string, number> = {
+  winners_qf: 4,
+  winners_sf: 2,
+  winners_final: 1,
+  losers_r1: 2,
+  losers_r2: 2,
+  losers_r3: 2,
+  losers_sf: 1,
+  losers_final: 1,
+  grand_final: 1,
+  grand_final_reset: 1,
+};
+
+function build8Player(
+  builder: FinalsWriteBuilder,
+  byRound: Map<string, CdmMatch[]>,
+  mode: CdmVersusMode,
+): CdmCellWrite[] {
+  logger.warn("Finals: 8-player bracket — advancement formulas value-overwritten (no Excel recompute)", {
+    mode,
+  });
+
+  // B-position list (1..8) from the 8-player structure's winners_qf seeds.
+  const structure8 = generateBracketStructure(EIGHT);
+  const qfStructure = structure8.filter((m) => m.round === "winners_qf");
+  const appQf = byRound.get("winners_qf") ?? [];
+  const bPositionPlayers = new Map<number, CdmPlayer>();
+  appQf.forEach((appMatch, matchIndex) => {
+    const struct = qfStructure[matchIndex];
+    if (!struct) return;
+    if (struct.player1Seed != null) bPositionPlayers.set(struct.player1Seed, appMatch.player1);
+    if (struct.player2Seed != null) bPositionPlayers.set(struct.player2Seed, appMatch.player2);
+  });
+
+  // Empty every unused slot first (formula cells stripped, typed cells cleared);
+  // used slots are overwritten below. A slot is unused if its round is not one of
+  // the 8-player rounds or its index exceeds that round's 8-player match count
+  // (e.g. losers_r1/r2 rows 49/53, all of losers_r4, Top16, Barrage).
+  const usedRounds = new Set<string>(EIGHT_PLAYER_ROUNDS);
+  for (const round of ALL_FINALS_ROUNDS) {
+    const geometries = FINALS_BRACKET_SLOTS[round];
+    const usedCount = usedRounds.has(round) ? EIGHT_PLAYER_ROUND_SIZES[round] ?? 0 : 0;
+    geometries.forEach((_, matchIndex) => {
+      if (matchIndex < usedCount) return; // used slot handled in the write pass.
+      for (const slotIndex of [0, 1]) emptyUnusedSlot(builder, round, matchIndex, slotIndex);
+    });
+  }
+
+  writeSeedList(builder, bPositionPlayers, EIGHT, mode);
+
+  // Write each used slot's name + score directly from the app match record.
+  // slot1 <- player1 / slot2 <- player2, except losers_final which the template
+  // stores reversed vs the app (slot1 = WF loser, slot2 = LSF winner). The app
+  // seeds the losers_sf winner as player1 (position:2 in double-elimination.ts),
+  // so we swap to keep names and scores under the right slot.
+  for (const round of EIGHT_PLAYER_ROUNDS) {
+    const list = byRound.get(round) ?? [];
+    const usedCount = EIGHT_PLAYER_ROUND_SIZES[round] ?? 0;
+    list.forEach((match, matchIndex) => {
+      if (matchIndex >= usedCount) {
+        logger.warn("8-player finals: match index exceeds bracket size; skipping", {
+          mode,
+          round,
+          matchIndex,
+        });
+        return;
+      }
+      writeEightPlayerSlot(builder, round, matchIndex, match, mode);
+    });
+  }
+
+  return builder.build();
+}
+
+/** Overwrite one 8-player match's two slots (name + score) from its record. */
+function writeEightPlayerSlot(
+  builder: FinalsWriteBuilder,
+  round: string,
+  matchIndex: number,
+  match: CdmMatch,
+  mode: CdmVersusMode,
+): void {
+  // losers_final: template slot1 = Winners-Final loser, slot2 = Losers-SF winner.
+  // The app stores the Losers-SF winner as player1, so map player1 -> slot2.
+  const reversed = round === "losers_final";
+  for (const appSlot of [0, 1] as const) {
+    const targetSlot = reversed ? (1 - appSlot) : appSlot;
+    const cells = slotCells(round, matchIndex, targetSlot);
+    if (!cells) continue;
+    const player = appSlot === 0 ? match.player1 : match.player2;
+    builder.overwriteString(cells.nameRef, player.nickname);
+    if (match.completed) {
+      const score = scoreFor(match, mode, appSlot);
+      if (score == null) builder.clear(cells.scoreRef);
+      else builder.overwriteNumber(cells.scoreRef, score);
+    } else {
+      builder.clear(cells.scoreRef);
+    }
+  }
+}

--- a/smkc-score-app/src/lib/cdm-export/fill/main-hub.ts
+++ b/smkc-score-app/src/lib/cdm-export/fill/main-hub.ts
@@ -1,0 +1,240 @@
+/**
+ * Main Hub fill map — the Registration table (A1:L61) plus the Qualifying /
+ * Groups count inputs at O3:R3 / O4:R4.
+ *
+ * The Main Hub is the single source of truth the rest of the workbook reads
+ * via the `Registration[...]` structured references and the synthesized Order
+ * column. We therefore write only the human-input cells documented in
+ * docs/cdm-export-design.md §3.1 and verified against the template dump
+ * /tmp/cdm-analysis/sheet2025/sheet_Main_Hub.txt:
+ *
+ *   B = name        C = nickname      D = country (text; null -> clear)
+ *   E,F,G,H = TT,BM,MR,GP Order       I,J,K,L = TT,BM,MR,GP participation Yes/No
+ *   O3..R3 = Qualifying counts (TT,BM,MR,GP)   O4..R4 = group counts
+ *
+ * Never written (all formulas/spills in the template dump):
+ *   A (=ROW()-1), N2:R2 (COUNTIF), O2:R2, T/U (UNIQUE/COUNTIF country spill),
+ *   and the M/N labels column region.
+ *
+ * Ground-truth ordering note: the dump's rows are sorted by Name (column B),
+ * case-insensitive ascending — e.g. B2 "Alessandro Sona", B5 "Charly Greffier".
+ * (docs §3.1's "nickname ascending" remark is inaccurate for Main Hub; the
+ * sort key is Name. Functionally the order is irrelevant because FILTER/SORT
+ * re-derive every view, but we follow the template's observed Name order.)
+ */
+
+import { createLogger } from "@/lib/logger";
+import {
+  MAIN_HUB_FIRST_PLAYER_ROW,
+  MAIN_HUB_MAX_PLAYERS,
+  MAIN_HUB_LAST_PLAYER_ROW,
+  MAIN_HUB_QUALIFYING_ROW,
+  MAIN_HUB_GROUPS_ROW,
+  MAIN_HUB_COUNT_COLUMNS,
+} from "../cdm-constants";
+import type {
+  CdmMatch,
+  CdmModeQualification,
+  CdmPlayer,
+  CdmTournamentData,
+  CdmVersusMode,
+} from "../types";
+import {
+  SheetWriteBuilder,
+  excelCaseInsensitiveCompare,
+  synthesizeModeOrders,
+} from "./sheet-player-order";
+
+const logger = createLogger("cdm-export");
+
+const SHEET = "Main Hub" as const;
+
+/** Per-row data columns to clear on unused Registration rows (B..L). */
+const REGISTRATION_DATA_COLUMNS = [
+  "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L",
+] as const;
+
+/** Order column letters E,F,G,H indexed as [TT, BM, MR, GP]. */
+const ORDER_COLUMNS = ["E", "F", "G", "H"] as const;
+/** Participation Yes/No column letters I,J,K,L indexed as [TT, BM, MR, GP]. */
+const PARTICIPATION_COLUMNS = ["I", "J", "K", "L"] as const;
+
+/** A bracket-size hint derived from which finals/playoff rounds exist. */
+const FULL_BRACKET = 24;
+
+/**
+ * Read the distinct player count that has at least one recorded result across
+ * the supplied TT phase rounds. Used for the Qualifying count when the finals
+ * phases have started (overrides the qualification-headcount default).
+ */
+function distinctTtPhasePlayers(data: CdmTournamentData): number {
+  const ids = new Set<string>();
+  for (const round of data.ttPhaseRounds) {
+    const results = round.results;
+    if (!Array.isArray(results)) continue;
+    for (const entry of results) {
+      const playerId = (entry as { playerId?: unknown }).playerId;
+      if (typeof playerId === "string") ids.add(playerId);
+    }
+  }
+  return ids.size;
+}
+
+/**
+ * Bracket size for a versus mode based on the finals/playoff matches present:
+ *   any stage="playoff" match            -> 24 (16 direct + 12 playoff)
+ *   round="winners_r1"                    -> 16
+ *   round="winners_qf" (and no winners_r1) -> 8
+ *   otherwise                            -> min(24, qualifier count)
+ * Mirrors docs §3.1 / §4 "Qualifying count" derivation.
+ */
+function bracketSize(matches: CdmMatch[], qualifierCount: number): number {
+  const hasPlayoff = matches.some((m) => m.stage === "playoff");
+  if (hasPlayoff) return FULL_BRACKET;
+  const hasR1 = matches.some((m) => m.round === "winners_r1");
+  if (hasR1) return 16;
+  const hasQf = matches.some((m) => m.round === "winners_qf");
+  if (hasQf) return 8;
+  return Math.min(FULL_BRACKET, qualifierCount);
+}
+
+/** Distinct group labels used by a mode's qualifications. */
+function distinctGroupCount(quals: CdmModeQualification[]): number {
+  return new Set(quals.map((q) => q.group)).size;
+}
+
+/**
+ * Build the deduplicated player universe: every player that appears in any
+ * versus-mode qualification or as a TT entry. Keyed by player id (a player can
+ * be in several modes). Returned sorted by name, case-insensitive ascending.
+ */
+function collectPlayerUniverse(data: CdmTournamentData): CdmPlayer[] {
+  const byId = new Map<string, CdmPlayer>();
+  const add = (p: CdmPlayer) => {
+    if (!byId.has(p.id)) byId.set(p.id, p);
+  };
+  for (const q of data.bmQualifications) add(q.player);
+  for (const q of data.mrQualifications) add(q.player);
+  for (const q of data.gpQualifications) add(q.player);
+  for (const e of data.ttEntries) add(e.player);
+
+  return [...byId.values()].sort((a, b) =>
+    excelCaseInsensitiveCompare(a.name, b.name),
+  );
+}
+
+export function buildMainHubWrites(data: CdmTournamentData): CdmCellWrites {
+  const builder = new SheetWriteBuilder(SHEET);
+
+  // --- Per-player Order lookups -------------------------------------------
+  // BM/MR/GP Orders are synthesized so the sheet re-derives the app groups.
+  const bmOrders = synthesizeModeOrders(data.bmQualifications);
+  const mrOrders = synthesizeModeOrders(data.mrQualifications);
+  const gpOrders = synthesizeModeOrders(data.gpQualifications);
+
+  // TT Order comes straight from the qualification entry's seeding; TT
+  // participation is "is there a qualification-stage entry". Non-qualification
+  // stages (phase1/2/3) do not count as TT participation here.
+  const ttQualByPlayer = new Map<string, { seeding: number | null }>();
+  for (const entry of data.ttEntries) {
+    if (entry.stage === "qualification") {
+      ttQualByPlayer.set(entry.player.id, { seeding: entry.seeding });
+    }
+  }
+
+  // --- Player rows (2..61, max 60) ----------------------------------------
+  const universe = collectPlayerUniverse(data);
+  if (universe.length > MAIN_HUB_MAX_PLAYERS) {
+    logger.warn("Main Hub player universe exceeds 60; truncating", {
+      total: universe.length,
+      kept: MAIN_HUB_MAX_PLAYERS,
+    });
+  }
+  const players = universe.slice(0, MAIN_HUB_MAX_PLAYERS);
+
+  players.forEach((player, index) => {
+    const row = MAIN_HUB_FIRST_PLAYER_ROW + index;
+
+    builder.setString(`B${row}`, player.name);
+    builder.setString(`C${row}`, player.nickname);
+    // Country was a rich-value flag image; we write plain text and clear when
+    // absent (clearing keeps the styled cell and any XLOOKUP-on-image formulas
+    // elsewhere evaluating blank gracefully). XML detail: the template D cells
+    // are rich-value error shells (t="e" vm=..), and clearValue only drops the
+    // cached <v>, so a cleared cell keeps that typed-empty shell. Excel treats
+    // a value-less cell as blank regardless of its t attribute, and D is not
+    // referenced by any spill anchor, so the leftover shell is inert — accepted
+    // alongside the documented flag-image degradation (design doc §6).
+    builder.setStringOrClear(`D${row}`, player.country ?? null);
+
+    // E..H Orders: [TT, BM, MR, GP]. Absent participation -> clear (blank),
+    // never 0, so the sheet's interleave/XLOOKUP treat the player as not in the
+    // mode rather than as Order 0.
+    const ttEntry = ttQualByPlayer.get(player.id);
+    builder.setNumberOrClear(`${ORDER_COLUMNS[0]}${row}`, ttEntry ? ttEntry.seeding : null);
+    builder.setNumberOrClear(`${ORDER_COLUMNS[1]}${row}`, bmOrders.get(player.id) ?? null);
+    builder.setNumberOrClear(`${ORDER_COLUMNS[2]}${row}`, mrOrders.get(player.id) ?? null);
+    builder.setNumberOrClear(`${ORDER_COLUMNS[3]}${row}`, gpOrders.get(player.id) ?? null);
+
+    // I..L participation Yes/No: [TT, BM, MR, GP].
+    builder.setString(`${PARTICIPATION_COLUMNS[0]}${row}`, ttEntry ? "Yes" : "No");
+    builder.setString(`${PARTICIPATION_COLUMNS[1]}${row}`, bmOrders.has(player.id) ? "Yes" : "No");
+    builder.setString(`${PARTICIPATION_COLUMNS[2]}${row}`, mrOrders.has(player.id) ? "Yes" : "No");
+    builder.setString(`${PARTICIPATION_COLUMNS[3]}${row}`, gpOrders.has(player.id) ? "Yes" : "No");
+  });
+
+  // --- Spare rows: clear B..L from (players+2) through 61 ------------------
+  for (
+    let row = MAIN_HUB_FIRST_PLAYER_ROW + players.length;
+    row <= MAIN_HUB_LAST_PLAYER_ROW;
+    row++
+  ) {
+    for (const col of REGISTRATION_DATA_COLUMNS) builder.clear(`${col}${row}`);
+  }
+
+  // --- Qualifying counts O3..R3 -------------------------------------------
+  // TT: O3 drives the TT Finals roster spill
+  // (B3 = OFFSET('TT Qualifications'!CN2,0,0,'Main Hub'!O3)), so it must equal
+  // the finals UNIVERSE the lives replay writes rows for: the top
+  // min(24, qualifier-count) of the qualification standing — NOT the distinct
+  // phase-participant count. Mid-tournament the phases only contain a subset
+  // (phase1 = ranks 17..24), yet the sheet still lists the full top-24 roster
+  // with non-runners at Time=0, exactly like the CDM 2025 workbook. Distinct
+  // phase players is only a fallback for the degenerate "finals data without
+  // qualification entries" case.
+  const ttQualCount = ttQualByPlayer.size;
+  const ttQualifying =
+    ttQualCount > 0
+      ? Math.min(FULL_BRACKET, ttQualCount)
+      : distinctTtPhasePlayers(data);
+
+  const qualifying: Record<CdmVersusMode | "tt", number> = {
+    tt: ttQualifying,
+    bm: bracketSize(data.bmMatches, data.bmQualifications.length),
+    mr: bracketSize(data.mrMatches, data.mrQualifications.length),
+    gp: bracketSize(data.gpMatches, data.gpQualifications.length),
+  };
+  // Column order is [TT, BM, MR, GP] = [O, P, Q, R].
+  const qualifyingByColumn = [qualifying.tt, qualifying.bm, qualifying.mr, qualifying.gp];
+  qualifyingByColumn.forEach((value, i) => {
+    builder.setNumber(`${MAIN_HUB_COUNT_COLUMNS[i]}${MAIN_HUB_QUALIFYING_ROW}`, value);
+  });
+
+  // --- Group counts O4..R4 ------------------------------------------------
+  // TT has no groups (always 0); BM/MR/GP use their distinct group counts.
+  const groupsByColumn = [
+    0,
+    distinctGroupCount(data.bmQualifications),
+    distinctGroupCount(data.mrQualifications),
+    distinctGroupCount(data.gpQualifications),
+  ];
+  groupsByColumn.forEach((value, i) => {
+    builder.setNumber(`${MAIN_HUB_COUNT_COLUMNS[i]}${MAIN_HUB_GROUPS_ROW}`, value);
+  });
+
+  return builder.build();
+}
+
+// Local alias keeps the public signature readable without re-importing the type
+// name everywhere. CdmCellWrite[] is the contract consumed by the XML patcher.
+type CdmCellWrites = import("../types").CdmCellWrite[];

--- a/smkc-score-app/src/lib/cdm-export/fill/qualifications.ts
+++ b/smkc-score-app/src/lib/cdm-export/fill/qualifications.ts
@@ -1,0 +1,254 @@
+/**
+ * BM/MR/GP Qualifications fill map — per-player match blocks.
+ *
+ * Layout verified against /tmp/cdm-analysis/sheet2025/sheet_{BM,MR,GP}_Qualifications.txt:
+ *
+ *   Block i (0-based) data rows QUAL_BLOCK_FIRST_DATA_ROW + i*QUAL_BLOCK_STRIDE,
+ *   for QUAL_BLOCK_DATA_ROWS rows. Block 0 = rows 2..16; row 17 is a repeated
+ *   header ('Match','TV #','Player','Name','Score','Name','Player') and MUST NOT
+ *   be written or cleared. Block 1 = rows 18..32, … up to 48 blocks (last data
+ *   row 768). The owner column V is constant down a block (V2..V16 = 'Drew').
+ *
+ *   Block i is owned by computeSheetPlayerOrder(quals)[i] — the sheet's G2#
+ *   spill order (group A by app seeding asc, then B, C, D). Each qualification
+ *   match appears once in EACH of its two players' blocks, written from that
+ *   owner's perspective.
+ *
+ *   Per row (owner perspective), the INPUT cells are:
+ *     S  matchNumber
+ *     T  tvNumber                     (null -> clear)
+ *     U  owner side                   (owner is p1 -> player1Side??1, else player2Side??2)
+ *     V  owner nickname
+ *     W  owner score                  (BM/MR: score1/score2; GP: points1/points2)
+ *     Z  opponent nickname            (BREAK_PLAYER_ID -> 'Break')
+ *     AA opponent side
+ *     Y  GP ONLY: opponent points     (BM/MR keep the template formula =4-W)
+ *     AB..AE  MR ONLY: assignedCourses[0..3]   /   AB GP ONLY: cup name
+ *
+ *   Never touched: X (literal '-'), the BM/MR Y formula, the W/T/L formula
+ *   columns (BM AB/AC/AD, MR AF/AG/AH, GP AC/AD/AE), the standings block E..Q,
+ *   and everything from AF onward (sorted-rank / out-order spills). Writing
+ *   there is exactly what produced the old exporter's #SPILL! corruption.
+ *
+ * Incomplete matches clear the score cell(s) (never write a bogus 0); the
+ * template formulas treat blank scores as "not played yet". Unused rows within
+ * an owned block and every cell of an unused block are cleared so a re-used
+ * template never keeps stale data.
+ */
+
+import { createLogger } from "@/lib/logger";
+import { BREAK_PLAYER_ID } from "@/lib/round-robin";
+import {
+  CDM_QUALIFICATION_SHEETS,
+  QUAL_BLOCK_FIRST_DATA_ROW,
+  QUAL_BLOCK_STRIDE,
+  QUAL_BLOCK_DATA_ROWS,
+  QUAL_BLOCK_MAX_BLOCKS,
+  QUAL_MATCH_COLUMNS,
+  toColumnLetters,
+} from "../cdm-constants";
+import type {
+  CdmCellWrite,
+  CdmMatch,
+  CdmModeQualification,
+  CdmPlayer,
+  CdmTournamentData,
+  CdmVersusMode,
+} from "../types";
+import { SheetWriteBuilder, computeSheetPlayerOrder } from "./sheet-player-order";
+
+const logger = createLogger("cdm-export");
+
+const COLS = QUAL_MATCH_COLUMNS;
+
+/** MR course columns AB..AE (4 assigned courses), derived from AB. */
+const MR_COURSE_COLUMNS = (() => {
+  const first = columnNumber(COLS.extraFirstColumn); // AB
+  return [0, 1, 2, 3].map((d) => toColumnLetters(first + d)); // AB, AC, AD, AE
+})();
+
+/** 1-based column number for an A1 column-letters string (inverse of toColumnLetters). */
+function columnNumber(letters: string): number {
+  let n = 0;
+  for (const ch of letters) n = n * 26 + (ch.charCodeAt(0) - 64);
+  return n;
+}
+
+/** First data row of block i (0-based). */
+function blockFirstRow(i: number): number {
+  return QUAL_BLOCK_FIRST_DATA_ROW + i * QUAL_BLOCK_STRIDE;
+}
+
+/**
+ * Read MR assignedCourses (typed `unknown`) as a string[]. Returns an empty
+ * array when absent/!array; non-string entries become null slots downstream.
+ */
+function readAssignedCourses(value: unknown): (string | null)[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((v) => (typeof v === "string" ? v : null));
+}
+
+/** Pick the per-mode qualifications and matches off the tournament data. */
+function selectMode(
+  data: CdmTournamentData,
+  mode: CdmVersusMode,
+): { quals: CdmModeQualification[]; matches: CdmMatch[] } {
+  switch (mode) {
+    case "bm":
+      return { quals: data.bmQualifications, matches: data.bmMatches };
+    case "mr":
+      return { quals: data.mrQualifications, matches: data.mrMatches };
+    case "gp":
+      return { quals: data.gpQualifications, matches: data.gpMatches };
+  }
+}
+
+/**
+ * Owner score for a match, from the owner's side. BM/MR use the round-win
+ * scores (score1/score2); GP uses driver points (points1/points2). Returns
+ * null when the field is absent so the caller clears the cell.
+ */
+function ownerScore(match: CdmMatch, ownerIsP1: boolean, mode: CdmVersusMode): number | null {
+  if (mode === "gp") {
+    const v = ownerIsP1 ? match.points1 : match.points2;
+    return v ?? null;
+  }
+  const v = ownerIsP1 ? match.score1 : match.score2;
+  return v ?? null;
+}
+
+/** Opponent score (GP only writes this column). */
+function opponentScore(match: CdmMatch, ownerIsP1: boolean): number | null {
+  // From the owner's perspective the opponent is the other player.
+  const v = ownerIsP1 ? match.points2 : match.points1;
+  return v ?? null;
+}
+
+/** A match listed under one owner, with the owner/opponent already resolved. */
+interface OwnerView {
+  match: CdmMatch;
+  ownerIsP1: boolean;
+  opponent: CdmPlayer;
+}
+
+/**
+ * All qualification matches an owner plays, from the owner's perspective,
+ * ordered by roundNumber then matchNumber ascending (the sheet lists a player's
+ * matches top-to-bottom in schedule order). BREAK matches store the real player
+ * as player1, so they only surface in the real player's block.
+ */
+function ownerMatches(matches: CdmMatch[], ownerId: string): OwnerView[] {
+  const views: OwnerView[] = [];
+  for (const match of matches) {
+    if (match.stage !== "qualification") continue;
+    if (match.player1.id === ownerId) {
+      views.push({ match, ownerIsP1: true, opponent: match.player2 });
+    } else if (match.player2.id === ownerId) {
+      views.push({ match, ownerIsP1: false, opponent: match.player1 });
+    }
+  }
+  views.sort((a, b) => {
+    const ra = a.match.roundNumber ?? 0;
+    const rb = b.match.roundNumber ?? 0;
+    if (ra !== rb) return ra - rb;
+    return a.match.matchNumber - b.match.matchNumber;
+  });
+  return views;
+}
+
+export function buildQualificationWrites(
+  data: CdmTournamentData,
+  mode: CdmVersusMode,
+): CdmCellWrite[] {
+  const sheet = CDM_QUALIFICATION_SHEETS[mode];
+  const builder = new SheetWriteBuilder(sheet);
+  const { quals, matches } = selectMode(data, mode);
+
+  const owners = computeSheetPlayerOrder(quals); // block i owner = owners[i]
+
+  /**
+   * Clear every input cell of one data row. Includes the mode-specific extras
+   * (GP: opponent points Y + cup AB; MR: courses AB..AE) so a re-used template
+   * never keeps stale values in a now-unused row/block. X / Y(BM,MR) / W-T-L
+   * formula columns are deliberately excluded — they are never inputs.
+   */
+  const clearRow = (row: number) => {
+    builder.clear(`${COLS.matchNumber}${row}`);
+    builder.clear(`${COLS.tvNumber}${row}`);
+    builder.clear(`${COLS.ownerSide}${row}`);
+    builder.clear(`${COLS.ownerNickname}${row}`);
+    builder.clear(`${COLS.ownerScore}${row}`);
+    builder.clear(`${COLS.opponentNickname}${row}`);
+    builder.clear(`${COLS.opponentSide}${row}`);
+    if (mode === "gp") {
+      builder.clear(`${COLS.opponentScore}${row}`); // Y opponent points
+      builder.clear(`${COLS.extraFirstColumn}${row}`); // AB cup
+    } else if (mode === "mr") {
+      for (const col of MR_COURSE_COLUMNS) builder.clear(`${col}${row}`); // AB..AE
+    }
+  };
+
+  /** Write one owner-perspective match into a data row. */
+  const writeRow = (row: number, view: OwnerView) => {
+    const { match, ownerIsP1, opponent } = view;
+    const owner = ownerIsP1 ? match.player1 : match.player2;
+
+    builder.setNumber(`${COLS.matchNumber}${row}`, match.matchNumber);
+    builder.setNumberOrClear(`${COLS.tvNumber}${row}`, match.tvNumber ?? null);
+    // Side defaults mirror the schema (player1Side default 1, player2Side 2).
+    const ownerSide = ownerIsP1 ? (match.player1Side ?? 1) : (match.player2Side ?? 2);
+    const oppSide = ownerIsP1 ? (match.player2Side ?? 2) : (match.player1Side ?? 1);
+    builder.setNumber(`${COLS.ownerSide}${row}`, ownerSide);
+    builder.setString(`${COLS.ownerNickname}${row}`, owner.nickname);
+    // Score is cleared while pending so a blank (not 0) feeds the template.
+    builder.setNumberOrClear(
+      `${COLS.ownerScore}${row}`,
+      match.completed ? ownerScore(match, ownerIsP1, mode) : null,
+    );
+    // BREAK opponents render as the literal 'Break' the sheet expects.
+    const opponentNickname = opponent.id === BREAK_PLAYER_ID ? "Break" : opponent.nickname;
+    builder.setString(`${COLS.opponentNickname}${row}`, opponentNickname);
+    builder.setNumber(`${COLS.opponentSide}${row}`, oppSide);
+
+    if (mode === "gp") {
+      // GP Y is a real input (opponent driver points); cleared while pending.
+      builder.setNumberOrClear(
+        `${COLS.opponentScore}${row}`,
+        match.completed ? opponentScore(match, ownerIsP1) : null,
+      );
+      // AB = cup name (null -> clear).
+      builder.setStringOrClear(`${COLS.extraFirstColumn}${row}`, match.cup ?? null);
+    } else if (mode === "mr") {
+      // AB..AE = the four assigned battle courses; missing slots clear.
+      const courses = readAssignedCourses(match.assignedCourses);
+      MR_COURSE_COLUMNS.forEach((col, idx) => {
+        builder.setStringOrClear(`${col}${row}`, courses[idx] ?? null);
+      });
+    }
+  };
+
+  // --- Fill / clear every block (always all 48 so stale data can't survive) -
+  for (let block = 0; block < QUAL_BLOCK_MAX_BLOCKS; block++) {
+    const firstRow = blockFirstRow(block);
+    const owner = owners[block];
+    const views = owner ? ownerMatches(matches, owner.player.id) : [];
+
+    if (views.length > QUAL_BLOCK_DATA_ROWS) {
+      logger.warn("qualification matches exceed block capacity; truncating", {
+        sheet,
+        owner: owner?.player.nickname,
+        total: views.length,
+        kept: QUAL_BLOCK_DATA_ROWS,
+      });
+    }
+
+    for (let r = 0; r < QUAL_BLOCK_DATA_ROWS; r++) {
+      const row = firstRow + r; // header row 17/33/… is never in this range
+      const view = views[r];
+      if (view) writeRow(row, view);
+      else clearRow(row);
+    }
+  }
+
+  return builder.build();
+}

--- a/smkc-score-app/src/lib/cdm-export/fill/sheet-player-order.ts
+++ b/smkc-score-app/src/lib/cdm-export/fill/sheet-player-order.ts
@@ -1,0 +1,183 @@
+/**
+ * CDM qualification sheet — player ordering helpers (shared by BM/MR/GP).
+ *
+ * The CDM template derives, for every versus mode, two ordered views of the
+ * qualifiers entirely from Main Hub's synthesized "Order" column:
+ *
+ *   F2 = VSTACK(
+ *          IF(P4>0, SEQUENCE(P2/P4, 1, 1, P4), ""),   // group A: Orders 1, 1+G, 1+2G…
+ *          IF(P4>1, SEQUENCE(P2/P4, 1, 2, P4), ""),   // group B: Orders 2, 2+G, …
+ *          IF(P4>2, SEQUENCE(P2/P4, 1, 3, P4), ""),   // group C
+ *          IF(P4>3, SEQUENCE(P2/P4, 1, 4, P4), ""))   // group D
+ *   G2 = XLOOKUP(F2, Order, Nickname)                 // the G2# spill order
+ *
+ * (Verified against /tmp/cdm-analysis/sheet2025/sheet_BM_Qualifications.txt,
+ * cells E2/F2/G2; P2 = group size * groups, P4 = group count G.)
+ *
+ * Because that listing emits group A in full, then group B in full, etc., and
+ * because within a group the SEQUENCE step is `+G` (so it walks the group's
+ * members in their Order-ascending sequence), the spill order — and therefore
+ * the per-player match-block order on the sheet — is simply:
+ *
+ *     group label ascending, then app seeding ascending within the group.
+ *
+ * To make the sheet re-derive the *app's* groups (its serpentine assignment,
+ * not the template's interleave), we synthesize each player's Main Hub Order as
+ * `Order = groupIndex + 1 + k*G` for the k-th (0-based, seeding-ascending)
+ * player of that group. See docs/cdm-export-design.md §3.1.1.
+ */
+
+import type { CdmCellWrite, CdmSheetName } from "../types";
+import type { CdmModeQualification } from "../types";
+
+/** Group labels in the order the template lists them (A, B, C, D). */
+const GROUP_LABELS = ["A", "B", "C", "D"] as const;
+
+/**
+ * Accumulates cell writes for one sheet, keyed by A1 ref so that a later write
+ * to the same cell overwrites the earlier one (last-wins) instead of emitting a
+ * duplicate. This lets a fill map "clear then conditionally overwrite" a cell
+ * without producing two ops for it — the downstream XML patcher applies the
+ * array in order, and we keep that array one-op-per-cell.
+ *
+ * Insertion order is preserved (Map iteration order) so the emitted array stays
+ * deterministic and reviewable.
+ */
+export class SheetWriteBuilder {
+  private readonly ops = new Map<string, CdmCellWrite>();
+
+  constructor(private readonly sheet: CdmSheetName) {}
+
+  /** Set an inline string value (cell must not be a formula in the template). */
+  setString(ref: string, value: string): void {
+    this.ops.set(ref, { sheet: this.sheet, ref, op: "inlineString", value });
+  }
+
+  /** Set a numeric value (cell must not be a formula in the template). */
+  setNumber(ref: string, value: number): void {
+    this.ops.set(ref, { sheet: this.sheet, ref, op: "number", value });
+  }
+
+  /** Drop the cached value but keep the cell, its style and any formula. */
+  clear(ref: string): void {
+    this.ops.set(ref, { sheet: this.sheet, ref, op: "clearValue" });
+  }
+
+  /**
+   * Write either a number or, when the value is null/undefined, clear the cell.
+   * Centralises the "absent input becomes a blank, never a bogus 0" rule that
+   * every CDM input column relies on (0 would rank as fastest time / a real
+   * score). Returns nothing; mutates the builder.
+   */
+  setNumberOrClear(ref: string, value: number | null | undefined): void {
+    if (value == null) this.clear(ref);
+    else this.setNumber(ref, value);
+  }
+
+  /** As {@link setNumberOrClear} but for inline strings. */
+  setStringOrClear(ref: string, value: string | null | undefined): void {
+    if (value == null || value === "") this.clear(ref);
+    else this.setString(ref, value);
+  }
+
+  /** Materialise the accumulated ops as a flat array (one per cell). */
+  build(): CdmCellWrite[] {
+    return [...this.ops.values()];
+  }
+}
+
+/**
+ * Excel SORT / SORTBY ascending comparison: case-insensitive, with a stable
+ * tie-break on the raw UTF-16 code units so equal-ignoring-case strings keep a
+ * deterministic order. The TT Qualifications sheet sorts nicknames with
+ * `SORT(FILTER(...))`, which is case-insensitive and stable; reproducing that
+ * here lets us place each player on the correct row. Non-ASCII collation may
+ * differ from Excel's locale-aware compare — a documented known limitation.
+ */
+export function excelCaseInsensitiveCompare(a: string, b: string): number {
+  const la = a.toLowerCase();
+  const lb = b.toLowerCase();
+  if (la < lb) return -1;
+  if (la > lb) return 1;
+  // Case-insensitively equal: stabilise on the original code units so the
+  // ordering is deterministic regardless of the engine's sort stability.
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+/**
+ * Group a mode's qualifications by their group label and, within each group,
+ * order them by app seeding ascending (null seeds last, in stable input order).
+ *
+ * The result is the canonical "sheet order": iterating groups A→B→C→D and, in
+ * each, seeding-ascending. Both {@link computeSheetPlayerOrder} and
+ * {@link synthesizeModeOrders} are built on this single ordering so the block
+ * placement and the synthesized Main Hub Order can never disagree.
+ */
+function groupedSeededOrder(quals: CdmModeQualification[]): CdmModeQualification[][] {
+  // Collect the distinct groups that actually appear, in canonical A→D order.
+  // Unknown labels (defensive) are appended after the known ones, sorted, so
+  // the function never silently drops a player.
+  const present = new Set(quals.map((q) => q.group));
+  const knownGroups = GROUP_LABELS.filter((g) => present.has(g));
+  const extraGroups = [...present]
+    .filter((g) => !GROUP_LABELS.includes(g as (typeof GROUP_LABELS)[number]))
+    .sort(excelCaseInsensitiveCompare);
+  const orderedGroups = [...knownGroups, ...extraGroups];
+
+  return orderedGroups.map((group) => {
+    // Preserve input order for the stable null-seed tail by remembering the
+    // original index; sort seeded players ascending and keep nulls after them.
+    const members = quals
+      .map((q, index) => ({ q, index }))
+      .filter((entry) => entry.q.group === group);
+    members.sort((x, y) => {
+      const sx = x.q.seeding;
+      const sy = y.q.seeding;
+      if (sx == null && sy == null) return x.index - y.index; // both null: stable
+      if (sx == null) return 1; // nulls sort last
+      if (sy == null) return -1;
+      if (sx !== sy) return sx - sy; // seeding ascending
+      return x.index - y.index; // equal seeding: stable input order
+    });
+    return members.map((entry) => entry.q);
+  });
+}
+
+/**
+ * Reproduce the sheet's G2# spill order: group A players (app seeding
+ * ascending), then group B, then C, then D. Block i on the qualification sheet
+ * is owned by `computeSheetPlayerOrder(quals)[i]`.
+ */
+export function computeSheetPlayerOrder(
+  quals: CdmModeQualification[],
+): CdmModeQualification[] {
+  return groupedSeededOrder(quals).flat();
+}
+
+/**
+ * Synthesize each player's Main Hub Order so the sheet's interleave re-derives
+ * the app's groups. For the k-th (0-based) player of group g (group index gi),
+ * `Order = gi + 1 + k*G` where G is the distinct group count.
+ *
+ * Returns a Map keyed by playerId. Players appear exactly once (one
+ * qualification per player per mode is guaranteed by the unique DB constraint).
+ */
+export function synthesizeModeOrders(
+  quals: CdmModeQualification[],
+): Map<string, number> {
+  const groups = groupedSeededOrder(quals);
+  const groupCount = groups.length; // G
+  const orders = new Map<string, number>();
+
+  groups.forEach((members, groupIndex) => {
+    members.forEach((member, k) => {
+      // gi + 1 + k*G — interleaved so XLOOKUP(SEQUENCE(...,gi+1,G)) recovers
+      // exactly this group's members in this order.
+      orders.set(member.player.id, groupIndex + 1 + k * groupCount);
+    });
+  });
+
+  return orders;
+}

--- a/smkc-score-app/src/lib/cdm-export/fill/tt-finals.ts
+++ b/smkc-score-app/src/lib/cdm-export/fill/tt-finals.ts
@@ -1,0 +1,221 @@
+/**
+ * CDM "TT Finals" fill map (pure function: app data → CdmCellWrite[]).
+ *
+ * The TT Finals sheet is a 24-row life ledger spanning up to 40 round blocks
+ * (TT_FINALS_MAX_ROUNDS). Standings, the per-round name ordering and the
+ * running "Left" (lives remaining) column are Excel dynamic-array formulas; the
+ * workbook accepts only three human inputs per round block — the per-player
+ * Gain, the per-player Time and the per-player Lost flag — plus the round-1
+ * initial "Left" column and the per-round display header. See
+ * docs/cdm-export-design.md §3.5 and cdm-constants.ts for the verified
+ * geometry, and tt-lives-replay.ts for how each round's inputs are reconstructed
+ * from the TA-finals engine state.
+ *
+ * Column geometry (verified against /tmp/cdm-analysis/sheet2025/sheet_TT_Finals.txt):
+ *   round r (1-based) input block first column  = 1 + 13*(r-1)  (A, N, AA, …)
+ *   round r display block first column          = 7 + 13*(r-1)  (G, T, AG, …)
+ *   input block:  +0 #(formula) +1 Name(formula) +2 Left +3 Gain +4 Time
+ *   display block: +0 #(f) +1 Name(f) +2 Flag(f) +3 Time(f) +4 Lost +5 Left(f)
+ *   • Left (+2) is a human input ONLY in round 1 (template C3..C26 = 1). From
+ *     round 2 it is the spill formula `=SORT(...)` (dump P3 etc.) and MUST NOT
+ *     be written — doing so would corrupt the ledger's life carry.
+ *   • The display block's row-1 header cell holds the typed string
+ *     `Round {r} - {course full name}`.
+ *   • The final standings block TA..TD is pure formulas (Overall Ranking reads
+ *     its TT Bonus from there) and is never written.
+ *
+ * Clearing contract: the template ships with CDM 2025's real data in these
+ * input cells (e.g. C3..C26=1, E19..E26=times, K26=1). Every input cell we do
+ * not set for a given round must therefore be CLEARED, and every round block
+ * the current tournament does not use must be cleared wholesale — otherwise the
+ * exported workbook would show last year's finals. We emit clears first and let
+ * the SheetWriteBuilder's last-wins Map collapse a "clear then set" into the
+ * single set op (so the output array stays one op per cell, matching the
+ * one-op-per-ref invariant the patcher and tests rely on).
+ */
+
+import {
+  TT_FINALS_MAX_ROUNDS,
+  TT_FINALS_ROUND_STRIDE,
+  TT_FINALS_INPUT_FIRST_COLUMN,
+  TT_FINALS_DISPLAY_FIRST_COLUMN,
+  TT_FINALS_FIRST_DATA_ROW,
+  TT_FINALS_MAX_FINALISTS,
+  TT_FINALS_INPUT_LEFT_OFFSET,
+  TT_FINALS_INPUT_GAIN_OFFSET,
+  TT_FINALS_INPUT_TIME_OFFSET,
+  TT_FINALS_DISPLAY_LOST_OFFSET,
+  CDM_COURSE_NAMES,
+  toColumnLetters,
+} from "../cdm-constants";
+import { msToCdmTime } from "../time-format";
+import type { CdmCellWrite, CdmTournamentData } from "../types";
+import { SheetWriteBuilder } from "./sheet-player-order";
+import { replayTTFinals, type TTFinalsReplayRound } from "./tt-lives-replay";
+
+const SHEET = "TT Finals" as const;
+
+/** Last data row of a block (inclusive): 24 finalists → rows 3..26. */
+const LAST_DATA_ROW = TT_FINALS_FIRST_DATA_ROW + TT_FINALS_MAX_FINALISTS - 1;
+
+/**
+ * The 1-based column numbers of one round block's input cells and the display
+ * "Lost" cell. Computed from the verified stride so r=1 → C/D/E + K, r=2 →
+ * P/Q/R + X, … (see cdm-constants.ts and the dump).
+ */
+interface BlockColumns {
+  /** Input "Left" column (typed only in round 1). */
+  left: number;
+  /** Input "Gain" column. */
+  gain: number;
+  /** Input "Time" column. */
+  time: number;
+  /** Display "Lost" column. */
+  lost: number;
+  /** Display block first column — its row-1 cell is the header string. */
+  displayFirst: number;
+}
+
+function blockColumns(round: number): BlockColumns {
+  const inputFirst =
+    TT_FINALS_INPUT_FIRST_COLUMN + (round - 1) * TT_FINALS_ROUND_STRIDE;
+  const displayFirst =
+    TT_FINALS_DISPLAY_FIRST_COLUMN + (round - 1) * TT_FINALS_ROUND_STRIDE;
+  return {
+    left: inputFirst + TT_FINALS_INPUT_LEFT_OFFSET,
+    gain: inputFirst + TT_FINALS_INPUT_GAIN_OFFSET,
+    time: inputFirst + TT_FINALS_INPUT_TIME_OFFSET,
+    lost: displayFirst + TT_FINALS_DISPLAY_LOST_OFFSET,
+    displayFirst,
+  };
+}
+
+/** A1 ref for (1-based column, 1-based row). */
+function ref(column: number, row: number): string {
+  return `${toColumnLetters(column)}${row}`;
+}
+
+/**
+ * Clear all human-input cells of a round block: Gain and Time for every round,
+ * the display Lost flag, and (only in round 1) the initial Left column. The
+ * display header is cleared too. From round 2 the Left column is a spill formula
+ * and is deliberately left untouched.
+ */
+function clearBlockInputs(builder: SheetWriteBuilder, round: number): void {
+  const cols = blockColumns(round);
+  // Header (display block row 1): a typed string in the template.
+  builder.clear(ref(cols.displayFirst, 1));
+  for (let row = TT_FINALS_FIRST_DATA_ROW; row <= LAST_DATA_ROW; row++) {
+    if (round === 1) {
+      // Left is a human input only in round 1 (initial lives). For r>=2 it is a
+      // formula; never clear it.
+      builder.clear(ref(cols.left, row));
+    }
+    builder.clear(ref(cols.gain, row));
+    builder.clear(ref(cols.time, row));
+    builder.clear(ref(cols.lost, row));
+  }
+}
+
+/**
+ * Write one reconstructed round into its block. Caller has already cleared the
+ * block (clear-then-set collapses to a single op per cell via the builder).
+ *
+ * @param round   the 1-based sheet round number (== array index + 1)
+ * @param replay  the reconstructed round from replayTTFinals
+ */
+function writeRound(
+  builder: SheetWriteBuilder,
+  round: number,
+  replay: TTFinalsReplayRound,
+): void {
+  const cols = blockColumns(round);
+
+  // --- Header: "Round {r} - {course full name}" -----------------------------
+  const courseName = CDM_COURSE_NAMES[replay.course] ?? replay.course;
+  builder.setString(ref(cols.displayFirst, 1), `Round ${round} - ${courseName}`);
+
+  // --- Input rows: map each player to its physical row via inputRowOrder. ----
+  // inputRowOrder lists players top→bottom for this round's input block. Row of
+  // the k-th player = TT_FINALS_FIRST_DATA_ROW + k. Any player beyond
+  // TT_FINALS_MAX_FINALISTS cannot be placed (the block only has 24 rows); the
+  // universe is capped at 24 upstream so this is defensive.
+  const inputOrder = replay.inputRowOrder.slice(0, TT_FINALS_MAX_FINALISTS);
+  inputOrder.forEach((playerId, index) => {
+    const row = TT_FINALS_FIRST_DATA_ROW + index;
+
+    // Round 1 only: seed the initial life ledger with 1 for every universe row
+    // (template C3..C26 = 1). From round 2 the Left cell is a formula and was
+    // intentionally not cleared above, so we never touch it here either.
+    if (round === 1) {
+      builder.setNumber(ref(cols.left, row), 1);
+    }
+
+    // Gain: bonus lives granted this round (phase-3 entry top-up / reset). Rows
+    // without a grant keep the cleared blank — a blank Gain reads as 0 in the
+    // ledger formula `Left = inputLeft + Gain - Lost`.
+    const gain = replay.gains.get(playerId);
+    if (gain !== undefined && gain !== 0) {
+      builder.setNumber(ref(cols.gain, row), gain);
+    }
+
+    // Time: a runner writes its MSSCC-encoded time; a universe player who sat
+    // the round out writes 0 (the template uses 0 to mean "did not run", which
+    // also sorts that row to the top of the display block). A runner with a
+    // null time (should not occur for stored results — submitRoundResults
+    // requires a numeric time, retries become RETRY_PENALTY_MS) is treated as
+    // a non-runner 0, matching how the replay sorts a null time.
+    if (replay.participants.has(playerId)) {
+      const timeMs = replay.participants.get(playerId) ?? null;
+      if (timeMs === null) {
+        builder.setNumber(ref(cols.time, row), 0);
+      } else {
+        builder.setNumber(ref(cols.time, row), msToCdmTime(timeMs));
+      }
+    } else {
+      builder.setNumber(ref(cols.time, row), 0);
+    }
+  });
+
+  // --- Display rows: Lost flag on the loser's SORTED display row. ------------
+  // displayRowOrder lists players top→bottom in the display block (sorted by
+  // Time ASC). Lost=1 marks every player that lost a life this round. By
+  // construction lostLife ⊆ participants ⊆ displayRowOrder (the replay builds
+  // lostLife only from universe participants and displayRowOrder is a
+  // permutation of the universe input order), so every loser has a row.
+  const displayOrder = replay.displayRowOrder.slice(0, TT_FINALS_MAX_FINALISTS);
+  displayOrder.forEach((playerId, index) => {
+    if (replay.lostLife.has(playerId)) {
+      const row = TT_FINALS_FIRST_DATA_ROW + index;
+      builder.setNumber(ref(cols.lost, row), 1);
+    }
+  });
+}
+
+/**
+ * Build the "TT Finals" fill map.
+ *
+ * With no TT-finals data every round block's input cells are cleared so the
+ * template's leftover CDM 2025 inputs do not surface in the export. With data,
+ * the reconstructed rounds (replayTTFinals) are written into their blocks and
+ * any trailing unused blocks are cleared.
+ */
+export function buildTTFinalsWrites(data: CdmTournamentData): CdmCellWrite[] {
+  const builder = new SheetWriteBuilder(SHEET);
+
+  const rounds = replayTTFinals(data);
+
+  for (let round = 1; round <= TT_FINALS_MAX_ROUNDS; round++) {
+    // Always clear the block first so unused input cells (and any unused
+    // trailing round) drop their leftover template values. For used rounds the
+    // subsequent writes overwrite the clears via the builder's last-wins Map.
+    clearBlockInputs(builder, round);
+
+    const replay = rounds[round - 1];
+    if (replay) {
+      writeRound(builder, round, replay);
+    }
+  }
+
+  return builder.build();
+}

--- a/smkc-score-app/src/lib/cdm-export/fill/tt-lives-replay.ts
+++ b/smkc-score-app/src/lib/cdm-export/fill/tt-lives-replay.ts
@@ -1,0 +1,446 @@
+/**
+ * TT Finals — life "replay" (pure function).
+ *
+ * The CDM 2025 "TT Finals" sheet is a single 24-row life ledger spanning up to
+ * 40 round blocks. Standings, the per-round name ordering and the running
+ * "Left" (lives remaining) column are all Excel formulas; the workbook only
+ * accepts three human inputs per round block: the per-player Gain, the
+ * per-player Time, and the per-player Lost flag (see docs/cdm-export-design.md
+ * §3.5 and cdm-constants.ts). To produce those inputs we must reconstruct, for
+ * every sheet round, who ran, who lost a life, and how many bonus lives were
+ * granted — exactly as the TA finals engine would have.
+ *
+ * The authoritative rules live in src/lib/ta/finals-phase-manager.ts; this
+ * module derives its behaviour from that code (cited inline), NOT from prose:
+ *
+ * - Phase 1 (PHASE_CONFIG.phase1, lines 47-54) and Phase 2 (lines 55-62):
+ *   `hasLives:false`, entries stored with `lives:0`. processEliminationPhaseResult
+ *   (lines 580-651) eliminates exactly the single slowest runner each round
+ *   until `survivorsNeeded` (4) remain. In the CDM ledger these players are
+ *   modelled as holding ONE life: the eliminated runner loses it (Lost=1,
+ *   ending Left=0), every survivor keeps Left=1. No Gain is ever granted.
+ *
+ * - Phase 3 (PHASE_CONFIG.phase3, lines 63-72): `initialLives:3`,
+ *   `lifeResetThresholds:[8,4,2]`. processPhase3Result (lines 669-830): the
+ *   bottom half of the round's runners — `sorted.slice(Math.ceil(n/2))` by
+ *   time ascending (lines 698-705) — EACH lose one life (lines 718-742,
+ *   `lives = max(0, lives-1)` is written for every bottom-half player, not only
+ *   the eliminated ones). A life reset to 3 happens AFTER the round when an
+ *   elimination occurred and the surviving count hits 8/4/2 (lines 786-802).
+ *
+ * The CDM ledger detail that makes Gain computable: round r+1's input "Left"
+ * formula equals round r's display "Left", and a row's display Left equals
+ * `inputLeft + Gain - Lost`. So we simulate `leftCarried` forward and emit Gain
+ * only where the engine injects bonus lives:
+ *   - Phase-3 ENTRY round: every phase-3 entrant is brought from its carried
+ *     Left (always 1 — see below) up to the initial 3 lives BEFORE that round's
+ *     loss is applied. Gain = initialLives - leftCarried (= 2). The round's own
+ *     loss then lands on top (display Left = 3 - Lost). This reproduces the
+ *     verified template fact `DD3..DD18 = 2` at round 9 of CDM 2025.
+ *   - Life-RESET round: the reset forces every survivor back to 3 AFTER the
+ *     round's loss, so display Left must equal 3. With display = inputLeft +
+ *     Gain - Lost we need Gain = initialLives - inputLeft + Lost for survivors.
+ *
+ * Universe: the 24 round-1 rows are qualification ranks 1..24 (the sheet's
+ * B3 = OFFSET('TT Qualifications'!CN2,0,0,'Main Hub'!O3) spills the qualifying
+ * order). Every finalist therefore owns a row from round 1; players who have
+ * not entered a phase yet simply sit out (Time=0) with Left=1, which is why the
+ * phase-3 entrants all carry Left=1 into round 9.
+ *
+ * This module performs NO database access and is exhaustively unit-tested.
+ */
+
+import type {
+  CdmTournamentData,
+  CdmTTEntry,
+  CdmTTPhaseRound,
+} from "../types";
+import {
+  compareQualificationRankOrder,
+  type EntryWithTotal,
+} from "@/lib/ta/rank-calculation";
+import { createLogger } from "@/lib/logger";
+import { TT_FINALS_MAX_ROUNDS, TT_FINALS_MAX_FINALISTS } from "../cdm-constants";
+
+/** Mirrors PHASE_CONFIG.phase3.initialLives (finals-phase-manager.ts:70). */
+const PHASE3_INITIAL_LIVES = 3;
+// Note: the reset thresholds [8,4,2] (PHASE_CONFIG.phase3.lifeResetThresholds)
+// are intentionally NOT recomputed here. processPhase3Result already collapses
+// "did a reset happen this round" into the persisted round.livesReset flag
+// (finals-phase-manager.ts:786-803), so detectLivesReset reads that flag rather
+// than re-deriving the survivor count — which would also require replaying the
+// elimination cap. Reading the stored flag is both simpler and authoritative.
+
+/** Phase order in which the engine plays rounds, lowest first. */
+const PHASE_SEQUENCE = ["phase1", "phase2", "phase3"] as const;
+type FinalsPhase = (typeof PHASE_SEQUENCE)[number];
+
+/**
+ * One reconstructed sheet round. Field meanings map 1:1 onto the cells the
+ * caller writes (buildTTFinalsWrites): `gains`→Gain column, `participants`→Time
+ * column, `lostLife`→display Lost column, the *RowOrder arrays→which physical
+ * row each player occupies in the input / display blocks.
+ */
+export interface TTFinalsReplayRound {
+  /** Course abbreviation for the round (e.g. "MC1"). */
+  course: string;
+  /**
+   * Runners of this round and their time in ms (null when a runner has no
+   * recorded time yet). Players NOT in this map sat the round out (Time=0).
+   */
+  participants: Map<string, number | null>;
+  /** Players who lost a life this round (Lost=1 on their display row). */
+  lostLife: Set<string>;
+  /** Bonus lives granted this round per player (phase-3 entry / reset top-up). */
+  gains: Map<string, number>;
+  /** Player ids in input-block row order (top → bottom). */
+  inputRowOrder: string[];
+  /** Player ids in display-block row order (top → bottom). */
+  displayRowOrder: string[];
+  /** Lives each player holds AFTER this round (the display "Left" value). */
+  livesAfter: Map<string, number>;
+}
+
+/** A phase round paired with the optional sudden-death rounds that follow it. */
+interface OrderedRound {
+  phase: FinalsPhase;
+  round: CdmTTPhaseRound;
+}
+
+interface ResultRow {
+  playerId: string;
+  timeMs: number | null;
+}
+
+/**
+ * Reconstruct every sheet round from the tournament's TA-finals data.
+ *
+ * Returns the rounds in sheet order (phase1 by roundNumber, then phase2, then
+ * phase3). At most TT_FINALS_MAX_ROUNDS rounds are returned; any excess is
+ * dropped with a warning so the writer never addresses a non-existent block.
+ */
+export function replayTTFinals(data: CdmTournamentData): TTFinalsReplayRound[] {
+  const logger = createLogger("cdm-tt-finals-replay");
+
+  // ---- 1. Build the 24-player universe from the qualification ranking. ----
+  // The sheet's round-1 rows are qualification ranks 1..24 in finishing order.
+  // We honour the persisted `rank` when present (it is the canonical TT final
+  // rank) and fall back to the documented comparator (qualificationPoints DESC,
+  // totalTime ASC) for any ties / missing ranks so the ordering is total.
+  const qualEntries = data.ttEntries.filter((e) => e.stage === "qualification");
+  const universe = orderQualificationUniverse(qualEntries).slice(
+    0,
+    TT_FINALS_MAX_FINALISTS,
+  );
+  const universeIds = universe.map((e) => e.playerId);
+  const universeSet = new Set(universeIds);
+
+  // ---- 2. Order the phase rounds the way the engine played them. ----
+  const orderedRounds = orderPhaseRounds(data.ttPhaseRounds);
+
+  // ---- 3. Carry life ledger forward, one round at a time. ----
+  // Every universe row starts round 1 with one life (template C3..C26 = 1).
+  const livesCarried = new Map<string, number>(
+    universeIds.map((id) => [id, 1]),
+  );
+  // Tracks which players have already been topped-up to phase-3 initial lives,
+  // so the +2 entry grant is emitted exactly once (on a player's first phase-3
+  // round) regardless of how the rounds are interleaved.
+  const phase3Entered = new Set<string>();
+
+  const rounds: TTFinalsReplayRound[] = [];
+  for (const { phase, round } of orderedRounds) {
+    if (rounds.length >= TT_FINALS_MAX_ROUNDS) {
+      logger.warn(
+        `TT Finals exceeds ${TT_FINALS_MAX_ROUNDS} sheet rounds; dropping ${phase} round ${round.roundNumber} and beyond`,
+      );
+      break;
+    }
+
+    const results = parseRoundResults(round.results);
+    // Participants restricted to the known universe: a result for an unknown id
+    // cannot be placed on the sheet, so it is ignored (and warned) rather than
+    // silently shifting row positions.
+    const participants = new Map<string, number | null>();
+    for (const row of results) {
+      if (!universeSet.has(row.playerId)) {
+        logger.warn(
+          `TT Finals ${phase} round ${round.roundNumber}: result for player ${row.playerId} is outside the 24-player universe; skipping`,
+        );
+        continue;
+      }
+      participants.set(row.playerId, row.timeMs);
+    }
+
+    // --- Gains: phase-3 entry top-up (applied BEFORE this round's loss). ---
+    const gains = new Map<string, number>();
+    if (phase === "phase3") {
+      for (const id of participants.keys()) {
+        if (!phase3Entered.has(id)) {
+          phase3Entered.add(id);
+          const carried = livesCarried.get(id) ?? 1;
+          const grant = PHASE3_INITIAL_LIVES - carried;
+          if (grant !== 0) gains.set(id, grant);
+          // Effective lives going into the loss step is the topped-up value.
+          livesCarried.set(id, carried + grant);
+        }
+      }
+    }
+
+    // --- Who lost a life this round. ---
+    const lostLife = computeLostLife(phase, round, participants, results);
+
+    // --- Detect a life reset for this round (phase-3 only, after the loss). ---
+    const isResetRound = phase === "phase3" && detectLivesReset(round);
+
+    // --- Apply per-row life arithmetic to obtain display "Left". ---
+    const livesAfter = new Map<string, number>();
+    for (const id of universeIds) {
+      const before = livesCarried.get(id) ?? 0;
+      const lost = lostLife.has(id) ? 1 : 0;
+      let after = before - lost;
+      // The engine resets ONLY surviving phase-3 participants
+      // (processPhase3Result, finals-phase-manager.ts:793-802 —
+      // `updateMany where stage:"phase3", eliminated:false`). A universe
+      // bystander that has never entered phase 3 keeps its single carried life
+      // and must NOT be lifted to 3 (doing so would corrupt its display Left and
+      // every subsequent round's SORTBY-ending-lives input order). We mirror the
+      // engine's predicate via phase3Entered (membership == "has a phase-3
+      // entry") and `after > 0` (== not eliminated this round).
+      if (isResetRound && phase3Entered.has(id) && after > 0) {
+        // Surviving players are reset to the initial lives; encode the delta as
+        // additional Gain so display Left (= before + Gain - lost) equals 3.
+        const extra = PHASE3_INITIAL_LIVES - after;
+        if (extra !== 0) {
+          gains.set(id, (gains.get(id) ?? 0) + extra);
+        }
+        after = PHASE3_INITIAL_LIVES;
+      }
+      livesAfter.set(id, after);
+      livesCarried.set(id, after);
+    }
+
+    rounds.push({
+      course: round.course,
+      participants,
+      lostLife,
+      gains,
+      inputRowOrder: [],
+      displayRowOrder: [],
+      livesAfter,
+    });
+  }
+
+  // ---- 4. Compute input/display row orders across the whole sequence. ----
+  // Round 1 input order is the qualification universe; subsequent input orders
+  // depend on the PREVIOUS round's display order + ending lives, so this must
+  // run after every round's livesAfter is known.
+  assignRowOrders(rounds, universeIds);
+
+  return rounds;
+}
+
+/**
+ * Order qualification entries into the 24-row universe. Uses the persisted
+ * `rank` (1-based, canonical) as the primary key; entries lacking a rank are
+ * appended in comparator order. Within a rank tie the comparator
+ * (qualificationPoints DESC, totalTime ASC, id ASC) breaks it deterministically.
+ */
+function orderQualificationUniverse(entries: CdmTTEntry[]): CdmTTEntry[] {
+  return [...entries].sort((a, b) => {
+    const ra = rankOf(a);
+    const rb = rankOf(b);
+    if (ra !== rb) return ra - rb;
+    return compareQualificationRankOrder(toComparable(a), toComparable(b));
+  });
+}
+
+/** Entries without a usable rank sort after ranked ones (sentinel = +∞). */
+function rankOf(entry: CdmTTEntry): number {
+  const raw = (entry as { rank?: number | null }).rank;
+  return typeof raw === "number" && raw > 0 ? raw : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Adapt a CdmTTEntry to the EntryWithTotal shape compareQualificationRankOrder
+ * expects. The comparator only inspects qualificationPoints, totalTime and id
+ * (rank-calculation.ts:57-67); the remaining fields are required by the type but
+ * unused here, so they carry neutral placeholders. We use the player id as the
+ * comparable id so the comparator's final id.localeCompare tie-break is stable
+ * across entries (it matches the qualification ranking's deterministic order).
+ */
+function toComparable(entry: CdmTTEntry): EntryWithTotal {
+  return {
+    id: entry.playerId,
+    totalTime: entry.totalTime ?? null,
+    qualificationPoints: entry.qualificationPoints ?? 0,
+    lives: 0,
+    eliminated: false,
+    stage: entry.stage,
+    courseScores: {},
+  };
+}
+
+/**
+ * Order phase rounds the way the engine plays them: phase1 by roundNumber, then
+ * phase2, then phase3. Unknown phase labels are dropped with a warning.
+ */
+function orderPhaseRounds(phaseRounds: CdmTTPhaseRound[]): OrderedRound[] {
+  const logger = createLogger("cdm-tt-finals-replay");
+  const ordered: OrderedRound[] = [];
+  for (const phase of PHASE_SEQUENCE) {
+    const inPhase = phaseRounds
+      .filter((r) => r.phase === phase)
+      .sort((a, b) => a.roundNumber - b.roundNumber);
+    for (const round of inPhase) {
+      ordered.push({ phase, round });
+    }
+  }
+  const known = new Set<string>(PHASE_SEQUENCE);
+  for (const r of phaseRounds) {
+    if (!known.has(r.phase)) {
+      logger.warn(
+        `TT Finals: ignoring round with unknown phase "${r.phase}"`,
+      );
+    }
+  }
+  return ordered;
+}
+
+/**
+ * Determine which players lost a life this round.
+ *
+ * Phase 1/2: only the eliminated runner loses its single life. We trust the
+ * persisted `eliminatedIds` (the engine's record of the slowest, tie-resolved
+ * loser); when absent (e.g. the survivor floor was already reached and no one
+ * was eliminated) nobody loses a life.
+ *
+ * Phase 3: the entire bottom half of the round's runners loses a life,
+ * replicating processPhase3Result's `sorted.slice(Math.ceil(n/2))` selection by
+ * time ascending. `eliminatedIds` is the engine's capped *elimination* set,
+ * which is a subset of the life-losers, so it cannot be used here.
+ */
+function computeLostLife(
+  phase: FinalsPhase,
+  round: CdmTTPhaseRound,
+  participants: Map<string, number | null>,
+  results: ResultRow[],
+): Set<string> {
+  if (phase === "phase1" || phase === "phase2") {
+    const eliminated = parseStringArray(round.eliminatedIds);
+    return new Set(eliminated.filter((id) => participants.has(id)));
+  }
+
+  // Phase 3: bottom half by ascending time. Only runners present in the
+  // universe participate in the ranking; a runner with no time (null) is
+  // treated as slowest (Number.POSITIVE_INFINITY), matching how a missing time
+  // would sort last and how the retry penalty pushes a runner to the bottom.
+  const runners = results.filter((r) => participants.has(r.playerId));
+  if (runners.length < 2) {
+    // With 0 or 1 runner there is no bottom half to penalise (mirrors the
+    // `activePlayers.length <= 1` early-out in processPhase3Result:688).
+    return new Set();
+  }
+  const sorted = [...runners].sort(
+    (a, b) => timeForSort(a.timeMs) - timeForSort(b.timeMs),
+  );
+  const halfwayPoint = Math.ceil(sorted.length / 2);
+  return new Set(sorted.slice(halfwayPoint).map((r) => r.playerId));
+}
+
+/** Treat a missing time as the slowest possible value for ordering. */
+function timeForSort(timeMs: number | null): number {
+  return timeMs ?? Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Whether this phase-3 round triggered a life reset. We prefer the persisted
+ * `livesReset` flag (the engine's own record). It is the single source of
+ * truth: processPhase3Result only sets it when an elimination actually pushed
+ * the field onto a [8,4,2] threshold (lines 786-802), the exact condition we
+ * must reproduce.
+ */
+function detectLivesReset(round: CdmTTPhaseRound): boolean {
+  return round.livesReset === true;
+}
+
+/**
+ * Fill in inputRowOrder / displayRowOrder for every round.
+ *
+ * - Round 1 input order = qualification universe (rank 1..24).
+ * - Round r≥2 input order = SORTBY(previous display names, previous ending
+ *   lives DESC) with Excel's STABLE semantics: equal lives keep the previous
+ *   display order. We reproduce this by a stable sort keyed on the negated
+ *   ending-lives, applied to the previous round's display order.
+ * - Display order (every round) = SORTBY(input names, this round's Time ASC),
+ *   stable. Non-runners have Time=0, which sorts them to the top ahead of any
+ *   positive recorded time, preserving input order among themselves.
+ */
+function assignRowOrders(
+  rounds: TTFinalsReplayRound[],
+  universeIds: string[],
+): void {
+  for (let i = 0; i < rounds.length; i++) {
+    const round = rounds[i];
+
+    // --- input order ---
+    let inputOrder: string[];
+    if (i === 0) {
+      inputOrder = [...universeIds];
+    } else {
+      const prev = rounds[i - 1];
+      // Stable sort of the previous display order by ending lives DESC.
+      inputOrder = stableSort(prev.displayRowOrder, (id) => {
+        const lives = prev.livesAfter.get(id) ?? 0;
+        return -lives; // higher lives first
+      });
+    }
+    round.inputRowOrder = inputOrder;
+
+    // --- display order: stable sort of input order by this round's Time ASC ---
+    round.displayRowOrder = stableSort(inputOrder, (id) => {
+      const t = round.participants.get(id);
+      // Non-runner (absent from participants) → Time 0 (sheet writes 0).
+      // A runner with a null time is encoded as 0 on the sheet too, so it sorts
+      // with the non-runners; this matches the template (E/R/.. = 0 rows first).
+      return t ?? 0;
+    });
+  }
+}
+
+/**
+ * Stable sort returning a new array. JS Array.prototype.sort is spec-stable
+ * (ES2019+), but we implement an explicit index-tiebreak to make the stability
+ * contract obvious and immune to engine differences in test environments.
+ */
+function stableSort<T>(items: T[], key: (item: T) => number): T[] {
+  return items
+    .map((item, index) => ({ item, index, k: key(item) }))
+    .sort((a, b) => (a.k !== b.k ? a.k - b.k : a.index - b.index))
+    .map((wrapped) => wrapped.item);
+}
+
+/** Parse a TTPhaseRound.results JSON value into typed rows (defensive). */
+function parseRoundResults(raw: unknown): ResultRow[] {
+  if (!Array.isArray(raw)) return [];
+  const rows: ResultRow[] = [];
+  for (const item of raw) {
+    if (item && typeof item === "object" && "playerId" in item) {
+      const playerId = (item as { playerId: unknown }).playerId;
+      const timeMs = (item as { timeMs?: unknown }).timeMs;
+      if (typeof playerId === "string") {
+        rows.push({
+          playerId,
+          timeMs: typeof timeMs === "number" ? timeMs : null,
+        });
+      }
+    }
+  }
+  return rows;
+}
+
+/** Parse a JSON value expected to be a string[] (e.g. eliminatedIds). */
+function parseStringArray(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((x): x is string => typeof x === "string");
+}

--- a/smkc-score-app/src/lib/cdm-export/fill/tt-qualifications.ts
+++ b/smkc-score-app/src/lib/cdm-export/fill/tt-qualifications.ts
@@ -1,0 +1,108 @@
+/**
+ * TT Qualifications fill map — lap-time inputs only.
+ *
+ * The TT Qualifications sheet is fully formula-driven except for the 20
+ * per-course lap-time cells of each finalist. Verified against the template
+ * dump /tmp/cdm-analysis/sheet2025/sheet_TT_Qualifications.txt:
+ *
+ *   Header G1..Z1 = the 20 CDM_COURSES in order (MC1, DP1, … RR).
+ *   A2/B2/C2 = #, FILTER(Registration[Nickname], TT="Yes"), XLOOKUP(... TT Order)
+ *   E2/F2    = #, SORT(ANCHORARRAY(B2))   ← the displayed (sorted) nickname spill
+ *   G2       = 11034, H2 = 13948, …       ← the only inputs (raw MSSCC integers)
+ *   AA2..    = score conversions (formulas)
+ *
+ * F2 is `SORT(FILTER(Registration[Nickname], TT="Yes"))`, so row r (2-based)
+ * holds the player at position (r-2) of the nicknames sorted case-insensitively
+ * ascending. We reproduce that ordering with excelCaseInsensitiveCompare so each
+ * player's times land on the row the sheet will display them on. (Excel SORT is
+ * case-insensitive and stable; non-ASCII collation differences are a documented
+ * known limitation — see docs/cdm-export-design.md §3.2.)
+ *
+ * We write ONLY G..Z (columns 7..26) for the player rows and clear the same
+ * columns on the spare rows so a re-used template never keeps stale times.
+ * E, F and AA.. are formulas and are never touched. A missing/empty course time
+ * is cleared (not written as 0) because 0 would rank as the fastest time and the
+ * sheet treats a blank as "no time".
+ */
+
+import { createLogger } from "@/lib/logger";
+import {
+  CDM_COURSES,
+  TT_QUAL_FIRST_ROW,
+  TT_QUAL_MAX_PLAYERS,
+  TT_QUAL_FIRST_TIME_COLUMN,
+  toColumnLetters,
+} from "../cdm-constants";
+import type { CdmCellWrite, CdmTournamentData, CdmTTEntry } from "../types";
+import { timeStringToCdmTime } from "../time-format";
+import {
+  SheetWriteBuilder,
+  excelCaseInsensitiveCompare,
+} from "./sheet-player-order";
+
+const logger = createLogger("cdm-export");
+
+const SHEET = "TT Qualifications" as const;
+
+/** Last input row of the 47-player table (rows 2..48). */
+const TT_QUAL_LAST_ROW = TT_QUAL_FIRST_ROW + TT_QUAL_MAX_PLAYERS - 1; // 48
+
+/** A1 column letters for the 20 course cells, indexed like CDM_COURSES. */
+const COURSE_COLUMNS = CDM_COURSES.map((_, i) =>
+  toColumnLetters(TT_QUAL_FIRST_TIME_COLUMN + i),
+);
+
+/**
+ * Safely read TTEntry.times (typed `unknown`) as a course→string lookup.
+ * Returns null when the field is absent or not an object, so callers clear the
+ * row. Non-string values are ignored at read time (timeStringToCdmTime also
+ * rejects them, yielding a cleared cell).
+ */
+function readTimes(entry: CdmTTEntry): Record<string, unknown> | null {
+  const times = entry.times;
+  if (times == null || typeof times !== "object") return null;
+  return times as Record<string, unknown>;
+}
+
+export function buildTTQualificationWrites(
+  data: CdmTournamentData,
+): CdmCellWrite[] {
+  const builder = new SheetWriteBuilder(SHEET);
+
+  // Only qualification-stage entries appear in the TT Qualifications table;
+  // phase1/2/3 entries belong to TT Finals. Sort by nickname (case-insensitive
+  // ascending) to mirror the sheet's SORT(FILTER(...)) display order.
+  const qualifiers = data.ttEntries
+    .filter((e) => e.stage === "qualification")
+    .sort((a, b) =>
+      excelCaseInsensitiveCompare(a.player.nickname, b.player.nickname),
+    );
+
+  if (qualifiers.length > TT_QUAL_MAX_PLAYERS) {
+    logger.warn("TT qualifiers exceed sheet capacity; truncating", {
+      total: qualifiers.length,
+      kept: TT_QUAL_MAX_PLAYERS,
+    });
+  }
+  const kept = qualifiers.slice(0, TT_QUAL_MAX_PLAYERS);
+
+  // --- Player rows: write/clear each course time -------------------------
+  kept.forEach((entry, index) => {
+    const row = TT_QUAL_FIRST_ROW + index;
+    const times = readTimes(entry);
+    CDM_COURSES.forEach((course, i) => {
+      const ref = `${COURSE_COLUMNS[i]}${row}`;
+      // timeStringToCdmTime returns null for missing/empty/unparsable values,
+      // and setNumberOrClear turns that into a cell clear (never a bogus 0).
+      const value = times ? timeStringToCdmTime(times[course]) : null;
+      builder.setNumberOrClear(ref, value);
+    });
+  });
+
+  // --- Spare rows: clear G..Z so stale times never survive a re-use ------
+  for (let row = TT_QUAL_FIRST_ROW + kept.length; row <= TT_QUAL_LAST_ROW; row++) {
+    for (const col of COURSE_COLUMNS) builder.clear(`${col}${row}`);
+  }
+
+  return builder.build();
+}

--- a/smkc-score-app/src/lib/cdm-export/index.ts
+++ b/smkc-score-app/src/lib/cdm-export/index.ts
@@ -1,0 +1,52 @@
+/**
+ * CDM workbook export — public entry point.
+ *
+ * `generateCdmWorkbook` is the single function the export route calls. It turns a
+ * fully-assembled CdmTournamentData into a finished .xlsm by:
+ *   1. asking every fill builder for its CdmCellWrite[] (each builder is a pure
+ *      function over the tournament data — see fill/*.ts and
+ *      docs/cdm-export-design.md §3), and
+ *   2. concatenating those writes and applying them to the template ONCE via
+ *      patchCdmWorkbook (ZIP surgery: only the touched worksheet XML changes;
+ *      tables/richData/metadata/styles/sharedStrings pass through byte-for-byte).
+ *
+ * Builder order matters only for human readability of the resulting array —
+ * patchCdmWorkbook groups writes by sheet, and the per-sheet builders each own a
+ * disjoint set of sheets, so there is no cross-builder ref collision. We keep
+ * the order Main Hub → TT Qualifications → BM/MR/GP Qualifications → BM/MR/GP
+ * Finals → TT Finals to mirror the workbook's tab order and the design doc.
+ *
+ * This module is deliberately thin: it adds NO data transformation of its own.
+ * The route is responsible for mapping prisma rows into CdmTournamentData; the
+ * builders own every cell-level decision; the patcher owns the OOXML surgery.
+ */
+import type { CdmCellWrite, CdmTournamentData } from "./types";
+import { patchCdmWorkbook } from "./xlsx-zip-patcher";
+import { buildMainHubWrites } from "./fill/main-hub";
+import { buildTTQualificationWrites } from "./fill/tt-qualifications";
+import { buildQualificationWrites } from "./fill/qualifications";
+import { buildFinalsWrites } from "./fill/finals";
+import { buildTTFinalsWrites } from "./fill/tt-finals";
+
+export function generateCdmWorkbook(
+  template: Uint8Array,
+  data: CdmTournamentData,
+): Uint8Array {
+  // Each builder returns one op per cell for its own sheet(s); concatenating is
+  // safe because no two builders write the same sheet (Main Hub, TT
+  // Qualifications, the three Qualification sheets, the three Finals sheets and
+  // TT Finals are all disjoint). Order follows the workbook tab layout.
+  const writes: CdmCellWrite[] = [
+    ...buildMainHubWrites(data),
+    ...buildTTQualificationWrites(data),
+    ...buildQualificationWrites(data, "bm"),
+    ...buildQualificationWrites(data, "mr"),
+    ...buildQualificationWrites(data, "gp"),
+    ...buildFinalsWrites(data, "bm"),
+    ...buildFinalsWrites(data, "mr"),
+    ...buildFinalsWrites(data, "gp"),
+    ...buildTTFinalsWrites(data),
+  ];
+
+  return patchCdmWorkbook(template, writes);
+}

--- a/smkc-score-app/src/lib/cdm-export/sheet-xml-patcher.ts
+++ b/smkc-score-app/src/lib/cdm-export/sheet-xml-patcher.ts
@@ -1,0 +1,493 @@
+/**
+ * SheetXmlPatcher — surgical, byte-stable editing of an Excel worksheet XML.
+ *
+ * Why a string/region patcher instead of a DOM:
+ * The CDM template (public/templates/cdm-2025-template.xlsm) is a fully
+ * formula-driven workbook. Re-serialising it through a generic XML/DOM library
+ * reorders attributes, drops namespaces and rewrites whitespace, which is what
+ * destroyed the dynamic-array formula web in the previous SheetJS-based export.
+ * This patcher therefore keeps the original worksheet string intact and only
+ * rebuilds the exact <c> (cell) substrings it has to change. Untouched cells
+ * and the whole worksheet envelope (prolog, sheetPr, cols, pageMargins, tables…)
+ * are emitted as verbatim byte slices of the input — so `serialize()` of an
+ * unmodified patcher is identical to the input, and a single edit changes only
+ * that one cell's bytes.
+ *
+ * Strategy:
+ *  - Parse once: locate <sheetData>…</sheetData>, then index every <row> and,
+ *    lazily, the cells inside a row only when that row is first written to.
+ *  - apply(): record the desired op per cell ref. O(1) amortised; no full-string
+ *    scan per op (the design budgets tens of thousands of ops per sheet).
+ *  - serialize(): one pass. For each region (pre-sheetData, each row, gaps,
+ *    post-sheetData) emit either the original slice (if untouched) or a rebuilt
+ *    string (if any cell/row in it changed). New rows/cells are inserted in
+ *    A1 order.
+ *
+ * The cell/row grammar handled matches what Excel emits and what the template
+ * actually contains (verified against the real file):
+ *   <c r="B2" s="2" t="s"><v>13</v></c>           shared string
+ *   <c r="C2" s="4"><v>38</v></c>                  number
+ *   <c r="A2" s="40"><f>ROW()-1</f><v>1</v></c>    formula
+ *   <c r="D2" cm="1" vm="1"><f t="array" ref="..">..</f><v>..</v></c>
+ *   <c r="E4" s="23"/>                              self-closing styled shell
+ *   <row r="6" spans="1:6" ht="15" customHeight="1"/>  self-closing empty row
+ */
+import type { CdmCellOp } from "@/lib/cdm-export/types";
+
+/** Parse "B12" → { col: 2, row: 12 }. Column letters are case-insensitive. */
+function parseRef(ref: string): { col: number; row: number } {
+  const match = /^([A-Za-z]+)(\d+)$/.exec(ref);
+  if (!match) {
+    throw new Error(`SheetXmlPatcher: invalid cell reference "${ref}"`);
+  }
+  let col = 0;
+  const letters = match[1].toUpperCase();
+  for (let i = 0; i < letters.length; i++) {
+    col = col * 26 + (letters.charCodeAt(i) - 64);
+  }
+  return { col, row: Number(match[2]) };
+}
+
+/** Escape a string for inclusion in XML text/attribute content. */
+function escapeXml(value: string): string {
+  // Order matters: ampersand first so the entities we insert are not re-escaped.
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Render a JS number as Excel-compatible plain decimal.
+ * Excel stores numbers as decimal text and never as scientific notation, so we
+ * reject non-finite values and expand any exponential form JS would produce.
+ */
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) {
+    throw new Error(`SheetXmlPatcher: non-finite number ${value}`);
+  }
+  const text = String(value);
+  if (!/[eE]/.test(text)) {
+    return text;
+  }
+  // Expand exponential notation (e.g. 1e-7 → 0.0000001). 20 fractional digits
+  // is Excel's display ceiling and is plenty for the integer-ish values the CDM
+  // sheet uses (times, scores, counts). Trim trailing zeros for stability.
+  let expanded = value.toFixed(20);
+  if (expanded.includes(".")) {
+    expanded = expanded.replace(/0+$/, "").replace(/\.$/, "");
+  }
+  return expanded;
+}
+
+/**
+ * The attributes of a <c> element, parsed from its start tag. We keep them as
+ * an ordered list so the original attribute order/spelling is reproduced for
+ * untouched-but-rebuilt cells, while still allowing targeted add/remove.
+ */
+interface CellAttrs {
+  /** r is always present and never mutated (it is the cell address). */
+  r: string;
+  s?: string;
+  t?: string;
+  cm?: string;
+  vm?: string;
+}
+
+/** A single cell, either parsed from the source or freshly created. */
+interface CellModel {
+  col: number;
+  attrs: CellAttrs;
+  /** Inner XML between <c …> and </c>; undefined for a self-closing shell. */
+  inner: string | undefined;
+  /** Verbatim source slice for an unmodified existing cell (fast path). */
+  raw?: string;
+  /** Set once the cell has been mutated; raw must then be ignored. */
+  dirty: boolean;
+}
+
+/** A row of the worksheet, parsed lazily. */
+interface RowModel {
+  row: number;
+  /** The "<row …>" start tag (without the closing ">"); used when rebuilding. */
+  startTag: string;
+  /** Verbatim source slice of the whole row; undefined for newly created rows. */
+  raw?: string;
+  /** Parsed cells, indexed and sorted lazily on first write to the row. */
+  cells?: CellModel[];
+  /** True once any cell in this row changed and the row must be rebuilt. */
+  dirty: boolean;
+}
+
+const ROW_OPEN = "<row";
+const ROW_CLOSE = "</row>";
+
+export class SheetXmlPatcher {
+  /** Bytes before "<sheetData…" (prolog + sheet header), emitted verbatim. */
+  private readonly prefix: string;
+  /** Bytes from "</sheetData>" onward, emitted verbatim. */
+  private readonly suffix: string;
+  /** The exact "<sheetData …>" open tag (handles attributes if present). */
+  private readonly sheetDataOpen: string;
+  /** Whether the source had an empty <sheetData/> (no rows, no close tag). */
+  private readonly emptySheetData: boolean;
+  /** Rows in document order. */
+  private readonly rows: RowModel[];
+  /** row number → index in `rows`, for O(1) lookup and ordered insertion. */
+  private readonly rowIndex = new Map<number, number>();
+
+  constructor(sheetXml: string) {
+    // Locate the sheetData container. Excel always emits <sheetData> for a
+    // worksheet that has cells; an entirely empty sheet may use <sheetData/>.
+    const openSelfClose = sheetXml.indexOf("<sheetData/>");
+    if (openSelfClose !== -1) {
+      this.prefix = sheetXml.slice(0, openSelfClose);
+      this.suffix = sheetXml.slice(openSelfClose + "<sheetData/>".length);
+      this.sheetDataOpen = "<sheetData>";
+      this.emptySheetData = true;
+      this.rows = [];
+      return;
+    }
+
+    const openStart = sheetXml.indexOf("<sheetData");
+    if (openStart === -1) {
+      throw new Error("SheetXmlPatcher: <sheetData> not found");
+    }
+    const openEnd = sheetXml.indexOf(">", openStart);
+    const closeStart = sheetXml.indexOf("</sheetData>", openEnd);
+    if (closeStart === -1) {
+      throw new Error("SheetXmlPatcher: </sheetData> not found");
+    }
+    this.prefix = sheetXml.slice(0, openStart);
+    this.sheetDataOpen = sheetXml.slice(openStart, openEnd + 1);
+    this.suffix = sheetXml.slice(closeStart); // includes "</sheetData>"
+    this.emptySheetData = false;
+
+    this.rows = [];
+    this.indexRows(sheetXml.slice(openEnd + 1, closeStart));
+  }
+
+  /**
+   * Single pass over the sheetData body splitting it into <row> regions.
+   * Cells inside a row are NOT parsed here — that work is deferred to the first
+   * write into the row, keeping construction linear and cheap even for the
+   * largest sheets (hundreds of KB) when only a few rows are touched.
+   */
+  private indexRows(body: string): void {
+    let pos = 0;
+    while (pos < body.length) {
+      const rowStart = body.indexOf(ROW_OPEN, pos);
+      if (rowStart === -1) break;
+      const tagEnd = body.indexOf(">", rowStart);
+      const startTag = body.slice(rowStart, tagEnd); // no trailing ">"
+      const selfClosing = body[tagEnd - 1] === "/";
+
+      let rowEnd: number;
+      if (selfClosing) {
+        rowEnd = tagEnd + 1; // past ">"
+      } else {
+        const close = body.indexOf(ROW_CLOSE, tagEnd);
+        rowEnd = close + ROW_CLOSE.length;
+      }
+
+      const raw = body.slice(rowStart, rowEnd);
+      const rowNum = this.extractRowNumber(startTag);
+      this.rowIndex.set(rowNum, this.rows.length);
+      this.rows.push({
+        row: rowNum,
+        // For a self-closing row, normalise the start tag to a non-self-closing
+        // form so we can append cells if needed; the "/" is dropped here and
+        // re-added on serialize only if the row stays empty.
+        startTag: selfClosing ? startTag.slice(0, -1) : startTag,
+        raw,
+        dirty: false,
+      });
+      pos = rowEnd;
+    }
+  }
+
+  private extractRowNumber(startTag: string): number {
+    const m = /\br="(\d+)"/.exec(startTag);
+    if (!m) {
+      throw new Error(`SheetXmlPatcher: <row> without r attribute: ${startTag}`);
+    }
+    return Number(m[1]);
+  }
+
+  /**
+   * Apply a single op to a cell. Ops are applied in call order; a later op on
+   * the same ref overwrites the earlier result (last-write-wins) because each
+   * op mutates the live cell model in place.
+   */
+  apply(ref: string, op: CdmCellOp): void {
+    const { col, row } = parseRef(ref);
+
+    // For ops that are no-ops on missing cells, avoid materialising the row.
+    const cellMustExist = op.op === "clearValue" || op.op === "strip";
+
+    let rowModel = this.getRow(row);
+    if (!rowModel) {
+      if (cellMustExist) return; // no-op
+      rowModel = this.insertRow(row);
+    }
+
+    this.ensureRowParsed(rowModel);
+    let cell = rowModel.cells!.find((c) => c.col === col);
+    if (!cell) {
+      if (cellMustExist) return; // no-op
+      cell = this.insertCell(rowModel, ref, col);
+    }
+
+    this.applyToCell(cell, ref, op);
+    cell.dirty = true;
+    rowModel.dirty = true;
+  }
+
+  private getRow(row: number): RowModel | undefined {
+    const idx = this.rowIndex.get(row);
+    return idx === undefined ? undefined : this.rows[idx];
+  }
+
+  /** Insert a new empty row keeping rows sorted by row number. */
+  private insertRow(row: number): RowModel {
+    const model: RowModel = {
+      row,
+      startTag: `<row r="${row}"`,
+      cells: [],
+      dirty: true,
+    };
+    // Find the first existing row with a greater number and splice before it.
+    let insertAt = this.rows.length;
+    for (let i = 0; i < this.rows.length; i++) {
+      if (this.rows[i].row > row) {
+        insertAt = i;
+        break;
+      }
+    }
+    this.rows.splice(insertAt, 0, model);
+    // Indices shifted; rebuild the row index map for correctness.
+    this.reindexRows();
+    return model;
+  }
+
+  private reindexRows(): void {
+    this.rowIndex.clear();
+    for (let i = 0; i < this.rows.length; i++) {
+      this.rowIndex.set(this.rows[i].row, i);
+    }
+  }
+
+  /** Insert a new cell into a parsed row, keeping cells sorted by column. */
+  private insertCell(rowModel: RowModel, ref: string, col: number): CellModel {
+    const cell: CellModel = {
+      col,
+      attrs: { r: ref },
+      inner: "",
+      dirty: true,
+    };
+    const cells = rowModel.cells!;
+    let insertAt = cells.length;
+    for (let i = 0; i < cells.length; i++) {
+      if (cells[i].col > col) {
+        insertAt = i;
+        break;
+      }
+    }
+    cells.splice(insertAt, 0, cell);
+    return cell;
+  }
+
+  /**
+   * Parse the cells of a row on first write. Existing cells keep their verbatim
+   * `raw` slice so untouched cells in a rebuilt row are reproduced byte-exact.
+   */
+  private ensureRowParsed(rowModel: RowModel): void {
+    if (rowModel.cells) return;
+    const cells: CellModel[] = [];
+    const raw = rowModel.raw ?? "";
+    // The row inner content lies between the start tag's ">" and "</row>".
+    const tagEnd = raw.indexOf(">");
+    const inner = raw.slice(tagEnd + 1, raw.length - ROW_CLOSE.length);
+
+    let pos = 0;
+    while (pos < inner.length) {
+      const cStart = inner.indexOf("<c", pos);
+      if (cStart === -1) break;
+      const cTagEnd = inner.indexOf(">", cStart);
+      const selfClosing = inner[cTagEnd - 1] === "/";
+      let cEnd: number;
+      if (selfClosing) {
+        cEnd = cTagEnd + 1;
+      } else {
+        const close = inner.indexOf("</c>", cTagEnd);
+        cEnd = close + "</c>".length;
+      }
+      const rawCell = inner.slice(cStart, cEnd);
+      const startTag = inner.slice(
+        cStart,
+        selfClosing ? cTagEnd - 1 : cTagEnd
+      ); // attributes region without ">" or "/>"
+      const attrs = this.parseCellAttrs(startTag);
+      const innerXml = selfClosing
+        ? undefined
+        : inner.slice(cTagEnd + 1, cEnd - "</c>".length);
+      cells.push({
+        col: parseRef(attrs.r).col,
+        attrs,
+        inner: innerXml,
+        raw: rawCell,
+        dirty: false,
+      });
+      pos = cEnd;
+    }
+    rowModel.cells = cells;
+  }
+
+  /** Parse the attribute string of a <c …> start tag into a CellAttrs. */
+  private parseCellAttrs(startTag: string): CellAttrs {
+    const read = (name: string): string | undefined => {
+      const m = new RegExp(`\\b${name}="([^"]*)"`).exec(startTag);
+      return m ? m[1] : undefined;
+    };
+    const r = read("r");
+    if (!r) {
+      throw new Error(`SheetXmlPatcher: <c> without r attribute: ${startTag}`);
+    }
+    return { r, s: read("s"), t: read("t"), cm: read("cm"), vm: read("vm") };
+  }
+
+  /** Mutate a cell model according to the op (validation included). */
+  private applyToCell(cell: CellModel, ref: string, op: CdmCellOp): void {
+    const hasFormula = cell.inner !== undefined && cell.inner.includes("<f");
+
+    switch (op.op) {
+      case "number":
+      case "inlineString": {
+        // Guard: writing a value over a formula cell would silently corrupt the
+        // template's dynamic-array web (the exact failure of the old exporter).
+        if (hasFormula) {
+          throw new Error(
+            `SheetXmlPatcher: refusing to write a value over the formula cell ${ref}; ` +
+              `the fill map disagrees with the template`
+          );
+        }
+        // Drop rich-value markers; they index a value we are replacing.
+        delete cell.attrs.cm;
+        delete cell.attrs.vm;
+        if (op.op === "number") {
+          delete cell.attrs.t; // number is the default (no t attribute)
+          cell.inner = `<v>${formatNumber(op.value)}</v>`;
+        } else {
+          cell.attrs.t = "inlineStr";
+          cell.inner = renderInlineString(op.value);
+        }
+        return;
+      }
+      case "clearValue": {
+        // Keep formula, style and attributes; remove only the cached value.
+        // [\s\S] is used instead of the dotAll (`/s`) flag so the pattern still
+        // spans newlines (an <is> value can contain line breaks) while staying
+        // compilable under the project's ES2017 target (the `/s` flag is only
+        // recognised by tsc from ES2018 onward — TS1501).
+        if (cell.inner !== undefined) {
+          cell.inner = cell.inner
+            .replace(/<v>[\s\S]*?<\/v>/, "")
+            .replace(/<is>[\s\S]*?<\/is>/, "");
+        }
+        return;
+      }
+      case "overwriteNumber":
+      case "overwriteString": {
+        // Degraded modes: replace value AND remove any formula.
+        delete cell.attrs.cm;
+        delete cell.attrs.vm;
+        if (op.op === "overwriteNumber") {
+          delete cell.attrs.t;
+          cell.inner = `<v>${formatNumber(op.value)}</v>`;
+        } else {
+          cell.attrs.t = "inlineStr";
+          cell.inner = renderInlineString(op.value);
+        }
+        return;
+      }
+      case "strip": {
+        // Reduce to a styled empty shell: drop formula, value, t/cm/vm.
+        delete cell.attrs.t;
+        delete cell.attrs.cm;
+        delete cell.attrs.vm;
+        cell.inner = undefined;
+        return;
+      }
+      default: {
+        // Exhaustiveness guard.
+        const never: never = op;
+        throw new Error(`SheetXmlPatcher: unknown op ${JSON.stringify(never)}`);
+      }
+    }
+  }
+
+  /** Serialise one cell model back to XML (verbatim if clean, rebuilt if dirty). */
+  private serializeCell(cell: CellModel): string {
+    if (!cell.dirty && cell.raw !== undefined) {
+      return cell.raw;
+    }
+    // Rebuild the start tag preserving the canonical attribute order
+    // r, s, t, cm, vm — matching how Excel writes these on input cells.
+    let tag = `<c r="${cell.attrs.r}"`;
+    if (cell.attrs.s !== undefined) tag += ` s="${cell.attrs.s}"`;
+    if (cell.attrs.t !== undefined) tag += ` t="${cell.attrs.t}"`;
+    if (cell.attrs.cm !== undefined) tag += ` cm="${cell.attrs.cm}"`;
+    if (cell.attrs.vm !== undefined) tag += ` vm="${cell.attrs.vm}"`;
+    if (cell.inner === undefined || cell.inner === "") {
+      return `${tag}/>`;
+    }
+    return `${tag}>${cell.inner}</c>`;
+  }
+
+  /** Serialise one row, verbatim when untouched. */
+  private serializeRow(rowModel: RowModel): string {
+    if (!rowModel.dirty && rowModel.raw !== undefined) {
+      return rowModel.raw;
+    }
+    const cells = rowModel.cells ?? [];
+    if (cells.length === 0) {
+      // No cells: emit a self-closing row, reusing the original attributes.
+      return `${rowModel.startTag}/>`;
+    }
+    let out = `${rowModel.startTag}>`;
+    for (const cell of cells) {
+      out += this.serializeCell(cell);
+    }
+    out += ROW_CLOSE;
+    return out;
+  }
+
+  serialize(): string {
+    if (this.rows.length === 0) {
+      // Nothing was ever inserted; reproduce the original (possibly empty) body.
+      if (this.emptySheetData) {
+        return `${this.prefix}<sheetData/>${this.suffix}`;
+      }
+      return `${this.prefix}${this.sheetDataOpen}${this.suffix}`;
+    }
+    const parts: string[] = [this.prefix, this.sheetDataOpen];
+    for (const rowModel of this.rows) {
+      parts.push(this.serializeRow(rowModel));
+    }
+    parts.push(this.suffix);
+    return parts.join("");
+  }
+}
+
+/**
+ * Render an inline-string body: <is><t>…</t></is>, adding xml:space="preserve"
+ * when leading/trailing whitespace would otherwise be collapsed by Excel.
+ */
+function renderInlineString(value: string): string {
+  const escaped = escapeXml(value);
+  const needsPreserve = /^\s|\s$/.test(value);
+  const t = needsPreserve ? `<t xml:space="preserve">${escaped}</t>` : `<t>${escaped}</t>`;
+  return `<is>${t}</is>`;
+}

--- a/smkc-score-app/src/lib/cdm-export/time-format.ts
+++ b/smkc-score-app/src/lib/cdm-export/time-format.ts
@@ -1,0 +1,38 @@
+/**
+ * CDM workbook time encoding.
+ *
+ * The CDM template stores lap times as plain integers shaped
+ * M*10000 + SS*100 + CC (minutes / seconds / centiseconds), e.g.
+ * 1:10.34 → 11034 and 0:59.79 → 5979. The TT sheets decode this with
+ * `INT(t/10000)*6000 + NUMBERVALUE(RIGHT(t,4))` so the encoding must keep
+ * seconds+centiseconds in the last four digits. Writing milliseconds here
+ * (the old exporter's bug) shifts every time by a factor of ~10.
+ *
+ * SMK itself is centisecond-precision; app times that carry milliseconds
+ * are rounded half-up to centiseconds.
+ */
+
+import { timeToMs } from "@/lib/ta/time-utils";
+
+/** Encode a duration in milliseconds as a CDM MSSCC integer. */
+export function msToCdmTime(ms: number): number {
+  if (!Number.isFinite(ms) || ms < 0) {
+    throw new Error(`msToCdmTime: invalid duration ${ms}`);
+  }
+  const centis = Math.round(ms / 10);
+  const minutes = Math.floor(centis / 6000);
+  const rest = centis % 6000; // SS*100 + CC, always < 6000 so 4 digits max
+  return minutes * 10000 + rest;
+}
+
+/**
+ * Encode an app time string ("M:SS.cc" / "M:SS.ccc") as a CDM integer.
+ * Returns null for missing or unparsable values so callers can clear the
+ * cell instead of writing a bogus 0 (0 would rank as the fastest time).
+ */
+export function timeStringToCdmTime(value: unknown): number | null {
+  if (typeof value !== "string" || value.trim() === "") return null;
+  const ms = timeToMs(value.trim());
+  if (ms === null) return null;
+  return msToCdmTime(ms);
+}

--- a/smkc-score-app/src/lib/cdm-export/types.ts
+++ b/smkc-score-app/src/lib/cdm-export/types.ts
@@ -1,0 +1,140 @@
+/**
+ * CDM workbook export — shared types.
+ *
+ * The CDM 2025 score sheet (public/templates/cdm-2025-template.xlsm) is a
+ * formula-driven workbook: standings, bracket advancement and the overall
+ * ranking are computed by Excel dynamic-array formulas. The export therefore
+ * writes ONLY the workbook's true input cells and must leave every other
+ * cell and zip part untouched. See docs/cdm-export-design.md for the full
+ * cell contract; coordinates live in cdm-constants.ts.
+ */
+
+/** Worksheet names of the CDM template (must match xl/workbook.xml exactly). */
+export type CdmSheetName =
+  | "Main Hub"
+  | "Parameters"
+  | "TT Qualifications"
+  | "TT Finals"
+  | "TT for Scoub"
+  | "BM Qualifications"
+  | "BM Finals"
+  | "MR Qualifications"
+  | "MR Finals"
+  | "GP Qualifications"
+  | "GP Finals"
+  | "Overall Ranking";
+
+/**
+ * One cell mutation against a template worksheet.
+ *
+ * Op semantics (enforced by sheet-xml-patcher):
+ * - "number" / "inlineString": set a value on a cell that must NOT hold a
+ *   formula in the template. Writing over a formula cell throws — it means
+ *   the fill map disagrees with the template and the export would silently
+ *   corrupt the formula web (the exact failure mode of the old exporter).
+ * - "clearValue": drop the cached <v>/<is> but keep the cell, its style and
+ *   any formula. Used for unused input rows so template formulas keep
+ *   evaluating blanks gracefully.
+ * - "overwriteNumber" / "overwriteString": replace value AND remove any
+ *   formula. Reserved for the degraded bracket modes (8-player / 16-player
+ *   without playoff) where the template's advancement formulas cannot
+ *   represent the app bracket. Never used on the faithful 24-player path.
+ * - "strip": remove value and formula but keep the styled cell shell, so
+ *   bracket borders/fills survive in regions the event does not use.
+ */
+export type CdmCellOp =
+  | { op: "number"; value: number }
+  | { op: "inlineString"; value: string }
+  | { op: "clearValue" }
+  | { op: "overwriteNumber"; value: number }
+  | { op: "overwriteString"; value: string }
+  | { op: "strip" };
+
+export type CdmCellWrite = CdmCellOp & {
+  sheet: CdmSheetName;
+  /** A1-style cell reference, e.g. "B12". */
+  ref: string;
+};
+
+/** Player fields the fill maps need (public projection only — never password). */
+export interface CdmPlayer {
+  id: string;
+  name: string;
+  nickname: string;
+  country?: string | null;
+}
+
+export interface CdmModeQualification {
+  player: CdmPlayer;
+  seeding: number | null;
+  group: string;
+  rankOverride?: number | null;
+  points: number;
+  score: number;
+}
+
+export interface CdmMatch {
+  matchNumber: number;
+  stage: string; // 'qualification' | 'playoff' | 'finals'
+  round?: string | null;
+  bracketPosition?: string | null;
+  isGrandFinal?: boolean;
+  roundNumber?: number | null;
+  tvNumber?: number | null;
+  isBye?: boolean;
+  player1: CdmPlayer;
+  player2: CdmPlayer;
+  player1Side?: number | null;
+  player2Side?: number | null;
+  score1?: number | null;
+  score2?: number | null;
+  points1?: number | null;
+  points2?: number | null;
+  completed: boolean;
+  assignedCourses?: unknown; // MR: ["MC1", ...]
+  cup?: string | null; // GP
+}
+
+export interface CdmTTEntry {
+  player: CdmPlayer;
+  playerId: string;
+  stage: string; // 'qualification' | 'phase1' | 'phase2' | 'phase3'
+  seeding: number | null;
+  lives: number;
+  eliminated: boolean;
+  times?: unknown; // {"MC1": "1:23.45", ...}
+  totalTime?: number | null;
+  qualificationPoints?: number | null;
+  /**
+   * Persisted canonical TT qualification rank (TTEntry.rank). The TT Finals
+   * sheet orders its round-1 rows by final qualification standing, so the
+   * replay uses this as the primary key and only falls back to the
+   * points-desc / totalTime-asc comparator when ranks are missing.
+   */
+  rank?: number | null;
+}
+
+export interface CdmTTPhaseRound {
+  phase: string; // 'phase1' | 'phase2' | 'phase3'
+  roundNumber: number;
+  course: string; // course abbreviation, e.g. "MC1"
+  results: unknown; // [{playerId, timeMs, isRetry}]
+  eliminatedIds?: unknown; // playerId[]
+  livesReset: boolean;
+}
+
+/** Everything the generator needs; assembled by the export route from prisma. */
+export interface CdmTournamentData {
+  name: string;
+  date: Date;
+  bmQualifications: CdmModeQualification[];
+  mrQualifications: CdmModeQualification[];
+  gpQualifications: CdmModeQualification[];
+  bmMatches: CdmMatch[];
+  mrMatches: CdmMatch[];
+  gpMatches: CdmMatch[];
+  ttEntries: CdmTTEntry[];
+  ttPhaseRounds: CdmTTPhaseRound[];
+}
+
+export type CdmVersusMode = "bm" | "mr" | "gp";

--- a/smkc-score-app/src/lib/cdm-export/xlsx-zip-patcher.ts
+++ b/smkc-score-app/src/lib/cdm-export/xlsx-zip-patcher.ts
@@ -1,0 +1,254 @@
+/**
+ * patchCdmWorkbook — ZIP-surgery filler for the CDM 2025 score sheet.
+ *
+ * The template (public/templates/cdm-2025-template.xlsm) is a fully
+ * dynamic-array-formula-driven workbook with NO VBA. Standings, bracket
+ * advancement and the overall ranking are all computed by Excel formulas that
+ * depend on structured-table references (Registration[...]), rich-value flag
+ * images and a metadata-backed spill web. The previous exporter round-tripped
+ * the file through SheetJS, which silently dropped xl/tables/* and
+ * xl/richData/* and rewrote the worksheet XML, collapsing every formula to
+ * #NAME?/#SPILL!.
+ *
+ * This module instead performs surgery on the OOXML package:
+ *  1. unzip with fflate (synchronous, Workers-compatible — no streams, no fs);
+ *  2. patch ONLY the input cells of the touched worksheets via SheetXmlPatcher,
+ *     which rewrites just the changed <c>/<row> regions and reproduces every
+ *     other byte of the sheet verbatim;
+ *  3. force a full recalculation on open (fullCalcOnLoad) and drop the now-stale
+ *     calcChain so Excel rebuilds the dependency order itself;
+ *  4. pass through EVERY other part (tables, richData, media, styles, metadata,
+ *     sharedStrings, printerSettings, customXml, docProps, ...) byte-for-byte,
+ *     keeping the original zip entry order so a diff against the template shows
+ *     only the three parts we intentionally edit.
+ *
+ * The only parts that may differ from the template after a no-op patch are:
+ *   - xl/workbook.xml          (calcPr gains fullCalcOnLoad="1")
+ *   - [Content_Types].xml      (calcChain Override removed)
+ *   - xl/_rels/workbook.xml.rels (calcChain Relationship removed)
+ * and xl/calcChain.xml is removed entirely.
+ */
+import { unzipSync, zipSync, strFromU8, strToU8 } from "fflate";
+import type { CdmCellWrite, CdmSheetName } from "@/lib/cdm-export/types";
+import { SheetXmlPatcher } from "@/lib/cdm-export/sheet-xml-patcher";
+
+/** OOXML part path of the worksheet relationship Content-Type filter. */
+const WORKSHEET_REL_TYPE =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet";
+
+const CALC_CHAIN_PART = "xl/calcChain.xml";
+const WORKBOOK_PART = "xl/workbook.xml";
+const WORKBOOK_RELS_PART = "xl/_rels/workbook.xml.rels";
+const CONTENT_TYPES_PART = "[Content_Types].xml";
+
+/**
+ * Resolve "<sheet name=..>" → "xl/worksheets/sheetN.xml" from the workbook
+ * itself. The numeric sheet index is NOT positional in OOXML — a workbook's
+ * Nth <sheet> may map to any sheetK.xml — so we follow r:id through
+ * workbook.xml.rels rather than hard-coding sheet numbers (which would silently
+ * write into the wrong sheet if the template is ever re-saved).
+ */
+function buildSheetPathResolver(
+  workbookXml: string,
+  workbookRelsXml: string
+): Map<string, string> {
+  // r:id → Target path (relative to xl/), worksheet relationships only.
+  const ridToTarget = new Map<string, string>();
+  // Each <Relationship Id=".." Type=".." Target=".."/>; attribute order varies,
+  // so read attributes independently instead of assuming a fixed sequence.
+  const relRegex = /<Relationship\b[^>]*\/>/g;
+  let relMatch: RegExpExecArray | null;
+  while ((relMatch = relRegex.exec(workbookRelsXml)) !== null) {
+    const tag = relMatch[0];
+    const type = readAttr(tag, "Type");
+    if (type !== WORKSHEET_REL_TYPE) continue;
+    const id = readAttr(tag, "Id");
+    const target = readAttr(tag, "Target");
+    if (id && target) {
+      // Targets are relative to the xl/ folder, e.g. "worksheets/sheet1.xml".
+      ridToTarget.set(id, `xl/${target}`);
+    }
+  }
+
+  // sheet display name → part path, via <sheet name=".." r:id=".."/>.
+  const nameToPath = new Map<string, string>();
+  const sheetRegex = /<sheet\b[^>]*\/>/g;
+  let sheetMatch: RegExpExecArray | null;
+  while ((sheetMatch = sheetRegex.exec(workbookXml)) !== null) {
+    const tag = sheetMatch[0];
+    const name = readAttr(tag, "name");
+    const rid = readAttr(tag, "r:id");
+    if (name && rid) {
+      const path = ridToTarget.get(rid);
+      if (path) nameToPath.set(decodeXmlEntities(name), path);
+    }
+  }
+  return nameToPath;
+}
+
+/** Read a double-quoted attribute value from a start-tag string, or undefined. */
+function readAttr(tag: string, name: string): string | undefined {
+  // Escape ":" in qualified names (r:id) for the RegExp; "\b" before a "r" in
+  // "r:id" still anchors on the word boundary preceding it.
+  const re = new RegExp(`\\b${name.replace(/[:.]/g, "\\$&")}="([^"]*)"`);
+  const m = re.exec(tag);
+  return m ? m[1] : undefined;
+}
+
+/** Decode the XML entities Excel may use inside a sheet name attribute. */
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&"); // ampersand last so we do not double-decode
+}
+
+/**
+ * Add fullCalcOnLoad="1" to <calcPr>, idempotently. With the calcChain gone,
+ * this is what tells Excel to recompute the whole formula web on first open
+ * (otherwise cached <v> values would show until an edit triggers calc).
+ */
+function ensureFullCalcOnLoad(workbookXml: string): string {
+  const calcPrMatch = /<calcPr\b([^>]*)\/>/.exec(workbookXml);
+  if (calcPrMatch) {
+    const attrs = calcPrMatch[1];
+    if (/\bfullCalcOnLoad="1"/.test(attrs)) {
+      return workbookXml; // already set — idempotent
+    }
+    const replacement = `<calcPr${attrs} fullCalcOnLoad="1"/>`;
+    return workbookXml.replace(calcPrMatch[0], replacement);
+  }
+  // No <calcPr> at all: insert one right after </sheets>, the schema-valid slot
+  // for calcPr (CT_Workbook orders sheets before calcPr). Falling back to just
+  // before </workbook> would violate the element order and can make Excel
+  // repair the file, so we anchor on </sheets> instead.
+  const sheetsClose = workbookXml.indexOf("</sheets>");
+  if (sheetsClose !== -1) {
+    const insertAt = sheetsClose + "</sheets>".length;
+    return (
+      workbookXml.slice(0, insertAt) +
+      '<calcPr calcId="0" fullCalcOnLoad="1"/>' +
+      workbookXml.slice(insertAt)
+    );
+  }
+  // Last resort: a workbook without <sheets> is malformed for our purposes.
+  throw new Error("patchCdmWorkbook: workbook.xml has neither <calcPr> nor <sheets>");
+}
+
+/**
+ * Remove the calcChain Override from [Content_Types].xml. The calcChain is the
+ * only part we delete, and an Override pointing at a missing part makes Excel
+ * flag the package as corrupt, so the Override must go with it.
+ */
+function removeCalcChainOverride(contentTypesXml: string): string {
+  // Match the single self-closing Override whose PartName targets calcChain.
+  return contentTypesXml.replace(
+    /<Override\b[^>]*PartName="\/xl\/calcChain\.xml"[^>]*\/>/,
+    ""
+  );
+}
+
+/**
+ * Remove the calcChain Relationship from workbook.xml.rels. Same reasoning as
+ * the Content-Type Override: a dangling relationship target breaks the package.
+ */
+function removeCalcChainRelationship(workbookRelsXml: string): string {
+  // The Relationship may declare its attributes in any order; match any
+  // self-closing Relationship whose Target ends in calcChain.xml.
+  return workbookRelsXml.replace(
+    /<Relationship\b[^>]*Target="calcChain\.xml"[^>]*\/>/,
+    ""
+  );
+}
+
+/**
+ * Fill the CDM template with the given cell writes and return a fresh .xlsm.
+ *
+ * Writes are grouped per sheet and applied to that sheet's XML in array order
+ * (so a later write to the same ref wins, matching SheetXmlPatcher semantics).
+ * An unknown sheet name throws — it means the fill map references a sheet the
+ * template does not contain, which must never be silently ignored.
+ */
+export function patchCdmWorkbook(
+  template: Uint8Array,
+  writes: CdmCellWrite[]
+): Uint8Array {
+  const parts = unzipSync(template);
+
+  const workbookBytes = parts[WORKBOOK_PART];
+  const workbookRelsBytes = parts[WORKBOOK_RELS_PART];
+  if (!workbookBytes || !workbookRelsBytes) {
+    throw new Error("patchCdmWorkbook: template is missing workbook.xml or its rels");
+  }
+  const workbookXml = strFromU8(workbookBytes);
+  const workbookRelsXml = strFromU8(workbookRelsBytes);
+
+  const sheetPathByName = buildSheetPathResolver(workbookXml, workbookRelsXml);
+
+  // Group writes by sheet, preserving their relative order within a sheet so
+  // last-write-wins is honoured by SheetXmlPatcher.
+  const writesBySheet = new Map<CdmSheetName, CdmCellWrite[]>();
+  for (const write of writes) {
+    const path = sheetPathByName.get(write.sheet);
+    if (!path) {
+      throw new Error(
+        `patchCdmWorkbook: unknown sheet name "${write.sheet}" — not present in workbook.xml`
+      );
+    }
+    const list = writesBySheet.get(write.sheet);
+    if (list) {
+      list.push(write);
+    } else {
+      writesBySheet.set(write.sheet, [write]);
+    }
+  }
+
+  // Patch each touched worksheet's XML in place within the parts map. The map
+  // still holds verbatim bytes for everything else, which is what guarantees
+  // byte-fidelity of the untouched parts.
+  for (const [sheet, sheetWrites] of writesBySheet) {
+    const path = sheetPathByName.get(sheet)!;
+    const sheetBytes = parts[path];
+    if (!sheetBytes) {
+      throw new Error(`patchCdmWorkbook: worksheet part "${path}" not found in package`);
+    }
+    const patcher = new SheetXmlPatcher(strFromU8(sheetBytes));
+    for (const write of sheetWrites) {
+      // CdmCellWrite is CdmCellOp & { sheet, ref }; SheetXmlPatcher.apply takes
+      // the op shape, so we pass the write through (the extra sheet/ref fields
+      // are ignored by the discriminated-union switch).
+      patcher.apply(write.ref, write);
+    }
+    parts[path] = strToU8(patcher.serialize());
+  }
+
+  // Force recalculation on open and remove the stale calc chain.
+  // `workbookXml` is the string read before the patch loop; that is safe
+  // because cell writes only ever touch worksheet parts (the loop above writes
+  // back to `parts[path]` for sheet paths only), so xl/workbook.xml cannot have
+  // changed in between. If a future op kind ever mutates workbook.xml, re-read
+  // parts[WORKBOOK_PART] here instead of reusing this string.
+  parts[WORKBOOK_PART] = strToU8(ensureFullCalcOnLoad(workbookXml));
+  parts[CONTENT_TYPES_PART] = strToU8(
+    removeCalcChainOverride(strFromU8(parts[CONTENT_TYPES_PART]))
+  );
+  parts[WORKBOOK_RELS_PART] = strToU8(removeCalcChainRelationship(workbookRelsXml));
+
+  // Rebuild the zip preserving the original entry order minus the dropped
+  // calcChain. fflate zipSync iterates the object in insertion order, and
+  // unzipSync produced `parts` in the package's entry order, so we re-key into
+  // a fresh object skipping calcChain to keep ordering stable and deterministic.
+  const outParts: Record<string, Uint8Array> = {};
+  for (const path of Object.keys(parts)) {
+    if (path === CALC_CHAIN_PART) continue; // Excel rebuilds it from fullCalcOnLoad
+    outParts[path] = parts[path];
+  }
+
+  // Pin mtime to the DOS-date epoch (1980-01-01) so repeated exports of the
+  // same data are byte-stable. fflate's default mtime is Date.now(), which
+  // would make every export differ; 0 (1970) is outside the DOS date range, so
+  // we use the earliest representable timestamp instead.
+  return zipSync(outParts, { mtime: new Date("1980-01-01T00:00:00Z") });
+}


### PR DESCRIPTION
## Summary
- CDM 試合結果シート (`cdm-2025-template.xlsm`) をトーナメント結果・途中状態から正しく生成できるよう、エクスポータを全面再設計
- 旧 SheetJS read→write 方式は `xl/tables/*`（Registration 等の構造化テーブル）と `xl/richData/*`（国旗）を喪失させ、動的配列スピル範囲への値書込で `#SPILL!`、シード数値セルへの文字列書込で `#N/A`、TT タイムのミリ秒誤エンコードを起こしていた（実測で確認）
- 新方式は「ZIP 外科手術」: fflate で解凍し、`SheetXmlPatcher` で**入力セルのみ**を書き換え、他パートはバイト同一で素通し。テンプレート数式が順位表・ブラケット進行・総合ランキングを再計算するため、**途中状態は "Winner of B1,1" プレースホルダー等で自然に表現される**
- 設計書: `smkc-score-app/docs/cdm-export-design.md`（セル契約・スロット意味論・縮退モード・既知の限界）

## 実装
- `src/lib/cdm-export/`: zip/XML パッチャー + シート別 fill map（Main Hub / TT 予選 / BM・MR・GP 予選 / 決勝ブラケット / TT 決勝ライフ replay）
- 決勝はテンプレート数式のスロット意味論（検証済みトポロジー表）に基づく同一性解決スコア書込。16+playoff=faithful、16/8 人は縮退モード
- route は CSV パス完全不変、CDM 分岐のみ差し替え。`playerScores` include 削除（Overall Ranking は数式駆動）
- E2E TC-816A を新契約（構造回帰ガード + 入力セル検証）に書換。2コミット目は初回ライブ実行で発見した playoff-only 途中状態のアサーション修正

## Test plan
- [x] 単体/統合: 234 suites / 3228 tests green（実テンプレートに対する byte-fidelity 検証含む）
- [x] openpyxl（独立パーサー）で生成物検証: 数式・テーブル・richData 無傷、値配置 76 チェック合格
- [x] tdd-test-reviewer レビュー: BLOCKER 0、SHOULD/NIT 全対応
- [x] preview 環境ライブ E2E: TC-358/TC-359 PASS、TC-816A は本 PR の修正で対応（構造ガード・シード/スコアセル検証）
- [ ] Excel 実機で開封確認（手元にExcel が無いため要目視: `/tmp/cdm-analysis/generated-*.xlsm` にサンプルあり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)