### PR TITLE
fix: treat Wrangler stdout JSON CLOUDFLARE_API_TOKEN errors as auth setup noise

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -130,6 +130,18 @@
 - **期待結果**: 認証/ログ初期化だけの失敗は通常 preview E2E を本体開始前に止めず、schema missing / SQLite error / timeout / strict preflight は従来どおり診断つきで失敗する。TC-2161 の E2E scenario 文字列確認は `preview-schema-preflight.test.ts` 側に集約し、drift test は preview preflight 実装と補助テストの対応だけを監視する
 - **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
 
+## TC-2333: Preview D1 preflight は Wrangler stdout JSON CLOUDFLARE_API_TOKEN エラーを auth setup noise として扱う
+- **URL**: n/a (runner configuration / preview suite)
+- **authRequired**: true (Cloudflare D1 token is optional unless strict preflight is requested)
+- **背景**: issue #2333。非インタラクティブ環境で CLOUDFLARE_API_TOKEN が未設定の場合、Wrangler は `stderr` を空にしたまま stdout に `{ "error": { "text": "...CLOUDFLARE_API_TOKEN..." } }` という JSON を出力して非ゼロ終了する。既存の `isWranglerAuthOrLogFailure` は `stderr` しか検査しないため、この形式はハードフェイルパスに落ちていた。`isWranglerStdoutAuthError` を追加して stdout JSON 内の auth error を認証/ログ初期化失敗として分類し、TC-2161 と同じ non-blocking 扱いにする。
+- **手順**:
+  1. Wrangler が `stderr: ""` / `stdout: {"error":{"text":"...CLOUDFLARE_API_TOKEN..."}}` を返す preflight を模擬する
+  2. 通常の `npm run e2e:preview:all` 相当では警告を出して preflight を通過することを確認する (`console.warn` に `stdout:` と `CLOUDFLARE_API_TOKEN` が含まれる)
+  3. `E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1` 指定時は同じ stdout auth error がブラウザ起動前に失敗することを確認する
+  4. `isWranglerStdoutAuthError` が `{ "error": { "text": "...non-interactive environment..." } }` をも検出することを確認する
+- **期待結果**: stdout JSON auth error は TC-2161 の stderr auth error と同様に non-blocking として扱われ、strict フラグで hard fail に戻せる。スキーマ drift / SQLite error は引き続き失敗する
+- **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
+
 ## TC-2236: Preview E2E は共有 fixture 作成前に admin session 不在を fast-fail する
 - **URL**: n/a (runner configuration / preview suite)
 - **authRequired**: true (persistent preview admin profile)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -430,6 +430,22 @@ describe('E2E case drift coverage', () => {
     expect(preflightTest).toContain('keeps Wrangler auth/log message helpers private to the preflight runner');
   });
 
+  it('keeps TC-2333 aligned with stdout JSON CLOUDFLARE_API_TOKEN auth error classification', () => {
+    const section = e2eCaseSection('TC-2333');
+    const preflight = readE2eLib('preview-schema-preflight.js');
+    const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');
+
+    expect(section).toContain('issue #2333');
+    expect(section).toContain('isWranglerStdoutAuthError');
+    expect(section).toContain('__tests__/e2e/preview-schema-preflight.test.ts');
+    expect(preflight).toContain('isWranglerStdoutAuthError');
+    expect(preflight).toContain('CLOUDFLARE_API_TOKEN');
+    expect(preflight).toContain('non-interactive environment');
+    expect(preflightTest).toContain('detects CLOUDFLARE_API_TOKEN auth error in Wrangler stdout JSON');
+    expect(preflightTest).toContain('continues preview startup on Wrangler stdout JSON CLOUDFLARE_API_TOKEN auth error by default');
+    expect(preflightTest).toContain('keeps TC-2333 documented as stdout JSON CLOUDFLARE_API_TOKEN auth error coverage');
+  });
+
   it('keeps TC-2236 aligned with preview admin session preflight coverage', () => {
     const section = e2eCaseSection('TC-2236');
     const runner = readE2eScript('run-preview.js');

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -258,6 +258,75 @@ describe('preview schema preflight', () => {
     expect(preflight.isWranglerAuthOrLogFailure('Failed to fetch auth token: 400 Bad Request')).toBe(true);
   });
 
+  it('detects CLOUDFLARE_API_TOKEN auth error in Wrangler stdout JSON', () => {
+    const preflight = loadPreflight();
+
+    // nested {"error": {"text": "..."}} shape
+    const stdoutJson = JSON.stringify({
+      error: {
+        text: "In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work.",
+      },
+    });
+    expect(preflight.isWranglerStdoutAuthError(stdoutJson)).toBe(true);
+    // flat {"error": "..."} string shape
+    expect(preflight.isWranglerStdoutAuthError('{"error": "CLOUDFLARE_API_TOKEN environment variable required"}')).toBe(true);
+    expect(preflight.isWranglerStdoutAuthError('{"error": "non-interactive environment detected"}')).toBe(true);
+    expect(preflight.isWranglerStdoutAuthError('')).toBe(false);
+    expect(preflight.isWranglerStdoutAuthError('{"results": []}')).toBe(false);
+    expect(preflight.isWranglerStdoutAuthError('{"error": {"text": "Unknown D1 error"}}')).toBe(false);
+    expect(preflight.isWranglerStdoutAuthError('not json at all')).toBe(false);
+  });
+
+  it('continues preview startup on Wrangler stdout JSON CLOUDFLARE_API_TOKEN auth error by default', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: JSON.stringify({
+        error: {
+          text: "In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work. Please go to https://developers.cloudflare.com/fundamentals/api/get-started/create-token/ for instructions on how to create an api token, and assign its value to CLOUDFLARE_API_TOKEN.",
+        },
+      }),
+      stderr: '',
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({})).not.toThrow();
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    const message = String((console.warn as jest.Mock).mock.calls[0]?.[0] ?? '');
+    expect(message).toMatch(/Wrangler auth\/log setup failed/);
+    expect(message).toMatch(/E2E run will continue/);
+    expect(message).toMatch(/WRANGLER_LOG_PATH/);
+    expect(message).toMatch(/stdout:/);
+    expect(message).toMatch(/CLOUDFLARE_API_TOKEN/);
+  });
+
+  it('can require Wrangler stdout JSON CLOUDFLARE_API_TOKEN auth errors to block preview startup', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: JSON.stringify({
+        error: {
+          text: "In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work.",
+        },
+      }),
+      stderr: '',
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({ E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT: '1' })).toThrow(
+      /Wrangler auth\/log setup failed/,
+    );
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('keeps TC-2333 documented as stdout JSON CLOUDFLARE_API_TOKEN auth error coverage', () => {
+    const section = readFileSync(path.join(process.cwd(), '..', 'E2E_TEST_CASES.md'), 'utf8');
+
+    expect(section).toContain('TC-2333');
+    expect(section).toContain('issue #2333');
+    expect(section).toContain('isWranglerStdoutAuthError');
+    expect(section).toContain('__tests__/e2e/preview-schema-preflight.test.ts');
+  });
+
   it('continues preview startup on Wrangler auth and log setup failures by default', () => {
     const preflight = loadPreflight();
     spawnSyncMock.mockReturnValue({

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -81,6 +81,19 @@ function isWranglerAuthOrLogFailure(stderr) {
   ].some((pattern) => pattern.test(stderr));
 }
 
+// Detects the non-interactive CLOUDFLARE_API_TOKEN auth error that Wrangler emits in stdout
+// as { "error": { "text": "..." } } or { "error": "..." } when stderr is empty.
+// Wrangler CLI in non-interactive CI environments routes this error to stdout JSON instead
+// of stderr, bypassing the existing isWranglerAuthOrLogFailure check.
+function isWranglerStdoutAuthError(stdout) {
+  const parsed = extractWranglerJson(stdout);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
+  // Handle both { "error": { "text": "..." } } and { "error": "..." } Wrangler output shapes
+  const errorField = parsed.error;
+  const text = typeof errorField === 'string' ? errorField : String(errorField?.text || '');
+  return /CLOUDFLARE_API_TOKEN/i.test(text) || /non-interactive environment/i.test(text);
+}
+
 function isWranglerSchemaFailure(stderr) {
   return [
     /no such (table|column)/i,
@@ -108,11 +121,12 @@ function shouldFailOnWranglerAuthOrLogFailure(env = process.env) {
   return env.E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT === '1';
 }
 
-function buildWranglerAuthOrLogFailureMessage(status, stderr, wranglerEnv) {
+function buildWranglerAuthOrLogFailureMessage(status, stderr, stdout, wranglerEnv) {
   return formatPreflightError([
     'Preview D1 schema preflight could not verify the remote database because Wrangler auth/log setup failed.',
     `Command exited ${status}.`,
-    stderr ? `stderr: ${stderr}` : '',
+    stderr ? `stderr: ${boundedOutput(stderr)}` : '',
+    stdout ? `stdout: ${boundedOutput(stdout)}` : '',
     `WRANGLER_LOG_PATH=${wranglerEnv.WRANGLER_LOG_PATH}`,
     'The preview E2E run will continue because this is an environment credential/setup problem, not confirmed schema drift.',
     'Set CLOUDFLARE_API_TOKEN with D1 read access or refresh wrangler login, then rerun with E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1 to make this failure block browser launch.',
@@ -167,8 +181,9 @@ function assertPreviewD1Schema(env = process.env) {
 
   if (result.status !== 0) {
     const stderr = String(result.stderr || '').trim();
-    if (isWranglerAuthOrLogFailure(stderr)) {
-      const message = buildWranglerAuthOrLogFailureMessage(result.status, stderr, wranglerEnv);
+    const stdout = String(result.stdout || '').trim();
+    if (isWranglerAuthOrLogFailure(stderr) || isWranglerStdoutAuthError(stdout)) {
+      const message = buildWranglerAuthOrLogFailureMessage(result.status, stderr, stdout, wranglerEnv);
       if (shouldFailOnWranglerAuthOrLogFailure(env)) {
         throw new Error(message);
       }
@@ -214,6 +229,7 @@ module.exports = {
   DEFAULT_WRANGLER_LOG_PATH,
   isWranglerSchemaFailure,
   isWranglerAuthOrLogFailure,
+  isWranglerStdoutAuthError,
   parsePresentColumns,
   WRANGLER_TRANSIENT_STATUS_RETRIES,
   WRANGLER_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

- `isWranglerStdoutAuthError` を追加: Wrangler が非インタラクティブ CI 環境で stderr を空にして stdout に `{"error":{"text":"...CLOUDFLARE_API_TOKEN..."}}` を出力する形式を検出
- `{"error": "..."}` のフラット文字列形式も同時に対応 (Wrangler バージョン差異への防御的対応)
- `buildWranglerAuthOrLogFailureMessage` に `stdout` パラメータ追加、`boundedOutput` を適用して generic fatal-error path と一貫性を保つ
- `assertPreviewD1Schema` が stderr auth error (既存) と stdout JSON auth error (新規) の両方を non-blocking として扱う
- TC-2333 を `E2E_TEST_CASES.md` に追加、drift test と unit test で coverage を確保

## Issues

Closes #2333

## Validation

```sh
npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts --ci --forceExit
# Test Suites: 2 passed, Tests: 227 passed

npm test -- --ci --forceExit
# Test Suites: 234 passed, Tests: 3266 passed
```

新規テストケース:
- `detects CLOUDFLARE_API_TOKEN auth error in Wrangler stdout JSON` (nested + flat shape)
- `continues preview startup on Wrangler stdout JSON CLOUDFLARE_API_TOKEN auth error by default`
- `can require Wrangler stdout JSON CLOUDFLARE_API_TOKEN auth errors to block preview startup`
- `keeps TC-2333 documented as stdout JSON CLOUDFLARE_API_TOKEN auth error coverage`
- drift: `keeps TC-2333 aligned with stdout JSON CLOUDFLARE_API_TOKEN auth error classification`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MH4cPpftHR1T2b8jVJ3tM2)_