### PR TITLE
test: TC-2334 E2E + unit coverage for duplicate rankOverride collision tiebreaker

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -142,6 +142,19 @@
 - **期待結果**: stdout JSON auth error は TC-2161 の stderr auth error と同様に non-blocking として扱われ、strict フラグで hard fail に戻せる。スキーマ drift / SQLite error は引き続き失敗する
 - **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
 
+## TC-2334: BM 16-player finals — duplicate rankOverride collision は latest rankOverrideAt を優先する
+- **URL**: `/api/tournaments/[id]/bm/finals`
+- **authRequired**: true (admin)
+- **背景**: issue #2357。BM 予選で複数プレイヤーが同一の `rankOverride` 値を持つ場合、Top-16 finals bracket の seed 順は最新の `rankOverrideAt` タイムスタンプを持つ qualification が優先される。これは大会ディレクターの「最後の明示的修正が有効」という契約であり、unit test (`uses the latest manual rankOverride when duplicate override ranks collide`) とは別に E2E で end-to-end の動作を確認する必要がある。
+- **手順**:
+  1. 16 名のプレイヤーで BM 予選を完了させる
+  2. player[0] に `rankOverride: 1` を PATCH する（earlier タイムスタンプ）
+  3. player[15] に同じ `rankOverride: 1` を PATCH する（later タイムスタンプ）
+  4. BM 予選を confirm し、16-player finals bracket を生成する
+  5. `seededPlayers[0]` が player[15] であることを確認する（最新 override が seed 1 に来る）
+- **期待結果**: rankOverride が衝突した場合に最新の `rankOverrideAt` を持つプレイヤーが seed 1 となる
+- **スクリプト**: `E2E_TESTS=TC-2334 node e2e/tc-bm.js` + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts` + `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-2236: Preview E2E は共有 fixture 作成前に admin session 不在を fast-fail する
 - **URL**: n/a (runner configuration / preview suite)
 - **authRequired**: true (persistent preview admin profile)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1137,6 +1137,26 @@ describe('E2E case drift coverage', () => {
     expect(overallRankingTest).toContain('maps 16-player finals and Top24 playoff losses to standard point bands');
   });
 
+  it('keeps TC-2334 aligned with the BM duplicate rankOverride collision coverage', () => {
+    const section = e2eCaseSection('TC-2334');
+    const finalsRouteTest = readRepoFile(
+      'smkc-score-app',
+      '__tests__',
+      'lib',
+      'api-factories',
+      'finals-route.test.ts',
+    );
+
+    expect(section).toContain('issue #2357');
+    expect(section).toContain('rankOverride');
+    expect(section).toContain('rankOverrideAt');
+    expect(section).toContain('E2E_TESTS=TC-2334 node e2e/tc-bm.js');
+    expect(tcBm).toContain("{ name: 'TC-2334', fn: runTc2334 }");
+    expect(finalsRouteTest).toContain('uses the latest manual rankOverride when duplicate override ranks collide');
+    expect(finalsRouteTest).toContain('falls back to latest rankOverrideAt timestamp when both players share the same rankOverride value');
+    expect(finalsRouteTest).toContain('uses manual rankOverride values before timestamps when both overridden players are tied');
+  });
+
   it('keeps TC-1007 aligned with the GroupSetupDialog static guard', () => {
     const section = e2eCaseSection('TC-1007');
     const followupSection = e2eCaseSection('TC-1678');

--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1022,6 +1022,7 @@ describe('Finals Route Factory', () => {
     });
 
     it('uses manual rankOverride values before timestamps when both overridden players are tied', async () => {
+      // player-0: rankOverride=1 (wins) + earliestOverride; player-1: rankOverride=2 (loses) + latestOverride — opposing directions prove rankOverride value beats timestamp.
       const latestOverride = new Date('2026-01-02T00:00:00Z');
       const earliestOverride = new Date('2026-01-01T00:00:00Z');
       const qualifications = Array.from({ length: 16 }, (_, index) => ({
@@ -1031,7 +1032,7 @@ describe('Finals Route Factory', () => {
         score: 10,
         points: 10,
         rankOverride: index === 0 ? 1 : index === 1 ? 2 : null,
-        rankOverrideAt: index === 0 ? latestOverride : index === 1 ? earliestOverride : null,
+        rankOverrideAt: index === 0 ? earliestOverride : index === 1 ? latestOverride : null,
         player: { id: `player-${index}`, name: `Player ${index + 1}` },
       }));
       (prisma.bMQualification as any).findMany.mockResolvedValue(qualifications);
@@ -1055,6 +1056,44 @@ describe('Finals Route Factory', () => {
       expect(response.status).toBe(201);
       const json = await response.json();
       expect(json.data.seededPlayers[0].playerId).toBe('player-0');
+    });
+
+    it('falls back to latest rankOverrideAt timestamp when both players share the same rankOverride value', async () => {
+      // Both player-0 and player-1 have rankOverride=1 (collision); player-1 has later rankOverrideAt.
+      // Verifies the timestamp tie-breaker: the most-recent correction wins the seed.
+      const earlyOverride = new Date('2026-01-01T00:00:00Z');
+      const latestOverride = new Date('2026-01-02T00:00:00Z');
+      const qualifications = Array.from({ length: 16 }, (_, index) => ({
+        id: `qual-${index}`,
+        playerId: `player-${index}`,
+        group: 'A',
+        score: 10,
+        points: 10,
+        rankOverride: index === 0 || index === 1 ? 1 : null,
+        rankOverrideAt: index === 0 ? earlyOverride : index === 1 ? latestOverride : null,
+        player: { id: `player-${index}`, name: `Player ${index + 1}` },
+      }));
+      (prisma.bMQualification as any).findMany.mockResolvedValue(qualifications);
+      (prisma.bMMatch as any).deleteMany.mockResolvedValue({ count: 0 });
+      (prisma.bMMatch as any).createMany.mockResolvedValue({ count: 31 });
+      (prisma.bMMatch as any).findMany.mockResolvedValue([]);
+
+      const config = createMockConfig({
+        qualificationOrderBy: [{ score: 'desc' }, { points: 'desc' }],
+      });
+      const { POST } = createFinalsHandlers(config);
+
+      const request = new NextRequest('http://localhost:3000', {
+        method: 'POST',
+        body: JSON.stringify({ topN: 16 }),
+      });
+      const response = await POST(request, {
+        params: Promise.resolve({ id: 'tournament-123' }),
+      });
+
+      expect(response.status).toBe(201);
+      const json = await response.json();
+      expect(json.data.seededPlayers[0].playerId).toBe('player-1');
     });
 
     it('does not fetch H2H matches when qualificationOrderBy is empty', async () => {

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -1282,6 +1282,62 @@ async function runTc1010(adminPage) {
   }
 }
 
+// TC-2334: E2E counterpart to 'uses the latest manual rankOverride when duplicate override ranks collide'.
+async function runTc2334(adminPage) {
+  let tournamentId = null;
+  try {
+    const players = sharedBmPlayers(16);
+    tournamentId = await uiCreateTournament(adminPage, `E2E BM TC-2334 ${Date.now()}`);
+    await setupBmQualViaUi(adminPage, tournamentId, players, { randomize: true });
+
+    const bmData = await apiFetchBm(adminPage, tournamentId);
+    const qualifications = bmData.qualifications || bmData.data?.qualifications || [];
+    const earlyTarget = qualifications.find((q) => q.playerId === players[0].id);
+    const latestTarget = qualifications.find((q) => q.playerId === players[15].id);
+    if (!earlyTarget || !latestTarget) throw new Error('TC-2334: override targets not found');
+
+    // PATCH player[0] first to record its rankOverrideAt, then player[15] second (should be later).
+    const res0 = await adminPage.evaluate(async ([url, body]) => {
+      const r = await fetch(url, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [`/api/tournaments/${tournamentId}/bm`, { qualificationId: earlyTarget.id, rankOverride: 1 }]);
+    if (res0.s !== 200) throw new Error(`TC-2334: first rankOverride PATCH failed (${res0.s})`);
+
+    const res15 = await adminPage.evaluate(async ([url, body]) => {
+      const r = await fetch(url, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+      return { s: r.status, b: await r.json().catch(() => ({})) };
+    }, [`/api/tournaments/${tournamentId}/bm`, { qualificationId: latestTarget.id, rankOverride: 1 }]);
+    if (res15.s !== 200) throw new Error(`TC-2334: second rankOverride PATCH failed (${res15.s})`);
+
+    // Guard: confirm the server assigned distinct timestamps so the tie-breaker path is exercised.
+    // If both PATCHes land in the same clock tick, the seeding would fall back to array index order
+    // rather than testing the rankOverrideAt tie-breaker.
+    const bmAfter = await apiFetchBm(adminPage, tournamentId);
+    const qualsAfter = bmAfter.qualifications || bmAfter.data?.qualifications || [];
+    const q0 = qualsAfter.find((q) => q.playerId === players[0].id);
+    const q15 = qualsAfter.find((q) => q.playerId === players[15].id);
+    if (!q0?.rankOverrideAt || !q15?.rankOverrideAt) throw new Error('TC-2334: rankOverrideAt missing after PATCH');
+    const t0 = new Date(q0.rankOverrideAt).getTime();
+    const t15 = new Date(q15.rankOverrideAt).getTime();
+    if (t15 <= t0) throw new Error(`TC-2334: timestamps not distinct — both PATCHes in the same clock tick (q0=${q0.rankOverrideAt} q15=${q15.rankOverrideAt})`);
+
+    const confirmRes = await apiUpdateTournament(adminPage, tournamentId, { bmQualificationConfirmed: true });
+    if (confirmRes.s !== 200) throw new Error(`TC-2334: qualification confirm failed (${confirmRes.s})`);
+
+    const gen = await apiGenerateBmFinals(adminPage, tournamentId, 16);
+    if (gen.s !== 200 && gen.s !== 201) throw new Error(`TC-2334: 16-player finals generation failed (${gen.s})`);
+    const seededPlayers = gen.b?.data?.seededPlayers || [];
+
+    const latestWinsSeed1 = seededPlayers[0]?.playerId === players[15].id;
+    log('TC-2334', latestWinsSeed1 ? 'PASS' : 'FAIL',
+      !latestWinsSeed1 ? `expected seed1=${players[15].id} got ${seededPlayers[0]?.playerId}` : '');
+  } catch (err) {
+    log('TC-2334', 'FAIL', err instanceof Error ? err.message : 'TC-2334 failed');
+  } finally {
+    if (tournamentId) await apiDeleteTournament(adminPage, tournamentId);
+  }
+}
+
 /* ───────── TC-505: BM Grand Final → champion (28-player full) ─────────
  * Drives M1..M16 with player1 sweeping 5-0 each so seeds propagate
  * deterministically. Winners-side champion takes the GF; the champion
@@ -2472,6 +2528,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
       { name: 'TC-504', fn: runTc504 },
       { name: 'TC-510', fn: runTc510 },
       { name: 'TC-1010', fn: runTc1010 },
+      { name: 'TC-2334', fn: runTc2334 },
       { name: 'TC-1046', fn: runTc1046 },
       { name: 'TC-1052', fn: runTc1052 },
       { name: 'TC-515', fn: runTc515 },
@@ -2497,7 +2554,7 @@ function getSuite({ sharedFixture: externalFixture = null } = {}) {
 
 module.exports = {
   runTc501, runTc502, runTc322, runTc503, runTc504, runTc505, runTc506, runTc511, runTc512, runTc513,
-  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522, runTc523, runTc524, runTc525, runTc526, runTc528, runTc529, runTc530, runTc531, runTc533, runTc1010, runTc1046, runTc1052,
+  runTc507, runTc508, runTc509, runTc515, runTc516, runTc517, runTc519, runTc520, runTc521, runTc522, runTc523, runTc524, runTc525, runTc526, runTc528, runTc529, runTc530, runTc531, runTc533, runTc1010, runTc2334, runTc1046, runTc1052,
   bmFinalsTargetWinsForMatch,
   getSuite,
   results,


### PR DESCRIPTION
## Summary

- Add **TC-2334** to `E2E_TEST_CASES.md` documenting the duplicate `rankOverride` collision scenario where the latest `rankOverrideAt` timestamp wins seed 1
- Add `runTc2334` to `e2e/tc-bm.js` as the E2E counterpart to the existing unit test; includes a **timestamp guard** after both PATCHes to detect same-clock-tick collisions that would make the assertion non-deterministic
- Fix the existing `'uses manual rankOverride values before timestamps'` unit test to use **opposing fixtures** (player-0: lower override + earlier timestamp; player-1: higher override + later timestamp), proving `rankOverride` value beats timestamp rather than coincidentally winning both criteria
- Add new unit test `'falls back to latest rankOverrideAt timestamp when both players share the same rankOverride value'` covering the timestamp tie-breaker path for equal `rankOverride` values
- Add drift test for TC-2334 to guard against regression in the alignment between E2E scenario, script, and unit tests

## Issues

Closes #2357
Closes #1911
Closes #1908

## Validation

```
npm test -- --runTestsByPath \
  '__tests__/lib/api-factories/finals-route.test.ts' \
  '__tests__/docs/e2e-cases-drift.test.ts' \
  --ci --forceExit

Test Suites: 2 passed, 2 total
Tests:       287 passed, 287 total
```


---
_Generated by [Claude Code](https://claude.ai/code/session_016wTZZ1sm7f3jDrJZq5ujou)_