### PR TITLE
test: TC-2334 rankOverride collision tie-breaker coverage + review fixes

### DIFF
--- a/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
+++ b/smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts
@@ -1061,7 +1061,7 @@ describe('Finals Route Factory', () => {
     it('falls back to latest rankOverrideAt timestamp when both players share the same rankOverride value', async () => {
       // Both player-0 and player-1 have rankOverride=1 (collision); player-1 has later rankOverrideAt.
       // Verifies the timestamp tie-breaker: the most-recent correction wins the seed.
-      const earlyOverride = new Date('2026-01-01T00:00:00Z');
+      const earliestOverride = new Date('2026-01-01T00:00:00Z');
       const latestOverride = new Date('2026-01-02T00:00:00Z');
       const qualifications = Array.from({ length: 16 }, (_, index) => ({
         id: `qual-${index}`,
@@ -1070,7 +1070,7 @@ describe('Finals Route Factory', () => {
         score: 10,
         points: 10,
         rankOverride: index === 0 || index === 1 ? 1 : null,
-        rankOverrideAt: index === 0 ? earlyOverride : index === 1 ? latestOverride : null,
+        rankOverrideAt: index === 0 ? earliestOverride : index === 1 ? latestOverride : null,
         player: { id: `player-${index}`, name: `Player ${index + 1}` },
       }));
       (prisma.bMQualification as any).findMany.mockResolvedValue(qualifications);

--- a/smkc-score-app/e2e/tc-bm.js
+++ b/smkc-score-app/e2e/tc-bm.js
@@ -1303,6 +1303,9 @@ async function runTc2334(adminPage) {
     }, [`/api/tournaments/${tournamentId}/bm`, { qualificationId: earlyTarget.id, rankOverride: 1 }]);
     if (res0.s !== 200) throw new Error(`TC-2334: first rankOverride PATCH failed (${res0.s})`);
 
+    // Ensure timestamps are distinct across clock ticks in CI environments with low clock resolution.
+    await new Promise((r) => setTimeout(r, 50));
+
     const res15 = await adminPage.evaluate(async ([url, body]) => {
       const r = await fetch(url, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
       return { s: r.status, b: await r.json().catch(() => ({})) };


### PR DESCRIPTION
## Summary

- Add TC-2334 E2E and unit test coverage for duplicate `rankOverride` collision tie-breaker (latest `rankOverrideAt` timestamp wins seed 1)
- Fix `earlyOverride` → `earliestOverride` variable naming in TC-2334 unit test to match adjacent test conventions
- Add 50ms sleep between the two `rankOverride` PATCH calls in `e2e/tc-bm.js` to ensure timestamps are distinct on CI environments with low clock resolution

## Issues

Closes #2357
Closes #1911
Closes #1908
Closes #2387
Closes #2388

## Validation

- `finals-route.test.ts` (91 tests) — all pass
- `e2e-cases-drift.test.ts` (196 tests) — all pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01FETF5GxvLpgoaJNUwqEB3S)_