### PR TITLE
test: handle preview D1 auth 7403 stdout

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -142,6 +142,19 @@
 - **期待結果**: stdout JSON auth error は TC-2161 の stderr auth error と同様に non-blocking として扱われ、strict フラグで hard fail に戻せる。スキーマ drift / SQLite error は引き続き失敗する
 - **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
 
+## TC-2385: Preview D1 preflight は Wrangler stdout JSON Cloudflare API 7403 を auth setup noise として扱う
+- **URL**: n/a (runner configuration / preview suite)
+- **authRequired**: true (Cloudflare D1 token is optional unless strict preflight is requested)
+- **背景**: issue #2385。Wrangler が Cloudflare API permission failure を stdout JSON の `error.code: 7403` と `notes[].text: "The given account is not valid or is not authorized..."` として返す場合、stderr は空のまま非ゼロ終了する。これは schema drift ではなく token/account setup failure なので、通常 preview E2E では TC-2161/TC-2333 と同じ non-blocking preflight warning に分類する必要がある。
+- **手順**:
+  1. Wrangler が `stderr: ""` / `stdout: {"error":{"code":7403,"notes":[{"text":"The given account is not valid or is not authorized to access this service [code: 7403]"}]}}` を返す preflight を模擬する
+  2. `isWranglerStdoutAuthError` が stdout JSON 内の Cloudflare API 7403 authorization failure を検出することを確認する
+  3. 通常の `npm run e2e:preview:all` 相当では警告を出して preflight を通過することを確認する (`console.warn` に `stdout:`, `7403`, `not valid or is not authorized` が含まれる)
+  4. `E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1` 指定時は同じ stdout auth error がブラウザ起動前に失敗することを確認する
+  5. `error.code: 7403` だけで authorization 文言がない stdout JSON は auth setup noise として扱わないことを確認する
+- **期待結果**: Cloudflare API 7403 authorization stdout JSON は通常 preview E2E を本体開始前に止めず、strict フラグで hard fail に戻せる。スキーマ drift / SQLite error は引き続き失敗する
+- **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-2334: BM 16-player finals — duplicate rankOverride collision は latest rankOverrideAt を優先する
 - **URL**: `/api/tournaments/[id]/bm/finals`
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -446,6 +446,22 @@ describe('E2E case drift coverage', () => {
     expect(preflightTest).toContain('keeps TC-2333 documented as stdout JSON CLOUDFLARE_API_TOKEN auth error coverage');
   });
 
+  it('keeps TC-2385 aligned with stdout JSON Cloudflare API 7403 auth error classification', () => {
+    const section = e2eCaseSection('TC-2385');
+    const preflight = readE2eLib('preview-schema-preflight.js');
+    const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');
+
+    expect(section).toContain('issue #2385');
+    expect(section).toContain('Cloudflare API 7403');
+    expect(section).toContain('isWranglerStdoutAuthError');
+    expect(section).toContain('__tests__/e2e/preview-schema-preflight.test.ts');
+    expect(preflight).toContain('Number(errorField?.code) === 7403');
+    expect(preflight).toContain('not valid or is not authorized');
+    expect(preflightTest).toContain('detects Cloudflare API 7403 authorization errors in Wrangler stdout JSON');
+    expect(preflightTest).toContain('continues preview startup on Cloudflare API 7403 authorization stdout JSON by default');
+    expect(preflightTest).toContain('keeps TC-2385 documented as stdout JSON Cloudflare API 7403 auth error coverage');
+  });
+
   it('keeps TC-2236 aligned with preview admin session preflight coverage', () => {
     const section = e2eCaseSection('TC-2236');
     const runner = readE2eScript('run-preview.js');

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -277,6 +277,27 @@ describe('preview schema preflight', () => {
     expect(preflight.isWranglerStdoutAuthError('not json at all')).toBe(false);
   });
 
+  it('detects Cloudflare API 7403 authorization errors in Wrangler stdout JSON', () => {
+    const preflight = loadPreflight();
+    const stdoutJson = JSON.stringify({
+      error: {
+        text: 'A request to the Cloudflare API (/accounts/example/d1/database/example/query) failed.',
+        notes: [
+          {
+            text: 'The given account is not valid or is not authorized to access this service [code: 7403]',
+          },
+        ],
+        kind: 'error',
+        name: 'APIError',
+        code: 7403,
+        accountTag: 'example',
+      },
+    });
+
+    expect(preflight.isWranglerStdoutAuthError(stdoutJson)).toBe(true);
+    expect(preflight.isWranglerStdoutAuthError('{"error":{"code":7403,"notes":[{"text":"database missing table"}]}}')).toBe(false);
+  });
+
   it('continues preview startup on Wrangler stdout JSON CLOUDFLARE_API_TOKEN auth error by default', () => {
     const preflight = loadPreflight();
     spawnSyncMock.mockReturnValue({
@@ -300,6 +321,38 @@ describe('preview schema preflight', () => {
     expect(message).toMatch(/CLOUDFLARE_API_TOKEN/);
   });
 
+  it('continues preview startup on Cloudflare API 7403 authorization stdout JSON by default', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: JSON.stringify({
+        error: {
+          text: 'A request to the Cloudflare API (/accounts/example/d1/database/example/query) failed.',
+          notes: [
+            {
+              text: 'The given account is not valid or is not authorized to access this service [code: 7403]',
+            },
+          ],
+          kind: 'error',
+          name: 'APIError',
+          code: 7403,
+          accountTag: 'example',
+        },
+      }),
+      stderr: '',
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({})).not.toThrow();
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    const message = String((console.warn as jest.Mock).mock.calls[0]?.[0] ?? '');
+    expect(message).toMatch(/Wrangler auth\/log setup failed/);
+    expect(message).toMatch(/E2E run will continue/);
+    expect(message).toMatch(/stdout:/);
+    expect(message).toMatch(/code.*7403/);
+    expect(message).toMatch(/not valid or is not authorized/);
+  });
+
   it('can require Wrangler stdout JSON CLOUDFLARE_API_TOKEN auth errors to block preview startup', () => {
     const preflight = loadPreflight();
     spawnSyncMock.mockReturnValue({
@@ -318,12 +371,47 @@ describe('preview schema preflight', () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 
+  it('can require Cloudflare API 7403 authorization stdout JSON to block preview startup', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: JSON.stringify({
+        error: {
+          text: 'A request to the Cloudflare API (/accounts/example/d1/database/example/query) failed.',
+          notes: [
+            {
+              text: 'The given account is not valid or is not authorized to access this service [code: 7403]',
+            },
+          ],
+          kind: 'error',
+          name: 'APIError',
+          code: 7403,
+        },
+      }),
+      stderr: '',
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({ E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT: '1' })).toThrow(
+      /Wrangler auth\/log setup failed/,
+    );
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
   it('keeps TC-2333 documented as stdout JSON CLOUDFLARE_API_TOKEN auth error coverage', () => {
     const section = readFileSync(path.join(process.cwd(), '..', 'E2E_TEST_CASES.md'), 'utf8');
 
     expect(section).toContain('TC-2333');
     expect(section).toContain('issue #2333');
     expect(section).toContain('isWranglerStdoutAuthError');
+    expect(section).toContain('__tests__/e2e/preview-schema-preflight.test.ts');
+  });
+
+  it('keeps TC-2385 documented as stdout JSON Cloudflare API 7403 auth error coverage', () => {
+    const section = readFileSync(path.join(process.cwd(), '..', 'E2E_TEST_CASES.md'), 'utf8');
+
+    expect(section).toContain('TC-2385');
+    expect(section).toContain('issue #2385');
+    expect(section).toContain('Cloudflare API 7403');
     expect(section).toContain('__tests__/e2e/preview-schema-preflight.test.ts');
   });
 

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -81,17 +81,23 @@ function isWranglerAuthOrLogFailure(stderr) {
   ].some((pattern) => pattern.test(stderr));
 }
 
-// Detects the non-interactive CLOUDFLARE_API_TOKEN auth error that Wrangler emits in stdout
-// as { "error": { "text": "..." } } or { "error": "..." } when stderr is empty.
-// Wrangler CLI in non-interactive CI environments routes this error to stdout JSON instead
-// of stderr, bypassing the existing isWranglerAuthOrLogFailure check.
+// Detects auth/setup errors that Wrangler emits in stdout JSON instead of stderr.
 function isWranglerStdoutAuthError(stdout) {
   const parsed = extractWranglerJson(stdout);
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
-  // Handle both { "error": { "text": "..." } } and { "error": "..." } Wrangler output shapes
   const errorField = parsed.error;
-  const text = typeof errorField === 'string' ? errorField : String(errorField?.text || '');
-  return /CLOUDFLARE_API_TOKEN/i.test(text) || /non-interactive environment/i.test(text);
+  const notes = Array.isArray(errorField?.notes) ? errorField.notes : [];
+  const text = [
+    typeof errorField === 'string' ? errorField : '',
+    errorField?.text,
+    errorField?.name,
+    ...notes.map((note) => note?.text),
+  ].filter(Boolean).join('\n');
+  return (
+    /CLOUDFLARE_API_TOKEN/i.test(text)
+    || /non-interactive environment/i.test(text)
+    || (Number(errorField?.code) === 7403 && /not valid or is not authorized/i.test(text))
+  );
 }
 
 function isWranglerSchemaFailure(stderr) {


### PR DESCRIPTION
## Summary

- Add TC-2385 coverage for Wrangler stdout JSON Cloudflare API 7403 authorization failures.
- Classify Cloudflare API 7403 permission/setup output as non-blocking preview D1 preflight auth noise by default.
- Preserve strict preflight behavior with `E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1`.

## Issues

Closes #2385

## Validation

- `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts --ci --forceExit`
- `npm test -- --ci --forceExit`
- `npm run lint`
- `npm run build:cf`
