### PR TITLE
fix: classify Cloudflare API 7403 stdout JSON as auth setup noise in preview preflight

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -155,6 +155,19 @@
 - **期待結果**: rankOverride が衝突した場合に最新の `rankOverrideAt` を持つプレイヤーが seed 1 となる
 - **スクリプト**: `E2E_TESTS=TC-2334 node e2e/tc-bm.js` + `smkc-score-app/__tests__/lib/api-factories/finals-route.test.ts` + `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2335: Preview D1 preflight は Wrangler stdout JSON Cloudflare API 7403 アカウント認証エラーを auth setup noise として扱う
+- **URL**: n/a (runner configuration / preview suite)
+- **authRequired**: true (Cloudflare D1 token with sufficient account permissions required unless strict preflight is requested)
+- **背景**: issue #2385。Wrangler が Cloudflare API に接続したが対象アカウントが無効またはサービスへのアクセス権がない場合、stdout に `{ "error": { "code": 7403, "text": "...", "notes": [{"text": "The given account is not valid or is not authorized..."}] } }` という JSON を出力して非ゼロ終了する。既存の `isWranglerStdoutAuthError` は `CLOUDFLARE_API_TOKEN` と `non-interactive environment` のパターンしか検査しないため、この 7403 形式はハードフェイルパスに落ちていた。`isWranglerStdoutAuthError` を拡張して `error.code === 7403` または notes 内の `not valid or is not authorized` パターンも認証/アカウント権限失敗として分類し、TC-2333 と同じ non-blocking 扱いにする。
+- **手順**:
+  1. Wrangler が `stderr: ""` / `stdout: {"error":{"code":7403,"text":"...","notes":[{"text":"The given account is not valid..."}]}}` を返す preflight を模擬する
+  2. 通常の `npm run e2e:preview:all` 相当では警告を出して preflight を通過することを確認する (`console.warn` に `Wrangler auth/log setup failed` と `E2E run will continue` が含まれる)
+  3. `E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1` 指定時は同じ 7403 エラーがブラウザ起動前に失敗することを確認する
+  4. `isWranglerStdoutAuthError` が `error.code === 7403` を直接検出することを確認する
+  5. スキーマ drift / SQLite missing table エラーは 7403 分類に影響されず引き続き失敗することを確認する
+- **期待結果**: stdout JSON Cloudflare API 7403 auth error は TC-2333 の CLOUDFLARE_API_TOKEN auth error と同様に non-blocking として扱われ、strict フラグで hard fail に戻せる。スキーマ drift / SQLite error は引き続き失敗する
+- **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts`
+
 ## TC-2236: Preview E2E は共有 fixture 作成前に admin session 不在を fast-fail する
 - **URL**: n/a (runner configuration / preview suite)
 - **authRequired**: true (persistent preview admin profile)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -446,6 +446,22 @@ describe('E2E case drift coverage', () => {
     expect(preflightTest).toContain('keeps TC-2333 documented as stdout JSON CLOUDFLARE_API_TOKEN auth error coverage');
   });
 
+  it('keeps TC-2335 aligned with stdout JSON Cloudflare API 7403 auth error classification', () => {
+    const section = e2eCaseSection('TC-2335');
+    const preflight = readE2eLib('preview-schema-preflight.js');
+    const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');
+
+    expect(section).toContain('issue #2385');
+    expect(section).toContain('7403');
+    expect(section).toContain('isWranglerStdoutAuthError');
+    expect(section).toContain('__tests__/e2e/preview-schema-preflight.test.ts');
+    expect(preflight).toContain('7403');
+    expect(preflight).toContain('not valid or is not authorized');
+    expect(preflightTest).toContain('detects Cloudflare API 7403 authorization error in Wrangler stdout JSON');
+    expect(preflightTest).toContain('continues preview startup on Wrangler stdout JSON Cloudflare API 7403 authorization error by default');
+    expect(preflightTest).toContain('keeps TC-2335 documented as stdout JSON Cloudflare API 7403 auth error coverage');
+  });
+
   it('keeps TC-2236 aligned with preview admin session preflight coverage', () => {
     const section = e2eCaseSection('TC-2236');
     const runner = readE2eScript('run-preview.js');

--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -277,6 +277,93 @@ describe('preview schema preflight', () => {
     expect(preflight.isWranglerStdoutAuthError('not json at all')).toBe(false);
   });
 
+  it('detects Cloudflare API 7403 authorization error in Wrangler stdout JSON', () => {
+    const preflight = loadPreflight();
+
+    // nested { "error": { "code": 7403, ... } } shape from Cloudflare API
+    const stdoutJson7403 = JSON.stringify({
+      error: {
+        text: 'A request to the Cloudflare API (/accounts/xxx/d1/database/yyy/query) failed.',
+        notes: [{ text: 'The given account is not valid or is not authorized to access this service [code: 7403]' }],
+        kind: 'error',
+        name: 'APIError',
+        code: 7403,
+        accountTag: 'xxx',
+      },
+    });
+    expect(preflight.isWranglerStdoutAuthError(stdoutJson7403)).toBe(true);
+
+    // error.code alone is sufficient for detection
+    expect(preflight.isWranglerStdoutAuthError('{"error":{"code":7403,"text":"Some auth error"}}')).toBe(true);
+
+    // notes text matching "not valid or is not authorized" is also detected
+    const stdoutWithNotes = JSON.stringify({
+      error: { text: 'CF API error', notes: [{ text: 'The given account is not valid or is not authorized to access this service [code: 7403]' }] },
+    });
+    expect(preflight.isWranglerStdoutAuthError(stdoutWithNotes)).toBe(true);
+
+    // non-7403 error codes are not classified as auth errors
+    expect(preflight.isWranglerStdoutAuthError('{"error":{"code":9999,"text":"Some other error"}}')).toBe(false);
+    expect(preflight.isWranglerStdoutAuthError('{"error":{"text":"Unknown D1 error","notes":[{"text":"Some unrelated error"}]}}')).toBe(false);
+  });
+
+  it('continues preview startup on Wrangler stdout JSON Cloudflare API 7403 authorization error by default', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: JSON.stringify({
+        error: {
+          text: 'A request to the Cloudflare API (/accounts/b9ab93f1f71640b6965a60c646b2392b/d1/database/5a974a4a-a606-4ea2-b619-4b50db03857d/query) failed.',
+          notes: [{ text: 'The given account is not valid or is not authorized to access this service [code: 7403]' }],
+          kind: 'error',
+          name: 'APIError',
+          code: 7403,
+          accountTag: 'b9ab93f1f71640b6965a60c646b2392b',
+        },
+      }),
+      stderr: '',
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({})).not.toThrow();
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    const message = String((console.warn as jest.Mock).mock.calls[0]?.[0] ?? '');
+    expect(message).toMatch(/Wrangler auth\/log setup failed/);
+    expect(message).toMatch(/E2E run will continue/);
+    expect(message).toMatch(/WRANGLER_LOG_PATH/);
+    expect(message).toMatch(/stdout:/);
+  });
+
+  it('can require Wrangler stdout JSON Cloudflare API 7403 errors to block preview startup', () => {
+    const preflight = loadPreflight();
+    spawnSyncMock.mockReturnValue({
+      status: 1,
+      stdout: JSON.stringify({
+        error: {
+          text: 'A request to the Cloudflare API failed.',
+          notes: [{ text: 'The given account is not valid or is not authorized to access this service [code: 7403]' }],
+          code: 7403,
+        },
+      }),
+      stderr: '',
+    });
+
+    expect(() => preflight.assertPreviewD1Schema({ E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT: '1' })).toThrow(
+      /Wrangler auth\/log setup failed/,
+    );
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('keeps TC-2335 documented as stdout JSON Cloudflare API 7403 auth error coverage', () => {
+    const section = readFileSync(path.join(process.cwd(), '..', 'E2E_TEST_CASES.md'), 'utf8');
+
+    expect(section).toContain('TC-2335');
+    expect(section).toContain('issue #2385');
+    expect(section).toContain('7403');
+    expect(section).toContain('isWranglerStdoutAuthError');
+    expect(section).toContain('__tests__/e2e/preview-schema-preflight.test.ts');
+  });
+
   it('continues preview startup on Wrangler stdout JSON CLOUDFLARE_API_TOKEN auth error by default', () => {
     const preflight = loadPreflight();
     spawnSyncMock.mockReturnValue({

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -83,7 +83,9 @@ function isWranglerAuthOrLogFailure(stderr) {
 
 // Detects the non-interactive CLOUDFLARE_API_TOKEN auth error that Wrangler emits in stdout
 // as { "error": { "text": "..." } } or { "error": "..." } when stderr is empty.
-// Wrangler CLI in non-interactive CI environments routes this error to stdout JSON instead
+// Also detects Cloudflare API account authorization errors (code 7403) that Wrangler emits as
+// { "error": { "code": 7403, "text": "...", "notes": [...] } } when the account/token lacks D1 access.
+// Wrangler CLI in non-interactive CI environments routes these errors to stdout JSON instead
 // of stderr, bypassing the existing isWranglerAuthOrLogFailure check.
 function isWranglerStdoutAuthError(stdout) {
   const parsed = extractWranglerJson(stdout);
@@ -91,7 +93,16 @@ function isWranglerStdoutAuthError(stdout) {
   // Handle both { "error": { "text": "..." } } and { "error": "..." } Wrangler output shapes
   const errorField = parsed.error;
   const text = typeof errorField === 'string' ? errorField : String(errorField?.text || '');
-  return /CLOUDFLARE_API_TOKEN/i.test(text) || /non-interactive environment/i.test(text);
+  if (/CLOUDFLARE_API_TOKEN/i.test(text) || /non-interactive environment/i.test(text)) return true;
+  // Cloudflare API 7403: account not valid or not authorized — emitted when token has no D1 access
+  if (typeof errorField === 'object' && errorField !== null) {
+    if (errorField.code === 7403) return true;
+    const notesText = Array.isArray(errorField.notes)
+      ? errorField.notes.map((n) => String(n?.text || '')).join('\n')
+      : '';
+    if (/not valid or is not authorized/i.test(notesText)) return true;
+  }
+  return false;
 }
 
 function isWranglerSchemaFailure(stderr) {


### PR DESCRIPTION
## Summary

When Wrangler queries the preview D1 database but the Cloudflare account/token lacks D1 access, it exits non-zero with stdout JSON containing `{ "error": { "code": 7403, "text": "...", "notes": [{"text": "The given account is not valid or is not authorized..."}] } }` and an empty stderr. Previously this fell through to the hard-fail path, blocking the preview E2E run entirely.

This PR extends `isWranglerStdoutAuthError` to also detect:
- `error.code === 7403` (direct code check)
- `error.notes[].text` matching "not valid or is not authorized" (notes-based check)

The 7403 error is now treated the same as TC-2333 (CLOUDFLARE_API_TOKEN errors): non-blocking by default (warn and continue), hard-failing when `E2E_REQUIRE_PREVIEW_SCHEMA_PREFLIGHT=1`.

## Issues

Closes #2385

## Validation

- `preview-schema-preflight.test.ts` (36 tests) — all pass
- `e2e-cases-drift.test.ts` (197 tests) — all pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01FETF5GxvLpgoaJNUwqEB3S)_