### PR TITLE
feat: fail fast when live process holds Playwright SingletonLock (#2360)

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -155,6 +155,21 @@
 - **期待結果**: Cloudflare API 7403 authorization stdout JSON は通常 preview E2E を本体開始前に止めず、strict フラグで hard fail に戻せる。スキーマ drift / SQLite error は引き続き失敗する
 - **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2360: Preview E2E は live な SingletonLock 保持プロセス検出で fast-fail する
+- **URL**: n/a (browser launch / preview suite)
+- **authRequired**: true (persistent preview admin profile)
+- **背景**: issue #2360。`npm run e2e:preview:all` が persistent Chromium 起動時に既存の SingletonLock で失敗するケースが発生した。既存の workaround `rm -f .../SingletonLock` は lock 保持プロセスが生存中の場合に unsafe であり、第2の Chromium が profile DB ロックでタイムアウトする。`launchPersistentChromiumContext` の内部で `detectSingletonLockOwner(profileDir)` を呼び出し、lock が live プロセスに保持されていれば actionable なメッセージで fast-fail し、stale（dead process）なら起動を継続する。
+- **手順**:
+  1. `detectSingletonLockOwner(profileDir)` が SingletonLock シンボリックリンクを読み、`hostname-pid` 形式から PID を取得する
+  2. `process.kill(pid, 0)` で保持プロセスの生存を確認する（alive: true / false）
+  3. SingletonLock が存在しない場合は null を返す
+  4. 保持プロセスが生存中の場合、`launchPersistentChromiumContext` は PID を含む actionable エラーで即座に失敗する
+  5. 保持プロセスが dead（stale lock）の場合は起動を継続する（caller が lock cleanup する）
+  6. EPERM（シグナル送信権限なし）は alive 扱いにする（プロセスは存在する）
+  7. `pkill -f chromium` は使用しない。cleanup は SingletonLock ファイルのみを対象にする
+- **期待結果**: SingletonLock が live プロセスに保持される場合、180秒タイムアウトを待たずに PID と操作案内を含むエラーで即時失敗する
+- **スクリプト**: `npm test -- --runTestsByPath __tests__/lib/e2e-browser-launch.test.ts __tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-2334: BM 16-player finals — duplicate rankOverride collision は latest rankOverrideAt を優先する
 - **URL**: `/api/tournaments/[id]/bm/finals`
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -446,6 +446,23 @@ describe('E2E case drift coverage', () => {
     expect(preflightTest).toContain('keeps TC-2333 documented as stdout JSON CLOUDFLARE_API_TOKEN auth error coverage');
   });
 
+  it('keeps TC-2360 aligned with SingletonLock live-owner fast-fail coverage', () => {
+    const section = e2eCaseSection('TC-2360');
+    const commonLib = readE2eLib('common.js');
+    const browserLaunchTest = readRepoFile('smkc-score-app', '__tests__', 'lib', 'e2e-browser-launch.test.ts');
+
+    expect(section).toContain('issue #2360');
+    expect(section).toContain('detectSingletonLockOwner');
+    expect(section).toContain('SingletonLock');
+    expect(section).toContain('__tests__/lib/e2e-browser-launch.test.ts');
+    expect(commonLib).toContain('detectSingletonLockOwner');
+    expect(commonLib).toContain('process.kill(pid, 0)');
+    expect(browserLaunchTest).toContain('returns null when SingletonLock does not exist');
+    expect(browserLaunchTest).toContain('returns alive owner when lock target process is running');
+    expect(browserLaunchTest).toContain('throws with live owner PID before launching Chromium');
+    expect(browserLaunchTest).toContain('keeps TC-2360 documented as SingletonLock live-owner fast-fail coverage');
+  });
+
   it('keeps TC-2385 aligned with stdout JSON Cloudflare API 7403 auth error classification', () => {
     const section = e2eCaseSection('TC-2385');
     const preflight = readE2eLib('preview-schema-preflight.js');

--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -212,4 +212,92 @@ describe('E2E browser launch helpers', () => {
     expect(formatted).toContain('PLAYWRIGHT_BROWSERS_PATH=/tmp/jsmkc-browser-home/ms-playwright npm run e2e:install-browser');
     expect(formatted).toContain('E2E_EXECUTABLE_PATH=/absolute/path/to/chromium-compatible-browser');
   });
+
+  describe('detectSingletonLockOwner', () => {
+    it('returns null when SingletonLock does not exist', () => {
+      jest.spyOn(fs, 'readlinkSync').mockImplementation(() => {
+        const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        throw err;
+      });
+
+      expect(common.detectSingletonLockOwner('/tmp/test-profile')).toBeNull();
+    });
+
+    it('returns null when SingletonLock is not a symlink', () => {
+      jest.spyOn(fs, 'readlinkSync').mockImplementation(() => {
+        const err = Object.assign(new Error('EINVAL'), { code: 'EINVAL' });
+        throw err;
+      });
+
+      expect(common.detectSingletonLockOwner('/tmp/test-profile')).toBeNull();
+    });
+
+    it('returns alive owner when lock target process is running', () => {
+      jest.spyOn(fs, 'readlinkSync').mockReturnValue('AzMacMiniM4.local-28661');
+      (jest.spyOn(process, 'kill') as jest.Mock).mockReturnValue(true);
+
+      expect(common.detectSingletonLockOwner('/tmp/test-profile')).toEqual({
+        pid: 28661,
+        target: 'AzMacMiniM4.local-28661',
+        alive: true,
+      });
+    });
+
+    it('returns dead owner when lock target process no longer exists', () => {
+      jest.spyOn(fs, 'readlinkSync').mockReturnValue('AzMacMiniM4.local-99999');
+      (jest.spyOn(process, 'kill') as jest.Mock).mockImplementation(() => {
+        throw Object.assign(new Error('kill ESRCH 99999'), { code: 'ESRCH' });
+      });
+
+      expect(common.detectSingletonLockOwner('/tmp/test-profile')).toEqual({
+        pid: 99999,
+        target: 'AzMacMiniM4.local-99999',
+        alive: false,
+      });
+    });
+
+    it('treats EPERM as alive because the process exists but cannot be signaled', () => {
+      jest.spyOn(fs, 'readlinkSync').mockReturnValue('host-55555');
+      (jest.spyOn(process, 'kill') as jest.Mock).mockImplementation(() => {
+        throw Object.assign(new Error('kill EPERM 55555'), { code: 'EPERM' });
+      });
+
+      expect(common.detectSingletonLockOwner('/tmp/test-profile')).toEqual({
+        pid: 55555,
+        target: 'host-55555',
+        alive: true,
+      });
+    });
+
+    it('returns null when lock target has no parseable PID', () => {
+      jest.spyOn(fs, 'readlinkSync').mockReturnValue('AzMacMiniM4.local-notanumber');
+
+      expect(common.detectSingletonLockOwner('/tmp/test-profile')).toBeNull();
+    });
+
+    it('keeps TC-2360 documented as SingletonLock live-owner fast-fail coverage', () => {
+      expect(common.detectSingletonLockOwner).toBeInstanceOf(Function);
+    });
+  });
+
+  describe('launchPersistentChromiumContext SingletonLock guard', () => {
+    it('throws with live owner PID before launching Chromium', async () => {
+      const mockLaunchPersistentContext = jest.fn();
+      jest.doMock('playwright', () => ({
+        chromium: {
+          launch: jest.fn(),
+          launchPersistentContext: mockLaunchPersistentContext,
+        },
+      }));
+      common = loadCommon();
+
+      jest.spyOn(fs, 'readlinkSync').mockReturnValue('AzMacMiniM4.local-28661');
+      (jest.spyOn(process, 'kill') as jest.Mock).mockReturnValue(true);
+
+      await expect(common.launchPersistentChromiumContext('/tmp/test-profile')).rejects.toThrow(
+        /PID 28661/,
+      );
+      expect(mockLaunchPersistentContext).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -412,7 +412,62 @@ async function launchChromium(options = {}) {
   }
 }
 
+/**
+ * Reads the Playwright persistent-profile SingletonLock and checks if the owning process is live.
+ *
+ * Chromium creates SingletonLock as a symlink whose target is `${hostname}-${pid}`.
+ * Returns:
+ *   { pid, target, alive: true }  — owning process is still running (or EPERM, meaning it exists)
+ *   { pid, target, alive: false } — lock target PID no longer exists (stale lock)
+ *   null                          — no lock, not a symlink, or unreadable (proceed normally)
+ *
+ * Never removes the lock. Callers decide what to do with the result.
+ * Do NOT use pkill -f chromium; only target the SingletonLock file itself.
+ */
+function detectSingletonLockOwner(profileDir) {
+  const lockPath = path.join(profileDir, 'SingletonLock');
+  let target;
+  try {
+    target = fs.readlinkSync(lockPath);
+  } catch (_err) {
+    // ENOENT = no lock present; EINVAL = not a symlink; either way the profile is free.
+    return null;
+  }
+
+  // Lock target format: `${hostname}-${pid}` — parse PID from after the last dash.
+  const dashIndex = target.lastIndexOf('-');
+  if (dashIndex < 0) return null;
+  const pid = Number(target.slice(dashIndex + 1));
+  if (!Number.isFinite(pid) || !Number.isInteger(pid) || pid <= 0) return null;
+
+  let alive = false;
+  try {
+    // Signal 0 checks for process existence without sending a real signal.
+    process.kill(pid, 0);
+    alive = true;
+  } catch (err) {
+    // EPERM = exists but no permission to signal it; treat as alive.
+    // ESRCH = no such process; stale lock.
+    alive = err.code === 'EPERM';
+  }
+
+  return { pid, target, alive };
+}
+
 async function launchPersistentChromiumContext(profileDir, options = {}) {
+  const lockOwner = detectSingletonLockOwner(profileDir);
+  if (lockOwner?.alive) {
+    throw new Error(
+      [
+        `Preview E2E cannot launch: ${profileDir}/SingletonLock is held by a live process (PID ${lockOwner.pid}).`,
+        `Lock target: ${lockOwner.target}`,
+        'Another E2E run is still active. Wait for it to finish or stop it manually.',
+        `To inspect the owner: ps -p ${lockOwner.pid} -o pid,etime,cmd`,
+        'Do NOT rm -f the lock while the owner is alive — doing so causes the next Chromium to hang on profile DB locks.',
+      ].join('\n'),
+    );
+  }
+
   try {
     return await chromium.launchPersistentContext(profileDir, {
       ...options,
@@ -1085,24 +1140,6 @@ async function apiSeedTtEntry(page, tournamentId, entryId, times, totalTimeMs, r
   });
   if (res.s !== 200) {
     throw new Error(`Failed to seed TT entry ${entryId} (${res.s}): ${JSON.stringify(res.b).slice(0, 200)}`);
-  }
-  return res;
-}
-
-/** Force a TTEntry rank without sending times so recalculateRanks is NOT
- * triggered. Use after apiSeedTtEntry when the desired rank (e.g. 17) would
- * be overwritten by the server's rank recalculation across all tournament
- * entries. Sends only `{version, rank}` — the PUT route only calls
- * recalculateRanks when `times` is present in the body. */
-async function apiForceRankOnly(page, tournamentId, entryId, rank) {
-  const ge = await apiGetTtEntry(page, tournamentId, entryId);
-  const version = ge.b?.data?.version;
-  if (ge.s !== 200 || typeof version !== 'number') {
-    throw new Error(`Failed to fetch TT entry version for rank-only update (${entryId}, status=${ge.s})`);
-  }
-  const res = await apiUpdateTtEntry(page, tournamentId, entryId, { version, rank });
-  if (res.s !== 200) {
-    throw new Error(`Failed to force rank ${rank} for entry ${entryId} (${res.s}): ${JSON.stringify(res.b).slice(0, 120)}`);
   }
   return res;
 }
@@ -2892,6 +2929,7 @@ module.exports = {
   formatE2EErrorForLog,
   getChromiumArgs,
   shouldUseMacSingleProcessLaunch,
+  detectSingletonLockOwner,
   launchChromium,
   launchPersistentChromiumContext,
   /* retry */


### PR DESCRIPTION
## Summary

- Add `detectSingletonLockOwner(profileDir)` to `e2e/lib/common.js` that reads `SingletonLock` as a symlink (`hostname-pid` format), checks process liveness via `process.kill(pid, 0)`, and returns `{ pid, target, alive }` or `null` when no lock exists
- Modify `launchPersistentChromiumContext` to call the lock check before launching; if the lock owner is alive, throw immediately with the PID and a `ps -p` command — no 180-second timeout
- Stale locks (dead process, ESRCH) proceed normally; EPERM is treated as alive
- Remove the pre-existing duplicate `apiForceRankOnly` declaration that was silently shadowed by function hoisting

## Issues

Closes #2360

## Validation

- TDD: wrote failing tests first, then implemented
- 219 tests pass: `npm test -- --runTestsByPath __tests__/lib/e2e-browser-launch.test.ts __tests__/docs/e2e-cases-drift.test.ts`
- New unit tests cover: no lock (ENOENT), not-a-symlink (EINVAL), live process, dead process (ESRCH), EPERM (alive), non-numeric PID, `launchPersistentChromiumContext` throws before calling playwright when lock is live
- Drift test in `e2e-cases-drift.test.ts` keeps TC-2360 aligned with implementation
- No new TypeScript errors
- No `pkill -f chromium` used; only `SingletonLock` file is referenced

---
_Generated by [Claude Code](https://claude.ai/code/session_01FETF5GxvLpgoaJNUwqEB3S)_