### PR TITLE
test: cover dashIndex<0 branch and strengthen TC-2360 drift sentinel (#2396 #2397)

### DIFF
--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -269,6 +269,12 @@ describe('E2E browser launch helpers', () => {
       });
     });
 
+    it('returns null when lock target contains no dash', () => {
+      jest.spyOn(fs, 'readlinkSync').mockReturnValue('nodashhere');
+
+      expect(common.detectSingletonLockOwner('/tmp/test-profile')).toBeNull();
+    });
+
     it('returns null when lock target has no parseable PID', () => {
       jest.spyOn(fs, 'readlinkSync').mockReturnValue('AzMacMiniM4.local-notanumber');
 
@@ -276,7 +282,9 @@ describe('E2E browser launch helpers', () => {
     });
 
     it('keeps TC-2360 documented as SingletonLock live-owner fast-fail coverage', () => {
-      expect(common.detectSingletonLockOwner).toBeInstanceOf(Function);
+      const commonLib = fs.readFileSync(path.join(__dirname, '../../e2e/lib/common.js'), 'utf8');
+      expect(commonLib).toContain("err.code === 'EPERM'");
+      expect(commonLib).toContain('lockOwner?.alive');
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `'returns null when lock target contains no dash'` test to cover the `dashIndex < 0` early-return in `detectSingletonLockOwner` — previously uncovered branch
- Replace `toBeInstanceOf(Function)` stub in the TC-2360 drift sentinel with source-text assertions on `err.code === 'EPERM'` and `lockOwner?.alive` so the sentinel actually detects regressions in those implementation details

## Issues

Closes #2396
Closes #2397

## Validation

- 22 tests pass (was 21): `npm test -- --runTestsByPath __tests__/lib/e2e-browser-launch.test.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FETF5GxvLpgoaJNUwqEB3S)_