### PR TITLE
feat(e2e): classify GPU/SIGSEGV persistent-context crash with recovery guidance

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -420,6 +420,7 @@
   14. macOS では sandboxed automation の Mach/Crashpad launch abort を避けるため `--single-process` / `--no-zygote` を付与し、`E2E_MAC_SINGLE_PROCESS=0` で明示的に無効化できることを確認する
   15. preview runner は `E2E_HEADLESS` 未指定時に `1` を補完し、明示指定は保持することを確認する
   16. `npm run e2e:preview:launch-smoke` が TC 本体に入る前の browser launch だけを検証する入口として存在することを確認する
+  17. `launchPersistentChromiumContext` が GPU process クラッシュ (exit_code=5) / SEGV_ACCERR / ネットワークサービスクラッシュ / ブラウザコンテキスト閉鎖を検出し、`addPersistentContextCrashHelp` が Recovery steps (SingletonLock 削除手順・`E2E_MAC_SINGLE_PROCESS=0` 無効化・issue #2352 参照) を error.message に付与することを確認する (`smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts` の `addPersistentContextCrashHelp` describe ブロックで補助検証)
 - **期待結果**: alias が存在し、TC 本体に入る前の missing script / DNS / empty managed browser cache / Crashpad permission failure で停止しても project-specific bootstrap guidance が表示され、macOS sandboxed automation では launch-smoke で起動だけを検証できる
 - **スクリプト**: `npm run e2e:preview`, `npm run e2e:preview:all`, `npm run e2e:preview:launch-smoke`
 - **補助検証**: `smkc-score-app/__tests__/e2e/run-preview.test.ts`, `smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts`（どちらも runner command 扱いで、URL 欄には環境変数名を入れない）

--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -308,4 +308,68 @@ describe('E2E browser launch helpers', () => {
       expect(mockLaunchPersistentContext).not.toHaveBeenCalled();
     });
   });
+
+  describe('addPersistentContextCrashHelp', () => {
+    it('appends recovery guidance on GPU process crash signature', () => {
+      const error = new Error('[pid=123][err] GPU process exited unexpectedly: exit_code=5');
+      const result = common.addPersistentContextCrashHelp(error, '/tmp/test-profile');
+
+      expect(result).toBe(error);
+      expect(result.message).toContain('Recovery steps:');
+      expect(result.message).toContain('rm -f /tmp/test-profile/SingletonLock');
+    });
+
+    it('appends recovery guidance on SEGV_ACCERR signature', () => {
+      const error = new Error('[pid=42][err] Received signal 11 SEGV_ACCERR addr=0x0');
+      const result = common.addPersistentContextCrashHelp(error, '/tmp/test-profile');
+
+      expect(result.message).toContain('Recovery steps:');
+      expect(result.message).toContain('E2E_MAC_SINGLE_PROCESS=0');
+    });
+
+    it('appends recovery guidance on network service crashed signature', () => {
+      const error = new Error('Network service crashed, restarting service.');
+      const result = common.addPersistentContextCrashHelp(error, '/tmp/test-profile');
+
+      expect(result.message).toContain('Recovery steps:');
+    });
+
+    it('appends recovery guidance on browser context closed signature', () => {
+      const error = new Error('browserContext.newPage: Target page, context or browser has been closed');
+      const result = common.addPersistentContextCrashHelp(error, '/tmp/test-profile');
+
+      expect(result.message).toContain('Recovery steps:');
+    });
+
+    it('returns the error unchanged for unrelated errors', () => {
+      const error = new Error('some unrelated error');
+      const original = error.message;
+      const result = common.addPersistentContextCrashHelp(error, '/tmp/test-profile');
+
+      expect(result).toBe(error);
+      expect(result.message).toBe(original);
+    });
+
+    it('returns non-Error values as-is', () => {
+      const value = { code: 'ENOENT' };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = common.addPersistentContextCrashHelp(value as any, '/tmp/test-profile');
+
+      expect(result).toBe(value);
+    });
+
+    it('uses default profile lock path when profileDir is omitted', () => {
+      const error = new Error('[pid=1][err] GPU process exited unexpectedly: exit_code=5');
+      const result = common.addPersistentContextCrashHelp(error, undefined);
+
+      expect(result.message).toContain('/tmp/playwright-smkc-preview-profile/SingletonLock');
+    });
+
+    it('keeps TC-2352 documented as GPU crash classification coverage', () => {
+      const commonLib = fs.readFileSync(path.join(__dirname, '../../e2e/lib/common.js'), 'utf8');
+      expect(commonLib).toContain('GPU process exited');
+      expect(commonLib).toContain('SEGV_ACCERR');
+      expect(commonLib).toContain('addPersistentContextCrashHelp');
+    });
+  });
 });

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -390,6 +390,53 @@ function addChromiumLaunchHelp(error) {
   return error;
 }
 
+/**
+ * Detects GPU process crash / SIGSEGV signatures in a persistent-context launch
+ * error and adds actionable recovery guidance (issue #2352).
+ *
+ * Chromium's --single-process mode on macOS can trigger a GPU process crash
+ * (SEGV_ACCERR, exit_code=5) before the first page is opened. This failure
+ * class is distinct from:
+ *   - "Executable doesn't exist"  → handled by addChromiumLaunchHelp
+ *   - SingletonLock live-owner    → handled by detectSingletonLockOwner
+ *
+ * Observed signatures (issue #2352):
+ *   [pid=N][err] GPU process exited unexpectedly: exit_code=5
+ *   [pid=N][err] Received signal 11 SEGV_ACCERR ...
+ *   browserContext.newPage: Target page, context or browser has been closed
+ */
+function addPersistentContextCrashHelp(error, profileDir) {
+  if (!(error instanceof Error)) return error;
+  const text = `${error.message || ''}\n${error.stack || ''}`;
+
+  const isGpuCrash =
+    /GPU process exited/i.test(text) ||
+    /SEGV_ACCERR|signal 11 SEGV/i.test(text) ||
+    /Network service crashed/i.test(text);
+  const isBrowserClosed = /Target page.*context.*browser has been closed/i.test(text);
+
+  if (!isGpuCrash && !isBrowserClosed) return error;
+
+  const lockPath = profileDir
+    ? `${profileDir}/SingletonLock`
+    : '/tmp/playwright-smkc-preview-profile/SingletonLock';
+  const hint = [
+    '',
+    'Persistent Chromium context crashed before first page (GPU process / SIGSEGV).',
+    'Recovery steps:',
+    `  1. Remove stale profile lock (only if no owner is alive): rm -f ${lockPath}`,
+    '  2. Isolate browser launch: npm run e2e:preview:launch-smoke',
+    '  3. macOS: disable --single-process mode: E2E_MAC_SINGLE_PROCESS=0 npm run e2e:preview',
+    '  See issue #2352 for full diagnosis.',
+  ].join('\n');
+
+  error.message = `${error.message || ''}${hint}`;
+  if (error.stack && !error.stack.includes('Recovery steps:')) {
+    error.stack = `${error.stack}${hint}`;
+  }
+  return error;
+}
+
 function formatE2EErrorForLog(error) {
   if (!(error instanceof Error)) return error;
   const stack = error.stack || '';
@@ -398,7 +445,8 @@ function formatE2EErrorForLog(error) {
   if (message.includes('Recommended bootstrap:') && !stack.includes('Recommended bootstrap:')) {
     return `${stack}\n${message}`;
   }
-  return stack || message;
+  // !stack was already handled above, so stack is always truthy here
+  return stack;
 }
 
 async function launchChromium(options = {}) {
@@ -474,7 +522,7 @@ async function launchPersistentChromiumContext(profileDir, options = {}) {
       ...getChromiumLaunchConfig(),
     });
   } catch (error) {
-    throw addChromiumLaunchHelp(error);
+    throw addPersistentContextCrashHelp(addChromiumLaunchHelp(error), profileDir);
   }
 }
 
@@ -2926,6 +2974,7 @@ module.exports = {
   resolvePlaywrightBrowsersPath,
   getChromiumLaunchConfig,
   addChromiumLaunchHelp,
+  addPersistentContextCrashHelp,
   formatE2EErrorForLog,
   getChromiumArgs,
   shouldUseMacSingleProcessLaunch,


### PR DESCRIPTION
## Summary

- Add `addPersistentContextCrashHelp(error, profileDir)` to `e2e/lib/common.js` — detects GPU process exit (exit_code=5), SEGV_ACCERR, Network service crash, and `browserContext.newPage` closed signals; appends Recovery steps (SingletonLock removal, `E2E_MAC_SINGLE_PROCESS=0` opt-out, issue #2352 reference)
- Update `launchPersistentChromiumContext` catch to chain both helpers: `addPersistentContextCrashHelp(addChromiumLaunchHelp(error), profileDir)`
- Fix dead code in `formatE2EErrorForLog`: the unreachable `|| message` branch was removed (issue #2338)
- Export `addPersistentContextCrashHelp` from `module.exports`
- Add 8 unit tests for `addPersistentContextCrashHelp` in `__tests__/lib/e2e-browser-launch.test.ts` including TC-2352 sentinel
- Add TC-109 step 17 documenting GPU crash classification in `E2E_TEST_CASES.md`

## Issues

Closes #2352
Closes #2338

## Validation

- `npx jest --runTestsByPath __tests__/lib/e2e-browser-launch.test.ts` → **30 tests pass**
- `npx jest --runTestsByPath __tests__/docs/e2e-cases-drift.test.ts` → **198 tests pass**
- `npm run lint` → 0 errors (26 pre-existing warnings, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019a5BZUNKAN85VbKaRH8Xkc

---
_Generated by [Claude Code](https://claude.ai/code/session_019a5BZUNKAN85VbKaRH8Xkc)_