### PR TITLE
fix: remove dead null guards in finals-route rankOverride sort, add exact-key BM_MR_MATCH_LEAN_SELECT guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -1342,12 +1342,13 @@
 ## TC-2006-2007: BM/MR match lean select — shallow boolean payload contract
 - **URL**: n/a
 - **authRequired**: false
-- **背景**: issue #2006/#2007。`BM_MR_MATCH_LEAN_SELECT` は BM/MR 予選 match payload の共有 select 契約であり、必須 field set は `satisfies` 型契約で守り、unit test では Prisma select として shallow な `true` 値だけを持つことを確認する。
+- **背景**: issue #2006/#2007/#2024。`BM_MR_MATCH_LEAN_SELECT` は BM/MR 予選 match payload の共有 select 契約であり、必須 field set は `satisfies` 型契約で守り、unit test では Prisma select として shallow な `true` 値だけを持つことを確認する。また、`satisfies` 制約は余分なフィールドの追加を検出しないため (issue #2024)、`Object.keys` による exact key 検証も実施する。
 - **手順**:
   1. `prisma-selects.test.ts` が `Object.entries(BM_MR_MATCH_LEAN_SELECT)` から selected entries を検証することを確認する
   2. selected entries が空でなく、各 entry が空でない key と `true` 値だけを持つことを確認する
-  3. drift test が本 TC と unit coverage の対応を検証する
-- **期待結果**: BM/MR 共有 match payload は shallow な boolean select として維持され、必須 field set の増減は `satisfies` 型契約で検出する
+  3. `Object.keys(BM_MR_MATCH_LEAN_SELECT)` が `EXPECTED_FIELDS` と完全一致することを確認する (accidental addition guard)
+  4. drift test が本 TC と unit coverage の対応を検証する
+- **期待結果**: BM/MR 共有 match payload は shallow な boolean select として維持され、必須 field set の削除は `satisfies` 型契約で、余分な追加は exact-key unit test で検出する
 - **スクリプト**: n/a (unit/static coverage) — `smkc-score-app/__tests__/lib/prisma-selects.test.ts`, `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
 
 ## TC-320: BM/MR/GP マッチリスト行レベルのスコア入力リンク非表示化 ✅ FIXED (PR #407)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -2230,8 +2230,9 @@ describe('E2E case drift coverage', () => {
     expect(prismaSelectsTest).toContain('Object.entries(BM_MR_MATCH_LEAN_SELECT)');
     expect(prismaSelectsTest).toContain('selectedFields.length');
     expect(prismaSelectsTest).toContain('key.length > 0 && value === true');
-    expect(prismaSelectsTest).not.toContain('const expectedFields');
-    expect(prismaSelectsTest).not.toContain('Object.keys(BM_MR_MATCH_LEAN_SELECT)');
+    // Issue #2024: exact-key guard must also be present (detects accidental field additions).
+    expect(prismaSelectsTest).toContain('Object.keys(BM_MR_MATCH_LEAN_SELECT)');
+    expect(prismaSelectsTest).toContain('EXPECTED_FIELDS');
   });
 
   it('keeps TC-1090-1091 aligned with overall-ranking static and unit coverage', () => {

--- a/smkc-score-app/__tests__/lib/prisma-selects.test.ts
+++ b/smkc-score-app/__tests__/lib/prisma-selects.test.ts
@@ -7,4 +7,15 @@ describe('prisma selects', () => {
     expect(selectedFields.length).toBeGreaterThan(0);
     expect(selectedFields.every(([key, value]) => key.length > 0 && value === true)).toBe(true);
   });
+
+  it('BM_MR_MATCH_LEAN_SELECT contains exactly the expected fields', () => {
+    // Issue #2024: satisfies only catches required-field deletions. This guards against
+    // accidental additions (e.g. createdAt: true) that would silently inflate lean queries
+    // and potentially expose unexpected fields in BM/MR API responses.
+    const EXPECTED_FIELDS = [
+      'id', 'tournamentId', 'player1Id', 'player2Id',
+      'score1', 'score2', 'rounds', 'completed', 'isBye',
+    ];
+    expect(Object.keys(BM_MR_MATCH_LEAN_SELECT)).toEqual(EXPECTED_FIELDS);
+  });
 });

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -876,10 +876,10 @@ export function createFinalsHandlers(config: FinalsConfig) {
         const bOverride = b.qualification.rankOverride != null;
         if (aOverride !== bOverride) return aOverride ? -1 : 1;
         if (aOverride) {
-          if (b.qualification.rankOverride == null) return -1;
-          if (a.qualification.rankOverride == null) return 1;
-          const aRankOverride = a.qualification.rankOverride;
-          const bRankOverride = b.qualification.rankOverride;
+          // Both aOverride and bOverride are true here (line 877 returns early when they differ),
+          // so rankOverride is guaranteed non-null for both.
+          const aRankOverride = a.qualification.rankOverride!;
+          const bRankOverride = b.qualification.rankOverride!;
           if (aRankOverride !== bRankOverride) return aRankOverride - bRankOverride;
 
           // When manual overrides collide on the same rank value, prefer the


### PR DESCRIPTION
## Summary

- **#2356/#1907**: `finals-route.ts` の rankOverride ソートロジック内にある到達不能な null チェックを削除。`if (aOverride !== bOverride)` のアーリーリターンにより、`if (aOverride)` ブロック内では `aOverride` と `bOverride` が両方 `true` であることが保証されており、`rankOverride` は絶対に null/undefined にならない。その不変条件をコメントと `!` アサーションで明示した。
- **#2024**: `BM_MR_MATCH_LEAN_SELECT` のユニットテストに exact-key 検証を追加。`satisfies` 制約は必須フィールドの削除は検出できるが、`createdAt: true` のような偶発的な追加は検出できなかった。`Object.keys` で完全一致チェックを行うことで、未意図の payload 肥大化を防止する。
- TC-2006-2007 の `E2E_TEST_CASES.md` とドリフトテストを更新し、新しい exact-key 要件を文書化・ガードする。

## Issues

Closes #2356
Closes #1907
Closes #2024

## Validation

- `npm test -- --runTestsByPath '__tests__/lib/prisma-selects.test.ts' '__tests__/docs/e2e-cases-drift.test.ts' '__tests__/lib/api-factories/finals-route.test.ts' --no-coverage` → 全テスト PASS
- `npm test -- --no-coverage` → **3297 tests pass**, 234 suites
- `npm run lint` → 0 errors (26 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01135oEYxv3vssfzRM4fv5wP

---
_Generated by [Claude Code](https://claude.ai/code/session_01135oEYxv3vssfzRM4fv5wP)_