### PR TITLE
fix(test): harden order-sensitive assertions, remove unnecessary async, restore env var scope

### DIFF
--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -173,6 +173,9 @@ describe('E2E browser launch helpers', () => {
       process.env.E2E_MAC_SINGLE_PROCESS = '0';
       expect(common.shouldUseMacSingleProcessLaunch()).toBe(false);
       expect(common.getChromiumArgs()).not.toContain('--single-process');
+      // Explicitly restore so the env var doesn't leak past withPlatform's scope;
+      // afterEach also resets it, but this keeps the scope of the mutation explicit.
+      delete process.env.E2E_MAC_SINGLE_PROCESS;
     });
   });
 

--- a/smkc-score-app/__tests__/lib/prisma-selects.test.ts
+++ b/smkc-score-app/__tests__/lib/prisma-selects.test.ts
@@ -16,6 +16,8 @@ describe('prisma selects', () => {
       'id', 'tournamentId', 'player1Id', 'player2Id',
       'score1', 'score2', 'rounds', 'completed', 'isBye',
     ];
-    expect(Object.keys(BM_MR_MATCH_LEAN_SELECT)).toEqual(EXPECTED_FIELDS);
+    // Use Set comparison so field definition order in BM_MR_MATCH_LEAN_SELECT doesn't
+    // cause false-positive failures when the object is semantically unchanged.
+    expect(new Set(Object.keys(BM_MR_MATCH_LEAN_SELECT))).toEqual(new Set(EXPECTED_FIELDS));
   });
 });

--- a/smkc-score-app/__tests__/lib/tc939-reporting.test.ts
+++ b/smkc-score-app/__tests__/lib/tc939-reporting.test.ts
@@ -11,7 +11,7 @@ describe('describeTc939TabNavigation', () => {
     ({ describeTc939TabNavigation } = (await import('../../e2e/lib/tc939-reporting.js')) as Tc939ReportingModule);
   });
 
-  it('passes with no detail when SPA state and hydrated classes are both valid', async () => {
+  it('passes with no detail when SPA state and hydrated classes are both valid', () => {
     expect(describeTc939TabNavigation({
       spaMarker: 'alive',
       cleanClasses: true,
@@ -21,7 +21,7 @@ describe('describeTc939TabNavigation', () => {
     });
   });
 
-  it('reports both independent TC-939 failure reasons', async () => {
+  it('reports both independent TC-939 failure reasons', () => {
     expect(describeTc939TabNavigation({
       spaMarker: 'lost',
       cleanClasses: false,
@@ -31,7 +31,7 @@ describe('describeTc939TabNavigation', () => {
     });
   });
 
-  it('reports null SPA markers as full reload failures with className detail', async () => {
+  it('reports null SPA markers as full reload failures with className detail', () => {
     expect(describeTc939TabNavigation({
       spaMarker: null,
       cleanClasses: false,
@@ -41,7 +41,7 @@ describe('describeTc939TabNavigation', () => {
     });
   });
 
-  it('reports reload-only failure without className issues', async () => {
+  it('reports reload-only failure without className issues', () => {
     expect(describeTc939TabNavigation({
       spaMarker: 'reload-only',
       cleanClasses: true,
@@ -51,7 +51,7 @@ describe('describeTc939TabNavigation', () => {
     });
   });
 
-  it('reports a className-only failure without a reload message', async () => {
+  it('reports a className-only failure without a reload message', () => {
     expect(describeTc939TabNavigation({
       spaMarker: 'alive',
       cleanClasses: false,
@@ -61,7 +61,7 @@ describe('describeTc939TabNavigation', () => {
     });
   });
 
-  it('uses the shared TC-939 reporter declaration without local input/result casts', async () => {
+  it('uses the shared TC-939 reporter declaration without local input/result casts', () => {
     const pass = describeTc939TabNavigation({
       spaMarker: 'alive',
       cleanClasses: true,

--- a/smkc-score-app/e2e/lib/common.js
+++ b/smkc-score-app/e2e/lib/common.js
@@ -445,7 +445,8 @@ function formatE2EErrorForLog(error) {
   if (message.includes('Recommended bootstrap:') && !stack.includes('Recommended bootstrap:')) {
     return `${stack}\n${message}`;
   }
-  // !stack was already handled above, so stack is always truthy here
+  // Node.js Error instances always have .stack; the guard above covers any edge case,
+  // so stack is guaranteed non-empty at this point.
   return stack;
 }
 


### PR DESCRIPTION
## Summary

- **#2407/#2408**: `prisma-selects.test.ts` の `Object.keys(BM_MR_MATCH_LEAN_SELECT).toEqual(EXPECTED_FIELDS)` を `new Set(...)` 比較に変更。フィールド定義順序変更だけでテストが誤落ちしないようにした
- **#2378**: `tc939-reporting.test.ts` の5つの `it` コールバックから不要な `async` キーワードを削除。`describeTc939TabNavigation` は同期関数であり `await` を一度も使用していない
- **#2376**: `e2e-browser-launch.test.ts` の `withPlatform` コールバック内で `process.env.E2E_MAC_SINGLE_PROCESS = '0'` 使用後に明示的に `delete` を追加。`afterEach` でも復元されるが、スコープを明確にするため
- **#2404**: `e2e/lib/common.js` の `formatE2EErrorForLog` 内コメントを修正。「`!stack` was already handled above」という記述が不正確だったため、Node.js Error が常に `.stack` を持つこと + `!stack` ガードの組み合わせである旨を明記

## Issues

Closes #2407
Closes #2408
Closes #2378
Closes #2376
Closes #2404

## Validation

- `npx jest --runTestsByPath '__tests__/lib/prisma-selects.test.ts' '__tests__/lib/tc939-reporting.test.ts' '__tests__/lib/e2e-browser-launch.test.ts' --no-coverage` → **38 tests pass**
- `npx jest --runTestsByPath '__tests__/docs/e2e-cases-drift.test.ts' --no-coverage` → **199 tests pass**


---
_Generated by [Claude Code](https://claude.ai/code/session_01RHRq3D52xS6ikqRFFVPFvk)_