### PR TITLE
refactor(ta): extract shared TaTimeEntryRow and TaParticipantTimeInputRow components

### DIFF
--- a/smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
@@ -3,16 +3,15 @@
  */
 import { fireEvent, render, screen } from '@testing-library/react';
 
-import { TaFinalsTimeEntryRow } from '@/app/tournaments/[id]/ta/finals/page';
-import { TAEliminationPhaseRow } from '@/components/tournament/ta-elimination-phase';
-import { TaParticipantTimeInputRow } from '@/app/tournaments/[id]/ta/participant/page';
+import { TaTimeEntryRow } from '@/components/tournament/ta-time-entry-row';
+import { TaParticipantTimeInputRow } from '@/components/tournament/ta-participant-time-input-row';
 
 const timeInputProps = {
   inputMode: 'decimal',
   autoComplete: 'off',
 } as const;
 
-describe('TaFinalsTimeEntryRow', () => {
+describe('TaTimeEntryRow (finals phase — with livesLabel)', () => {
   it('renders props and calls callbacks with correct arguments', () => {
     const onTvChange = jest.fn();
     const onTimeChange = jest.fn();
@@ -20,7 +19,7 @@ describe('TaFinalsTimeEntryRow', () => {
     const onRetryToggle = jest.fn();
 
     render(
-      <TaFinalsTimeEntryRow
+      <TaTimeEntryRow
         playerId="player-1"
         playerName="Alice"
         livesLabel="L3"
@@ -61,7 +60,7 @@ describe('TaFinalsTimeEntryRow', () => {
 
   it('disables retry button when editing is disabled', () => {
     render(
-      <TaFinalsTimeEntryRow
+      <TaTimeEntryRow
         playerId="player-1"
         playerName="Alice"
         livesLabel="L3"
@@ -83,9 +82,59 @@ describe('TaFinalsTimeEntryRow', () => {
 
     expect(screen.getByRole('button', { name: 'Retry' })).toBeDisabled();
   });
+
+  it('renders livesLabel when provided', () => {
+    render(
+      <TaTimeEntryRow
+        playerId="player-1"
+        playerName="Alice"
+        livesLabel={<span data-testid="lives">♥♥♥</span>}
+        tvNumber={null}
+        tvLabel="TV number"
+        timeValue=""
+        timePlaceholder="Time"
+        isRetry={false}
+        isEditingDisabled={false}
+        retryLabel="Retry"
+        retryTitle="Retry time"
+        timeInputProps={timeInputProps}
+        onTvChange={jest.fn()}
+        onTimeChange={jest.fn()}
+        onTimeBlur={jest.fn()}
+        onRetryToggle={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('lives')).toBeInTheDocument();
+  });
+
+  it('omits livesLabel container when livesLabel is not provided', () => {
+    render(
+      <TaTimeEntryRow
+        playerId="player-2"
+        playerName="Bob"
+        tvNumber={null}
+        tvLabel="TV number"
+        timeValue=""
+        timePlaceholder="Time"
+        isRetry={false}
+        isEditingDisabled={false}
+        retryLabel="Penalty"
+        retryTitle="Toggle penalty"
+        timeInputProps={timeInputProps}
+        onTvChange={jest.fn()}
+        onTimeChange={jest.fn()}
+        onTimeBlur={jest.fn()}
+        onRetryToggle={jest.fn()}
+      />
+    );
+
+    // No lives container rendered when livesLabel omitted (elimination phase usage)
+    expect(screen.queryByTestId('lives')).not.toBeInTheDocument();
+  });
 });
 
-describe('TAEliminationPhaseRow', () => {
+describe('TaTimeEntryRow (elimination phase — without livesLabel)', () => {
   it('renders props and calls callbacks with correct arguments', () => {
     const onTvChange = jest.fn();
     const onTimeChange = jest.fn();
@@ -93,7 +142,7 @@ describe('TAEliminationPhaseRow', () => {
     const onRetryToggle = jest.fn();
 
     render(
-      <TAEliminationPhaseRow
+      <TaTimeEntryRow
         playerId="player-2"
         playerName="Bob"
         tvNumber={1}
@@ -130,7 +179,7 @@ describe('TAEliminationPhaseRow', () => {
 
   it('disables retry button when editing is disabled', () => {
     render(
-      <TAEliminationPhaseRow
+      <TaTimeEntryRow
         playerId="player-2"
         playerName="Bob"
         tvNumber={null}

--- a/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
+++ b/smkc-score-app/__tests__/static/ta-time-input-props-usememo.test.ts
@@ -26,18 +26,13 @@ const targets = [
 const memoizedRowTargets = [
   {
     label: 'TA participant row component',
-    path: ['src', 'app', 'tournaments', '[id]', 'ta', 'participant', 'page.tsx'],
+    path: ['src', 'components', 'tournament', 'ta-participant-time-input-row.tsx'],
     componentName: 'TaParticipantTimeInputRow',
   },
   {
-    label: 'TA elimination phase row component',
-    path: ['src', 'components', 'tournament', 'ta-elimination-phase.tsx'],
-    componentName: 'TAEliminationPhaseRow',
-  },
-  {
-    label: 'TA finals row component',
-    path: ['src', 'app', 'tournaments', '[id]', 'ta', 'finals', 'page.tsx'],
-    componentName: 'TaFinalsTimeEntryRow',
+    label: 'TA time entry row component (shared by finals and elimination phases)',
+    path: ['src', 'components', 'tournament', 'ta-time-entry-row.tsx'],
+    componentName: 'TaTimeEntryRow',
   },
 ] as const;
 

--- a/smkc-score-app/e2e/tc-ta.js
+++ b/smkc-score-app/e2e/tc-ta.js
@@ -730,16 +730,16 @@ async function runTc896(adminPage) {
     await nav(adminPage, `/tournaments/${tournamentId}/ta/finals`);
     await uiPhaseStartRound(adminPage, tournamentId, 'phase3');
 
-    const names = adminPage.locator('[data-testid="ta-finals-round-player-name"]');
+    const names = adminPage.locator('[data-testid="ta-time-entry-player-name"]');
     const rowCount = await names.count();
     if (rowCount < 2) throw new Error(`expected at least 2 visible player names, got ${rowCount}`);
 
-    const rows = adminPage.locator('[data-testid="ta-finals-round-entry-row"]');
+    const rows = adminPage.locator('[data-testid="ta-time-entry-row"]');
     let layoutProblem = '';
     for (let i = 0; i < rowCount; i++) {
       const row = rows.nth(i);
-      const name = row.locator('[data-testid="ta-finals-round-player-name"]');
-      const controls = row.locator('[data-testid="ta-finals-round-controls"]');
+      const name = row.locator('[data-testid="ta-time-entry-player-name"]');
+      const controls = row.locator('[data-testid="ta-time-entry-controls"]');
       const nameText = (await name.innerText()).trim();
       const rowClass = await row.getAttribute('class');
       const nameClass = await name.getAttribute('class');
@@ -828,7 +828,7 @@ async function runTc1996(adminPage) {
       throw new Error(`expected two active phase3 entries, got ${activeEntries.length}`);
     }
 
-    const tvRow = adminPage.locator('[data-testid="ta-finals-round-entry-row"]')
+    const tvRow = adminPage.locator('[data-testid="ta-time-entry-row"]')
       .filter({ hasText: tvEntry.player.nickname })
       .first();
     await tvRow.locator('select').selectOption('3');

--- a/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/finals/page.tsx
@@ -27,11 +27,10 @@
  * - 3-second auto-refresh for live tracking
  */
 
-import { memo, useState, useEffect, useCallback, use, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, use, useMemo, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Card,
@@ -74,19 +73,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { COURSE_INFO, RETRY_PENALTY_DISPLAY, RETRY_PENALTY_MS, TV_NUMBER_OPTIONS } from "@/lib/constants";
+import { COURSE_INFO, RETRY_PENALTY_DISPLAY, RETRY_PENALTY_MS } from "@/lib/constants";
 import { autoFormatTime, generateRandomTimeString, msToDisplayTime, timeToMs } from "@/lib/ta/time-utils";
 import {
-  TA_FINALS_ROUND_CONTROLS_CLASS,
-  TA_FINALS_ROUND_ENTRY_ROW_CLASS,
-  TA_FINALS_ROUND_PLAYER_LABEL_CLASS,
-  TA_FINALS_ROUND_PLAYER_NAME_CLASS,
-  TA_FINALS_TIME_INPUT_CLASS,
   TA_TIME_INPUT_HELP_CLASS,
-  type TaTimeInputProps,
   getTaTimeInputProps,
-  parseTvNumberInput,
 } from "@/lib/ta/time-entry-layout";
+import { TaTimeEntryRow } from "@/components/tournament/ta-time-entry-row";
 import { getCourseCycleStatus } from "@/lib/ta/course-cycle-status";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { Dice5 } from "lucide-react";
@@ -160,102 +153,6 @@ function renderLives(lives: number, eliminated: boolean, eliminatedLabel: string
   return <span>{hearts}</span>;
 }
 
-type TaFinalsTimeEntryRowProps = {
-  playerId: string;
-  playerName: string;
-  livesLabel: React.ReactNode;
-  tvNumber: number | null;
-  tvLabel: string;
-  timeValue: string;
-  timePlaceholder: string;
-  isRetry: boolean;
-  isEditingDisabled: boolean;
-  retryLabel: string;
-  retryTitle: string;
-  timeInputProps: TaTimeInputProps;
-  onTvChange: (playerId: string, value: number | null) => void;
-  onTimeChange: (playerId: string, value: string) => void;
-  onTimeBlur: (playerId: string) => void;
-  onRetryToggle: (playerId: string) => void;
-};
-
-export const TaFinalsTimeEntryRow = memo(function TaFinalsTimeEntryRow({
-  playerId,
-  playerName,
-  livesLabel,
-  tvNumber,
-  tvLabel,
-  timeValue,
-  timePlaceholder,
-  isRetry,
-  isEditingDisabled,
-  retryLabel,
-  retryTitle,
-  timeInputProps,
-  onTvChange,
-  onTimeChange,
-  onTimeBlur,
-  onRetryToggle,
-}: TaFinalsTimeEntryRowProps) {
-  // Keep the memoized row output stable while remaining responsive to submission state.
-  return (
-    <div
-      className={TA_FINALS_ROUND_ENTRY_ROW_CLASS}
-      data-testid="ta-finals-round-entry-row"
-    >
-      <div className={TA_FINALS_ROUND_PLAYER_LABEL_CLASS}>
-        <Label
-          className={TA_FINALS_ROUND_PLAYER_NAME_CLASS}
-          data-testid="ta-finals-round-player-name"
-        >
-          {playerName}
-        </Label>
-        <div className="text-xs text-muted-foreground">
-          {livesLabel}
-        </div>
-      </div>
-      <div
-        className={TA_FINALS_ROUND_CONTROLS_CLASS}
-        data-testid="ta-finals-round-controls"
-      >
-        <select
-          className="h-9 w-full rounded border bg-background px-2 text-center text-sm sm:h-8 sm:w-16 sm:shrink-0"
-          value={tvNumber ?? ""}
-          onChange={(e) =>
-            onTvChange(playerId, parseTvNumberInput(e.target.value))
-          }
-          aria-label={tvLabel}
-        >
-          <option value="">-</option>
-          {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>TV{n}</option>)}
-        </select>
-        <Input
-          type="text"
-          {...timeInputProps}
-          placeholder={timePlaceholder}
-          value={timeValue}
-          onChange={(e) =>
-            onTimeChange(playerId, e.target.value)
-          }
-          onBlur={() => onTimeBlur(playerId)}
-          disabled={isRetry}
-          className={TA_FINALS_TIME_INPUT_CLASS}
-        />
-        <Button
-          variant={isRetry ? "destructive" : "outline"}
-          size="sm"
-          onClick={() => onRetryToggle(playerId)}
-          title={retryTitle}
-          disabled={isEditingDisabled}
-        >
-          {retryLabel}
-        </Button>
-      </div>
-    </div>
-  );
-});
-
-TaFinalsTimeEntryRow.displayName = 'TaFinalsTimeEntryRow';
 
 export default function TimeAttackFinals({
   params,
@@ -957,7 +854,7 @@ export default function TimeAttackFinals({
                   {tTaFinals('timeInputHelp')}
                 </p>
                 {activeEntries.map((entry) => (
-                  <TaFinalsTimeEntryRow
+                  <TaTimeEntryRow
                     key={entry.id}
                     playerId={entry.playerId}
                     playerName={entry.player.nickname}

--- a/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
+++ b/smkc-score-app/src/app/tournaments/[id]/ta/participant/page.tsx
@@ -25,14 +25,13 @@
  * - Namespaces: participant, ta, common
  */
 
-import { memo, useState, useEffect, useCallback, use, useMemo } from 'react';
+import { useState, useEffect, useCallback, use, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSession } from 'next-auth/react';
 import { usePolling } from '@/lib/hooks/usePolling';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+import { TaParticipantTimeInputRow } from '@/components/tournament/ta-participant-time-input-row';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AlertTriangle, Trophy, Users, Timer, LogIn, Dice5, Lock } from 'lucide-react';
 import Link from 'next/link';
@@ -78,45 +77,6 @@ interface TAApiData {
   taPlayerSelfEdit?: boolean;
 }
 
-type TaParticipantTimeInputRowProps = {
-  courseAbbr: string;
-  value: string;
-  placeholder: string;
-  disabled: boolean;
-  inputClassName: string;
-  timeInputProps: TaTimeInputProps;
-  onChange: (course: string, value: string) => void;
-  onBlur: (course: string) => void;
-};
-
-export const TaParticipantTimeInputRow = memo(function TaParticipantTimeInputRow({
-  courseAbbr,
-  value,
-  placeholder,
-  disabled,
-  inputClassName,
-  timeInputProps,
-  onChange,
-  onBlur,
-}: TaParticipantTimeInputRowProps) {
-  return (
-    <div className="flex items-center gap-2">
-      <Label className="w-12 text-xs font-mono">{courseAbbr}</Label>
-      <Input
-        type="text"
-        {...timeInputProps}
-        placeholder={placeholder}
-        value={value}
-        onChange={(e) => onChange(courseAbbr, e.target.value)}
-        onBlur={() => onBlur(courseAbbr)}
-        disabled={disabled}
-        className={inputClassName}
-      />
-    </div>
-  );
-});
-
-TaParticipantTimeInputRow.displayName = 'TaParticipantTimeInputRow';
 
 /**
  * Convert display time string to milliseconds for preview calculation.

--- a/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
+++ b/smkc-score-app/src/components/tournament/ta-elimination-phase.tsx
@@ -20,11 +20,10 @@
  * - Auto-refresh every 3 seconds for live tournament tracking
  */
 
-import { memo, useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Card,
@@ -57,19 +56,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { COURSE_INFO, RETRY_PENALTY_DISPLAY, RETRY_PENALTY_MS, TV_NUMBER_OPTIONS } from "@/lib/constants";
+import { COURSE_INFO, RETRY_PENALTY_DISPLAY, RETRY_PENALTY_MS } from "@/lib/constants";
 import { autoFormatTime, generateRandomTimeString, msToDisplayTime, timeToMs } from "@/lib/ta/time-utils";
 import {
-  TA_FINALS_ROUND_CONTROLS_CLASS,
-  TA_FINALS_ROUND_ENTRY_ROW_CLASS,
-  TA_FINALS_ROUND_PLAYER_LABEL_CLASS,
-  TA_FINALS_ROUND_PLAYER_NAME_CLASS,
-  TA_FINALS_TIME_INPUT_CLASS,
   TA_TIME_INPUT_HELP_CLASS,
-  type TaTimeInputProps,
   getTaTimeInputProps,
-  parseTvNumberInput,
 } from "@/lib/ta/time-entry-layout";
+import { TaTimeEntryRow } from "@/components/tournament/ta-time-entry-row";
 import { getCourseCycleStatus } from "@/lib/ta/course-cycle-status";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { Dice5 } from "lucide-react";
@@ -96,97 +89,6 @@ export interface TAEliminationPhaseProps {
 }
 
 
-type TAEliminationPhaseRowProps = {
-  playerId: string;
-  playerName: string;
-  tvNumber: number | null;
-  tvLabel: string;
-  timeValue: string;
-  timePlaceholder: string;
-  isRetry: boolean;
-  isEditingDisabled: boolean;
-  retryLabel: string;
-  retryTitle: string;
-  timeInputProps: TaTimeInputProps;
-  onTvChange: (playerId: string, value: number | null) => void;
-  onTimeChange: (playerId: string, value: string) => void;
-  onTimeBlur: (playerId: string) => void;
-  onRetryToggle: (playerId: string) => void;
-};
-
-export const TAEliminationPhaseRow = memo(function TAEliminationPhaseRow({
-  playerId,
-  playerName,
-  tvNumber,
-  tvLabel,
-  timeValue,
-  timePlaceholder,
-  isRetry,
-  isEditingDisabled,
-  retryLabel,
-  retryTitle,
-  timeInputProps,
-  onTvChange,
-  onTimeChange,
-  onTimeBlur,
-  onRetryToggle,
-}: TAEliminationPhaseRowProps) {
-  return (
-    <div
-      className={TA_FINALS_ROUND_ENTRY_ROW_CLASS}
-      data-testid="ta-finals-round-entry-row"
-    >
-      <div className={TA_FINALS_ROUND_PLAYER_LABEL_CLASS}>
-        <Label
-          className={TA_FINALS_ROUND_PLAYER_NAME_CLASS}
-          data-testid="ta-finals-round-player-name"
-        >
-          {playerName}
-        </Label>
-      </div>
-      <div
-        className={TA_FINALS_ROUND_CONTROLS_CLASS}
-        data-testid="ta-finals-round-controls"
-      >
-        <select
-          className="h-9 w-full rounded border bg-background px-2 text-center text-sm sm:h-8 sm:w-16 sm:shrink-0"
-          value={tvNumber ?? ""}
-          onChange={(e) =>
-            onTvChange(playerId, parseTvNumberInput(e.target.value))
-          }
-          aria-label={tvLabel}
-        >
-          <option value="">-</option>
-          {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>TV{n}</option>)}
-        </select>
-        <Input
-          type="text"
-          {...timeInputProps}
-          placeholder={timePlaceholder}
-          value={timeValue}
-          onChange={(e) =>
-            onTimeChange(playerId, e.target.value)
-          }
-          onBlur={() => onTimeBlur(playerId)}
-          disabled={isRetry}
-          className={TA_FINALS_TIME_INPUT_CLASS}
-        />
-        {/* Retry penalty button: sets time to 9:59.990 */}
-        <Button
-          variant={isRetry ? "destructive" : "outline"}
-          size="sm"
-          onClick={() => onRetryToggle(playerId)}
-          title={retryTitle}
-          disabled={isEditingDisabled}
-        >
-          {retryLabel}
-        </Button>
-      </div>
-    </div>
-  );
-});
-
-TAEliminationPhaseRow.displayName = 'TAEliminationPhaseRow';
 
 /** TTEntry from the phases API */
 interface TTEntry {
@@ -885,7 +787,7 @@ export default function TAEliminationPhase({
                   {tElim('timeInputHelp')}
                 </p>
                 {activeEntries.map((entry) => (
-                  <TAEliminationPhaseRow
+                  <TaTimeEntryRow
                     key={entry.id}
                     playerId={entry.playerId}
                     playerName={entry.player.nickname}

--- a/smkc-score-app/src/components/tournament/ta-participant-time-input-row.tsx
+++ b/smkc-score-app/src/components/tournament/ta-participant-time-input-row.tsx
@@ -1,0 +1,42 @@
+import { memo } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { type TaTimeInputProps } from "@/lib/ta/time-entry-layout";
+
+type TaParticipantTimeInputRowProps = {
+  courseAbbr: string;
+  value: string;
+  placeholder: string;
+  disabled: boolean;
+  inputClassName: string;
+  timeInputProps: TaTimeInputProps;
+  onChange: (course: string, value: string) => void;
+  onBlur: (course: string) => void;
+};
+
+export const TaParticipantTimeInputRow = memo(function TaParticipantTimeInputRow({
+  courseAbbr,
+  value,
+  placeholder,
+  disabled,
+  inputClassName,
+  timeInputProps,
+  onChange,
+  onBlur,
+}: TaParticipantTimeInputRowProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <Label className="w-12 text-xs font-mono">{courseAbbr}</Label>
+      <Input
+        type="text"
+        {...timeInputProps}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(courseAbbr, e.target.value)}
+        onBlur={() => onBlur(courseAbbr)}
+        disabled={disabled}
+        className={inputClassName}
+      />
+    </div>
+  );
+});

--- a/smkc-score-app/src/components/tournament/ta-time-entry-row.tsx
+++ b/smkc-score-app/src/components/tournament/ta-time-entry-row.tsx
@@ -1,0 +1,113 @@
+import { memo } from "react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { TV_NUMBER_OPTIONS } from "@/lib/constants";
+import {
+  TA_FINALS_ROUND_CONTROLS_CLASS,
+  TA_FINALS_ROUND_ENTRY_ROW_CLASS,
+  TA_FINALS_ROUND_PLAYER_LABEL_CLASS,
+  TA_FINALS_ROUND_PLAYER_NAME_CLASS,
+  TA_FINALS_TIME_INPUT_CLASS,
+  type TaTimeInputProps,
+  parseTvNumberInput,
+} from "@/lib/ta/time-entry-layout";
+
+type TaTimeEntryRowProps = {
+  playerId: string;
+  playerName: string;
+  /** Optional lives indicator: finals phase renders heart icons, elimination phases omit it. */
+  livesLabel?: ReactNode;
+  tvNumber: number | null;
+  tvLabel: string;
+  timeValue: string;
+  timePlaceholder: string;
+  isRetry: boolean;
+  isEditingDisabled: boolean;
+  retryLabel: string;
+  retryTitle: string;
+  timeInputProps: TaTimeInputProps;
+  onTvChange: (playerId: string, value: number | null) => void;
+  onTimeChange: (playerId: string, value: string) => void;
+  onTimeBlur: (playerId: string) => void;
+  onRetryToggle: (playerId: string) => void;
+};
+
+export const TaTimeEntryRow = memo(function TaTimeEntryRow({
+  playerId,
+  playerName,
+  livesLabel,
+  tvNumber,
+  tvLabel,
+  timeValue,
+  timePlaceholder,
+  isRetry,
+  isEditingDisabled,
+  retryLabel,
+  retryTitle,
+  timeInputProps,
+  onTvChange,
+  onTimeChange,
+  onTimeBlur,
+  onRetryToggle,
+}: TaTimeEntryRowProps) {
+  return (
+    <div
+      className={TA_FINALS_ROUND_ENTRY_ROW_CLASS}
+      data-testid="ta-time-entry-row"
+    >
+      <div className={TA_FINALS_ROUND_PLAYER_LABEL_CLASS}>
+        <Label
+          className={TA_FINALS_ROUND_PLAYER_NAME_CLASS}
+          data-testid="ta-time-entry-player-name"
+        >
+          {playerName}
+        </Label>
+        {livesLabel != null && (
+          <div className="text-xs text-muted-foreground">
+            {livesLabel}
+          </div>
+        )}
+      </div>
+      <div
+        className={TA_FINALS_ROUND_CONTROLS_CLASS}
+        data-testid="ta-time-entry-controls"
+      >
+        <select
+          className="h-9 w-full rounded border bg-background px-2 text-center text-sm sm:h-8 sm:w-16 sm:shrink-0"
+          value={tvNumber ?? ""}
+          onChange={(e) =>
+            onTvChange(playerId, parseTvNumberInput(e.target.value))
+          }
+          aria-label={tvLabel}
+        >
+          <option value="">-</option>
+          {TV_NUMBER_OPTIONS.map((n) => <option key={n} value={n}>TV{n}</option>)}
+        </select>
+        <Input
+          type="text"
+          {...timeInputProps}
+          placeholder={timePlaceholder}
+          value={timeValue}
+          onChange={(e) =>
+            onTimeChange(playerId, e.target.value)
+          }
+          onBlur={() => onTimeBlur(playerId)}
+          disabled={isRetry}
+          className={TA_FINALS_TIME_INPUT_CLASS}
+        />
+        {/* Retry penalty button: sets time to 9:59.990 */}
+        <Button
+          variant={isRetry ? "destructive" : "outline"}
+          size="sm"
+          onClick={() => onRetryToggle(playerId)}
+          title={retryTitle}
+          disabled={isEditingDisabled}
+        >
+          {retryLabel}
+        </Button>
+      </div>
+    </div>
+  );
+});


### PR DESCRIPTION
## Summary

- Extract `TaTimeEntryRow` — shared by finals phase and elimination phases; optional `livesLabel?: ReactNode` renders heart icons for finals, omitted in elimination phase
- Extract `TaParticipantTimeInputRow` — extracted from `participant/page.tsx`
- Both wrapped in `memo(function Name(){})` for stable `.displayName` without redundant assignment
- Rename `data-testid` from `ta-finals-round-*` → `ta-time-entry-*` (now also used in elimination context); update `e2e/tc-ta.js`
- Replace namespace-style `import type React` with named `import type { ReactNode }`
- Shared `TaTimeInputProps` alias from `@/lib/ta/time-entry-layout` used in both row components

## Issues

Closes #1917, #1919, #1921, #1923, #1929, #1934

## Validation

- All 234 test suites pass (3297 tests)
- Static test `ta-time-input-props-usememo.test.ts` verifies `useMemo`, `memo(function Name)` pattern, and `TaTimeInputProps` alias in all target files
- Component test `ta-time-entry-rows.test.tsx` covers `TaTimeEntryRow` (with/without livesLabel) and `TaParticipantTimeInputRow`
- E2E testid selectors updated in `e2e/tc-ta.js`

## Test plan

- [ ] Run `npx jest` — all suites green
- [ ] Verify finals phase page still renders player rows with TV select, time input, retry button
- [ ] Verify elimination phase renders rows without lives indicator
- [ ] Verify participant page renders per-course time inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnX4t1y7rdsTH9AP18aW4Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnX4t1y7rdsTH9AP18aW4Q)_