### PR TITLE
refactor(ta): rename TA_FINALS_ROUND_* constants to TA_TIME_ENTRY_* (#2411)

### DIFF
--- a/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
@@ -1,6 +1,9 @@
 import {
-  TA_FINALS_ROUND_ENTRY_ROW_CLASS,
-  TA_FINALS_ROUND_PLAYER_NAME_CLASS,
+  TA_TIME_ENTRY_CONTROLS_CLASS,
+  TA_TIME_ENTRY_INPUT_CLASS,
+  TA_TIME_ENTRY_PLAYER_LABEL_CLASS,
+  TA_TIME_ENTRY_PLAYER_NAME_CLASS,
+  TA_TIME_ENTRY_ROW_CLASS,
   TA_TIME_ENTRY_CUP_GRID_CLASS,
   TA_TIME_INPUT_BASE_PROPS,
   TA_TIME_INPUT_HELP_CLASS,
@@ -39,13 +42,19 @@ describe("TA time entry layout", () => {
     );
   });
 
-  it("keeps TA finals player names on their own mobile row before sm layout", () => {
-    expect(TA_FINALS_ROUND_ENTRY_ROW_CLASS.split(" ")).toEqual(
+  it("keeps TA time entry player names on their own mobile row before sm layout", () => {
+    expect(TA_TIME_ENTRY_ROW_CLASS.split(" ")).toEqual(
       expect.arrayContaining(["space-y-2", "sm:flex", "sm:space-y-0"]),
     );
-    expect(TA_FINALS_ROUND_PLAYER_NAME_CLASS.split(" ")).toEqual(
+    expect(TA_TIME_ENTRY_PLAYER_NAME_CLASS.split(" ")).toEqual(
       expect.arrayContaining(["block", "truncate", "text-base", "sm:text-sm"]),
     );
+  });
+
+  it("time entry layout constants cover all shared row elements", () => {
+    expect(TA_TIME_ENTRY_PLAYER_LABEL_CLASS).toContain("sm:flex-1");
+    expect(TA_TIME_ENTRY_CONTROLS_CLASS).toContain("sm:flex");
+    expect(TA_TIME_ENTRY_INPUT_CLASS).toContain("font-mono");
   });
 
   it("parses TV number input with explicit radix", () => {

--- a/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/time-entry-layout.test.ts
@@ -51,10 +51,16 @@ describe("TA time entry layout", () => {
     );
   });
 
-  it("time entry layout constants cover all shared row elements", () => {
-    expect(TA_TIME_ENTRY_PLAYER_LABEL_CLASS).toContain("sm:flex-1");
-    expect(TA_TIME_ENTRY_CONTROLS_CLASS).toContain("sm:flex");
-    expect(TA_TIME_ENTRY_INPUT_CLASS).toContain("font-mono");
+  it("player-label, controls, and input constants carry expected Tailwind tokens", () => {
+    expect(TA_TIME_ENTRY_PLAYER_LABEL_CLASS.split(" ")).toEqual(
+      expect.arrayContaining(["min-w-0", "sm:flex-1"]),
+    );
+    expect(TA_TIME_ENTRY_CONTROLS_CLASS.split(" ")).toEqual(
+      expect.arrayContaining(["sm:flex", "sm:shrink-0"]),
+    );
+    expect(TA_TIME_ENTRY_INPUT_CLASS.split(" ")).toEqual(
+      expect.arrayContaining(["font-mono", "text-sm"]),
+    );
   });
 
   it("parses TV number input with explicit radix", () => {

--- a/smkc-score-app/src/components/tournament/ta-sudden-death-panel.tsx
+++ b/smkc-score-app/src/components/tournament/ta-sudden-death-panel.tsx
@@ -28,7 +28,7 @@ import {
 import { COURSE_INFO } from "@/lib/constants";
 import { autoFormatTime, timeToMs } from "@/lib/ta/time-utils";
 import {
-  TA_FINALS_TIME_INPUT_CLASS,
+  TA_TIME_ENTRY_INPUT_CLASS,
   TA_TIME_INPUT_HELP_CLASS,
 } from "@/lib/ta/time-entry-layout";
 
@@ -297,7 +297,7 @@ export function TASuddenDeathPanel<Entry extends TASuddenDeathEntry>({
                 value={suddenDeathTimes[entry.playerId] || ""}
                 onChange={(event) => onTimeChange(entry.playerId, event.target.value)}
                 onBlur={() => onTimeBlur(entry.playerId)}
-                className={TA_FINALS_TIME_INPUT_CLASS}
+                className={TA_TIME_ENTRY_INPUT_CLASS}
               />
             </div>
           ))}

--- a/smkc-score-app/src/components/tournament/ta-time-entry-row.tsx
+++ b/smkc-score-app/src/components/tournament/ta-time-entry-row.tsx
@@ -5,11 +5,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { TV_NUMBER_OPTIONS } from "@/lib/constants";
 import {
-  TA_FINALS_ROUND_CONTROLS_CLASS,
-  TA_FINALS_ROUND_ENTRY_ROW_CLASS,
-  TA_FINALS_ROUND_PLAYER_LABEL_CLASS,
-  TA_FINALS_ROUND_PLAYER_NAME_CLASS,
-  TA_FINALS_TIME_INPUT_CLASS,
+  TA_TIME_ENTRY_CONTROLS_CLASS,
+  TA_TIME_ENTRY_INPUT_CLASS,
+  TA_TIME_ENTRY_PLAYER_LABEL_CLASS,
+  TA_TIME_ENTRY_PLAYER_NAME_CLASS,
+  TA_TIME_ENTRY_ROW_CLASS,
   type TaTimeInputProps,
   parseTvNumberInput,
 } from "@/lib/ta/time-entry-layout";
@@ -54,12 +54,12 @@ export const TaTimeEntryRow = memo(function TaTimeEntryRow({
 }: TaTimeEntryRowProps) {
   return (
     <div
-      className={TA_FINALS_ROUND_ENTRY_ROW_CLASS}
+      className={TA_TIME_ENTRY_ROW_CLASS}
       data-testid="ta-time-entry-row"
     >
-      <div className={TA_FINALS_ROUND_PLAYER_LABEL_CLASS}>
+      <div className={TA_TIME_ENTRY_PLAYER_LABEL_CLASS}>
         <Label
-          className={TA_FINALS_ROUND_PLAYER_NAME_CLASS}
+          className={TA_TIME_ENTRY_PLAYER_NAME_CLASS}
           data-testid="ta-time-entry-player-name"
         >
           {playerName}
@@ -71,7 +71,7 @@ export const TaTimeEntryRow = memo(function TaTimeEntryRow({
         )}
       </div>
       <div
-        className={TA_FINALS_ROUND_CONTROLS_CLASS}
+        className={TA_TIME_ENTRY_CONTROLS_CLASS}
         data-testid="ta-time-entry-controls"
       >
         <select
@@ -95,7 +95,7 @@ export const TaTimeEntryRow = memo(function TaTimeEntryRow({
           }
           onBlur={() => onTimeBlur(playerId)}
           disabled={isRetry}
-          className={TA_FINALS_TIME_INPUT_CLASS}
+          className={TA_TIME_ENTRY_INPUT_CLASS}
         />
         {/* Retry penalty button: sets time to 9:59.990 */}
         <Button

--- a/smkc-score-app/src/lib/ta/time-entry-layout.ts
+++ b/smkc-score-app/src/lib/ta/time-entry-layout.ts
@@ -28,14 +28,14 @@ export function parseTvNumberInput(value: string): number | null {
   return Number.isNaN(tvNumber) ? null : tvNumber;
 }
 
-export const TA_FINALS_ROUND_ENTRY_ROW_CLASS =
+export const TA_TIME_ENTRY_ROW_CLASS =
   "rounded-md border bg-background/60 p-3 space-y-2 sm:flex sm:items-center sm:gap-2 sm:space-y-0 sm:border-0 sm:bg-transparent sm:p-0";
 
-export const TA_FINALS_ROUND_PLAYER_LABEL_CLASS = "min-w-0 sm:flex-1";
+export const TA_TIME_ENTRY_PLAYER_LABEL_CLASS = "min-w-0 sm:flex-1";
 
-export const TA_FINALS_ROUND_PLAYER_NAME_CLASS = "block truncate text-base sm:text-sm";
+export const TA_TIME_ENTRY_PLAYER_NAME_CLASS = "block truncate text-base sm:text-sm";
 
-export const TA_FINALS_ROUND_CONTROLS_CLASS =
+export const TA_TIME_ENTRY_CONTROLS_CLASS =
   "grid grid-cols-[4.5rem_minmax(0,1fr)_auto] items-center gap-2 sm:flex sm:shrink-0";
 
-export const TA_FINALS_TIME_INPUT_CLASS = "font-mono text-sm w-full sm:w-32";
+export const TA_TIME_ENTRY_INPUT_CLASS = "font-mono text-sm w-full sm:w-32";


### PR DESCRIPTION
## Summary

- `TA_FINALS_ROUND_*` / `TA_FINALS_TIME_INPUT_CLASS` 定数を `TA_TIME_ENTRY_*` に改名
- `TaTimeEntryRow` は決勝・予選の両フェーズで共有されるコンポーネントであり、定数名が `FINALS` を示すのは誤解を招いていた
- 全参照ファイルを更新: `ta-time-entry-row.tsx`, `ta-sudden-death-panel.tsx`, テスト

## Issues

Closes #2411

## Validation

- `npm test` 全3325テスト通過
- TypeScriptエラー数は変化なし（既存エラーのみ）
- 動作変更なし（CSS クラス値は同一、定数名のみ変更）

---
_Generated by [Claude Code](https://claude.ai/code/session_014WsrSsZhzaym4Ff8jLy9tx)_