### PR TITLE
perf(cdm-export): pre-compile RegExp + incremental row-index; fix console.debug (#2363 #2362 #1965)

### DIFF
--- a/smkc-score-app/__tests__/lib/cdm-export/sheet-xml-patcher.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/sheet-xml-patcher.test.ts
@@ -297,3 +297,50 @@ describe("SheetXmlPatcher — ordering and idempotency", () => {
     expect(a).toBe(b);
   });
 });
+
+describe("SheetXmlPatcher — multiple insertions keep correct row index (#2362)", () => {
+  it("writes to correct rows when inserting several new rows out of order", () => {
+    // Verify that row-index integrity is maintained after multiple insertions.
+    // A full-map rebuild (O(n) per insert) and an incremental update (O(k) per
+    // insert) must both produce the same document order — this test catches
+    // a bug where the incremental path mis-maps a row number to the wrong index.
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    // Insert between existing rows 2 and 4, plus before row 2 and after row 6.
+    patcher.apply("A1", { op: "number", value: 10 });
+    patcher.apply("A3", { op: "number", value: 30 });
+    patcher.apply("A5", { op: "number", value: 50 });
+    patcher.apply("A7", { op: "number", value: 70 });
+    const out = patcher.serialize();
+    // Rows must appear in ascending order and carry the correct values.
+    const r1 = out.indexOf('<row r="1"');
+    const r2 = out.indexOf('<row r="2"');
+    const r3 = out.indexOf('<row r="3"');
+    const r4 = out.indexOf('<row r="4"');
+    const r5 = out.indexOf('<row r="5"');
+    const r6 = out.indexOf('<row r="6"');
+    const r7 = out.indexOf('<row r="7"');
+    expect(r1).toBeGreaterThan(-1);
+    expect(r2).toBeGreaterThan(r1);
+    expect(r3).toBeGreaterThan(r2);
+    expect(r4).toBeGreaterThan(r3);
+    expect(r5).toBeGreaterThan(r4);
+    expect(r6).toBeGreaterThan(r5);
+    expect(r7).toBeGreaterThan(r6);
+    expect(out).toContain('<row r="1"><c r="A1"><v>10</v></c></row>');
+    expect(out).toContain('<row r="3"><c r="A3"><v>30</v></c></row>');
+    expect(out).toContain('<row r="5"><c r="A5"><v>50</v></c></row>');
+    expect(out).toContain('<row r="7"><c r="A7"><v>70</v></c></row>');
+  });
+
+  it("can overwrite a newly inserted row after subsequent insertions shift indices", () => {
+    // After inserting row 3 (between 2 and 4), inserting row 1 shifts row 3's
+    // index by 1. A subsequent apply("A3", …) must still find the correct row.
+    const patcher = new SheetXmlPatcher(FIXTURE_XML);
+    patcher.apply("A3", { op: "number", value: 99 });
+    patcher.apply("A1", { op: "number", value: 11 }); // shifts index of row 3
+    patcher.apply("A3", { op: "number", value: 33 }); // must overwrite row 3, not row 4
+    const out = patcher.serialize();
+    expect(out).toContain('<row r="3"><c r="A3"><v>33</v></c></row>');
+    expect(out).toContain('<row r="1"><c r="A1"><v>11</v></c></row>');
+  });
+});

--- a/smkc-score-app/e2e/login-preview-admin.js
+++ b/smkc-score-app/e2e/login-preview-admin.js
@@ -42,7 +42,8 @@ async function isAuthenticated(page) {
       throw error;
     }
 
-    console.debug(`[preview-login] ignoring transient Playwright ${PLAYWRIGHT_VERSION} login polling error`);
+    // Use console.log (not console.debug) so CI environments don't suppress this. (#1965)
+    console.log(`[preview-login] ignoring transient Playwright ${PLAYWRIGHT_VERSION} login polling error`);
     // Discord OAuth redirects can destroy the current page execution context
     // while the helper is polling. Treat those transient Playwright errors the
     // same as "not authenticated yet" so the manual login window remains open.

--- a/smkc-score-app/src/lib/cdm-export/sheet-xml-patcher.ts
+++ b/smkc-score-app/src/lib/cdm-export/sheet-xml-patcher.ts
@@ -124,6 +124,21 @@ interface RowModel {
 const ROW_OPEN = "<row";
 const ROW_CLOSE = "</row>";
 
+/**
+ * Pre-compiled attribute regexps for parseCellAttrs.
+ * Each <c> tag has up to 5 attributes (r, s, t, cm, vm). Compiling RegExp
+ * once at module load instead of per-attribute-per-cell avoids allocating a
+ * new RegExp object for every attribute on every cell during sheet parsing —
+ * a CDM sheet can have thousands of cells. (#2363)
+ */
+const CELL_ATTR_RE = {
+  r:  /\br="([^"]*)"/,
+  s:  /\bs="([^"]*)"/,
+  t:  /\bt="([^"]*)"/,
+  cm: /\bcm="([^"]*)"/,
+  vm: /\bvm="([^"]*)"/,
+} as const;
+
 export class SheetXmlPatcher {
   /** Bytes before "<sheetData…" (prolog + sheet header), emitted verbatim. */
   private readonly prefix: string;
@@ -267,16 +282,15 @@ export class SheetXmlPatcher {
       }
     }
     this.rows.splice(insertAt, 0, model);
-    // Indices shifted; rebuild the row index map for correctness.
-    this.reindexRows();
-    return model;
-  }
-
-  private reindexRows(): void {
-    this.rowIndex.clear();
-    for (let i = 0; i < this.rows.length; i++) {
+    // Only update indices for the new row and those shifted by the splice.
+    // A full-map rebuild after every insertion would be O(n) per insert, making
+    // repeated insertions O(n^2) in total. Incrementing only the tail is O(k)
+    // where k is the number of rows after the insertion point. (#2362)
+    this.rowIndex.set(row, insertAt);
+    for (let i = insertAt + 1; i < this.rows.length; i++) {
       this.rowIndex.set(this.rows[i].row, i);
     }
+    return model;
   }
 
   /** Insert a new cell into a parsed row, keeping cells sorted by column. */
@@ -347,15 +361,17 @@ export class SheetXmlPatcher {
 
   /** Parse the attribute string of a <c …> start tag into a CellAttrs. */
   private parseCellAttrs(startTag: string): CellAttrs {
-    const read = (name: string): string | undefined => {
-      const m = new RegExp(`\\b${name}="([^"]*)"`).exec(startTag);
+    // Use module-level pre-compiled CELL_ATTR_RE instead of constructing a new
+    // RegExp per attribute per cell. (#2363)
+    const read = (re: RegExp): string | undefined => {
+      const m = re.exec(startTag);
       return m ? m[1] : undefined;
     };
-    const r = read("r");
+    const r = read(CELL_ATTR_RE.r);
     if (!r) {
       throw new Error(`SheetXmlPatcher: <c> without r attribute: ${startTag}`);
     }
-    return { r, s: read("s"), t: read("t"), cm: read("cm"), vm: read("vm") };
+    return { r, s: read(CELL_ATTR_RE.s), t: read(CELL_ATTR_RE.t), cm: read(CELL_ATTR_RE.cm), vm: read(CELL_ATTR_RE.vm) };
   }
 
   /** Mutate a cell model according to the op (validation included). */


### PR DESCRIPTION
## Summary

- **#2363 (parseCellAttrs RegExp)**: `parseCellAttrs` 内で属性ごとに `new RegExp()` をランタイム構築していた問題を修正。5つの属性パターンをモジュールレベルの定数 `CELL_ATTR_RE` として事前コンパイルし、CDMシートのセル解析時の不要なオブジェクト生成を排除
- **#2362 (reindexRows O(n²))**: `insertRow` が行を splice するたびに `reindexRows()` で Map 全件を再構築しており、大量行挿入時に O(n²) になっていた。splice 後は挿入点以降のインデックスのみを更新する O(k) の実装に変更
- **#1965 (console.debug)**: `login-preview-admin.js` の一時エラー無視ログで `console.debug` を使用しており、CI環境でサプレスされる可能性があった。`console.log` に変更

## Issues

Closes #2363
Closes #2362
Closes #1965

## Validation

- `npx jest --runTestsByPath '__tests__/lib/cdm-export/sheet-xml-patcher.test.ts' --no-coverage` → **27 tests pass**（新規2テスト含む）
- `npx jest --runTestsByPath '__tests__/docs/e2e-cases-drift.test.ts' --no-coverage` → **199 tests pass**
- `npx jest --no-coverage` → **3300 tests pass**, 234 suites

### 新規テスト

`sheet-xml-patcher.test.ts` に「multiple insertions keep correct row index (#2362)」スイートを追加:
- 複数行を任意順で挿入しても正しいドキュメント順序になること
- インデックスシフト後にも正しい行に書き込めること

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfjpykVdn62EGJW26M2SFs)_