### PR TITLE
test: fix test quality issues (#2355, #2342, #2341, #2340, #1935)

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -957,6 +957,16 @@
 - **期待結果**: finals 入力セルは CDM 2025 テンプレートの native bracket coordinates に配置され、テンプレートの数式網（tables/richData）と calc 設定が壊れていないこと。チェック件数0は FAIL。
 - **スクリプト**: `tc-all.js TC-816A`, `__tests__/e2e/tc-816a-cdm-finals-fixture.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2087: CDM export — Main Hub 境界テストは共通 player fixture を使う
+- **URL**: /api/tournaments/[id]/export?format=cdm
+- **背景**: issue #2087 / issue #2091。60人ちょうどと61人超の境界テストが同じ player fixture を別々に定義すると、片方だけ変わってテスト意図がずれる。範囲外 sentinel も列ごとに表記ゆれがあると、保護対象セルの読み取りが紛らわしくなる。
+- **手順**:
+  1. CDM Main Hub 境界テストが shared helper `makeCdmMainHubPlayer` を使って60人/61人の TT entries を生成することを確認する
+  2. 61人超ケースの stale workbook が `B62` から `L62` まで同じ `KEEP-OUT-OF-BOUNDS` sentinel を保持することを確認する
+  3. `GET /api/tournaments/:id/export?format=cdm` 後も `B62` から `L62` が stale sentinel のまま残ることを確認する
+- **期待結果**: Main Hub の境界テストは単一 fixture helper を共有し、範囲外 row の sentinel 表記が揃っている
+- **スクリプト**: `__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`
+
 ## TC-2088: CDM export — Main Hub は60人ちょうどで B62 を空のままにする
 - **URL**: /api/tournaments/[id]/export?format=cdm
 - **背景**: issue #2088/#2193。Main Hub の player rows は B2 から B61 までの60行に限定される。60人ちょうどの境界テストでは、最終行 B61 への書き込みだけでなく、範囲外の B62 が作成されないことも明示的に確認する必要がある。メタテストは整形済みソース文字列ではなく TypeScript AST で 60件 fixture と B62 未書き込みアサーションを確認する。
@@ -967,16 +977,6 @@
   4. Main Hub の `B62` が `undefined` のままであることを確認する
 - **期待結果**: 60人ちょうどでは Main Hub の有効範囲だけが書き込まれ、61行目相当の `B62` は生成されない
 - **スクリプト**: `__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`, `__tests__/docs/e2e-cases-drift.test.ts`
-
-## TC-2087: CDM export — Main Hub 境界テストは共通 player fixture を使う
-- **URL**: /api/tournaments/[id]/export?format=cdm
-- **背景**: issue #2087 / issue #2091。60人ちょうどと61人超の境界テストが同じ player fixture を別々に定義すると、片方だけ変わってテスト意図がずれる。範囲外 sentinel も列ごとに表記ゆれがあると、保護対象セルの読み取りが紛らわしくなる。
-- **手順**:
-  1. CDM Main Hub 境界テストが shared helper `makeCdmMainHubPlayer` を使って60人/61人の TT entries を生成することを確認する
-  2. 61人超ケースの stale workbook が `B62` から `L62` まで同じ `KEEP-OUT-OF-BOUNDS` sentinel を保持することを確認する
-  3. `GET /api/tournaments/:id/export?format=cdm` 後も `B62` から `L62` が stale sentinel のまま残ることを確認する
-- **期待結果**: Main Hub の境界テストは単一 fixture helper を共有し、範囲外 row の sentinel 表記が揃っている
-- **スクリプト**: `__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts`, `__tests__/app/api/tournaments/[id]/export/route.test.ts`
 
 ## TC-2089A: CDM export — Main Hub の 60行上限で row 62 を保護する
 - **URL**: /api/tournaments/[id]/export?format=cdm

--- a/smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
@@ -51,6 +51,7 @@ describe('TaTimeEntryRow (finals phase — with livesLabel)', () => {
 
     fireEvent.blur(timeInput);
     expect(onTimeBlur).toHaveBeenCalledWith('player-1');
+    // disabled because isRetry={true} — not caused by blur
     expect(timeInput).toBeDisabled();
 
     const retryButton = screen.getByRole('button', { name: 'Retry' });

--- a/smkc-score-app/__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-2088-cdm-main-hub-boundary.test.ts
@@ -72,7 +72,7 @@ function bodyHasArrayFromLength60(body: ts.Node, sourceFile: ts.SourceFile) {
   return found;
 }
 
-function isMainHubCellAccess(node: ts.Node, cell: string) {
+function isMainHubCellAccess(node: ts.Node, cell: string, sourceFile: ts.SourceFile) {
   if (!ts.isPropertyAccessExpression(node) || node.name.text !== cell) return false;
   const sheetAccess = node.expression;
   return (
@@ -80,7 +80,7 @@ function isMainHubCellAccess(node: ts.Node, cell: string) {
     ts.isStringLiteral(sheetAccess.argumentExpression) &&
     sheetAccess.argumentExpression.text === 'Main Hub' &&
     ts.isPropertyAccessExpression(sheetAccess.expression) &&
-    sheetAccess.expression.expression.getText() === 'workbook' &&
+    sheetAccess.expression.expression.getText(sourceFile) === 'workbook' &&
     sheetAccess.expression.name.text === 'Sheets'
   );
 }
@@ -104,7 +104,7 @@ function bodyExpectsMainHubCellToBeUndefined(
       node.expression.expression.expression.text === 'expect'
     ) {
       const [expectArgument] = node.expression.expression.arguments;
-      found = Boolean(expectArgument && isMainHubCellAccess(expectArgument, cell));
+      found = Boolean(expectArgument && isMainHubCellAccess(expectArgument, cell, sourceFile));
       return;
     }
 
@@ -157,7 +157,8 @@ describe('TC-2088 CDM Main Hub boundary coverage', () => {
     expect(section).toContain('KEEP-OUT-OF-BOUNDS');
     expect(routeTest).toContain('const makeCdmMainHubPlayer = (index: number) => {');
     expect(routeTest).not.toContain('const makePlayer = (index: number) => {');
-    expect(routeTest.match(/makeCdmMainHubPlayer\(index\)/g)).toHaveLength(2);
+    // At least 2 calls: one for the 60-player boundary case and one for the 61-player out-of-bounds case.
+    expect(routeTest.match(/makeCdmMainHubPlayer\(index\)/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
     expect(routeTest).toContain("for (const column of ['B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L'])");
     expect(routeTest).not.toContain('KEEP-OUT-BOUNDS');
   });

--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -216,6 +216,30 @@ describe('E2E browser launch helpers', () => {
     expect(formatted).toContain('E2E_EXECUTABLE_PATH=/absolute/path/to/chromium-compatible-browser');
   });
 
+  describe('formatE2EErrorForLog', () => {
+    it('returns non-Error values as-is', () => {
+      common = loadCommon();
+      const value = { code: 'ENOENT' };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(common.formatE2EErrorForLog(value as any)).toBe(value);
+    });
+
+    it('returns error message when stack is absent', () => {
+      common = loadCommon();
+      const error = new Error('something went wrong');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (error as any).stack;
+      expect(common.formatE2EErrorForLog(error)).toBe('something went wrong');
+    });
+
+    it('returns error message when stack is empty string', () => {
+      common = loadCommon();
+      const error = new Error('something went wrong');
+      error.stack = '';
+      expect(common.formatE2EErrorForLog(error)).toBe('something went wrong');
+    });
+  });
+
   describe('detectSingletonLockOwner', () => {
     it('returns null when SingletonLock does not exist', () => {
       jest.spyOn(fs, 'readlinkSync').mockImplementation(() => {

--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -218,14 +218,12 @@ describe('E2E browser launch helpers', () => {
 
   describe('formatE2EErrorForLog', () => {
     it('returns non-Error values as-is', () => {
-      common = loadCommon();
       const value = { code: 'ENOENT' };
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect(common.formatE2EErrorForLog(value as any)).toBe(value);
     });
 
     it('returns error message when stack is absent', () => {
-      common = loadCommon();
       const error = new Error('something went wrong');
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (error as any).stack;
@@ -233,7 +231,6 @@ describe('E2E browser launch helpers', () => {
     });
 
     it('returns error message when stack is empty string', () => {
-      common = loadCommon();
       const error = new Error('something went wrong');
       error.stack = '';
       expect(common.formatE2EErrorForLog(error)).toBe('something went wrong');


### PR DESCRIPTION
## Summary

- **#2355**: `isMainHubCellAccess` — `getText()` に `sourceFile` 引数を追加し、TypeScript AST API の推奨パターンに統一
- **#2342**: `makeCdmMainHubPlayer` の呼び出し回数アサーションを `toHaveLength(2)` から `toBeGreaterThanOrEqual(2)` に緩和し、将来のテスト追加で壊れないよう説明コメント付与
- **#2341**: `E2E_TEST_CASES.md` で TC-2087 が TC-2088 の後に記述されていた順序逆転を修正
- **#2340**: `formatE2EErrorForLog` の未テストエッジケース（非 Error オブジェクト、stack 欠落、stack 空文字列）のユニットテストを追加
- **#1935**: `isRetry={true}` によって `disabled` になる理由をテストのコメントで明示（blur と無関係であることを説明）

## Issues

Closes #2355
Closes #2342
Closes #2341
Closes #2340
Closes #1935

## Validation

- `node_modules/.bin/jest` (234 suites, 3333 tests) — すべて PASS
- 新規テスト 3 件追加 (non-Error, absent stack, empty stack)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQgEdFeGsJoeDsS1Zk8MgG)_