### PR TITLE
refactor(test): remove dead code and fragile source-text assertions (#2392 #2393 #2394 #2399 #2339)

### DIFF
--- a/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
+++ b/smkc-score-app/__tests__/e2e/preview-schema-preflight.test.ts
@@ -277,24 +277,22 @@ describe('preview schema preflight', () => {
     expect(preflight.isWranglerStdoutAuthError('not json at all')).toBe(false);
   });
 
+  // Shared fixture for a real Cloudflare API 7403 authorization error in Wrangler stdout JSON.
+  const STUB_7403_STDOUT = JSON.stringify({
+    error: {
+      text: 'A request to the Cloudflare API (/accounts/example/d1/database/example/query) failed.',
+      notes: [{ text: 'The given account is not valid or is not authorized to access this service [code: 7403]' }],
+      kind: 'error',
+      name: 'APIError',
+      code: 7403,
+      accountTag: 'example',
+    },
+  });
+
   it('detects Cloudflare API 7403 authorization errors in Wrangler stdout JSON', () => {
     const preflight = loadPreflight();
-    const stdoutJson = JSON.stringify({
-      error: {
-        text: 'A request to the Cloudflare API (/accounts/example/d1/database/example/query) failed.',
-        notes: [
-          {
-            text: 'The given account is not valid or is not authorized to access this service [code: 7403]',
-          },
-        ],
-        kind: 'error',
-        name: 'APIError',
-        code: 7403,
-        accountTag: 'example',
-      },
-    });
 
-    expect(preflight.isWranglerStdoutAuthError(stdoutJson)).toBe(true);
+    expect(preflight.isWranglerStdoutAuthError(STUB_7403_STDOUT)).toBe(true);
     expect(preflight.isWranglerStdoutAuthError('{"error":{"code":7403,"notes":[{"text":"database missing table"}]}}')).toBe(false);
   });
 
@@ -325,20 +323,7 @@ describe('preview schema preflight', () => {
     const preflight = loadPreflight();
     spawnSyncMock.mockReturnValue({
       status: 1,
-      stdout: JSON.stringify({
-        error: {
-          text: 'A request to the Cloudflare API (/accounts/example/d1/database/example/query) failed.',
-          notes: [
-            {
-              text: 'The given account is not valid or is not authorized to access this service [code: 7403]',
-            },
-          ],
-          kind: 'error',
-          name: 'APIError',
-          code: 7403,
-          accountTag: 'example',
-        },
-      }),
+      stdout: STUB_7403_STDOUT,
       stderr: '',
     });
 
@@ -375,19 +360,7 @@ describe('preview schema preflight', () => {
     const preflight = loadPreflight();
     spawnSyncMock.mockReturnValue({
       status: 1,
-      stdout: JSON.stringify({
-        error: {
-          text: 'A request to the Cloudflare API (/accounts/example/d1/database/example/query) failed.',
-          notes: [
-            {
-              text: 'The given account is not valid or is not authorized to access this service [code: 7403]',
-            },
-          ],
-          kind: 'error',
-          name: 'APIError',
-          code: 7403,
-        },
-      }),
+      stdout: STUB_7403_STDOUT,
       stderr: '',
     });
 

--- a/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
+++ b/smkc-score-app/__tests__/lib/e2e-browser-launch.test.ts
@@ -214,6 +214,7 @@ describe('E2E browser launch helpers', () => {
     expect(formatted).toContain('Recommended bootstrap:');
     expect(formatted).toContain('PLAYWRIGHT_BROWSERS_PATH=/tmp/jsmkc-browser-home/ms-playwright npm run e2e:install-browser');
     expect(formatted).toContain('E2E_EXECUTABLE_PATH=/absolute/path/to/chromium-compatible-browser');
+    delete process.env.PLAYWRIGHT_BROWSERS_PATH;
   });
 
   describe('formatE2EErrorForLog', () => {
@@ -306,9 +307,11 @@ describe('E2E browser launch helpers', () => {
     });
 
     it('keeps TC-2360 documented as SingletonLock live-owner fast-fail coverage', () => {
-      const commonLib = fs.readFileSync(path.join(__dirname, '../../e2e/lib/common.js'), 'utf8');
-      expect(commonLib).toContain("err.code === 'EPERM'");
-      expect(commonLib).toContain('lockOwner?.alive');
+      // EPERM behavior is covered by 'treats EPERM as alive' above.
+      // This sentinel verifies detectSingletonLockOwner is exported and TC-2360 is documented.
+      const doc = fs.readFileSync(path.join(process.cwd(), '..', 'E2E_TEST_CASES.md'), 'utf8');
+      expect(doc).toContain('TC-2360');
+      expect(common.detectSingletonLockOwner).toBeInstanceOf(Function);
     });
   });
 

--- a/smkc-score-app/e2e/lib/preview-schema-preflight.js
+++ b/smkc-score-app/e2e/lib/preview-schema-preflight.js
@@ -82,15 +82,19 @@ function isWranglerAuthOrLogFailure(stderr) {
 }
 
 // Detects auth/setup errors that Wrangler emits in stdout JSON instead of stderr.
+// Patterns 1 & 2 (CLOUDFLARE_API_TOKEN / non-interactive) are exclusive to auth errors
+// in practice, so matching them anywhere in the error text is safe.
+// Pattern 3 (notes text) additionally requires code===7403 to avoid false-positives from
+// unrelated Cloudflare errors that happen to contain the authorization phrase.
 function isWranglerStdoutAuthError(stdout) {
   const parsed = extractWranglerJson(stdout);
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
   const errorField = parsed.error;
   const notes = Array.isArray(errorField?.notes) ? errorField.notes : [];
+  // errorField?.name ('APIError' etc.) is excluded: it never matches the auth patterns below.
   const text = [
     typeof errorField === 'string' ? errorField : '',
     errorField?.text,
-    errorField?.name,
     ...notes.map((note) => note?.text),
   ].filter(Boolean).join('\n');
   return (


### PR DESCRIPTION
## Summary

- **#2392**: `isWranglerStdoutAuthError` の text 連結から `errorField?.name` を削除。`'APIError'` 等の name は CLOUDFLARE_API_TOKEN / non-interactive / 7403 パターンにマッチしないため dead code だった
- **#2394**: Pattern 3（notes テキスト）が `code===7403` を必須とする理由をコメントで明示。Pattern 1 & 2 が全テキストフィールドを走査することも意図的設計と明記
- **#2393**: `preview-schema-preflight.test.ts` で 3 箇所に重複していた 7403 Cloudflare API エラー JSON フィクスチャを共有定数 `STUB_7403_STDOUT` に抽出
- **#2399**: TC-2360 ドリフトセンチネルのソーステキスト照合 (`err.code === 'EPERM'`, `lockOwner?.alive`) を行動ベースの確認（エクスポート確認 + E2E_TEST_CASES.md への言及確認）に置き換え。EPERM 挙動は既存の `'treats EPERM as alive'` テストでカバー済み
- **#2339**: install-browser ヒントテスト内で設定した `process.env.PLAYWRIGHT_BROWSERS_PATH` を afterEach の復元に加えてテスト末尾で明示的に削除し、スコープを明確化

## Issues

Closes #2392
Closes #2393
Closes #2394
Closes #2399
Closes #2339

## Validation

- `node_modules/.bin/jest --no-coverage --runTestsByPath '__tests__/e2e/preview-schema-preflight.test.ts' '__tests__/lib/e2e-browser-launch.test.ts' '__tests__/docs/e2e-cases-drift.test.ts'` → **69 + 202 tests pass**
- `node_modules/.bin/jest --no-coverage` → **3333 tests pass**, 234 suites


---
_Generated by [Claude Code](https://claude.ai/code/session_01DvCzsqfD8FVE9DK4Wq92DP)_