### PR TITLE
fix(test): strengthen drift guards and fix standings logging

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1854,7 +1854,8 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('round');
     expect(section).toContain('createdAt');
     expect(tc2196DriftGuard).toContain('overlayFinalsSelects.length');
-    expect(tc2196DriftGuard).toContain('toBeGreaterThanOrEqual');
+    // Verify the threshold (3) is also checked, not just the assertion name — see issue #2369
+    expect(tc2196DriftGuard).toContain('toBeGreaterThanOrEqual(3)');
   });
   // TC-2224-DRIFT-GUARD-END
 
@@ -1901,7 +1902,8 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('entry.rankOverride != null');
     expect(section).toContain('rankOverride: undefined');
     expect(serverRanking).toContain('if (entry.rankOverride != null)');
-    expect(serverRanking).not.toContain('const overrideRank = entry.rankOverride != null');
+    // Use regex so a rename of the boolean variable (e.g. overrideRank → hasOverride) still triggers detection — see issue #2353
+    expect(serverRanking).not.toMatch(/const \w+ = entry\.rankOverride != null/);
     expect(serverRankingTest).toContain('treats undefined rankOverride as auto-ranked');
     expect(serverRankingTest).toContain('rankOverride: undefined');
     expect(serverRankingTest).toContain('expect(autoRanked?._rankOverridden).toBeUndefined()');
@@ -1949,6 +1951,8 @@ describe('E2E case drift coverage', () => {
     expect(tc1083).toContain('apiFetchMr');
     expect(tc1083).toContain('apiFetchMrStandings');
     expect(tc1083).toContain('assertMrStandingStats');
+    // assertMrStandingStats must be wrapped in try-catch to avoid bypassing log() (issue #2370)
+    expect(tc1083).toContain('standingsErr');
     expect(mrReportRouteTest).toContain('useRoundDifferential: true');
     expect(mrStandingsAssertionsTest).toContain('MR standings ties for p2');
     expect(tc1083).not.toContain('waitForTimeout(3000)');
@@ -2057,7 +2061,8 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('suddenDeathWinnerId: null');
     expect(section).toContain('prisma.gPMatch.update');
     expect(section).toContain('gp/finals/route.test.ts');
-    expect(gpFinalsRouteTest).toContain('const updatedMatch = { ...mockMatch, suddenDeathWinnerId: null };');
+    // Use regex to tolerate Prettier line-wrap reformatting — see issue #2375
+    expect(gpFinalsRouteTest).toMatch(/const updatedMatch\s*=\s*\{\s*\.\.\.mockMatch,\s*suddenDeathWinnerId:\s*null\s*\}/);
     expect(gpFinalsRouteTest).not.toMatch(redundantUpdatedMatch);
     expect(gpFinalsRouteTest).toContain('points1: 2');
     expect(gpFinalsRouteTest).toContain('points2: 2');

--- a/smkc-score-app/__tests__/e2e/mr-standings-assertions.test.ts
+++ b/smkc-score-app/__tests__/e2e/mr-standings-assertions.test.ts
@@ -1,4 +1,28 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { assertMrStandingStats, normalizeMrStandingsPayload } from '../../e2e/lib/mr-standings-assertions';
+
+/** Verify .d.ts declarations stay in sync with the CJS module exports (issue #2373) */
+describe('mr-standings-assertions type declaration drift', () => {
+  const dtsPath = path.resolve(__dirname, '../../e2e/lib/mr-standings-assertions.d.ts');
+  const dtsSource = fs.readFileSync(dtsPath, 'utf-8');
+
+  it('.d.ts exports assertMrStandingStats', () => {
+    expect(dtsSource).toContain('export function assertMrStandingStats(');
+  });
+
+  it('.d.ts exports normalizeMrStandingsPayload', () => {
+    expect(dtsSource).toContain('export function normalizeMrStandingsPayload(');
+  });
+
+  it('.d.ts exports MrStandingEntry interface', () => {
+    expect(dtsSource).toContain('export interface MrStandingEntry');
+  });
+
+  it('.d.ts exports MrStandingStats interface', () => {
+    expect(dtsSource).toContain('export interface MrStandingStats');
+  });
+});
 
 describe('MR standings E2E assertions', () => {
   const standingsPayload = {

--- a/smkc-score-app/e2e/lib/mr-standings-assertions.d.ts
+++ b/smkc-score-app/e2e/lib/mr-standings-assertions.d.ts
@@ -1,0 +1,25 @@
+export interface MrStandingEntry {
+  playerId: string;
+  matchesPlayed: number;
+  wins: number;
+  ties: number;
+  losses: number;
+  points: number;
+  score: number;
+}
+
+export interface MrStandingStats {
+  matchesPlayed: number;
+  wins: number;
+  ties: number;
+  losses: number;
+  points: number;
+  score: number;
+}
+
+export function normalizeMrStandingsPayload(payload: unknown): MrStandingEntry[];
+export function assertMrStandingStats(
+  payload: unknown,
+  playerId: string,
+  expected: MrStandingStats,
+): MrStandingEntry;

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -389,29 +389,37 @@ async function runTc1083(adminPage) {
     const correctedMr = await apiFetchMr(adminPage, tournamentId);
     const correctedMatch = (correctedMr.matches || []).find((m) => m.id === match.id);
     const correctedStandings = await apiFetchMrStandings(adminPage, tournamentId);
-    assertMrStandingStats(correctedStandings, p1.id, {
-      matchesPlayed: 1,
-      wins: 0,
-      ties: 1,
-      losses: 0,
-      points: 0,
-      score: 1,
-    });
-    assertMrStandingStats(correctedStandings, match.player2Id, {
-      matchesPlayed: 1,
-      wins: 0,
-      ties: 1,
-      losses: 0,
-      points: 0,
-      score: 1,
-    });
+    // Incorporate standings failures as a boolean flag so log() is always reached
+    // even when assertMrStandingStats throws — avoids bypassing the explicit log call (issue #2370)
+    let standingsErr = '';
+    try {
+      assertMrStandingStats(correctedStandings, p1.id, {
+        matchesPlayed: 1,
+        wins: 0,
+        ties: 1,
+        losses: 0,
+        points: 0,
+        score: 1,
+      });
+      assertMrStandingStats(correctedStandings, match.player2Id, {
+        matchesPlayed: 1,
+        wins: 0,
+        ties: 1,
+        losses: 0,
+        points: 0,
+        score: 1,
+      });
+    } catch (e) {
+      standingsErr = e instanceof Error ? e.message : 'standings check failed';
+    }
     const ok =
+      !standingsErr &&
       correctedMatch?.completed === true &&
       correctedMatch.score1 === 2 &&
       correctedMatch.score2 === 2;
 
     log('TC-1083', ok ? 'PASS' : 'FAIL',
-      ok ? ''
+      standingsErr ? standingsErr
       : !correctedMatch ? 'Corrected MR match not found'
       : `completed=${correctedMatch.completed} score=${correctedMatch.score1}-${correctedMatch.score2}`);
   } catch (err) {
@@ -776,26 +784,34 @@ async function runTc608(adminPage) {
     const finalMatch = (finalCheck.matches || []).find((m) => m.id === match.id);
     const isComplete = finalMatch?.completed === true && finalMatch.score1 === 3 && finalMatch.score2 === 1;
     const finalStandings = await apiFetchMrStandings(adminPage, tournamentId);
-    assertMrStandingStats(finalStandings, match.player1Id, {
-      matchesPlayed: 1,
-      wins: 1,
-      ties: 0,
-      losses: 0,
-      points: 2,
-      score: 2,
-    });
-    assertMrStandingStats(finalStandings, match.player2Id, {
-      matchesPlayed: 1,
-      wins: 0,
-      ties: 0,
-      losses: 1,
-      points: -2,
-      score: 0,
-    });
+    // Incorporate standings failures as a boolean flag so log() is always reached
+    // even when assertMrStandingStats throws — avoids bypassing the explicit log call (issue #2370)
+    let standingsErr608 = '';
+    try {
+      assertMrStandingStats(finalStandings, match.player1Id, {
+        matchesPlayed: 1,
+        wins: 1,
+        ties: 0,
+        losses: 0,
+        points: 2,
+        score: 2,
+      });
+      assertMrStandingStats(finalStandings, match.player2Id, {
+        matchesPlayed: 1,
+        wins: 0,
+        ties: 0,
+        losses: 1,
+        points: -2,
+        score: 0,
+      });
+    } catch (e) {
+      standingsErr608 = e instanceof Error ? e.message : 'standings check failed';
+    }
 
     log('TC-608',
-      p1Waiting && stillPending && autoConfirmed && isComplete ? 'PASS' : 'FAIL',
-      !p1Waiting ? 'P1 report did not return waitingFor: player2'
+      p1Waiting && stillPending && autoConfirmed && isComplete && !standingsErr608 ? 'PASS' : 'FAIL',
+      standingsErr608 ? standingsErr608
+      : !p1Waiting ? 'P1 report did not return waitingFor: player2'
       : !stillPending ? 'Match became completed after single report'
       : !autoConfirmed ? 'P2 report did not auto-confirm'
       : !isComplete ? `Final state: completed=${finalMatch?.completed} score=${finalMatch?.score1}-${finalMatch?.score2}`


### PR DESCRIPTION
## Summary

- **#2369**: Add `toBeGreaterThanOrEqual(3)` threshold assertion to TC-2224 drift guard — previously only checked the assertion name, not the threshold value
- **#2353**: Replace exact-string `not.toContain` with regex for `rankOverride` variable drift guard — tolerates variable renaming (e.g. `overrideRank → hasOverride`)
- **#2375**: Replace exact-string `toContain` with regex for TC-2247 `updatedMatch` drift guard — tolerates Prettier line-wrap reformatting
- **#2370**: Wrap `assertMrStandingStats` calls in `tc-mr.js` (TC-1083, TC-608) in try-catch with boolean flag — prevents `log()` from being bypassed when assertion throws
- **#2373**: Create `mr-standings-assertions.d.ts` TypeScript declaration file and add drift tests that verify `.d.ts` stays in sync with CJS module exports

## Issues

Closes #2369
Closes #2353
Closes #2375
Closes #2370
Closes #2373

## Validation

- All 3333 tests pass (234 suites, 27 skipped)
- `npx jest --testPathPattern="__tests__/(docs/e2e-cases-drift|e2e/mr-standings-assertions)"` — 209 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJzibMvscoZQdHwSxWd6ES)_