### PR TITLE
fix(test): rename standingsErr608 and add TC-608 drift guard

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1958,6 +1958,12 @@ describe('E2E case drift coverage', () => {
     expect(tc1083).not.toContain('waitForTimeout(3000)');
   });
 
+  it('keeps TC-608 assertMrStandingStats wrapped in try-catch to avoid bypassing log()', () => {
+    const tc608 = sectionBetween(tcMr, 'async function runTc608', 'async function runTc609');
+    // assertMrStandingStats must be wrapped in try-catch to avoid bypassing log() (issue #2370/#2425)
+    expect(tc608).toContain('standingsErr');
+  });
+
   it('keeps TC-1082 aligned with shared BM/MR participant score input coverage', () => {
     const section = e2eCaseSection('TC-1082');
     const bmPage = readRepoFile(

--- a/smkc-score-app/e2e/tc-mr.js
+++ b/smkc-score-app/e2e/tc-mr.js
@@ -786,7 +786,7 @@ async function runTc608(adminPage) {
     const finalStandings = await apiFetchMrStandings(adminPage, tournamentId);
     // Incorporate standings failures as a boolean flag so log() is always reached
     // even when assertMrStandingStats throws — avoids bypassing the explicit log call (issue #2370)
-    let standingsErr608 = '';
+    let standingsErr = '';
     try {
       assertMrStandingStats(finalStandings, match.player1Id, {
         matchesPlayed: 1,
@@ -805,12 +805,12 @@ async function runTc608(adminPage) {
         score: 0,
       });
     } catch (e) {
-      standingsErr608 = e instanceof Error ? e.message : 'standings check failed';
+      standingsErr = e instanceof Error ? e.message : 'standings check failed';
     }
 
     log('TC-608',
-      p1Waiting && stillPending && autoConfirmed && isComplete && !standingsErr608 ? 'PASS' : 'FAIL',
-      standingsErr608 ? standingsErr608
+      p1Waiting && stillPending && autoConfirmed && isComplete && !standingsErr ? 'PASS' : 'FAIL',
+      standingsErr ? standingsErr
       : !p1Waiting ? 'P1 report did not return waitingFor: player2'
       : !stillPending ? 'Match became completed after single report'
       : !autoConfirmed ? 'P2 report did not auto-confirm'


### PR DESCRIPTION
## Summary

Follow-up to PR #2423, addressing two non-blocking review items from the claude[bot] review.

- **#2424**: Rename `standingsErr608` → `standingsErr` in `runTc608` — both TC-608 and TC-1083 live in separate function scopes, so the `608` suffix is unnecessary and inconsistent
- **#2425**: Add drift guard `expect(tc608).toContain('standingsErr')` — mirrors the TC-1083 guard added in #2423; ensures TC-608's `assertMrStandingStats` try-catch won't be silently removed

## Issues

Closes #2424
Closes #2425

## Validation

- 210 Jest tests pass (was 209 before — new TC-608 drift guard adds 1)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJzibMvscoZQdHwSxWd6ES)_