### PR TITLE
test: strengthen timer ID verification and fix redundant assertions (#1959 #2019 #2020)

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -3489,6 +3489,18 @@
 - **期待結果**: TV3/TV4 が選ばれている状態で「配信に反映」を押しても、利用者は TV3/TV4 がOBS表示対象外であることを画面上で確認できる
 - **スクリプト**: tc-ta.js TC-808A / e2e-cases-drift.test.ts / use-broadcast-reflect.test.ts
 
+## TC-1959: useBroadcastReflect — タイマーキャンセル時に正しい ID で clearTimeout が呼ばれる
+- **URL**: n/a (unit test)
+- **authRequired**: false
+- **背景**: issue #1959。`useBroadcastReflect` はブロードキャスト反映後に 3 秒で `idle` へ戻すタイマーを管理する。`resetBroadcastStatus()` やアンマウント時にタイマーをキャンセルする際、`clearTimeout` に「直前の `setTimeout` が返した ID」を渡すことで確実に正しいタイマーをキャンセルしなければならない。タイマー ID を検証しないと、`clearTimeout(undefined)` などの無効呼び出しでテストが通過してしまう。
+- **手順**:
+  1. `useBroadcastReflect` を `renderHook` でマウントし、`handleBroadcastReflect()` を呼んでタイマーをスケジュールする
+  2. `setTimeoutSpy.mock.results[0].value` でタイマー ID を捕捉する
+  3. `resetBroadcastStatus()` / `unmount()` / 再反映 のいずれかを実行する
+  4. `clearTimeoutSpy` が捕捉したタイマー ID と同じ値で呼ばれたことを確認する
+- **期待結果**: `clearTimeout` は常に「直前の `setTimeout` が返した正しい ID」で呼ばれる
+- **スクリプト**: `__tests__/lib/hooks/use-broadcast-reflect.test.ts`
+
 ## TC-897: TAタイム入力欄フォーカス時にスマホ数字キーボードを出す
 - **URL**: /auth/signin -> /tournaments/[temp-id]/ta
 - **authRequired**: true (player)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1245,11 +1245,12 @@ describe('E2E case drift coverage', () => {
     expect(helperAliasCallGuardSection).toContain('同一の `throwUnexpectedMockCall(...)` 呼び出し');
     expect(groupSetupHelperTest).not.toContain('const expectedPageRoleLookups');
     expect(groupSetupHelperTest).not.toContain('const actualPageRoleLookup');
-    expect(callExpressionWithArguments(groupSetupHelperTest, 'throwUnexpectedMockCall', [
+    // Throwing on not-found is the assertion — the return value always contains the required args
+    callExpressionWithArguments(groupSetupHelperTest, 'throwUnexpectedMockCall', [
       "'page.getByRole'",
       'roleLookup(_role, name)',
       'EXPECTED_PAGE_ROLE_LOOKUPS',
-    ])).toContain('EXPECTED_PAGE_ROLE_LOOKUPS');
+    ]);
     expect(guard).toContain("e2eCaseSection('TC-1007')");
     expect(guard).toContain("e2eCaseSection('TC-1678')");
     expect(guard).toContain("not.toContain('groupCount={groupCount}')");

--- a/smkc-score-app/__tests__/helpers/e2e-cases.ts
+++ b/smkc-score-app/__tests__/helpers/e2e-cases.ts
@@ -83,6 +83,8 @@ export function e2eCaseSection(tc: string, source = e2eCases) {
   return source.slice(start, end);
 }
 
+// AST-based: regex cannot safely verify all required args appear in the same call expression —
+// nested parens and multi-line formatting make string/regex co-occurrence checks unreliable.
 export function callExpressionWithArguments(
   source: string,
   functionName: string,

--- a/smkc-score-app/__tests__/lib/hooks/use-broadcast-reflect.test.ts
+++ b/smkc-score-app/__tests__/lib/hooks/use-broadcast-reflect.test.ts
@@ -119,6 +119,7 @@ describe('useBroadcastReflect', () => {
     it('clears the pending idle reset timer on unmount', async () => {
       mockFetchOk();
       const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
       const { result, unmount } = renderHook(() =>
         useBroadcastReflect(TOURNAMENT_ID, { p1: 1 }, entries)
       );
@@ -127,14 +128,17 @@ describe('useBroadcastReflect', () => {
         await result.current.handleBroadcastReflect();
       });
 
+      const timerId = setTimeoutSpy.mock.results[0].value;
       unmount();
 
-      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+      // Verifies the exact timer handle is cancelled, not just that clearTimeout was called
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timerId);
     });
 
     it('replaces the previous idle reset timer when reflecting again', async () => {
       mockFetchOk();
       const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
       const { result } = renderHook(() =>
         useBroadcastReflect(TOURNAMENT_ID, { p1: 1 }, entries)
       );
@@ -142,11 +146,13 @@ describe('useBroadcastReflect', () => {
       await act(async () => {
         await result.current.handleBroadcastReflect();
       });
+      const firstTimerId = setTimeoutSpy.mock.results[0].value;
       await act(async () => {
         await result.current.handleBroadcastReflect();
       });
 
-      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+      // The first timer must be cleared before scheduling the replacement
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(firstTimerId);
     });
 
     it('cancels a pending idle reset when resetBroadcastStatus is called', async () => {
@@ -161,12 +167,14 @@ describe('useBroadcastReflect', () => {
         await result.current.handleBroadcastReflect();
       });
 
+      const timerId = setTimeoutSpy.mock.results[0].value;
       act(() => {
         result.current.resetBroadcastStatus();
       });
 
       expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
-      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+      // Verifies the exact timer handle is cancelled (issue #1959)
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timerId);
       expect(result.current.broadcastStatus).toBe('idle');
     });
 


### PR DESCRIPTION
## Summary

- **#1959**: `use-broadcast-reflect.test.ts` で `clearTimeout` が正しいタイマー ID で呼ばれることを検証するよう強化。`toHaveBeenCalledTimes(1)` から `toHaveBeenCalledWith(timerId)` に変更し、3つのテスト（アンマウント・再反映・resetBroadcastStatus）すべてで実施
- **#2020**: `e2e-cases-drift.test.ts` の `callExpressionWithArguments` 戻り値への冗長な `.toContain('EXPECTED_PAGE_ROLE_LOOKUPS')` を削除。関数の throw-on-not-found がアサーション本体であり戻り値チェックは不要
- **#2019**: `callExpressionWithArguments` に AST 採用理由コメントを追加（CLAUDE.md の WHY コメント要件準拠）
- **E2E_TEST_CASES.md**: TC-1959 を追加してタイマーキャンセル ID コントラクトを文書化

## Issues

Closes #1959
Closes #2019
Closes #2020

## Validation

- `npm test` 全スイート: 3311 passed, 27 skipped, 0 failed (235 suites)
- コードレビュー実施済み: 主要候補はすべて REFUTED（`clearIdleResetTimer` の null ガードで二重キャンセル不可、React 19 は MessageChannel 使用で setTimeout index 0 は安全）


---
_Generated by [Claude Code](https://claude.ai/code/session_01M36tU21kUD49pr4e31E51h)_