### PR TITLE
test: recover missing preview browser cache

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -155,6 +155,19 @@
 - **期待結果**: Cloudflare API 7403 authorization stdout JSON は通常 preview E2E を本体開始前に止めず、strict フラグで hard fail に戻せる。スキーマ drift / SQLite error は引き続き失敗する
 - **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/preview-schema-preflight.test.ts __tests__/docs/e2e-cases-drift.test.ts`
 
+## TC-2427: Preview E2E は managed Playwright cache の実行ファイル欠落を1回だけ自動復旧する
+- **URL**: n/a (runner configuration / preview suite)
+- **authRequired**: true (persistent preview admin profile)
+- **背景**: issue #2427。`npm run e2e:preview:all` が admin session preflight に到達する前に、managed Playwright cache 内の `chromium_headless_shell-*` ディレクトリだけが存在し `chrome-headless-shell` 実行ファイルがない partial cache で失敗した。これは session 不在や app failure ではなく bootstrap failure なので、preview runner は `npm run e2e:install-browser` 相当を1回だけ実行してブラウザ cache を復旧し、その後に admin session preflight を再試行する必要がある。
+- **手順**:
+  1. `launchPreviewAdminSessionBrowser` が `Executable doesn't exist` / `chrome-headless-shell` を含む Playwright 起動エラーを返すケースを模擬する
+  2. `assertPreviewAdminSession` が `node e2e/install-browser.js chromium` を preview runtime env で1回だけ実行することを確認する
+  3. install 成功後、同じ admin session preflight を再試行して `/api/auth/session-status` を確認することを確認する
+  4. install 後も失敗する場合は、元の起動エラーを隠さず install 失敗として返す
+  5. admin session 不在 (`No active session`) は browser cache 問題ではないため自動loginせず、従来どおり `E2E_PROFILE_DIR=/tmp/playwright-smkc-preview-profile npm run e2e:preview:login` を案内して失敗する
+- **期待結果**: partial managed cache は preview runner が1回だけ自己修復し、認証が必要な blocker は admin-session preflight の明確なメッセージに集約される。`pkill -f chromium` は使用しない
+- **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/run-preview.test.ts __tests__/docs/e2e-cases-drift.test.ts`
+
 ## TC-2360: Preview E2E は live な SingletonLock 保持プロセス検出で fast-fail する
 - **URL**: n/a (browser launch / preview suite)
 - **authRequired**: true (persistent preview admin profile)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -494,6 +494,21 @@ describe('E2E case drift coverage', () => {
     expect(runnerTest).toContain('fails preview admin session preflight before fixture setup');
   });
 
+  it('keeps TC-2427 aligned with preview browser cache self-recovery coverage', () => {
+    const section = e2eCaseSection('TC-2427');
+    const runner = readE2eScript('run-preview.js');
+    const runnerTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'run-preview.test.ts');
+
+    expect(section).toContain('issue #2427');
+    expect(section).toContain('managed Playwright cache');
+    expect(section).toContain('node e2e/install-browser.js chromium');
+    expect(section).toContain('admin session preflight');
+    expect(runner).toContain('isMissingPlaywrightExecutableError');
+    expect(runner).toContain('installPreviewBrowser');
+    expect(runner).toContain('install-browser.js');
+    expect(runnerTest).toContain('bootstraps a missing managed Playwright browser once');
+  });
+
   it('keeps TC-2207 aligned with preview schema failure pattern coverage', () => {
     const section = e2eCaseSection('TC-2207');
     const preflightTest = readRepoFile('smkc-score-app', '__tests__', 'e2e', 'preview-schema-preflight.test.ts');

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -109,6 +109,13 @@ describe('preview E2E runner', () => {
     expect(typeof runner.assertPreviewAdminSession).toBe('function');
   });
 
+  it('exposes missing Playwright executable detection for preview bootstrap recovery', () => {
+    expect(runner.isMissingPlaywrightExecutableError(
+      new Error("browserType.launchPersistentContext: Executable doesn't exist at /tmp/ms-playwright/chromium_headless_shell-1217/chrome-headless-shell-mac-arm64/chrome-headless-shell"),
+    )).toBe(true);
+    expect(runner.isMissingPlaywrightExecutableError(new Error('No active session'))).toBe(false);
+  });
+
   it('regenerates Prisma Client before Cloudflare builds used by preview deploys', () => {
     expect(packageJson.scripts['prebuild:cf']).toBe('prisma generate');
     expect(packageJson.scripts['deploy:preview']).toContain('npm run build:cf');
@@ -273,6 +280,60 @@ describe('preview E2E runner', () => {
       }, launchBrowser as never),
     ).rejects.toThrow(/npm run e2e:preview:login/);
     expect(close).toHaveBeenCalled();
+  });
+
+  it('bootstraps a missing managed Playwright browser once before retrying admin session preflight', async () => {
+    const close = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const goto = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const evaluate = jest.fn<() => Promise<unknown>>().mockResolvedValue({
+      status: 200,
+      authenticated: true,
+      body: { data: { authenticated: true, user: { role: 'admin' } } },
+    });
+    const launchBrowser = jest.fn<() => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error("browserType.launchPersistentContext: Executable doesn't exist at /tmp/ms-playwright/chromium_headless_shell-1217/chrome-headless-shell-mac-arm64/chrome-headless-shell"))
+      .mockResolvedValueOnce({
+        pages: () => [{ goto, evaluate }],
+        close,
+      });
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: '', stderr: '' });
+
+    await expect(
+      runner.assertPreviewAdminSession({
+        E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
+        E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
+        PLAYWRIGHT_BROWSERS_PATH: '/tmp/playwright-e2e-home/ms-playwright',
+      }, launchBrowser as never),
+    ).resolves.toMatchObject({ authenticated: true });
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      process.execPath,
+      [expect.stringContaining('e2e/install-browser.js'), 'chromium'],
+      expect.objectContaining({
+        cwd: expect.stringContaining('smkc-score-app'),
+        env: expect.objectContaining({
+          PLAYWRIGHT_BROWSERS_PATH: '/tmp/playwright-e2e-home/ms-playwright',
+        }),
+        stdio: 'inherit',
+      }),
+    );
+    expect(launchBrowser).toHaveBeenCalledTimes(2);
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('surfaces install-browser failure when managed cache bootstrap cannot recover', async () => {
+    const launchBrowser = jest.fn<() => Promise<unknown>>()
+      .mockRejectedValue(new Error("browserType.launchPersistentContext: Executable doesn't exist at /tmp/ms-playwright/chromium_headless_shell-1217/chrome-headless-shell"));
+    spawnSyncMock.mockReturnValue({ status: 1, stdout: '', stderr: 'download failed' });
+
+    await expect(
+      runner.assertPreviewAdminSession({
+        E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
+        E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
+      }, launchBrowser as never),
+    ).rejects.toThrow(/failed to bootstrap Playwright browser cache/);
+
+    expect(launchBrowser).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to public DNS when local resolution fails', async () => {

--- a/smkc-score-app/e2e/run-preview.js
+++ b/smkc-score-app/e2e/run-preview.js
@@ -121,6 +121,38 @@ async function queryPreviewAdminSession(page) {
   });
 }
 
+function isMissingPlaywrightExecutableError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("Executable doesn't exist") &&
+    (
+      message.includes('chrome-headless-shell') ||
+      message.includes('chromium_headless_shell') ||
+      message.includes('playwright install')
+    )
+  );
+}
+
+function installPreviewBrowser(env) {
+  console.warn('[preview] managed Playwright browser executable is missing; running e2e/install-browser.js chromium once.');
+  const result = spawnSync(
+    process.execPath,
+    [path.join(__dirname, 'install-browser.js'), 'chromium'],
+    {
+      cwd: path.join(__dirname, '..'),
+      env,
+      stdio: 'inherit',
+    },
+  );
+
+  if (result.error) {
+    throw new Error(`[preview] failed to bootstrap Playwright browser cache: ${result.error.message}`);
+  }
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(`[preview] failed to bootstrap Playwright browser cache: install-browser exited ${result.status ?? 1}`);
+  }
+}
+
 function previewAdminSessionError(env, session) {
   const detail = session?.error
     ? session.error
@@ -141,7 +173,17 @@ async function assertPreviewAdminSession(env, launchBrowser = launchPreviewAdmin
     return { skipped: true };
   }
 
-  const browser = await launchBrowser(env);
+  let browser;
+  try {
+    browser = await launchBrowser(env);
+  } catch (error) {
+    if (!isMissingPlaywrightExecutableError(error)) {
+      throw error;
+    }
+    installPreviewBrowser(env);
+    browser = await launchBrowser(env);
+  }
+
   try {
     const page = browser.pages()[0] || await browser.newPage();
     await page.goto(`${env.E2E_BASE_URL}/tournaments`, {
@@ -209,6 +251,8 @@ module.exports = {
   assertBaseUrlResolvable,
   assertPreviewAdminSession,
   buildPreviewRuntimeEnv,
+  installPreviewBrowser,
+  isMissingPlaywrightExecutableError,
   resolveHostViaPublicDns,
   runTargetScript,
   assertPreviewD1Schema,


### PR DESCRIPTION
## Summary

- Add TC-2427 coverage for preview E2E managed Playwright cache recovery.
- Retry preview admin-session preflight once after bootstrapping a missing Playwright browser executable with e2e/install-browser.js.
- Keep admin profile absence as an explicit login-required failure instead of attempting automatic login.

## Issues

Closes #2427

## Validation

- npm test -- --runTestsByPath __tests__/e2e/run-preview.test.ts __tests__/docs/e2e-cases-drift.test.ts
- npm test -- --ci --forceExit
- npm run lint
- npm run build:cf
