### PR TITLE
test: fix platform-neutral path and add playwright install detection case

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -165,6 +165,7 @@
   3. install 成功後、同じ admin session preflight を再試行して `/api/auth/session-status` を確認することを確認する
   4. install 後も失敗する場合は、元の起動エラーを隠さず install 失敗として返す
   5. admin session 不在 (`No active session`) は browser cache 問題ではないため自動loginせず、従来どおり `E2E_PROFILE_DIR=/tmp/playwright-smkc-preview-profile npm run e2e:preview:login` を案内して失敗する
+  6. `isMissingPlaywrightExecutableError` は `"Executable doesn't exist"` + `"playwright install"` の組み合わせも検出する（`chrome-headless-shell` / `chromium_headless_shell` パスがない場合の Playwright フォールバックメッセージ）。なおサンプルパスはプラットフォームによって異なる（`linux-x64`, `mac-arm64` 等）が検出は部分文字列一致で行う
 - **期待結果**: partial managed cache は preview runner が1回だけ自己修復し、認証が必要な blocker は admin-session preflight の明確なメッセージに集約される。`pkill -f chromium` は使用しない
 - **スクリプト**: `npm run e2e:preview:all` / `npm test -- --runTestsByPath __tests__/e2e/run-preview.test.ts __tests__/docs/e2e-cases-drift.test.ts`
 

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -110,8 +110,13 @@ describe('preview E2E runner', () => {
   });
 
   it('exposes missing Playwright executable detection for preview bootstrap recovery', () => {
+    // Path suffix is platform-specific (linux-x64, mac-arm64, etc.); detection uses substring match on chrome-headless-shell
     expect(runner.isMissingPlaywrightExecutableError(
-      new Error("browserType.launchPersistentContext: Executable doesn't exist at /tmp/ms-playwright/chromium_headless_shell-1217/chrome-headless-shell-mac-arm64/chrome-headless-shell"),
+      new Error("browserType.launchPersistentContext: Executable doesn't exist at /tmp/ms-playwright/chromium_headless_shell-1217/chrome-headless-shell"),
+    )).toBe(true);
+    // Playwright may also emit a "playwright install" hint instead of the full path (issue #2431)
+    expect(runner.isMissingPlaywrightExecutableError(
+      new Error("browserType.launchPersistentContext: Executable doesn't exist\nRun: playwright install chromium"),
     )).toBe(true);
     expect(runner.isMissingPlaywrightExecutableError(new Error('No active session'))).toBe(false);
   });


### PR DESCRIPTION
## Summary

- Replace mac-arm64-specific sample path in `isMissingPlaywrightExecutableError` test with platform-neutral `chrome-headless-shell` substring — the detection is substring-based so the full platform-specific suffix is not needed and misleads Linux CI readers
- Add missing test case for the `"Executable doesn't exist" + "playwright install"` branch of `isMissingPlaywrightExecutableError`, which previously had no test coverage
- Update TC-2427 in `E2E_TEST_CASES.md` to document the `playwright install` detection case and clarify that sample paths are platform-neutral

## Issues

Closes #2431
Closes #2432

## Validation

- `npm test -- --runTestsByPath __tests__/e2e/run-preview.test.ts __tests__/docs/e2e-cases-drift.test.ts` → 234 tests passed
- `npm run lint` → 0 errors
- `npm run build:cf` → build succeeded

---
_Generated by [Claude Code](https://claude.ai/code/session_011hBYMQ1rE7PwzdVH9tKR6Y)_