### PR TITLE
test: strengthen assertions in selectRandomCourse, TC-2109 drift, and run-preview

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1973,7 +1973,8 @@ describe('E2E case drift coverage', () => {
     // assertMrStandingStats must be wrapped in try-catch to avoid bypassing log() (issue #2370)
     expect(tc1083).toContain('standingsErr');
     expect(mrReportRouteTest).toContain('useRoundDifferential: true');
-    expect(mrStandingsAssertionsTest).toContain('MR standings ties for p2');
+    // Use test case name instead of internal error message to avoid implementation-string dependency (#2372).
+    expect(mrStandingsAssertionsTest).toContain("'fails with a targeted stat diff'");
     expect(tc1083).not.toContain('waitForTimeout(3000)');
   });
 
@@ -2569,15 +2570,19 @@ describe('E2E case drift coverage', () => {
 
   it('documents TC-2109 as MR dual-report player-session coverage', () => {
     const section = e2eCaseSection('TC-2109');
+    // Narrow to the TC-822 function body to avoid false positives from other functions (#2436).
+    const tc822Source = sectionBetween(tcMr, 'async function runTc822', 'async function runTc2108');
 
     expect(section).toContain('Issue**: #2109');
     expect(section).toContain('P1 session');
     expect(section).toContain('P2 session');
-    // Check function calls rather than variable names to avoid fragility from renames (#2347/#2348).
-    expect(tcMr).toContain('loginSharedPlayer(adminPage, p1)');
-    expect(tcMr).toContain('loginSharedPlayer(adminPage, p2)');
-    // .page.evaluate only appears in runTc822's dual-session section; verifies player-context usage.
-    expect(tcMr).toContain('.page.evaluate');
+    // Check function calls in the TC-822 section specifically, not the whole file.
+    expect(tc822Source).toContain('loginSharedPlayer(adminPage, p1)');
+    expect(tc822Source).toContain('loginSharedPlayer(adminPage, p2)');
+    // p1Context.page.evaluate verifies the dual-session player-context usage.
+    expect(tc822Source).toContain('p1Context.page.evaluate');
+    // rejectedReport confirms post-confirm participant report is blocked (#2436).
+    expect(tc822Source).toContain('rejectedReport');
   });
 
   it('documents TC-821A as shared TA sudden-death UI and logic coverage', () => {

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -266,24 +266,15 @@ describe('preview E2E runner', () => {
       close,
     });
 
-    await expect(
-      runner.assertPreviewAdminSession({
-        E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
-        E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
-      }, launchBrowser as never),
-    ).rejects.toThrow(/Preview E2E admin session preflight failed/);
-    await expect(
-      runner.assertPreviewAdminSession({
-        E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
-        E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
-      }, launchBrowser as never),
-    ).rejects.toThrow(/No active session/);
-    await expect(
-      runner.assertPreviewAdminSession({
-        E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
-        E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
-      }, launchBrowser as never),
-    ).rejects.toThrow(/npm run e2e:preview:login/);
+    // Consolidate into a single call: catch the error once and assert all message parts (#2365).
+    const err = await runner.assertPreviewAdminSession({
+      E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
+      E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
+    }, launchBrowser as never).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/Preview E2E admin session preflight failed/);
+    expect((err as Error).message).toMatch(/No active session/);
+    expect((err as Error).message).toMatch(/npm run e2e:preview:login/);
     expect(close).toHaveBeenCalled();
   });
 

--- a/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
@@ -179,6 +179,9 @@ describe("selectRandomCourse", () => {
 
     // Both MC1 and DP1 were played in this cycle so both must be excluded.
     // Not asserting exact "GV1" to avoid coupling to COURSES array order (#2351).
+    // Positive inclusion check ensures the result is a real course, not garbage (#2437).
+    const validCandidates = COURSES.filter((c) => c !== "MC1" && c !== "DP1");
+    expect(validCandidates).toContain(selected);
     expect(selected).not.toBe("DP1"); // immediate-repeat avoidance: DP1 was last played
     expect(selected).not.toBe("MC1"); // cycle exclusion: MC1 was played earlier
   });


### PR DESCRIPTION
## Summary

- **#2437**: `selectRandomCourse` テストに正の包含アサーション追加 — `validCandidates.toContain(selected)` で除外後の有効コース集合内に収まることを検証（2つの否定アサーションだけでは不十分だった問題を解消）
- **#2436**: TC-2109 drift テストを `sectionBetween(tcMr, 'async function runTc822', 'async function runTc2108')` で TC-822 関数本体に絞り込み — ファイル全体を検索していたため他関数のパターンにも誤マッチしていた問題を解消。`p1Context.page.evaluate` と `rejectedReport` の検証も追加
- **#2372**: MR standings の drift チェックで内部エラーメッセージ文字列 `'MR standings ties for p2'` への直接依存をやめ、テストケース名 `'fails with a targeted stat diff'` で安定した検証に変更
- **#2365**: `assertPreviewAdminSession` 失敗テストで同じモックを3回呼び出していた冗長なパターンを1回の呼び出しでまとめ、エラーを `catch` してメッセージフラグメントを複数アサーション

## Issues

Closes #2437
Closes #2436
Closes #2372
Closes #2365

## Validation

- `npm test -- "course-selection" --no-coverage` → PASS (21 tests)
- `npm test -- "e2e-cases-drift" --no-coverage` → PASS (204 tests)
- `npm test -- "run-preview" --no-coverage` → PASS (30 tests)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrxDaThxy8zTXfVRiP3mM4)_