### PR TITLE
fix: remove redundant assertions, group count button variant, clarify toBe(0)

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -2880,14 +2880,14 @@
   - 将来 3+ グループ対応を戻す場合は guard 更新が必要になる
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts`
 
-## TC-1682: BM/MR/GP グループ設定 — disabled 固定グループ数を outline 表示にする
-- **背景**: issue #1682。固定値の disabled ボタンが `variant="default"` のままだと、環境によってはアクティブな選択ボタンに見える可能性がある。`variant="outline"` にして情報表示寄りの見た目にする。
+## TC-1682: BM/MR/GP グループ設定 — disabled 固定グループ数を secondary 表示にする
+- **背景**: issue #1682。固定値の disabled ボタンが `variant="outline"` だとアクティブな選択ボタンに見える可能性がある。`variant="secondary"` にして背景色付きの読み取り専用表示にする。
 - **手順**:
   1. TC-1682 の静的 E2E guard を実行する
   2. `GroupSetupDialog` の `LOCKED_GROUP_COUNT` 表示ボタンを検査する
-  3. ボタンが `variant="outline"` かつ `disabled` で、`onClick` がないことを確認する
+  3. ボタンが `variant="secondary"` かつ `disabled` で、`onClick` がないことを確認する
 - **期待結果**:
-  - 固定グループ数表示がアクティブ操作に見えにくい
+  - 固定グループ数表示が読み取り専用であることが視覚的に明確
   - disabled と non-clickable の契約は維持される
   - 将来 selectable UI に戻す場合は guard 更新が必要になる
 - **スクリプト**: `npm test -- --runTestsByPath __tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts`

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1254,7 +1254,7 @@ describe('E2E case drift coverage', () => {
     expect(disabledButtonSection).toContain('issue #1680');
     expect(disabledButtonSection).toContain('disabled');
     expect(outlineButtonSection).toContain('issue #1682');
-    expect(outlineButtonSection).toContain('variant="outline"');
+    expect(outlineButtonSection).toContain('variant="secondary"');
     expect(helperAliasSection).toContain('issue #1980 / #1982');
     expect(helperAliasSection).toContain('EXPECTED_PAGE_ROLE_LOOKUPS');
     expect(helperAliasGuardSection).toContain('issue #2012');
@@ -1274,7 +1274,7 @@ describe('E2E case drift coverage', () => {
     expect(guard).toContain("not.toContain('groupCount={groupCount}')");
     expect(guard).toContain("not.toContain('setGroupCount={setGroupCount}')");
     expect(guard).toContain("expect(groupCountButton).toContain('disabled')");
-    expect(guard).toContain('expect(groupCountButton).toContain(\'variant="outline"\')');
+    expect(guard).toContain('expect(groupCountButton).toContain(\'variant="secondary"\')');
   });
 
   it('keeps TC-1004 aligned with the CourseCycleStatus YAGNI guard', () => {

--- a/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
+++ b/smkc-score-app/__tests__/e2e/tc-all-registration.test.ts
@@ -66,6 +66,7 @@ describe('tc-all focused suite registration', () => {
     };
 
     expect(rootPage.context).not.toHaveBeenCalled();
+    // 0 = detected-and-resolved violations count; the mock env triggers no parallel violations.
     await expect(assertQualificationFetchesStartInParallel(rootPage, 'tournament-1', 'ta'))
       .resolves.toBe(0);
     expect(rootPage.context).toHaveBeenCalled();

--- a/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
@@ -180,10 +180,9 @@ describe("selectRandomCourse", () => {
     // Both MC1 and DP1 were played in this cycle so both must be excluded.
     // Not asserting exact "GV1" to avoid coupling to COURSES array order (#2351).
     // Positive inclusion check ensures the result is a real course, not garbage (#2437).
+    // If selected ∈ validCandidates (which excludes MC1 and DP1), the not.toBe assertions are implied.
     const validCandidates = COURSES.filter((c) => c !== "MC1" && c !== "DP1");
     expect(validCandidates).toContain(selected);
-    expect(selected).not.toBe("DP1"); // immediate-repeat avoidance: DP1 was last played
-    expect(selected).not.toBe("MC1"); // cycle exclusion: MC1 was played earlier
   });
 });
 

--- a/smkc-score-app/__tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts
@@ -21,7 +21,7 @@ describe('TC-1007 GroupSetupDialog prop contract', () => {
     expect(disabledButtonSection).toContain('issue #1680');
     expect(disabledButtonSection).toContain('disabled');
     expect(outlineButtonSection).toContain('issue #1682');
-    expect(outlineButtonSection).toContain('variant="outline"');
+    expect(outlineButtonSection).toContain('variant="secondary"');
     expect(section).toContain('tc-1007-group-setup-dialog-prop-contract.test.ts');
   });
 
@@ -49,7 +49,8 @@ describe('TC-1007 GroupSetupDialog prop contract', () => {
       '</Button>',
     );
     expect(groupCountButton).toContain('disabled');
-    expect(groupCountButton).toContain('variant="outline"');
+    // secondary variant signals a read-only display value rather than an actionable control (#1682)
+    expect(groupCountButton).toContain('variant="secondary"');
     expect(groupCountButton).not.toContain('onClick');
   });
 

--- a/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
+++ b/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
@@ -308,7 +308,7 @@ export function GroupSetupDialog({
                   {[LOCKED_GROUP_COUNT].map((n) => (
                     <Button
                       key={n}
-                      variant="outline"
+                      variant="secondary"
                       size="sm"
                       className="h-7 w-7 p-0 text-xs"
                       disabled


### PR DESCRIPTION
## Summary

- **#2439**: `course-selection.test.ts` — `expect(validCandidates).toContain(selected)` が成立すれば MC1/DP1 の `not.toBe` は論理的に自明なため削除。コメントで理由を明記
- **#1682**: `group-setup-dialog.tsx` — 固定グループ数ボタンの `variant="outline"` を `variant="secondary"` に変更。背景色付きの読み取り専用表示とすることでクリック可能なボタンと区別しやすくする
- **#2377**: `tc-all-registration.test.ts` — `.resolves.toBe(0)` の `0` が「検出された並列違反の件数」であることをコメントで明記

## Issues

Closes #2439
Closes #1682
Closes #2377

## Validation

- `node_modules/.bin/jest --no-coverage` → 3315 passed, 27 skipped, 0 failed (234 suites)
- 更新ファイル: static guard, drift guard, E2E_TEST_CASES.md TC-1682 セクションをすべて `variant="secondary"` に統一
- `npm run lint` → 0 errors (既存 warnings のみ)

---
_Generated by [Claude Code](https://claude.ai/code/session_0166qNYVi9jbg5U8iyNktLuT)_