### PR TITLE
test: fix disabled-element interactions and add isRetry combo coverage (#1930 #2364 #2444)

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -3547,6 +3547,18 @@
 - **期待結果**: TAのTV番号 helper は空入力・非数値入力を保存可能な数値として扱わず、`null` に正規化する
 - **スクリプト**: tc-ta.js TC-1987 / time-entry-layout.test.ts / ta-time-entry-rows.test.tsx
 
+## TC-2444: TA タイムエントリー row の isRetry/isEditingDisabled 組み合わせが disabled 状態を正しく制御する
+- **URL**: n/a (unit contract)
+- **authRequired**: false
+- **背景**: issue #1930。`TaTimeEntryRow` の time input は `isRetry={true}` で disabled になり、retry button は `isEditingDisabled={true}` で disabled になる。これらは独立したフラグであり、両方が true の場合は両要素が disabled になる。`fireEvent` はdisabled属性を無視してイベントを発火するため、disabled 要素へのインタラクションは行わず、描画直後にdisabled状態を検証すべき。
+- **手順**:
+  1. `isRetry={true}` で `TaTimeEntryRow` を描画し、time input が即座に disabled であることを確認する（blur イベント後に確認しない）
+  2. `isRetry={true}` 状態では `onTimeChange`・`onTimeBlur` コールバックが呼ばれないこと（disabled 要素のインタラクションは行わない）
+  3. `isRetry={false}` で描画し、time input が enabled で callbacks が正常に呼ばれることを確認する
+  4. `isRetry={true}` かつ `isEditingDisabled={true}` で描画し、time input と retry button の両方が disabled であることを確認する
+- **期待結果**: `isRetry` と `isEditingDisabled` は独立して動作し、組み合わせの disabled 状態が正しく描画される
+- **スクリプト**: n/a (unit coverage) / smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
+
 ## TC-1996: TA決勝 row のTV番号を送信 payload と履歴に保存する
 - **URL**: /tournaments/[temp-id]/ta/finals, /api/tournaments/[id]/ta/phases
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
@@ -12,7 +12,7 @@ const timeInputProps = {
 } as const;
 
 describe('TaTimeEntryRow (finals phase — with livesLabel)', () => {
-  it('renders props and calls callbacks with correct arguments', () => {
+  it('verifies time input is disabled and TV/retry callbacks work when isRetry=true', () => {
     const onTvChange = jest.fn();
     const onTimeChange = jest.fn();
     const onTimeBlur = jest.fn();
@@ -39,24 +39,60 @@ describe('TaTimeEntryRow (finals phase — with livesLabel)', () => {
       />
     );
 
+    // isRetry={true} disables the time input; assert before any interactions
+    const timeInput = screen.getByPlaceholderText('Time');
+    expect(timeInput).toBeDisabled();
+    expect(onTimeChange).not.toHaveBeenCalled();
+    expect(onTimeBlur).not.toHaveBeenCalled();
+
+    // TV select is independent of isRetry — callbacks still fire
     const tvSelect = screen.getByLabelText('TV number');
     fireEvent.change(tvSelect, { target: { value: '3' } });
     fireEvent.change(tvSelect, { target: { value: '' } });
     expect(onTvChange).toHaveBeenNthCalledWith(1, 'player-1', 3);
     expect(onTvChange).toHaveBeenNthCalledWith(2, 'player-1', null);
 
+    // retry button remains clickable when isRetry=true (toggling off)
+    const retryButton = screen.getByRole('button', { name: 'Retry' });
+    fireEvent.click(retryButton);
+    expect(onRetryToggle).toHaveBeenCalledWith('player-1');
+  });
+
+  it('calls time input callbacks when isRetry=false', () => {
+    const onTvChange = jest.fn();
+    const onTimeChange = jest.fn();
+    const onTimeBlur = jest.fn();
+    const onRetryToggle = jest.fn();
+
+    render(
+      <TaTimeEntryRow
+        playerId="player-1"
+        playerName="Alice"
+        livesLabel="L3"
+        tvNumber={2}
+        tvLabel="TV number"
+        timeValue="1:23.45"
+        timePlaceholder="Time"
+        isRetry={false}
+        isEditingDisabled={false}
+        retryLabel="Retry"
+        retryTitle="Retry time"
+        timeInputProps={timeInputProps}
+        onTvChange={onTvChange}
+        onTimeChange={onTimeChange}
+        onTimeBlur={onTimeBlur}
+        onRetryToggle={onRetryToggle}
+      />
+    );
+
     const timeInput = screen.getByPlaceholderText('Time');
+    expect(timeInput).not.toBeDisabled();
+
     fireEvent.change(timeInput, { target: { value: '1:10.00' } });
     expect(onTimeChange).toHaveBeenCalledWith('player-1', '1:10.00');
 
     fireEvent.blur(timeInput);
     expect(onTimeBlur).toHaveBeenCalledWith('player-1');
-    // disabled because isRetry={true} — not caused by blur
-    expect(timeInput).toBeDisabled();
-
-    const retryButton = screen.getByRole('button', { name: 'Retry' });
-    fireEvent.click(retryButton);
-    expect(onRetryToggle).toHaveBeenCalledWith('player-1');
   });
 
   it('disables retry button when editing is disabled', () => {
@@ -81,6 +117,33 @@ describe('TaTimeEntryRow (finals phase — with livesLabel)', () => {
       />
     );
 
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeDisabled();
+  });
+
+  it('disables both retry button and time input when isRetry=true and isEditingDisabled=true', () => {
+    // When both flags are set, time input is disabled by isRetry and retry button by isEditingDisabled
+    render(
+      <TaTimeEntryRow
+        playerId="player-1"
+        playerName="Alice"
+        livesLabel="L3"
+        tvNumber={null}
+        tvLabel="TV number"
+        timeValue="9:59.99"
+        timePlaceholder="Time"
+        isRetry={true}
+        isEditingDisabled={true}
+        retryLabel="Retry"
+        retryTitle="Retry time"
+        timeInputProps={timeInputProps}
+        onTvChange={jest.fn()}
+        onTimeChange={jest.fn()}
+        onTimeBlur={jest.fn()}
+        onRetryToggle={jest.fn()}
+      />
+    );
+
+    expect(screen.getByPlaceholderText('Time')).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Retry' })).toBeDisabled();
   });
 

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -273,6 +273,7 @@ describe('E2E case drift coverage', () => {
     ['TC-1528', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/e2e/ta-phase-submit-helper.test.ts'],
     ['TC-1669', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts'],
     ['TC-1671', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts'],
+    ['TC-2444', 'n/a (unit coverage)', 'smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx'],
     ['TC-803', 'TC-318 でカバー済み', 'TC-318'],
   ];
 

--- a/smkc-score-app/e2e/run-preview.js
+++ b/smkc-score-app/e2e/run-preview.js
@@ -74,6 +74,9 @@ function resolveHostViaPublicDns(hostname) {
 
 async function launchPreviewAdminSessionBrowser(env) {
   const { launchPersistentChromiumContext } = require('./lib/common');
+  // launchPersistentChromiumContext reads process.env for E2E_HOST_RESOLVER_RULES,
+  // E2E_MAC_SINGLE_PROCESS, E2E_EXECUTABLE_PATH, and E2E_BROWSER_CHANNEL internally,
+  // so env must be written to process.env before calling it and restored after.
   const previousEnv = {};
   for (const [key, value] of Object.entries(env)) {
     previousEnv[key] = process.env[key];


### PR DESCRIPTION
## Summary

- **#1930**: `TaTimeEntryRow` テストでdisabled要素への `fireEvent` 呼び出しを削除。`isRetry={true}` のtime inputに対して `fireEvent.change/blur` を実行していたが、disabled要素にはブラウザ本来イベントが発火しないため、テストとして誤り。修正内容：
  - 描画直後に `expect(timeInput).toBeDisabled()` をアサート（blurイベント後ではない）
  - disabled要素への `fireEvent.change/blur` を削除し `onTimeChange`・`onTimeBlur` が呼ばれないことをアサート
  - `isRetry={false}` の新テストを追加してtime callbackが正常動作することを検証
  - `isRetry=true + isEditingDisabled=true` の組み合わせテストを追加

- **#2364**: `launchPreviewAdminSessionBrowser` の `process.env` 一時書き換えブロックにコメントを追加。`launchPersistentChromiumContext` が `process.env.E2E_HOST_RESOLVER_RULES`, `E2E_MAC_SINGLE_PROCESS`, `E2E_EXECUTABLE_PATH`, `E2E_BROWSER_CHANNEL` を内部で読み込むため書き換えが必要であることを明記

- **TC-2444**: `E2E_TEST_CASES.md` に `isRetry`/`isEditingDisabled` の組み合わせ動作のユニット契約TCを追加。`tc109ClassifiedRows` ドリフトガードにも登録

## Issues

Closes #1930
Closes #2364

## Validation

```
Tests: 3318 passed, 27 skipped (234 suites)
npm run lint → 0 errors (既存 warnings のみ)
```

関連ドリフトテスト:
- `__tests__/docs/e2e-cases-drift.test.ts` → PASS (205 tests)
- `__tests__/components/tournament/ta-time-entry-rows.test.tsx` → PASS (10 tests)

---
_Generated by [Claude Code](https://claude.ai/code/session_016z2cgpHjuGymBw8zG28puM)_