### PR TITLE
fix: move process.env write loop inside try/finally in launchPreviewAdminSessionBrowser (#2446)

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -3559,6 +3559,18 @@
 - **期待結果**: `isRetry` と `isEditingDisabled` は独立して動作し、組み合わせの disabled 状態が正しく描画される
 - **スクリプト**: n/a (unit coverage) / smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx
 
+## TC-2446: run-preview の launchPreviewAdminSessionBrowser が process.env を finally で確実に復元する
+- **URL**: n/a (unit contract)
+- **authRequired**: false
+- **背景**: issue #2446。`launchPreviewAdminSessionBrowser` は `launchPersistentChromiumContext` 呼び出し前に env を `process.env` へ書き込み、finally ブロックで復元する。書き込みループが `try` の外にあると、ループ途中で例外が発生した場合に `finally` が実行されず `process.env` が汚染されたまま残る。ループを `try` 内に移動することで、どの段階で例外が起きても復元が保証される。
+- **手順**:
+  1. `launchPersistentChromiumContext` が失敗するよう `jest.doMock` + `jest.isolateModules` でモックした isolated runner を用意する
+  2. `process.env` にセンチネルキーを original-value でセットする
+  3. `assertPreviewAdminSession` を sentinel キー付き env で呼び出す（launchBrowser 引数なし = 実関数使用）
+  4. 呼び出しがエラーで reject した後、`process.env[sentinelKey]` が original-value に戻っていることを確認する
+- **期待結果**: `launchPersistentChromiumContext` 失敗後も `process.env` のエントリが呼び出し前の値に復元される
+- **スクリプト**: n/a (unit coverage) / smkc-score-app/__tests__/e2e/run-preview.test.ts
+
 ## TC-1996: TA決勝 row のTV番号を送信 payload と履歴に保存する
 - **URL**: /tournaments/[temp-id]/ta/finals, /api/tournaments/[id]/ta/phases
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -274,6 +274,7 @@ describe('E2E case drift coverage', () => {
     ['TC-1669', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/static/tc-1009-overall-ranking-bracket-threshold-comments.test.ts'],
     ['TC-1671', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts'],
     ['TC-2444', 'n/a (unit coverage)', 'smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx'],
+    ['TC-2446', 'n/a (unit coverage)', 'smkc-score-app/__tests__/e2e/run-preview.test.ts'],
     ['TC-803', 'TC-318 でカバー済み', 'TC-318'],
   ];
 

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -317,6 +317,39 @@ describe('preview E2E runner', () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it('restores process.env entries to their pre-call values when launchPersistentChromiumContext throws (TC-2446)', async () => {
+    // launchPreviewAdminSessionBrowser writes env into process.env before calling
+    // launchPersistentChromiumContext, then restores via finally. This test verifies
+    // that the write loop's finally-protection actually runs on launch failure.
+    const throwError = new Error('browser not available');
+    const throwingLaunch = jest.fn<() => Promise<never>>().mockRejectedValue(throwError);
+
+    let isolatedRunner: PreviewRunner | undefined;
+    jest.isolateModules(() => {
+      jest.doMock('../../e2e/lib/common', () => ({
+        launchPersistentChromiumContext: throwingLaunch,
+        getChromiumLaunchConfig: jest.fn(),
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      isolatedRunner = require('../../e2e/run-preview') as PreviewRunner;
+    });
+
+    const sentinelKey = 'E2E_RUN_PREVIEW_TEST_SENTINEL_2446';
+    process.env[sentinelKey] = 'original-value';
+
+    await expect(
+      isolatedRunner!.assertPreviewAdminSession({
+        E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
+        E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
+        [sentinelKey]: 'modified-value',
+      }),
+    ).rejects.toThrow('browser not available');
+
+    // finally block must have restored the sentinel to its original value
+    expect(process.env[sentinelKey]).toBe('original-value');
+    delete process.env[sentinelKey];
+  });
+
   it('surfaces install-browser failure when managed cache bootstrap cannot recover', async () => {
     const launchBrowser = jest.fn<() => Promise<unknown>>()
       .mockRejectedValue(new Error("browserType.launchPersistentContext: Executable doesn't exist at /tmp/ms-playwright/chromium_headless_shell-1217/chrome-headless-shell"));

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -317,13 +317,12 @@ describe('preview E2E runner', () => {
     expect(close).toHaveBeenCalled();
   });
 
-  it('restores process.env entries to their pre-call values when launchPersistentChromiumContext throws (TC-2446)', async () => {
-    // launchPreviewAdminSessionBrowser writes env into process.env before calling
-    // launchPersistentChromiumContext, then restores via finally. This test verifies
-    // that the write loop's finally-protection actually runs on launch failure.
-    const throwError = new Error('browser not available');
-    const throwingLaunch = jest.fn<() => Promise<never>>().mockRejectedValue(throwError);
-
+  it('restores process.env entries when launchPersistentChromiumContext throws (TC-2446)', async () => {
+    // launchPreviewAdminSessionBrowser writes env into process.env then restores via finally.
+    // jest.doMock inside isolateModules scopes the factory to the isolated registry so it
+    // intercepts the runtime require('./lib/common') inside launchPreviewAdminSessionBrowser
+    // without leaking into the global mock registry.
+    const throwingLaunch = jest.fn<() => Promise<never>>().mockRejectedValue(new Error('browser not available'));
     let isolatedRunner: PreviewRunner | undefined;
     jest.isolateModules(() => {
       jest.doMock('../../e2e/lib/common', () => ({
@@ -333,12 +332,13 @@ describe('preview E2E runner', () => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       isolatedRunner = require('../../e2e/run-preview') as PreviewRunner;
     });
+    if (!isolatedRunner) throw new Error('isolation failed — run-preview module not loaded');
 
     const sentinelKey = 'E2E_RUN_PREVIEW_TEST_SENTINEL_2446';
     process.env[sentinelKey] = 'original-value';
 
     await expect(
-      isolatedRunner!.assertPreviewAdminSession({
+      isolatedRunner.assertPreviewAdminSession({
         E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
         E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
         [sentinelKey]: 'modified-value',
@@ -348,6 +348,7 @@ describe('preview E2E runner', () => {
     // finally block must have restored the sentinel to its original value
     expect(process.env[sentinelKey]).toBe('original-value');
     delete process.env[sentinelKey];
+    jest.unmock('../../e2e/lib/common');
   });
 
   it('surfaces install-browser failure when managed cache bootstrap cannot recover', async () => {

--- a/smkc-score-app/e2e/run-preview.js
+++ b/smkc-score-app/e2e/run-preview.js
@@ -78,16 +78,15 @@ async function launchPreviewAdminSessionBrowser(env) {
   // E2E_MAC_SINGLE_PROCESS, E2E_EXECUTABLE_PATH, and E2E_BROWSER_CHANNEL internally,
   // so env must be written to process.env before calling it and restored after.
   const previousEnv = {};
-  for (const [key, value] of Object.entries(env)) {
-    previousEnv[key] = process.env[key];
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
-
   try {
+    for (const [key, value] of Object.entries(env)) {
+      previousEnv[key] = process.env[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
     return await launchPersistentChromiumContext(env.E2E_PROFILE_DIR, {
       headless: env.E2E_HEADLESS === '1',
       viewport: { width: 1280, height: 720 },


### PR DESCRIPTION
## Summary

- `launchPreviewAdminSessionBrowser` の process.env 書き込みループを `try` ブロック内に移動し、ループ途中で例外が発生した場合でも `finally` により復元が保証されるよう修正
- 単体テストを追加: `launchPersistentChromiumContext` が失敗した場合に `process.env` が復元されることを確認 (TC-2446)
- `jest.doMock` に `jest.unmock` クリーンアップを追加し、`!` 非nullアサーションを `if` ガードに変更
- TC-2446 を `E2E_TEST_CASES.md` と `e2e-cases-drift.test.ts` に登録

## Issues

Closes #2446
Closes #2445

## Validation

- `npx jest --testPathPattern="run-preview|e2e-cases-drift"` → 237 passed
- `npx jest --no-coverage` → 3320 passed, 0 failed

---
_Generated by [Claude Code](https://claude.ai/code/session_016z2cgpHjuGymBw8zG28puM)_