### PR TITLE
test(run-preview): add TC-2448 write-loop-abort coverage, fix unmock comment (#2448 #2449)

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -3571,6 +3571,19 @@
 - **期待結果**: `launchPersistentChromiumContext` 失敗後も `process.env` のエントリが呼び出し前の値に復元される
 - **スクリプト**: n/a (unit coverage) / smkc-score-app/__tests__/e2e/run-preview.test.ts
 
+## TC-2448: run-preview の書き込みループ途中例外でも process.env が finally で復元される
+- **URL**: n/a (unit contract)
+- **authRequired**: false
+- **背景**: issue #2448。TC-2446 が修正した本質は「書き込みループを try 内に移動したことで、ループ自体が途中で throw しても finally が実行される」点である。TC-2446 のテストは `launchPersistentChromiumContext` が throw するシナリオを検証しており、旧コードでも finally が正常動作していたケースだった。本 TC は「書き込みループ自体の途中 throw（`process.env` 代入時に `toString()` が失敗するケース）でセンチネルキーが復元されること」を直接検証する。
+- **手順**:
+  1. `launchPersistentChromiumContext` をモックした isolated runner を `jest.doMock` + `jest.isolateModules` で用意する
+  2. `process.env` にセンチネルキーを original-value でセットする
+  3. `toString()` が throw するオブジェクトを値に持つ env を作成する（センチネルキーより後に配置）
+  4. `assertPreviewAdminSession` を上記 env で呼び出す
+  5. 呼び出しが `'env stringify failed'` エラーで reject した後、`process.env[sentinelKey]` が original-value に戻っていることと、`launchPersistentChromiumContext` が未呼び出しであることを確認する
+- **期待結果**: 書き込みループが途中 throw した後も `process.env` のエントリが呼び出し前の値に復元される
+- **スクリプト**: n/a (unit coverage) / smkc-score-app/__tests__/e2e/run-preview.test.ts
+
 ## TC-1996: TA決勝 row のTV番号を送信 payload と履歴に保存する
 - **URL**: /tournaments/[temp-id]/ta/finals, /api/tournaments/[id]/ta/phases
 - **authRequired**: true (admin)

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -275,6 +275,7 @@ describe('E2E case drift coverage', () => {
     ['TC-1671', 'n/a (unit/static coverage)', 'smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts'],
     ['TC-2444', 'n/a (unit coverage)', 'smkc-score-app/__tests__/components/tournament/ta-time-entry-rows.test.tsx'],
     ['TC-2446', 'n/a (unit coverage)', 'smkc-score-app/__tests__/e2e/run-preview.test.ts'],
+    ['TC-2448', 'n/a (unit coverage)', 'smkc-score-app/__tests__/e2e/run-preview.test.ts'],
     ['TC-803', 'TC-318 でカバー済み', 'TC-318'],
   ];
 

--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -319,9 +319,9 @@ describe('preview E2E runner', () => {
 
   it('restores process.env entries when launchPersistentChromiumContext throws (TC-2446)', async () => {
     // launchPreviewAdminSessionBrowser writes env into process.env then restores via finally.
-    // jest.doMock inside isolateModules scopes the factory to the isolated registry so it
-    // intercepts the runtime require('./lib/common') inside launchPreviewAdminSessionBrowser
-    // without leaking into the global mock registry.
+    // jest.doMock registers in the GLOBAL mock registry (not an isolated one), so it must be
+    // cleaned up with jest.unmock after the test. jest.isolateModules ensures a fresh module
+    // instance picks up the factory, but the factory itself lives in the global registry.
     const throwingLaunch = jest.fn<() => Promise<never>>().mockRejectedValue(new Error('browser not available'));
     let isolatedRunner: PreviewRunner | undefined;
     jest.isolateModules(() => {
@@ -348,6 +348,58 @@ describe('preview E2E runner', () => {
     // finally block must have restored the sentinel to its original value
     expect(process.env[sentinelKey]).toBe('original-value');
     delete process.env[sentinelKey];
+    // jest.doMock registers globally — unmock to prevent factory leaking to subsequent tests
+    jest.unmock('../../e2e/lib/common');
+  });
+
+  it('restores process.env entries written before the write loop aborts mid-way (TC-2448)', async () => {
+    // Covers the core correctness of the #2446 fix: moving the write loop inside try ensures
+    // the finally block runs even when the loop itself throws mid-way (i.e. when a process.env
+    // write is interrupted). The sentinel key is inserted before the throwing key in the env
+    // object so its modified value is already in process.env when the throw occurs.
+    // beforeEach replaces process.env with a plain object, so we use Object.defineProperty to
+    // install a throwing setter on process.env['THROW_ON_WRITE'] — plain object assignment
+    // does not coerce values, making the toString() trick ineffective here.
+    const launchMock = jest.fn<() => Promise<never>>();
+    let isolatedRunner: PreviewRunner | undefined;
+    jest.isolateModules(() => {
+      jest.doMock('../../e2e/lib/common', () => ({
+        launchPersistentChromiumContext: launchMock,
+        getChromiumLaunchConfig: jest.fn(),
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      isolatedRunner = require('../../e2e/run-preview') as PreviewRunner;
+    });
+    if (!isolatedRunner) throw new Error('isolation failed — run-preview module not loaded');
+
+    const sentinelKey = 'E2E_RUN_PREVIEW_TEST_SENTINEL_2448';
+    process.env[sentinelKey] = 'original-value';
+
+    // Install a setter that throws when the write loop tries to assign THROW_ON_WRITE on
+    // process.env. The sentinel key appears before THROW_ON_WRITE in the env object, so its
+    // modified value ('modified-value') has already been written when the throw occurs.
+    Object.defineProperty(process.env, 'THROW_ON_WRITE', {
+      set() { throw new Error('env assignment failed'); },
+      get() { return undefined; },
+      configurable: true,
+      enumerable: false,
+    });
+
+    await expect(
+      isolatedRunner.assertPreviewAdminSession({
+        E2E_BASE_URL: 'https://preview.smkc.bluemoon.works',
+        E2E_PROFILE_DIR: '/tmp/playwright-smkc-preview-profile',
+        [sentinelKey]: 'modified-value',
+        THROW_ON_WRITE: 'any-value',
+      }),
+    ).rejects.toThrow('env assignment failed');
+
+    // finally block must have restored the sentinel to its original value
+    expect(process.env[sentinelKey]).toBe('original-value');
+    delete process.env[sentinelKey];
+    // launchPersistentChromiumContext is never reached when the loop aborts early
+    expect(launchMock).not.toHaveBeenCalled();
+    // jest.doMock registers globally — unmock to prevent factory leaking to subsequent tests
     jest.unmock('../../e2e/lib/common');
   });
 


### PR DESCRIPTION
## Summary

- **TC-2448**: Adds a test that directly covers the core correctness of the #2446 fix — the write loop aborting mid-way. Uses `Object.defineProperty` to install a throwing setter on `process.env['THROW_ON_WRITE']`, ensuring the sentinel key's modified value is already in `process.env` when the throw occurs. The finally block must restore it. This tests what the old code would have failed: partial writes without cleanup.

- **TC-2449 corrected**: The reviewer's finding that `jest.unmock` is a no-op was empirically wrong. `jest.doMock` inside `jest.isolateModules` registers in the **global** mock registry (not an isolated one). Without `jest.unmock`, TC-2446's factory leaks into TC-2448's isolated runner and the test picks up the wrong mock. Re-added `jest.unmock` to TC-2446 with an accurate comment; TC-2448 also calls `jest.unmock` at the end.

- Registered TC-2448 in `E2E_TEST_CASES.md` and `e2e-cases-drift.test.ts`.

## Why `toString()` trick was replaced

`beforeEach` replaces `process.env` with a plain JS object (`process.env = { ...originalEnv }`). Plain object assignment does not coerce values, so a value with a throwing `toString()` would just be stored as-is — no throw. `Object.defineProperty` with a setter is the correct approach for this environment.

## Test plan

- [x] `npx jest --no-coverage --testPathPattern="run-preview|e2e-cases-drift"` — 239 passed
- [x] `npx jest --no-coverage` (full suite) — 3322 passed, 27 skipped, 0 failed

Closes #2448
Closes #2449

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016z2cgpHjuGymBw8zG28puM

---
_Generated by [Claude Code](https://claude.ai/code/session_016z2cgpHjuGymBw8zG28puM)_