### PR TITLE
docs: fix TC-2448 steps in E2E_TEST_CASES.md to match actual implementation (#2451)

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -3578,9 +3578,9 @@
 - **手順**:
   1. `launchPersistentChromiumContext` をモックした isolated runner を `jest.doMock` + `jest.isolateModules` で用意する
   2. `process.env` にセンチネルキーを original-value でセットする
-  3. `toString()` が throw するオブジェクトを値に持つ env を作成する（センチネルキーより後に配置）
-  4. `assertPreviewAdminSession` を上記 env で呼び出す
-  5. 呼び出しが `'env stringify failed'` エラーで reject した後、`process.env[sentinelKey]` が original-value に戻っていることと、`launchPersistentChromiumContext` が未呼び出しであることを確認する
+  3. `Object.defineProperty` で `process.env['THROW_ON_WRITE']` に throw するセッターを設置する。センチネルキーは env パラメータ内で THROW_ON_WRITE より前に配置し、書き込みループがセンチネルを修正した後でセッターが発火するようにする
+  4. `assertPreviewAdminSession` を env = `{ ..., [sentinelKey]: 'modified-value', THROW_ON_WRITE: 'any-value' }` で呼び出す
+  5. 呼び出しが `'env assignment failed'` エラーで reject した後、`process.env[sentinelKey]` が original-value に戻っていることと、`launchPersistentChromiumContext` が未呼び出しであることを確認する
 - **期待結果**: 書き込みループが途中 throw した後も `process.env` のエントリが呼び出し前の値に復元される
 - **スクリプト**: n/a (unit coverage) / smkc-score-app/__tests__/e2e/run-preview.test.ts
 


### PR DESCRIPTION
## Summary

Fixes E2E_TEST_CASES.md documentation drift flagged in issue #2451.

Steps 3 and 5 for TC-2448 were written during the initial draft using the `toString()` approach, which was replaced by `Object.defineProperty` with a throwing setter before the test was finalized. The descriptions and error string were never updated.

**Changes:**
- Step 3: updated from "toString() が throw するオブジェクト" to describe `Object.defineProperty` with a throwing setter on `process.env['THROW_ON_WRITE']`, including the order constraint (sentinel before THROW_ON_WRITE)
- Step 5: corrected error string from `'env stringify failed'` → `'env assignment failed'`

No code changes — documentation only.

Closes #2451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016z2cgpHjuGymBw8zG28puM

---
_Generated by [Claude Code](https://claude.ai/code/session_016z2cgpHjuGymBw8zG28puM)_