### PR TITLE
fix(e2e): remove redundant optional chaining after preview.raw.data guard (#2458)

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -2808,6 +2808,9 @@ describe('E2E case drift coverage', () => {
     /* Guard for preview.raw.data absence must throw a diagnostic error (issue #2367). */
     expect(tcGp).toContain('TC-2234: preview.raw.data missing');
     expect(section).toContain('preview.raw.data');
+    /* After guard, optional chaining is dead – access must be preview.raw.data.* directly (issue #2458). */
+    expect(tcGp).toContain('preview.raw.data.playoffStructure');
+    expect(tcGp).toContain('preview.raw.data.seededPlayers');
   });
 
   it('documents TC-535 as BM Top-24 qualification label coverage', () => {

--- a/smkc-score-app/e2e/tc-gp.js
+++ b/smkc-score-app/e2e/tc-gp.js
@@ -1167,9 +1167,9 @@ async function runTc2234(adminPage) {
     const preview = await apiFetchGpFinalsState(adminPage, tournamentId);
     /* Guard: raw.data absence causes silent [] fallback and misleading 'upper seed missing' error. */
     if (!preview.raw?.data) throw new Error(`TC-2234: preview.raw.data missing – raw: ${JSON.stringify(preview.raw)}`);
-    const playoffStructure = preview.raw?.data?.playoffStructure || [];
+    const playoffStructure = preview.raw.data.playoffStructure || [];
     const upperSeed = playoffStructure.find((entry) => entry.matchNumber === tiedR2Match.matchNumber)?.advancesToUpperSeed;
-    const seededPlayers = preview.raw?.data?.seededPlayers || [];
+    const seededPlayers = preview.raw.data.seededPlayers || [];
     const seededWinner = seededPlayers.find((player) => player.seed === upperSeed);
     const tiedMatchPreview = preview.playoffMatches.find((match) => match.id === tiedR2Match.id);
 


### PR DESCRIPTION
## Summary

`runTc2234` の guard (`if (!preview.raw?.data) throw`) 追加後、guard 以降の `preview.raw?.data?.playoffStructure` / `?.seededPlayers` の optional chaining は dead code になっていた (#2458)。

guard が通過した時点で `preview.raw.data` は truthy が保証されるため、直接アクセスに置き換え。drift guard アサーションも追加。

## Issues

Closes #2458

## Validation

- `npm test` (e2e-cases-drift TC-2234) PASS
- 変更は tc-gp.js の2行と drift test の2アサーション追加のみ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQCAUVAwN16jRDnCEP77f1)_