### PR TITLE
test(ci-config): node-version の YAML 数値/文字列表記差異を String() で吸収 (#2467)

### DIFF
--- a/smkc-score-app/__tests__/docs/ci-config.test.ts
+++ b/smkc-score-app/__tests__/docs/ci-config.test.ts
@@ -102,7 +102,9 @@ describe('CI workflow configuration', () => {
       s.uses?.startsWith('actions/setup-node')
     );
     expect(setupNodeStep).toBeDefined();
-    expect(setupNodeStep?.with?.['node-version']).toBe('22');
+    // String() で YAML パーサの数値/文字列表記差異を吸収する (#2467)
+    // node-version: 22 (クォートなし整数) でも node-version: "22" (文字列) でも通る
+    expect(String(setupNodeStep?.with?.['node-version'])).toBe('22');
   });
 
   it('passes --ci and --forceExit flags to npm test', () => {


### PR DESCRIPTION
## Summary

`node-version: 22`（クォートなし）は YAML パーサが整数 `22` として返すため、
`toBe('22')` が将来誤検知する可能性があった。
`String()` キャストで数値/文字列の表記差異を吸収するように修正した。

## Issues

Closes #2467

## Validation

```
PASS __tests__/docs/ci-config.test.ts
Tests: 7 passed, 7 total
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01RoKspKUhEfLEQBaWWU44Ee)_