### PR TITLE
test(ci-config): node-version コメントを1行に集約 CLAUDE.md準拠 (#2469)

### DIFF
--- a/smkc-score-app/__tests__/docs/ci-config.test.ts
+++ b/smkc-score-app/__tests__/docs/ci-config.test.ts
@@ -102,8 +102,7 @@ describe('CI workflow configuration', () => {
       s.uses?.startsWith('actions/setup-node')
     );
     expect(setupNodeStep).toBeDefined();
-    // String() で YAML パーサの数値/文字列表記差異を吸収する (#2467)
-    // node-version: 22 (クォートなし整数) でも node-version: "22" (文字列) でも通る
+    // String() で YAML 数値/文字列表記差異を吸収 (#2467)
     expect(String(setupNodeStep?.with?.['node-version'])).toBe('22');
   });
 


### PR DESCRIPTION
## Summary

PR #2468 で追加されたコメントが2行になっており CLAUDE.md の「one short line max」ルールに違反していた。2行を1行に集約した。

## Issues

Closes #2469

## Validation

```
PASS __tests__/docs/ci-config.test.ts
Tests: 7 passed, 7 total
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01RoKspKUhEfLEQBaWWU44Ee)_