### PR TITLE
test(archive): remove @ts-nocheck, use jest.mocked(), stabilize drift guards (#2473 #2474)

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/archive/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/archive/route.test.ts
@@ -14,7 +14,6 @@
  * - Returns generated archive on success
  * - Returns 500 and logs error when persistTournamentArchive throws
  */
-// @ts-nocheck
 // Logger factory is hoisted, so the shared instance must live inside the factory.
 // Retrieve it later via jest.requireMock('@/lib/logger').createLogger().
 jest.mock('@/lib/logger', () => {
@@ -24,7 +23,7 @@ jest.mock('@/lib/logger', () => {
 
 jest.mock('next/server', () => ({
   NextResponse: {
-    json: jest.fn((data, options) => ({ data, status: options?.status ?? 200 })),
+    json: jest.fn((data: unknown, options?: { status?: number }) => ({ data, status: options?.status ?? 200 })),
   },
   NextRequest: jest.fn(),
 }));
@@ -42,19 +41,19 @@ jest.mock('@/lib/tournament-archive', () => ({
   persistTournamentArchive: jest.fn(),
 }));
 
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { auth } from '@/lib/auth';
 import { resolveTournament } from '@/lib/tournament-identifier';
-import { readTournamentArchive, persistTournamentArchive } from '@/lib/tournament-archive';
+import { readTournamentArchive, persistTournamentArchive, type TournamentArchiveBundle } from '@/lib/tournament-archive';
 import { GET, POST } from '@/app/api/tournaments/[id]/archive/route';
 
 const mockParams = (id: string) => ({ params: Promise.resolve({ id }) });
-const mockReq = () => ({} as any);
+const mockReq = () => ({} as unknown as NextRequest);
 
-const mockAuth = auth as jest.Mock;
-const mockResolveTournament = resolveTournament as jest.Mock;
-const mockReadTournamentArchive = readTournamentArchive as jest.Mock;
-const mockPersistTournamentArchive = persistTournamentArchive as jest.Mock;
+const mockAuth = auth as jest.Mock; // next-auth type via NextAuth(config as any) makes jest.mocked() infer 'never'
+const mockResolveTournament = jest.mocked(resolveTournament);
+const mockReadTournamentArchive = jest.mocked(readTournamentArchive);
+const mockPersistTournamentArchive = jest.mocked(persistTournamentArchive);
 
 function makeArchiveBundle(publicModes: string[]) {
   return {
@@ -79,7 +78,7 @@ function makeArchiveBundle(publicModes: string[]) {
     modes: { ta: { entries: [], phaseRounds: [] }, bm: {}, mr: {}, gp: {} },
     overallRanking: { rankings: [] },
     archived: true,
-  };
+  } as unknown as TournamentArchiveBundle;
 }
 
 describe('GET /api/tournaments/[id]/archive', () => {

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3139,17 +3139,18 @@ describe('E2E case drift coverage', () => {
   });
 
   // TC-2472〜TC-2475: Tournament Archive API ドリフトガード
+  // HTTP ステータスコードとエラーコードで検証する（自然言語の表現変更に対し安定）
   it('documents TC-2472 as archive GET 403 for empty publicModes', () => {
     const section = e2eCaseSection('TC-2472');
-    expect(section).toContain('publicModes');
     expect(section).toContain('403');
+    expect(section).toContain('FORBIDDEN');
     expect(section).toContain('__tests__/app/api/tournaments/[id]/archive/route.test.ts');
   });
 
   it('documents TC-2473 as archive GET 404 when no archive exists', () => {
     const section = e2eCaseSection('TC-2473');
-    expect(section).toContain('null');
     expect(section).toContain('404');
+    expect(section).toContain('NOT_FOUND');
     expect(section).toContain('__tests__/app/api/tournaments/[id]/archive/route.test.ts');
   });
 


### PR DESCRIPTION
## Summary

- **#2473**: Remove blanket `// @ts-nocheck` from archive route test. Replace 3 of 4 `as jest.Mock` casts with `jest.mocked()` for typed mock inference. `auth` retains `as jest.Mock` with an inline comment because next-auth generates its type via `NextAuth(config as any)`, which causes `jest.mocked()` to infer `never`. Import `type NextRequest` and `type TournamentArchiveBundle`; cast the minimal test fixture with `as unknown as TournamentArchiveBundle` instead of relying on `@ts-nocheck`.
- **#2474**: TC-2472/TC-2473 drift guards replace fragile natural-language keyword checks (`'publicModes'`, `'null'`) with stable API error-code strings (`'FORBIDDEN'`, `'NOT_FOUND'`). These are tied directly to the HTTP contract and won't break on benign documentation rewording.

## Issues

Closes #2473
Closes #2474

## Validation

- `npm test` passes (236 suites, 3355 tests)
- `tsc --noEmit` reports zero errors in the changed files
- Drift guard assertions verified against current E2E_TEST_CASES.md content

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYGffFf33XLzkZhU9YX1C6)_