### PR TITLE
docs(test): clarify isMissingPlaywrightExecutableError comment

### DIFF
--- a/smkc-score-app/__tests__/e2e/run-preview.test.ts
+++ b/smkc-score-app/__tests__/e2e/run-preview.test.ts
@@ -110,7 +110,8 @@ describe('preview E2E runner', () => {
   });
 
   it('exposes missing Playwright executable detection for preview bootstrap recovery', () => {
-    // Path suffix is platform-specific (linux-x64, mac-arm64, etc.); detection uses substring match on chrome-headless-shell
+    // Path suffix is platform-specific (linux-x64, mac-arm64, etc.);
+    // detection uses substring match on chrome-headless-shell OR chromium_headless_shell (directory name alone)
     expect(runner.isMissingPlaywrightExecutableError(
       new Error("browserType.launchPersistentContext: Executable doesn't exist at /tmp/ms-playwright/chromium_headless_shell-1217/chrome-headless-shell"),
     )).toBe(true);


### PR DESCRIPTION
## Summary

Closes #2497

Updates the comment above the `isMissingPlaywrightExecutableError` test to accurately describe both detection branches: `chrome-headless-shell` (binary name) and `chromium_headless_shell` (directory name alone). The old comment only mentioned `chrome-headless-shell`, which was misleading after TC-2488 added independent coverage of the directory-name-only path.

## Test plan

- [ ] `npm run test -- --testPathPattern="run-preview"` → 32 tests pass (comment-only change, no logic affected)
- [ ] CI lint-and-test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEtQtyoHaxTbsm9wxWauvu

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEtQtyoHaxTbsm9wxWauvu)_