### PR TITLE
test: harden drift tests against implementation-string fragility (#2023 #2347 #2348 #2351 #2354 #2382)

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -642,7 +642,8 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('test:` または `refactor:');
     expect(prTemplate).toContain('PR title and Conventional Commit type match the actual diff.');
     expect(prTemplate).toContain('Use `docs:` only when this PR changes documentation.');
-    expect(prTemplateTest).toContain('align the PR title type with the actual diff');
+    // Check actual assertion content rather than the it() description to avoid fragility from renames.
+    expect(prTemplateTest).toContain("Use `test:` or `refactor:` for test-only refactors.");
   });
 
   it('keeps TC-2118 documented with the shared tournament-tab hydration guard', () => {
@@ -1174,8 +1175,10 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #2088/#2193');
     expect(section).toContain('TypeScript AST');
     expect(section).toContain('tc-2088-cdm-main-hub-boundary.test.ts');
-    expect(tc2088BoundaryTest).toContain('bodyHasArrayFromLength60');
-    expect(tc2088BoundaryTest).toContain('bodyExpectsMainHubCellToBeUndefined');
+    // Check AST behavior targets rather than function names to avoid fragility on renames (#2354).
+    expect(tc2088BoundaryTest).toContain("'Array.from'");        // AST detects Array.from({ length: 60 }) call
+    expect(tc2088BoundaryTest).toContain("'Main Hub'");          // AST detects Main Hub cell boundary access
+    expect(tc2088BoundaryTest).toContain('ts.forEachChild');     // AST traversal approach still in use
     expect(tc2088BoundaryTest).not.toContain("toContain('Array.from({ length: 60 }')");
     expect(tc2088BoundaryTest).not.toContain('B62).toBeUndefined()');
     expect(exportRouteTest).toContain('should write the Main Hub player rows for exactly 60 players');
@@ -2256,7 +2259,6 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('smkc-score-app/__tests__/lib/prisma-selects.test.ts');
     expect(prismaSelectsTest).toContain('Object.entries(BM_MR_MATCH_LEAN_SELECT)');
     expect(prismaSelectsTest).toContain('selectedFields.length');
-    expect(prismaSelectsTest).toContain('key.length > 0 && value === true');
     // Issue #2024: exact-key guard must also be present (detects accidental field additions).
     expect(prismaSelectsTest).toContain('Object.keys(BM_MR_MATCH_LEAN_SELECT)');
     expect(prismaSelectsTest).toContain('EXPECTED_FIELDS');
@@ -2571,11 +2573,11 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('Issue**: #2109');
     expect(section).toContain('P1 session');
     expect(section).toContain('P2 session');
-    expect(tcMr).toContain('const p1Context = await loginSharedPlayer(adminPage, p1)');
-    expect(tcMr).toContain('const p2Context = await loginSharedPlayer(adminPage, p2)');
-    expect(tcMr).toContain('const p1Report = await p1Context.page.evaluate');
-    expect(tcMr).toContain('const p2Report = await p2Context.page.evaluate');
-    expect(tcMr).toContain('const rejectedReport = await p1Context.page.evaluate');
+    // Check function calls rather than variable names to avoid fragility from renames (#2347/#2348).
+    expect(tcMr).toContain('loginSharedPlayer(adminPage, p1)');
+    expect(tcMr).toContain('loginSharedPlayer(adminPage, p2)');
+    // .page.evaluate only appears in runTc822's dual-session section; verifies player-context usage.
+    expect(tcMr).toContain('.page.evaluate');
   });
 
   it('documents TC-821A as shared TA sudden-death UI and logic coverage', () => {

--- a/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
@@ -177,8 +177,10 @@ describe("selectRandomCourse", () => {
 
     const selected = await selectRandomCourse(prisma as any, "t1", "phase1");
 
-    expect(selected).toBe("GV1");
-    expect(selected).not.toBe("DP1");
+    // Both MC1 and DP1 were played in this cycle so both must be excluded.
+    // Not asserting exact "GV1" to avoid coupling to COURSES array order (#2351).
+    expect(selected).not.toBe("DP1"); // immediate-repeat avoidance: DP1 was last played
+    expect(selected).not.toBe("MC1"); // cycle exclusion: MC1 was played earlier
   });
 });
 


### PR DESCRIPTION
## Summary

- **#2351**: course-selection テストでハードコードされた "GV1" 期待値を削除。COURSES 配列順序に依存せず、プレイ済みコース (MC1, DP1) が除外されることをアサート
- **#2382**: e2e-cases-drift TC-2242 で `it()` 説明文文字列ではなく、実際のアサーションコンテンツ (`Use \`test:\` or \`refactor:\` for test-only refactors.`) を検証対象に変更
- **#2023**: e2e-cases-drift TC-2006-2007 から実装文字列 `key.length > 0 && value === true` チェックを削除。`Object.entries`/`keys`/`EXPECTED_FIELDS` ガードで十分なカバレッジを維持
- **#2347 #2348**: e2e-cases-drift TC-2109 で変数名チェック（`const p1Context =`）を `loginSharedPlayer(adminPage, p1)` 関数呼び出しパターンチェックに変更。変数名リネームで壊れない
- **#2354**: e2e-cases-drift TC-2088 で内部関数名チェック (`bodyHasArrayFromLength60`) を安定した動作ターゲット (`Array.from`, `Main Hub`, `ts.forEachChild`) チェックに変更

## Issues

Closes #2023
Closes #2347
Closes #2348
Closes #2351
Closes #2354
Closes #2382

## Validation

- `npm test` で全テストパス
- 変更はテストの安定性向上のみ（ロジック変更なし）


---
_Generated by [Claude Code](https://claude.ai/code/session_01X71zYM3GM4jHwQRbw1bGJm)_