### PR TITLE
fix: tighten AuthSessionResult type and document handleAuthzError equivalence

### DIFF
--- a/smkc-score-app/src/lib/api-auth.ts
+++ b/smkc-score-app/src/lib/api-auth.ts
@@ -13,9 +13,11 @@
 import { NextResponse } from 'next/server';
 import type { User } from 'next-auth';
 import { auth } from '@/lib/auth';
+// handleAuthzError() === createErrorResponse('Forbidden', 403, 'FORBIDDEN') — same body/headers (#2510)
 import { handleAuthzError } from '@/lib/error-handling';
 
-export type AuthSessionResult = { error?: NextResponse; session?: { user: User } | null };
+// session is never null on success: helpers return { error } on failure, { session } on success (#2511)
+export type AuthSessionResult = { error?: NextResponse; session?: { user: User } };
 
 /**
  * Requires an authenticated admin session.


### PR DESCRIPTION
## Summary

- **#2511**: `AuthSessionResult.session` から不要な `| null` を除去。ヘルパー関数は成功時に `{ session }` を返し、失敗時は `{ error }` のみを返すため `session` が `null` になるケースは存在しない
- **#2510**: `handleAuthzError()` が `createErrorResponse('Forbidden', 403, 'FORBIDDEN')` と同一レスポンスを返すことをインラインコメントで明示。PR #2509 での `ta/route.ts` エラー形式変更が意図的であることを記録

## Issues

Closes #2510
Closes #2511

## Validation

- `npm test -- __tests__/lib/api-auth.test.ts` — 8 tests passed
- `npm test -- __tests__/app/api/tournaments/[id]/ta/` — 89 tests passed（リグレッションなし）
- TypeScript: 変更ファイルにコンパイルエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BphPjNZ4DWFNpcTvYG4ak

---
_Generated by [Claude Code](https://claude.ai/code/session_018BphPjNZ4DWFNpcTvYG4ak)_