### PR TITLE
test: strengthen TC-2503 drift guard section token (#2517)

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3375,7 +3375,7 @@ describe('E2E case drift coverage', () => {
   it('documents TC-2503 as requireAdminOrPlayerSession returning session for admin role', () => {
     const section = e2eCaseSection('TC-2503');
     const apiAuthTest = readRepoFile('smkc-score-app', '__tests__', 'lib', 'api-auth.test.ts');
-    expect(section).toContain('admin');
+    expect(section).toContain('requireAdminOrPlayerSession'); // scenario-specific: distinguishes TC-2503 from TC-2501 which tests requireAdminSession
     expect(section).toContain('api-auth.test.ts');
     expect(apiAuthTest).toContain('TC-2503');
     expect(apiAuthTest).toContain("role: 'admin'");


### PR DESCRIPTION
## Summary

- TC-2503 のドリフトガードで `expect(section).toContain('admin')` が使われていたが、TC-2501 でも同一の汎用トークンが使われており一貫性に欠けていた
- `'requireAdminOrPlayerSession'` に変更することで、TC-2503 が `requireAdminSession`（admin 専用）ではなく `requireAdminOrPlayerSession`（admin/player OR ヘルパー）を文書化していることを明示する
- TC-2499 が `'{}'`（空セッションリテラル）をシナリオ固有トークンとして使うパターンに倣う

## Issues

Closes #2517

## Validation

- `npm test -- --testPathPattern="e2e-cases-drift" --ci --forceExit` → **274 tests passed**
- 変更は drift guard のアサーション文字列のみ（ロジック変更なし）

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTZfHvCSVrGUFv2GsNSa7V)_