### PR TITLE
fix(test): strengthen TC-2547 drift guard to toContain('toBe(16)') (#2545)

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3704,7 +3704,8 @@ describe('E2E case drift coverage', () => {
       expect(section).toContain('time-format.test.ts');
       expect(tfTest).toContain('TC-2547');
       expect(tfTest).toContain('155');
-      expect(tfTest).toContain('16');
+      // '16' は汎用的な数値リテラルなので toBe(16) の形式で確認し一意性を高める (#2545)
+      expect(tfTest).toContain('toBe(16)');
     });
 
     it('documents TC-2548 as msToCdmTime throwing for negative duration', () => {


### PR DESCRIPTION
## Summary

- TC-2547 ドリフトガードの `expect(tfTest).toContain('16')` を `expect(tfTest).toContain('toBe(16)')` に変更
- `'16'` は `time-format.test.ts` 内の他コンテキストでも出現しうる汎用的な数値リテラルであり、TC-2546 の「汎用リテラル省略」ポリシーとの一貫性に欠けていた
- `'toBe(16)'` という形式にすることで、アサーション自体（`expect(msToCdmTime(155)).toBe(16)`）の存在を確認でき、ドリフトガードの精度が高まる
- コメントで変更理由を明記し、TC-2546 との整合性を文書化

## Issues

Closes #2545

## Validation

- `npm test -- --testPathPatterns="e2e-cases-drift" --ci --forceExit` → **3593 tests passed, 0 failed** (248 suites)
- 変更はドリフトガードのアサーション文字列のみ（ロジック変更なし）

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqtoGmPR4BoNYNYwXhNpwo)_