### PR TITLE
test: harden drift tests against implementation-string fragility (#2023 #2347 #2348 #2351 #2354 #2382)

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -642,7 +642,8 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('test:` または `refactor:');
     expect(prTemplate).toContain('PR title and Conventional Commit type match the actual diff.');
     expect(prTemplate).toContain('Use `docs:` only when this PR changes documentation.');
-    expect(prTemplateTest).toContain('align the PR title type with the actual diff');
+    // Check actual assertion content rather than the it() description to avoid fragility from renames.
+    expect(prTemplateTest).toContain("Use `test:` or `refactor:` for test-only refactors.");
   });
 
   it('keeps TC-2118 documented with the shared tournament-tab hydration guard', () => {
@@ -1174,8 +1175,10 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('issue #2088/#2193');
     expect(section).toContain('TypeScript AST');
     expect(section).toContain('tc-2088-cdm-main-hub-boundary.test.ts');
-    expect(tc2088BoundaryTest).toContain('bodyHasArrayFromLength60');
-    expect(tc2088BoundaryTest).toContain('bodyExpectsMainHubCellToBeUndefined');
+    // Check AST behavior targets rather than function names to avoid fragility on renames (#2354).
+    expect(tc2088BoundaryTest).toContain("'Array.from'");        // AST detects Array.from({ length: 60 }) call
+    expect(tc2088BoundaryTest).toContain("'Main Hub'");          // AST detects Main Hub cell boundary access
+    expect(tc2088BoundaryTest).toContain('ts.forEachChild');     // AST traversal approach still in use
     expect(tc2088BoundaryTest).not.toContain("toContain('Array.from({ length: 60 }')");
     expect(tc2088BoundaryTest).not.toContain('B62).toBeUndefined()');
     expect(exportRouteTest).toContain('should write the Main Hub player rows for exactly 60 players');
@@ -2256,7 +2259,6 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('smkc-score-app/__tests__/lib/prisma-selects.test.ts');
     expect(prismaSelectsTest).toContain('Object.entries(BM_MR_MATCH_LEAN_SELECT)');
     expect(prismaSelectsTest).toContain('selectedFields.length');
-    expect(prismaSelectsTest).toContain('key.length > 0 && value === true');
     // Issue #2024: exact-key guard must also be present (detects accidental field additions).
     expect(prismaSelectsTest).toContain('Object.keys(BM_MR_MATCH_LEAN_SELECT)');
     expect(prismaSelectsTest).toContain('EXPECTED_FIELDS');
@@ -2571,11 +2573,11 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('Issue**: #2109');
     expect(section).toContain('P1 session');
     expect(section).toContain('P2 session');
-    expect(tcMr).toContain('const p1Context = await loginSharedPlayer(adminPage, p1)');
-    expect(tcMr).toContain('const p2Context = await loginSharedPlayer(adminPage, p2)');
-    expect(tcMr).toContain('const p1Report = await p1Context.page.evaluate');
-    expect(tcMr).toContain('const p2Report = await p2Context.page.evaluate');
-    expect(tcMr).toContain('const rejectedReport = await p1Context.page.evaluate');
+    // Check function calls rather than variable names to avoid fragility from renames (#2347/#2348).
+    expect(tcMr).toContain('loginSharedPlayer(adminPage, p1)');
+    expect(tcMr).toContain('loginSharedPlayer(adminPage, p2)');
+    // .page.evaluate only appears in runTc822's dual-session section; verifies player-context usage.
+    expect(tcMr).toContain('.page.evaluate');
   });
 
   it('documents TC-821A as shared TA sudden-death UI and logic coverage', () => {

--- a/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
+++ b/smkc-score-app/__tests__/lib/ta/course-selection.test.ts
@@ -177,8 +177,10 @@ describe("selectRandomCourse", () => {
 
     const selected = await selectRandomCourse(prisma as any, "t1", "phase1");
 
-    expect(selected).toBe("GV1");
-    expect(selected).not.toBe("DP1");
+    // Both MC1 and DP1 were played in this cycle so both must be excluded.
+    // Not asserting exact "GV1" to avoid coupling to COURSES array order (#2351).
+    expect(selected).not.toBe("DP1"); // immediate-repeat avoidance: DP1 was last played
+    expect(selected).not.toBe("MC1"); // cycle exclusion: MC1 was played earlier
   });
 });
 


### PR DESCRIPTION
## Summary

- ドリフトテストで実装の文字列リテラルに依存した脆弱なアサーションを強化
- 振る舞いキーワードに置き換え、リファクタリング耐性を向上
- Issues #2023 #2347 #2348 #2351 #2354 #2382 対応

---

Closing: このブランチの変更は既に main にスカッシュマージ済みです。

_Generated by [Claude Code](https://claude.ai/code/session_01UqtoGmPR4BoNYNYwXhNpwo)_