### PR TITLE
refactor: extract shared requireAdminSession helpers, strengthen TC-2497 drift guard (#2503 #2508)

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3316,5 +3316,6 @@ describe('E2E case drift coverage', () => {
     expect(section).toContain('undefined');
     expect(section).toContain('audit-log.test.ts');
     expect(auditTest).toContain('TC-2497');
+    expect(auditTest).toContain('id: undefined'); // user.id が undefined のケースを具体的にカバー
   });
 });

--- a/smkc-score-app/__tests__/lib/api-auth.test.ts
+++ b/smkc-score-app/__tests__/lib/api-auth.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/auth', () => ({ auth: jest.fn() }));
+jest.mock('@/lib/error-handling', () => ({
+  handleAuthzError: jest.fn(() => ({ status: 403 } as any)),
+}));
+
+import { requireAdminSession, requireAdminOrPlayerSession } from '@/lib/api-auth';
+import { auth } from '@/lib/auth';
+import { handleAuthzError } from '@/lib/error-handling';
+
+const mockAuth = auth as jest.Mock;
+const mockHandleAuthzError = handleAuthzError as jest.Mock;
+
+describe('api-auth', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('requireAdminSession', () => {
+    it('returns error for unauthenticated (null session)', async () => {
+      mockAuth.mockResolvedValue(null);
+      const result = await requireAdminSession();
+      expect(result.error).toBeDefined();
+      expect(mockHandleAuthzError).toHaveBeenCalled();
+      expect(result.session).toBeUndefined();
+    });
+
+    it('returns error when session has no user', async () => {
+      mockAuth.mockResolvedValue({});
+      const result = await requireAdminSession();
+      expect(result.error).toBeDefined();
+    });
+
+    it('returns error for player session (role !== admin)', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'p1', role: 'player', userType: 'player' } });
+      const result = await requireAdminSession();
+      expect(result.error).toBeDefined();
+    });
+
+    it('returns session for admin', async () => {
+      const session = { user: { id: 'admin-1', role: 'admin' } };
+      mockAuth.mockResolvedValue(session);
+      const result = await requireAdminSession();
+      expect(result.error).toBeUndefined();
+      expect(result.session).toBe(session);
+      expect(mockHandleAuthzError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requireAdminOrPlayerSession', () => {
+    it('returns error for unauthenticated (null session)', async () => {
+      mockAuth.mockResolvedValue(null);
+      const result = await requireAdminOrPlayerSession();
+      expect(result.error).toBeDefined();
+      expect(mockHandleAuthzError).toHaveBeenCalled();
+    });
+
+    it('returns session for admin role', async () => {
+      const session = { user: { id: 'admin-1', role: 'admin' } };
+      mockAuth.mockResolvedValue(session);
+      const result = await requireAdminOrPlayerSession();
+      expect(result.error).toBeUndefined();
+      expect(result.session).toBe(session);
+    });
+
+    it('returns session for player userType', async () => {
+      const session = { user: { id: 'player-1', userType: 'player' } };
+      mockAuth.mockResolvedValue(session);
+      const result = await requireAdminOrPlayerSession();
+      expect(result.error).toBeUndefined();
+      expect(result.session).toBe(session);
+    });
+
+    it('returns error for authenticated user with neither admin role nor player userType', async () => {
+      mockAuth.mockResolvedValue({ user: { id: 'other-1', role: 'guest' } });
+      const result = await requireAdminOrPlayerSession();
+      expect(result.error).toBeDefined();
+    });
+  });
+});

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
@@ -21,14 +21,13 @@ import { PLAYER_PUBLIC_SELECT } from '@/lib/prisma-selects';
 import prisma from "@/lib/prisma";
 import { getClientIdentifier, getUserAgent } from "@/lib/request-utils";
 import { sanitizeInput } from "@/lib/sanitize";
-import { auth } from "@/lib/auth";
+import { requireAdminSession } from "@/lib/api-auth";
 import { z } from "zod";
 import { createLogger } from "@/lib/logger";
 import { retryDbRead } from "@/lib/db-read-retry";
 import {
   createSuccessResponse,
   createErrorResponse,
-  handleAuthzError,
   handleValidationError,
 } from "@/lib/error-handling";
 import {
@@ -50,7 +49,6 @@ import { checkStageFrozen } from "@/lib/ta/freeze-check";
 import { RETRY_PENALTY_MS } from "@/lib/constants";
 import { resolveTournamentId } from "@/lib/tournament-identifier";
 import { resolveAuditUserId } from "@/lib/audit-log";
-import type { User } from "next-auth";
 import { readTournamentArchive } from "@/lib/tournament-archive";
 
 function normalizePhaseRound<T extends { results: unknown; eliminatedIds?: unknown }>(round: T) {
@@ -127,26 +125,6 @@ function sortPhaseEntriesForDisplay<T extends PhaseEntryForDisplay>(
     if (rankCompare !== 0) return rankCompare;
     return compareNullableNumber(a.totalTime, b.totalTime);
   });
-}
-
-/**
- * Admin authentication helper that returns the session.
- * Returns { error } if user is not authenticated or not admin.
- * Returns { session } if authentication succeeds.
- */
-async function requireAdminAndGetSession(): Promise<{
-  error?: NextResponse;
-  session?: { user: User } | null;
-}> {
-  const session = await auth();
-  if (!session?.user || session.user.role !== "admin") {
-    return {
-      error: handleAuthzError(),
-    };
-  }
-  // user is guaranteed non-null by the guard above; TS cannot narrow `user?` through
-  // optional-chaining checks so we assert the narrowed type explicitly.
-  return { session: session as { user: User } };
 }
 
 /** Valid phase names for URL query parameters and request bodies */
@@ -573,7 +551,7 @@ export async function POST(
   const tournamentId = await resolveTournamentId(id);
 
   // Require admin authentication
-  const { error: authError, session } = await requireAdminAndGetSession();
+  const { error: authError, session } = await requireAdminSession();
   if (authError) return authError;
 
   try {

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
@@ -26,9 +26,8 @@ import prisma from "@/lib/prisma";
 import { createAuditLog, createAuditLogs, AUDIT_ACTIONS, resolveAuditUserId } from "@/lib/audit-log";
 import { getClientIdentifier, getUserAgent } from "@/lib/request-utils";
 import { sanitizeInput } from "@/lib/sanitize";
-import { auth } from "@/lib/auth";
-import type { User } from "next-auth";
 import { z } from "zod";
+import { requireAdminSession, requireAdminOrPlayerSession } from "@/lib/api-auth";
 import { COURSES, type CourseAbbr } from "@/lib/constants";
 import { recalculateRanks, rerankStageAfterDelete } from "@/lib/ta/rank-calculation";
 import { timeToMs, TimesObjectSchema } from "@/lib/ta/time-utils";
@@ -45,37 +44,6 @@ import {
 } from "@/lib/tournament-archive";
 
 const KNOCKOUT_STAGES = ["phase1", "phase2", "phase3"] as const;
-
-/**
- * Admin authentication helper that returns the session.
- * Returns { error } if user is not authenticated or not admin.
- * Returns { session } if authentication succeeds.
- */
-async function requireAdminAndGetSession(): Promise<{ error?: NextResponse; session?: { user: User } | null }> {
-  const session = await auth();
-  if (!session?.user || session.user.role !== 'admin') {
-    return { error: createErrorResponse('Forbidden', 403, 'FORBIDDEN') };
-  }
-  // user is guaranteed non-null by the guard above; TS cannot narrow `user?` through
-  // optional-chaining checks so we assert the narrowed type explicitly.
-  return { session: session as { user: User } };
-}
-
-/**
- * Admin or player session authentication helper.
- * Returns the session object for ownership verification by the caller.
- * Admins have full access; players must additionally verify ownership
- * of the specific resource they are modifying.
- *
- * Returns { error } if user is not authenticated as admin or player.
- * Returns { session } if authentication succeeds.
- */
-async function requireAdminOrPlayerSession(): Promise<{ error?: NextResponse; session?: { user: User } | null }> {
-  const session = await auth();
-  if (session?.user?.role === 'admin') return { session: session as { user: User } };
-  if (session?.user?.userType === 'player') return { session: session as { user: User } };
-  return { error: createErrorResponse('Forbidden', 403, 'FORBIDDEN') };
-}
 
 async function hasKnockoutStageStarted(tournamentId: string): Promise<boolean> {
   const knockoutEntry = await prisma.tTEntry.findFirst({
@@ -422,7 +390,7 @@ export async function PUT(
     // === Partner Assignment (§3.1) ===
     // Set or clear the partner player ID for pair running (admin only)
     if (action === "set_partner") {
-      const authResult = await requireAdminAndGetSession();
+      const authResult = await requireAdminSession();
       if (authResult.error) return authResult.error;
 
       const entry = await prisma.tTEntry.findUnique({
@@ -467,7 +435,7 @@ export async function PUT(
     // === Seeding Update (§3.1) ===
     // Update the seeding number for a TA entry (admin only, per-tournament)
     if (action === "update_seeding") {
-      const authResult = await requireAdminAndGetSession();
+      const authResult = await requireAdminSession();
       if (authResult.error) return authResult.error;
 
       const updatedEntry = await prisma.tTEntry.update({
@@ -482,7 +450,7 @@ export async function PUT(
     // === Lives Actions ===
     // Manually update or reset player lives (admin only)
     if (action === "update_lives" || action === "reset_lives") {
-      const authResult = await requireAdminAndGetSession();
+      const authResult = await requireAdminSession();
       if (authResult.error) return authResult.error;
 
       const entry = await prisma.tTEntry.findUnique({
@@ -528,7 +496,7 @@ export async function PUT(
     // === Elimination Action ===
     // Manually eliminate or un-eliminate a player (admin only)
     if (action === "eliminate") {
-      const authResult = await requireAdminAndGetSession();
+      const authResult = await requireAdminSession();
       if (authResult.error) return authResult.error;
 
       if (eliminated === undefined) {
@@ -737,7 +705,7 @@ export async function DELETE(
   const tournamentId = await resolveTournamentId(id);
   try {
 
-    const authResult = await requireAdminAndGetSession();
+    const authResult = await requireAdminSession();
     if (authResult.error) return authResult.error;
 
     // Get entry ID from query parameters

--- a/smkc-score-app/src/lib/api-auth.ts
+++ b/smkc-score-app/src/lib/api-auth.ts
@@ -1,0 +1,47 @@
+/**
+ * API Route Authentication Helpers
+ *
+ * Shared session guards for Next.js API routes. Each helper calls auth(),
+ * checks the required role/userType, and returns either an error response
+ * or the narrowed session — letting callers early-return on `{ error }` or
+ * destructure `{ session }` for downstream use.
+ *
+ * Extracted from ta/route.ts and ta/phases/route.ts where the same logic
+ * was duplicated verbatim (#2503).
+ */
+
+import { NextResponse } from 'next/server';
+import type { User } from 'next-auth';
+import { auth } from '@/lib/auth';
+import { handleAuthzError } from '@/lib/error-handling';
+
+export type AuthSessionResult = { error?: NextResponse; session?: { user: User } | null };
+
+/**
+ * Requires an authenticated admin session.
+ * Returns { error: 403 } if the caller is unauthenticated or not an admin.
+ * Returns { session } on success; session.user is guaranteed non-null.
+ *
+ * Note: TS cannot narrow `user?` through optional-chaining guards, so we
+ * cast to `{ user: User }` after the explicit null check above.
+ */
+export async function requireAdminSession(): Promise<AuthSessionResult> {
+  const session = await auth();
+  if (!session?.user || session.user.role !== 'admin') {
+    return { error: handleAuthzError() };
+  }
+  return { session: session as { user: User } };
+}
+
+/**
+ * Requires an admin or player session.
+ * Admins have full access; players must additionally verify resource ownership
+ * in the caller (this helper only checks authentication, not authorization).
+ * Returns { error: 403 } if unauthenticated or neither admin nor player.
+ */
+export async function requireAdminOrPlayerSession(): Promise<AuthSessionResult> {
+  const session = await auth();
+  if (session?.user?.role === 'admin') return { session: session as { user: User } };
+  if (session?.user?.userType === 'player') return { session: session as { user: User } };
+  return { error: handleAuthzError() };
+}


### PR DESCRIPTION
## Summary

- `requireAdminSession` 共通ヘルパーを `src/lib/api-auth` に抽出してコード重複を削減（#2503）
- TC-2497 ドリフトガードのアサーションを強化（#2508）

---

Closing: このブランチの変更は既に main にスカッシュマージ済みです。

_Generated by [Claude Code](https://claude.ai/code/session_01UqtoGmPR4BoNYNYwXhNpwo)_