### PR TITLE
fix: remove | null from AuthSessionResult, document handleAuthzError equivalence (#2510 #2511)

### DIFF
--- a/smkc-score-app/src/lib/api-auth.ts
+++ b/smkc-score-app/src/lib/api-auth.ts
@@ -13,9 +13,11 @@
 import { NextResponse } from 'next/server';
 import type { User } from 'next-auth';
 import { auth } from '@/lib/auth';
+// handleAuthzError() === createErrorResponse('Forbidden', 403, 'FORBIDDEN') — same body/headers (#2510)
 import { handleAuthzError } from '@/lib/error-handling';
 
-export type AuthSessionResult = { error?: NextResponse; session?: { user: User } | null };
+// session is never null on success: helpers return { error } on failure, { session } on success (#2511)
+export type AuthSessionResult = { error?: NextResponse; session?: { user: User } };
 
 /**
  * Requires an authenticated admin session.


### PR DESCRIPTION
## Summary

- `AuthSessionResult` から `| null` を削除し型定義を正確化（#2510）
- `handleAuthzError` の等価性をドキュメントに明記（#2511）

## Validation

- 全テストスイート通過

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqtoGmPR4BoNYNYwXhNpwo)_