### PR TITLE
refactor(test): rename outlineButtonSection to secondaryButtonSection (#2441)

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -1235,7 +1235,7 @@ describe('E2E case drift coverage', () => {
     const section = e2eCaseSection('TC-1007');
     const followupSection = e2eCaseSection('TC-1678');
     const disabledButtonSection = e2eCaseSection('TC-1680');
-    const outlineButtonSection = e2eCaseSection('TC-1682');
+    const secondaryButtonSection = e2eCaseSection('TC-1682');
     const helperAliasSection = e2eCaseSection('TC-1980-1982');
     const helperAliasGuardSection = e2eCaseSection('TC-2012');
     const helperAliasCallGuardSection = e2eCaseSection('TC-2014');
@@ -1253,8 +1253,8 @@ describe('E2E case drift coverage', () => {
     expect(followupSection).toContain('setGroupCount');
     expect(disabledButtonSection).toContain('issue #1680');
     expect(disabledButtonSection).toContain('disabled');
-    expect(outlineButtonSection).toContain('issue #1682');
-    expect(outlineButtonSection).toContain('variant="secondary"');
+    expect(secondaryButtonSection).toContain('issue #1682');
+    expect(secondaryButtonSection).toContain('variant="secondary"');
     expect(helperAliasSection).toContain('issue #1980 / #1982');
     expect(helperAliasSection).toContain('EXPECTED_PAGE_ROLE_LOOKUPS');
     expect(helperAliasGuardSection).toContain('issue #2012');

--- a/smkc-score-app/__tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts
+++ b/smkc-score-app/__tests__/static/tc-1007-group-setup-dialog-prop-contract.test.ts
@@ -11,7 +11,7 @@ describe('TC-1007 GroupSetupDialog prop contract', () => {
     const section = e2eCaseSection('TC-1007');
     const followupSection = e2eCaseSection('TC-1678');
     const disabledButtonSection = e2eCaseSection('TC-1680');
-    const outlineButtonSection = e2eCaseSection('TC-1682');
+    const secondaryButtonSection = e2eCaseSection('TC-1682');
 
     expect(section).toContain('issue #1007');
     expect(section).toContain('GroupSetupDialog');
@@ -20,8 +20,8 @@ describe('TC-1007 GroupSetupDialog prop contract', () => {
     expect(followupSection).toContain('setGroupCount');
     expect(disabledButtonSection).toContain('issue #1680');
     expect(disabledButtonSection).toContain('disabled');
-    expect(outlineButtonSection).toContain('issue #1682');
-    expect(outlineButtonSection).toContain('variant="secondary"');
+    expect(secondaryButtonSection).toContain('issue #1682');
+    expect(secondaryButtonSection).toContain('variant="secondary"');
     expect(section).toContain('tc-1007-group-setup-dialog-prop-contract.test.ts');
   });
 


### PR DESCRIPTION
## Summary

- テスト内の `outlineButtonSection` を `secondaryButtonSection` にリネームして命名の一貫性を向上（#2441）

## Validation

- 全テストスイート通過

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqtoGmPR4BoNYNYwXhNpwo)_