### PR TITLE
fix(types): align resolveAuditUserId and TA auth helpers with auth() return type

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/debug-fill/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/debug-fill/route.test.ts
@@ -21,7 +21,7 @@ describe('POST /api/tournaments/[id]/bm/debug-fill (TC-2489)', () => {
 
   it('delegates to handleDebugFillRequest with mode "bm" and id from params', async () => {
     const mockResponse = { status: 200 };
-    mockHandleDebugFillRequest.mockResolvedValue(mockResponse as unknown as ReturnType<typeof handleDebugFillRequest> extends Promise<infer R> ? R : never);
+    mockHandleDebugFillRequest.mockResolvedValue(mockResponse as any);
 
     const request = {} as unknown as NextRequest;
     const result = await POST(request, { params: Promise.resolve({ id: 't-abc' }) });

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/phases/route.ts
@@ -50,7 +50,7 @@ import { checkStageFrozen } from "@/lib/ta/freeze-check";
 import { RETRY_PENALTY_MS } from "@/lib/constants";
 import { resolveTournamentId } from "@/lib/tournament-identifier";
 import { resolveAuditUserId } from "@/lib/audit-log";
-import type { Session } from "next-auth";
+import type { User } from "next-auth";
 import { readTournamentArchive } from "@/lib/tournament-archive";
 
 function normalizePhaseRound<T extends { results: unknown; eliminatedIds?: unknown }>(round: T) {
@@ -136,7 +136,7 @@ function sortPhaseEntriesForDisplay<T extends PhaseEntryForDisplay>(
  */
 async function requireAdminAndGetSession(): Promise<{
   error?: NextResponse;
-  session?: Session;
+  session?: { user: User } | null;
 }> {
   const session = await auth();
   if (!session?.user || session.user.role !== "admin") {
@@ -144,7 +144,9 @@ async function requireAdminAndGetSession(): Promise<{
       error: handleAuthzError(),
     };
   }
-  return { session };
+  // user is guaranteed non-null by the guard above; TS cannot narrow `user?` through
+  // optional-chaining checks so we assert the narrowed type explicitly.
+  return { session: session as { user: User } };
 }
 
 /** Valid phase names for URL query parameters and request bodies */

--- a/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/ta/route.ts
@@ -27,7 +27,7 @@ import { createAuditLog, createAuditLogs, AUDIT_ACTIONS, resolveAuditUserId } fr
 import { getClientIdentifier, getUserAgent } from "@/lib/request-utils";
 import { sanitizeInput } from "@/lib/sanitize";
 import { auth } from "@/lib/auth";
-import type { Session } from "next-auth";
+import type { User } from "next-auth";
 import { z } from "zod";
 import { COURSES, type CourseAbbr } from "@/lib/constants";
 import { recalculateRanks, rerankStageAfterDelete } from "@/lib/ta/rank-calculation";
@@ -51,12 +51,14 @@ const KNOCKOUT_STAGES = ["phase1", "phase2", "phase3"] as const;
  * Returns { error } if user is not authenticated or not admin.
  * Returns { session } if authentication succeeds.
  */
-async function requireAdminAndGetSession(): Promise<{ error?: NextResponse; session?: Session | null }> {
+async function requireAdminAndGetSession(): Promise<{ error?: NextResponse; session?: { user: User } | null }> {
   const session = await auth();
   if (!session?.user || session.user.role !== 'admin') {
     return { error: createErrorResponse('Forbidden', 403, 'FORBIDDEN') };
   }
-  return { session };
+  // user is guaranteed non-null by the guard above; TS cannot narrow `user?` through
+  // optional-chaining checks so we assert the narrowed type explicitly.
+  return { session: session as { user: User } };
 }
 
 /**
@@ -68,10 +70,10 @@ async function requireAdminAndGetSession(): Promise<{ error?: NextResponse; sess
  * Returns { error } if user is not authenticated as admin or player.
  * Returns { session } if authentication succeeds.
  */
-async function requireAdminOrPlayerSession(): Promise<{ error?: NextResponse; session?: Session | null }> {
+async function requireAdminOrPlayerSession(): Promise<{ error?: NextResponse; session?: { user: User } | null }> {
   const session = await auth();
-  if (session?.user?.role === 'admin') return { session };
-  if (session?.user?.userType === 'player') return { session };
+  if (session?.user?.role === 'admin') return { session: session as { user: User } };
+  if (session?.user?.userType === 'player') return { session: session as { user: User } };
   return { error: createErrorResponse('Forbidden', 403, 'FORBIDDEN') };
 }
 

--- a/smkc-score-app/src/lib/audit-log.ts
+++ b/smkc-score-app/src/lib/audit-log.ts
@@ -31,7 +31,7 @@
  *   });
  */
 
-import type { Session } from 'next-auth';
+import type { User } from 'next-auth';
 import prisma from '@/lib/prisma';
 import { createLogger } from '@/lib/logger';
 
@@ -121,7 +121,10 @@ function sanitizeObjectForAuditLog(
  * a FK violation on AuditLog.userId (#734). Returns undefined for player
  * sessions so the audit log row stores NULL instead.
  */
-export function resolveAuditUserId(session: Session | null | undefined): string | undefined {
+// Accept the type that `auth()` actually returns. The `Session` type from
+// next-auth also requires `expires`, which our auth() wrapper intentionally
+// omits (see src/lib/auth.ts §326–332).
+export function resolveAuditUserId(session: { user?: User | null } | null | undefined): string | undefined {
   if (!session?.user) return undefined;
   if (session.user.userType === 'player') return undefined;
   return session.user.id ?? undefined;


### PR DESCRIPTION
## Summary

- `resolveAuditUserId` および TA 認証ヘルパーの型を `auth()` の戻り値型に合わせて修正
- BM debug-fill ルートのモックキャストを他のルートテストに合わせてシンプル化

## Validation

- 全テストスイート通過

---

Closing: このブランチの変更は既に main にスカッシュマージ済みです。
- `audit-log.ts` の `{ user?: User | null }` 型修正は PR #2551 等で適用済み
- `bm/debug-fill/route.test.ts` のモックキャスト簡略化は既に upstream
- `ta/route.ts`, `ta/phases/route.ts` の型変更は PR #2550 (api-auth抽出リファクタ) と競合しており、機能的に不要

_Generated by [Claude Code](https://claude.ai/code/session_01UqtoGmPR4BoNYNYwXhNpwo)_