### PR TITLE
refactor: remove task-ref comments; add missing BM handleAuthzError assertion (#2565 #2566)

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/match/[matchId]/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/bm/match/[matchId]/route.test.ts
@@ -60,7 +60,8 @@ const {
   createSuccessResponse: _createSuccessResponse,
   createErrorResponse,
   handleValidationError,
-  handleDatabaseError
+  handleDatabaseError,
+  handleAuthzError,
 } = jest.requireMock('@/lib/error-handling');
 
 // Mock NextRequest class
@@ -254,6 +255,7 @@ describe('BM Match API Route - /api/tournaments/[id]/bm/match/[matchId]', () => 
         data: { error: 'Forbidden', code: 'FORBIDDEN' },
         status: 403
       });
+      expect(handleAuthzError).toHaveBeenCalled();
     });
 
     // Authorization failure case - Returns 403 when user is not admin
@@ -268,6 +270,7 @@ describe('BM Match API Route - /api/tournaments/[id]/bm/match/[matchId]', () => 
         data: { error: 'Forbidden', code: 'FORBIDDEN' },
         status: 403
       });
+      expect(handleAuthzError).toHaveBeenCalled();
     });
 
     // Success case - Updates match score with valid version

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/overlay-events/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/overlay-events/route.test.ts
@@ -246,7 +246,7 @@ describe('GET /api/tournaments/[id]/overlay-events', () => {
       const res = (await GET(makeRequest({ since: oneHourAgo }), makeParams(id))) as unknown as MockResponse;
 
       expect(res.status).toBe(200);
-      expect(res.data.data.events as unknown[]).toHaveLength(1); // TC-2555: toHaveLength idiom preferred (#2562)
+      expect(res.data.data.events as unknown[]).toHaveLength(1);
       expect(mockBuildOverlayEvents).toHaveBeenCalled();
     });
 

--- a/smkc-score-app/src/lib/api-factories/finals-bracket-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-bracket-route.ts
@@ -116,7 +116,7 @@ export function createFinalsBracketHandlers(config: FinalsBracketConfig) {
 
     /* Admin authorization required for bracket generation */
     if (!session?.user || session.user.role !== 'admin') {
-      return handleAuthzError(); // TC-2556: unified Forbidden response (#2563)
+      return handleAuthzError();
     }
 
     /* Rate limit: prevent abuse on bracket generation endpoint */

--- a/smkc-score-app/src/lib/api-factories/finals-matches-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-matches-route.ts
@@ -83,7 +83,7 @@ export function createFinalsMatchesHandlers(config: FinalsMatchesConfig) {
 
     /* Admin authorization required for match creation */
     if (!session?.user || session.user.role !== 'admin') {
-      return handleAuthzError(); // TC-2556: unified Forbidden response (#2563)
+      return handleAuthzError();
     }
 
     /* Rate limit: prevent abuse on match creation */

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -1374,7 +1374,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
     if (config.postRequiresAuth) {
       const session = await auth();
       if (!session?.user || session.user.role !== 'admin') {
-        return handleAuthzError(); // TC-2556: unified Forbidden response (#2563)
+        return handleAuthzError();
       }
     }
 
@@ -1949,7 +1949,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
     if (config.putRequiresAuth) {
       const session = await auth();
       if (!session?.user || session.user.role !== 'admin') {
-        return handleAuthzError(); // TC-2556: unified Forbidden response (#2563)
+        return handleAuthzError();
       }
     }
 

--- a/smkc-score-app/src/lib/api-factories/match-detail-route.ts
+++ b/smkc-score-app/src/lib/api-factories/match-detail-route.ts
@@ -177,7 +177,7 @@ export function createMatchDetailHandlers(config: MatchDetailConfig) {
     if (config.putRequiresAuth) {
       const session = await auth();
       if (!session?.user || session.user.role !== 'admin') {
-        return handleAuthzError(); // TC-2556: unified Forbidden response (#2563)
+        return handleAuthzError();
       }
     }
 

--- a/smkc-score-app/src/lib/api-factories/qualification-route.ts
+++ b/smkc-score-app/src/lib/api-factories/qualification-route.ts
@@ -416,7 +416,7 @@ export function createQualificationHandlers(config: EventTypeConfig) {
     if (config.postRequiresAuth) {
       const session = await auth();
       if (!session?.user || session.user.role !== 'admin') {
-        return handleAuthzError(); // TC-2556: unified Forbidden response (#2563)
+        return handleAuthzError();
       }
       currentSession = session;
     }
@@ -766,7 +766,7 @@ export function createQualificationHandlers(config: EventTypeConfig) {
     if (config.putRequiresAuth) {
       const session = await auth();
       if (!session?.user || session.user.role !== 'admin') {
-        return handleAuthzError(); // TC-2556: unified Forbidden response (#2563)
+        return handleAuthzError();
       }
     }
 
@@ -877,7 +877,7 @@ export function createQualificationHandlers(config: EventTypeConfig) {
 
     const session = await auth();
     if (!session?.user || session.user.role !== 'admin') {
-      return handleAuthzError(); // TC-2556: unified Forbidden response (#2563)
+      return handleAuthzError();
     }
 
     /* Rate limit: prevent abuse on admin update endpoints */

--- a/smkc-score-app/src/lib/api-factories/standings-route.ts
+++ b/smkc-score-app/src/lib/api-factories/standings-route.ts
@@ -91,7 +91,7 @@ export function createStandingsHandlers(config: StandingsConfig) {
      * it, leaving BM/MR/GP standings publicly readable. */
     const session = await auth();
     if (!session?.user || session.user.role !== 'admin') {
-      return handleAuthzError(); // TC-2556: unified Forbidden response (#2563)
+      return handleAuthzError();
     }
 
     const { id } = await params;


### PR DESCRIPTION
## Summary

フォローアップ #2565 / #2566 対応（PR #2564 レビュー指摘）

- **#2566**: api-factories ソースファイル 6 件・overlay-events テストから `// TC-2556: ...` / `// TC-2555: ...` タスク参照コメントを削除。CLAUDE.md 方針に従い、タスク・issue 参照はコミットメッセージと PR 説明で管理する。
- **#2565**: `bm/match/[matchId]/route.test.ts` の PUT 認証失敗テスト 2 件に `expect(handleAuthzError).toHaveBeenCalled()` を追加。GP/MR テストとの一貫性を確保。

## Test plan

- [x] `npm test` 全テスト通過 (3570 passed / 27 skipped)
- [x] BM auth failure tests で `handleAuthzError` の呼び出しを確認

Closes #2565
Closes #2566

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqtoGmPR4BoNYNYwXhNpwo

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqtoGmPR4BoNYNYwXhNpwo)_