### PR TITLE
test(ci-config): add lint order, Node.js version, and test flags drift guards (#2464 #2465)

### DIFF
--- a/smkc-score-app/__tests__/docs/ci-config.test.ts
+++ b/smkc-score-app/__tests__/docs/ci-config.test.ts
@@ -26,10 +26,11 @@ describe('CI workflow configuration', () => {
     const raw = fs.readFileSync(ciPath, 'utf8');
     const workflow = parse(raw) as CiWorkflow;
     // jobs キーが存在しない (不正な YAML、コンフリクトマーカー混入等) 場合に
-    // 各 it ブロックで TypeError が出るより明確なエラーにするための実行時ガード
-    if (!workflow?.jobs?.['lint-and-test']) {
+    // 各 it ブロックで TypeError が出るより明確なエラーにするための実行時ガード。
+    // steps が undefined/空の場合も同様に早期エラーとする (#2464)
+    if (!workflow?.jobs?.['lint-and-test']?.steps?.length) {
       throw new Error(
-        `ci.yml の jobs['lint-and-test'] が見つかりません。ジョブ名が変更された可能性があります。`
+        `ci.yml の jobs['lint-and-test'].steps が見つかりません。YAML 構造が変更された可能性があります。`
       );
     }
     lintAndTestJob = workflow.jobs['lint-and-test'];
@@ -58,8 +59,8 @@ describe('CI workflow configuration', () => {
     // 異なる job への誤参照を防ぐ (indexOf による文字列比較は使用しない)
     const steps = lintAndTestJob.steps;
 
-    // 各ステップが steps 配列に 1 件だけ存在することを確認してから
-    // インデックスを比較する (複数マッチ時の誤判定を防ぐ)
+    // 各ステップが steps 配列に 1 件だけ存在することを filter で確認してから
+    // indexOf でインデックスを取得する (#2465: findIndex の二重走査を解消)
     const auditSteps = steps.filter((s) => s.run?.includes('npm audit --audit-level=high'));
     // \bnpm test\b の語境界で絞り込み、npm run test:coverage 等の部分一致を排除する
     const testSteps = steps.filter((s) => s.run?.match(/\bnpm test\b/));
@@ -67,8 +68,10 @@ describe('CI workflow configuration', () => {
     expect(auditSteps).toHaveLength(1);
     expect(testSteps).toHaveLength(1);
 
-    const auditIdx = steps.findIndex((s) => s.run?.includes('npm audit --audit-level=high'));
-    const testIdx = steps.findIndex((s) => s.run?.match(/\bnpm test\b/));
+    // filter 結果から steps.indexOf で参照比較によりインデックスを得る
+    // (同じ predicate で findIndex を再実行する二重走査を回避)
+    const auditIdx = steps.indexOf(auditSteps[0]);
+    const testIdx = steps.indexOf(testSteps[0]);
     expect(testIdx).toBeGreaterThan(auditIdx);
   });
 });

--- a/smkc-score-app/__tests__/docs/ci-config.test.ts
+++ b/smkc-score-app/__tests__/docs/ci-config.test.ts
@@ -6,6 +6,9 @@ import { parse } from 'yaml';
 // (YAML パース結果は unknown なので as でキャストする前に実行時ガードを挟む)
 interface CiStep {
   run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+  env?: Record<string, string>;
 }
 
 interface CiJob {
@@ -73,5 +76,47 @@ describe('CI workflow configuration', () => {
     const auditIdx = steps.indexOf(auditSteps[0]);
     const testIdx = steps.indexOf(testSteps[0]);
     expect(testIdx).toBeGreaterThan(auditIdx);
+  });
+
+  it('runs lint before the security audit step', () => {
+    // Lint → Security audit → Unit tests の順序を保証する。
+    // lint エラーが早期に検出されるよう audit より前に配置する必要がある。
+    const steps = lintAndTestJob.steps;
+    const lintSteps = steps.filter((s) => s.run?.match(/\bnpm run lint\b/));
+    const auditSteps = steps.filter((s) => s.run?.includes('npm audit --audit-level=high'));
+
+    expect(lintSteps).toHaveLength(1);
+    expect(auditSteps).toHaveLength(1);
+
+    const lintIdx = steps.indexOf(lintSteps[0]);
+    const auditIdx = steps.indexOf(auditSteps[0]);
+    expect(lintIdx).toBeGreaterThanOrEqual(0);
+    expect(auditIdx).toBeGreaterThan(lintIdx);
+  });
+
+  it('uses Node.js 22 in setup-node step', () => {
+    // Node.js バージョンのドリフトを検出する。
+    // package.json engines や Cloudflare Workers ランタイムとの互換性を維持するため
+    // バージョンを 22 に固定している。
+    const setupNodeStep = lintAndTestJob.steps.find((s) =>
+      s.uses?.startsWith('actions/setup-node')
+    );
+    expect(setupNodeStep).toBeDefined();
+    expect(setupNodeStep?.with?.['node-version']).toBe('22');
+  });
+
+  it('passes --ci and --forceExit flags to npm test', () => {
+    // --ci: テスト失敗時に即座に終了し、スナップショットを自動更新しない
+    // --forceExit: 非同期タスクが残留しても CI がハングしないようにする
+    const testStep = lintAndTestJob.steps.find((s) => s.run?.match(/\bnpm test\b/));
+    expect(testStep?.run).toMatch(/--ci\b/);
+    expect(testStep?.run).toMatch(/--forceExit\b/);
+  });
+
+  it('sets SKIP_OPENNEXT_CLOUDFLARE_DEV env var in npm test step', () => {
+    // opennextjs-cloudflare の開発サーバー起動をスキップして
+    // CI でのテスト実行時間を削減するための環境変数
+    const testStep = lintAndTestJob.steps.find((s) => s.run?.match(/\bnpm test\b/));
+    expect(testStep?.env?.['SKIP_OPENNEXT_CLOUDFLARE_DEV']).toBe('1');
   });
 });


### PR DESCRIPTION
Closing: ci-config drift guards (#2464 #2465) は既に main にスカッシュマージ済みです。