### PR TITLE
refactor(test): extend RoundResult.timeMs to number|null; remove as-cast in TC-2567

### DIFF
--- a/smkc-score-app/__tests__/lib/cdm-export/fill/tt-finals.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/fill/tt-finals.test.ts
@@ -80,7 +80,7 @@ function qualEntry(
 
 interface RoundResult {
   playerId: string;
-  timeMs: number;
+  timeMs: number | null;
 }
 
 function phaseRound(
@@ -533,19 +533,12 @@ describe("replayTTFinals — row ordering", () => {
     const data = emptyData({
       ttEntries: Array.from({ length: 4 }, (_, i) => qualEntry(id(i + 1), i + 1)),
       ttPhaseRounds: [
-        {
-          phase: "phase3" as const,
-          roundNumber: 1,
-          course: "MC1",
-          results: [
-            { playerId: id(1), timeMs: 60000 },
-            { playerId: id(2), timeMs: null }, // null-time runner → key 0
-            { playerId: id(3), timeMs: 70000 },
-            // p04 is a non-runner → key 0
-          ],
-          eliminatedIds: null,
-          livesReset: false,
-        } as CdmTTPhaseRound,
+        phaseRound("phase3", 1, "MC1", [
+          { playerId: id(1), timeMs: 60000 },
+          { playerId: id(2), timeMs: null }, // null-time runner → key 0
+          { playerId: id(3), timeMs: 70000 },
+          // p04 is a non-runner → key 0
+        ]),
       ],
     });
     const r = replayTTFinals(data)[0];


### PR DESCRIPTION
## Summary

- `RoundResult.timeMs` を `number` から `number | null` に拡張し、`phaseRound()` ヘルパーが null タイムを受け付けられるよう修正
- TC-2567 の生オブジェクトリテラル + `as CdmTTPhaseRound` キャストを `phaseRound()` ヘルパー呼び出しに置き換え（型安全性向上）
- プロダクションコードへの変更なし

## Issues

Closes #2578

## Validation

- `npm test` 全 3596 テスト PASS（変更なし）
- TC-2567 は `phaseRound()` ヘルパーを使用し、`as CdmTTPhaseRound` キャスト不要

---
_Generated by [Claude Code](https://claude.ai/code/session_01UK5UBZgQmkSpgaSFTdreUr)_