### PR TITLE
test(overlay/layout): add TC-2583–TC-2586 edge-case unit tests + remove stale TC comment

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -4215,6 +4215,38 @@
 
 ---
 
+### TC-2583: normalizeOverlayBroadcastLayout — 非オブジェクト入力はすべてデフォルトにフォールバックする
+- **背景**: `normalizeOverlayBroadcastLayout` の `isRecord(value)` ガードは `null`/`undefined`/文字列/数値/配列を非レコードとして検出し、すべてのスロットをデフォルト値で初期化する。この境界動作が未テストのまま、呼び出し元が予期しない DB 値を渡した場合にレイアウトが壊れるリスクがある。
+- **手順**: `normalizeOverlayBroadcastLayout(null)`、`normalizeOverlayBroadcastLayout(undefined)`、`normalizeOverlayBroadcastLayout('string')`、`normalizeOverlayBroadcastLayout(42)`、`normalizeOverlayBroadcastLayout([])` を呼び出す。
+- **期待結果**: いずれも `DEFAULT_OVERLAY_BROADCAST_LAYOUT` と完全に等しい値を返す。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/lib/overlay/layout.test.ts
+
+---
+
+### TC-2584: normalizeOverlayBroadcastLayout — スロット値が非オブジェクトの場合はそのスロットをデフォルトにフォールバックする
+- **背景**: `normalizePosition(value, fallback)` は `isRecord(value)` で各スロット値を検証し、非レコード（`null`、文字列、数値など）の場合は `fallback` をそのまま返す。スロット単位のフォールバックが未テストであり、一部のスロットだけ壊れた入力が来た場合に他のスロットが正常に設定されることを保証する必要がある。
+- **手順**: `{ player1Name: null, player2Name: 'bad', player1Score: 999 }` を引数に `normalizeOverlayBroadcastLayout` を呼び出す。
+- **期待結果**: 返り値が `DEFAULT_OVERLAY_BROADCAST_LAYOUT` と等しい（壊れたスロットはデフォルトで上書きされ、未指定のスロットもデフォルトのまま）。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/lib/overlay/layout.test.ts
+
+---
+
+### TC-2585: normalizeOverlayBroadcastLayout — 非有限座標（NaN/Infinity）は座標単位でデフォルトにフォールバックする
+- **背景**: `isFiniteCoordinate(value)` は `Number.isFinite` を使い NaN や Infinity を除外する。座標が片方だけ非有限の場合は、その座標のみデフォルトに差し替えられ、有限な座標はそのまま保持される。この細粒度フォールバックが未テストであり、クライアントが Infinity/NaN を送信した場合に正しく処理されるかを保証する必要がある。
+- **手順**: `{ player1Name: { x: NaN, y: Infinity }, footer: { x: 180, y: NaN } }` を引数に `normalizeOverlayBroadcastLayout` を呼び出す。
+- **期待結果**: `player1Name` は `DEFAULT_OVERLAY_BROADCAST_LAYOUT.player1Name` と等しい（両座標ともデフォルト）。`footer` は `{ x: 180, y: DEFAULT_OVERLAY_BROADCAST_LAYOUT.footer.y }`（x は保持、y はデフォルト）。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/lib/overlay/layout.test.ts
+
+---
+
+### TC-2586: isOverlayBroadcastLayoutInput — 非オブジェクト入力は false を返す; 空オブジェクトは true を返す
+- **背景**: `isOverlayBroadcastLayoutInput` の入口ガード `isRecord(value)` は `null`/`undefined`/プリミティブを早期に `false` で弾く。空オブジェクト `{}` は "スロットなし" として有効（違反エントリがないので `every` が true）。さらに、スロット値が非オブジェクト（文字列など）の場合も `isRecord(position)` でブロックされる。これらの境界ケースが未テストである。
+- **手順**: `isOverlayBroadcastLayoutInput(null)`、`isOverlayBroadcastLayoutInput(undefined)`、`isOverlayBroadcastLayoutInput('string')`、`isOverlayBroadcastLayoutInput(42)`、`isOverlayBroadcastLayoutInput({})`、`isOverlayBroadcastLayoutInput({ player1Name: 'bad' })` を呼び出す。
+- **期待結果**: `null`/`undefined`/`'string'`/`42`/`{ player1Name: 'bad' }` は `false`。`{}` は `true`。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/lib/overlay/layout.test.ts
+
+---
+
 ## E2Eテスト実行ガイド
 
 ### セッション管理（重要）

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3894,6 +3894,28 @@ describe('E2E case drift coverage', () => {
       expect(standingsTest).toContain('prisma.bMQualification.findMany).not.toHaveBeenCalled()');
       expect(standingsTest).toContain('prisma.bMQualification.count).not.toHaveBeenCalled()');
     });
+
+    it('documents TC-2583 through TC-2586 as overlay layout edge-case unit tests in layout.test.ts', () => {
+      const layoutTest = readRepoFile(
+        'smkc-score-app',
+        '__tests__',
+        'lib',
+        'overlay',
+        'layout.test.ts',
+      );
+      for (const tc of ['TC-2583', 'TC-2584', 'TC-2585', 'TC-2586']) {
+        expect(layoutTest).toContain(tc);
+      }
+      expect(layoutTest).toContain('normalizeOverlayBroadcastLayout');
+      expect(layoutTest).toContain('isOverlayBroadcastLayoutInput');
+      // TC-2583: non-object inputs fall back to full defaults
+      expect(layoutTest).toContain('DEFAULT_OVERLAY_BROADCAST_LAYOUT');
+      // TC-2585: NaN and Infinity are handled per-coordinate
+      expect(layoutTest).toContain('Number.NaN');
+      expect(layoutTest).toContain('POSITIVE_INFINITY');
+      // TC-2586: empty object is valid
+      expect(layoutTest).toContain('isOverlayBroadcastLayoutInput({})');
+    });
   });
 });
 

--- a/smkc-score-app/__tests__/lib/overlay/layout.test.ts
+++ b/smkc-score-app/__tests__/lib/overlay/layout.test.ts
@@ -45,4 +45,47 @@ describe('overlay broadcast layout', () => {
       player1Name: { x: 0, y: 1081 },
     })).toBe(false);
   });
+
+  // TC-2583: normalizeOverlayBroadcastLayout falls back to all defaults for non-object input
+  it('TC-2583: returns full defaults when input is not an object', () => {
+    expect(normalizeOverlayBroadcastLayout(null)).toEqual(DEFAULT_OVERLAY_BROADCAST_LAYOUT);
+    expect(normalizeOverlayBroadcastLayout(undefined)).toEqual(DEFAULT_OVERLAY_BROADCAST_LAYOUT);
+    expect(normalizeOverlayBroadcastLayout('string')).toEqual(DEFAULT_OVERLAY_BROADCAST_LAYOUT);
+    expect(normalizeOverlayBroadcastLayout(42)).toEqual(DEFAULT_OVERLAY_BROADCAST_LAYOUT);
+    expect(normalizeOverlayBroadcastLayout([])).toEqual(DEFAULT_OVERLAY_BROADCAST_LAYOUT);
+  });
+
+  // TC-2584: normalizeOverlayBroadcastLayout falls back to slot defaults when position value is not an object
+  it('TC-2584: falls back to slot default when a position value is not an object', () => {
+    expect(normalizeOverlayBroadcastLayout({
+      player1Name: null,
+      player2Name: 'bad',
+      player1Score: 999,
+    })).toEqual(DEFAULT_OVERLAY_BROADCAST_LAYOUT);
+  });
+
+  // TC-2585: normalizeOverlayBroadcastLayout falls back per-coordinate for non-finite values
+  it('TC-2585: falls back per-coordinate when x or y is NaN or Infinity', () => {
+    const result = normalizeOverlayBroadcastLayout({
+      player1Name: { x: Number.NaN, y: Number.POSITIVE_INFINITY },
+      footer: { x: 180, y: Number.NaN },
+    });
+    expect(result.player1Name).toEqual(DEFAULT_OVERLAY_BROADCAST_LAYOUT.player1Name);
+    expect(result.footer).toEqual({
+      x: 180,
+      y: DEFAULT_OVERLAY_BROADCAST_LAYOUT.footer.y,
+    });
+  });
+
+  // TC-2586: isOverlayBroadcastLayoutInput — non-object returns false; empty object returns true
+  it('TC-2586: isOverlayBroadcastLayoutInput rejects non-objects and accepts empty object', () => {
+    expect(isOverlayBroadcastLayoutInput(null)).toBe(false);
+    expect(isOverlayBroadcastLayoutInput(undefined)).toBe(false);
+    expect(isOverlayBroadcastLayoutInput('string')).toBe(false);
+    expect(isOverlayBroadcastLayoutInput(42)).toBe(false);
+    // empty object is valid — no slots to violate
+    expect(isOverlayBroadcastLayoutInput({})).toBe(true);
+    // position value that is not an object (required to be record) → false
+    expect(isOverlayBroadcastLayoutInput({ player1Name: 'bad' })).toBe(false);
+  });
 });

--- a/smkc-score-app/src/lib/api-factories/finals-route.ts
+++ b/smkc-score-app/src/lib/api-factories/finals-route.ts
@@ -2337,7 +2337,7 @@ export function createFinalsHandlers(config: FinalsConfig) {
 
     const session = await auth();
     if (!session?.user || session.user.role !== 'admin') {
-      return handleAuthzError(); // TC-2556: unified Forbidden response (#2563)
+      return handleAuthzError();
     }
 
     const patchClientIp = getClientIdentifier(request);


### PR DESCRIPTION
## Summary

- Add TC-2583–TC-2586: unit tests for uncovered edge cases in `src/lib/overlay/layout.ts`
  - TC-2583: `normalizeOverlayBroadcastLayout` returns full defaults for `null`/`undefined`/primitives/arrays
  - TC-2584: per-slot fallback when a position value is non-object (`null`, string, number)
  - TC-2585: per-coordinate fallback for non-finite values (`NaN`, `Infinity`)
  - TC-2586: `isOverlayBroadcastLayoutInput` rejects non-objects; empty object `{}` is valid
- Add drift guards for TC-2583–TC-2586 in `e2e-cases-drift.test.ts`
- Update `E2E_TEST_CASES.md` with scenario descriptions for TC-2583–TC-2586
- Remove stale TC/issue reference comment from `finals-route.ts:2340` (per CLAUDE.md policy)

## Validation

- `npm test -- __tests__/lib/overlay/layout.test.ts --no-coverage` → 6 tests pass
- `npm test -- __tests__/docs/e2e-cases-drift.test.ts --no-coverage` → 372 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_012D67b3nttXiqzbe1BG3Wg5)_