### PR TITLE
test(overlay/layout): address review follow-ups #2597 and #2598

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3910,9 +3910,10 @@ describe('E2E case drift coverage', () => {
       expect(layoutTest).toContain('isOverlayBroadcastLayoutInput');
       // TC-2583: non-object inputs fall back to full defaults
       expect(layoutTest).toContain('DEFAULT_OVERLAY_BROADCAST_LAYOUT');
-      // TC-2585: NaN and Infinity are handled per-coordinate
-      expect(layoutTest).toContain('Number.NaN');
-      expect(layoutTest).toContain('POSITIVE_INFINITY');
+      // TC-2585: NaN and Infinity are handled per-coordinate — match substrings so
+      //          either Number.NaN/Number.POSITIVE_INFINITY or bare NaN/Infinity are accepted (#2598)
+      expect(layoutTest).toMatch(/NaN/);
+      expect(layoutTest).toMatch(/Infinity/);
       // TC-2586: empty object is valid
       expect(layoutTest).toContain('isOverlayBroadcastLayoutInput({})');
     });

--- a/smkc-score-app/__tests__/lib/overlay/layout.test.ts
+++ b/smkc-score-app/__tests__/lib/overlay/layout.test.ts
@@ -55,13 +55,24 @@ describe('overlay broadcast layout', () => {
     expect(normalizeOverlayBroadcastLayout([])).toEqual(DEFAULT_OVERLAY_BROADCAST_LAYOUT);
   });
 
-  // TC-2584: normalizeOverlayBroadcastLayout falls back to slot defaults when position value is not an object
+  // TC-2584: normalizeOverlayBroadcastLayout falls back to slot defaults when position value is not an object;
+  //          valid slots alongside invalid ones are preserved (#2597)
   it('TC-2584: falls back to slot default when a position value is not an object', () => {
+    // All-invalid: every bad slot defaults independently
     expect(normalizeOverlayBroadcastLayout({
       player1Name: null,
       player2Name: 'bad',
       player1Score: 999,
     })).toEqual(DEFAULT_OVERLAY_BROADCAST_LAYOUT);
+
+    // Mixed valid+invalid: valid slot is preserved, invalid slot falls back to default
+    expect(normalizeOverlayBroadcastLayout({
+      player1Name: null,
+      player2Name: { x: 120, y: 500 },
+    })).toEqual({
+      ...DEFAULT_OVERLAY_BROADCAST_LAYOUT,
+      player2Name: { x: 120, y: 500 },
+    });
   });
 
   // TC-2585: normalizeOverlayBroadcastLayout falls back per-coordinate for non-finite values


### PR DESCRIPTION
## Summary

Follow-up to #2596, addressing two MINOR items from the claude reviewer.

- **#2597**: TC-2584 now includes a mixed valid+invalid slot case — proves that a valid slot (`player2Name: {x:120, y:500}`) is preserved when an adjacent slot (`player1Name: null`) falls back to its default. The original test only validated all-invalid inputs, leaving the per-slot isolation behavior undemonstrated.
- **#2598**: Drift guard for TC-2585 replaced fragile `toContain('Number.NaN')` / `toContain('POSITIVE_INFINITY')` with `toMatch(/NaN/)` / `toMatch(/Infinity/)`, so the guard survives if the test is rewritten to use bare `NaN`/`Infinity` literals.

## Validation

- `npm test -- __tests__/lib/overlay/layout.test.ts --no-coverage` → 7 tests pass
- `npm test -- __tests__/docs/e2e-cases-drift.test.ts --no-coverage` → 372 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_012D67b3nttXiqzbe1BG3Wg5)_