### PR TITLE
test(drift-guard): use word-boundary regex for NaN/Infinity guard (#2600)

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3910,10 +3910,10 @@ describe('E2E case drift coverage', () => {
       expect(layoutTest).toContain('isOverlayBroadcastLayoutInput');
       // TC-2583: non-object inputs fall back to full defaults
       expect(layoutTest).toContain('DEFAULT_OVERLAY_BROADCAST_LAYOUT');
-      // TC-2585: NaN and Infinity are handled per-coordinate — match substrings so
-      //          either Number.NaN/Number.POSITIVE_INFINITY or bare NaN/Infinity are accepted (#2598)
-      expect(layoutTest).toMatch(/NaN/);
-      expect(layoutTest).toMatch(/Infinity/);
+      // TC-2585: NaN and Infinity are handled per-coordinate — word-boundary match so
+      //          isNaN/POSITIVE_INFINITY prefixes don't generate false positives (#2600)
+      expect(layoutTest).toMatch(/\bNaN\b/);
+      expect(layoutTest).toMatch(/\bInfinity\b/);
       // TC-2586: empty object is valid
       expect(layoutTest).toContain('isOverlayBroadcastLayoutInput({})');
     });


### PR DESCRIPTION
## Summary

- `toMatch(/NaN/)` → `toMatch(/\bNaN\b/)` に変更し、`isNaN` などの識別子がガードに誤マッチするファルスポジティブを防止
- `toMatch(/Infinity/)` → `toMatch(/\bInfinity\b/)` に変更し、`POSITIVE_INFINITY` 等との誤マッチを防止
- テストコードのみの変更、機能への影響なし

## Issues

Closes #2600

## Validation

- `npm test -- --testPathPatterns="e2e-cases-drift" --testNamePattern="TC-2585"` → PASS (7 tests)
- 変更は TC-2585 ドリフトガード該当箇所のみ、他テストに影響なし

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtnEzKUNixUCyx717Ru8pS)_