### PR TITLE
test(drift-guard): strengthen TC-2604 assertion to regex match on recalculateRanks

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3943,8 +3943,8 @@ describe('E2E case drift coverage', () => {
       expect(ttEntryTest).toContain('lastRecordedTime');
       expect(ttEntryTest).toContain('COURSES');
       // TC-2604: recalculateRanks called with tournamentId/stage from DB entry (not URL param)
-      expect(ttEntryTest).toContain('recalculateRanks');
-      expect(ttEntryTest).toContain('toHaveBeenCalledWith');
+      // Use a combined regex so the guard targets this specific assertion, not any toHaveBeenCalledWith
+      expect(ttEntryTest).toMatch(/expect\(recalculateRanks\)\.toHaveBeenCalledWith/);
     });
   });
 });


### PR DESCRIPTION
## Summary

TC-2604 の drift-guard で `toHaveBeenCalledWith` 単体チェックは `route.test.ts` 内の任意のモックアサーションにマッチしてしまい、TC-2604 が削除・空洞化されても誤通過するリスクがあった。

`expect(recalculateRanks).toHaveBeenCalledWith` の regex match に変更し、TC-2604 の特定のアサーション存在を確認するよう強化。

## Issues

Closes #2606

## Validation

- `npm test` — **250 suites / 3623 tests green** (27 skipped)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8bE7phxs8ndfbUbZzEwqW)_