### PR TITLE
refactor(test): resolve #2610–#2612 – i18n key-based toast assertions and non-null assertion cleanup

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3960,11 +3960,11 @@ describe('E2E case drift coverage', () => {
       }
       // TC-2606: verifies true is returned on debugMode=true response
       expect(debugModeTest).toContain('debugMode: true');
-      // TC-2609: verifies json.data wrapper unwrapping (createSuccessResponse format)
-      expect(debugModeTest).toContain('json.data');
-      // TC-2610: verifies cancelled flag prevents state update after unmount
+      // TC-2609: verifies mock uses wrapped { data: { debugMode } } shape (createSuccessResponse format)
+      expect(debugModeTest).toContain('data: { debugMode: true }');
+      // TC-2610: verifies cancellation of state update when unmounted; check behavior description, not internal var name
       expect(debugModeTest).toContain('unmount');
-      expect(debugModeTest).toContain('cancelled');
+      expect(debugModeTest).toContain('cancels state update');
       // URL correctness check
       expect(debugModeTest).toContain('?fields=summary');
     });
@@ -3988,19 +3988,19 @@ describe('E2E case drift coverage', () => {
       expect(qualActionsTest).toMatch(/expect\(refetch\)\.toHaveBeenCalledTimes\(1\)/);
       // TC-2613: handleBulkRankOverrideSave returns true on full success
       expect(qualActionsTest).toContain('handleBulkRankOverrideSave');
-      expect(qualActionsTest).toContain('returnValue!).toBe(true)');
+      expect(qualActionsTest).toContain('returnValue).toBe(true)');
       // TC-2614: handleBulkRankOverrideSave stops on failure and returns false
-      expect(qualActionsTest).toContain('returnValue!).toBe(false)');
+      expect(qualActionsTest).toContain('returnValue).toBe(false)');
       // TC-2615: handleTvAssign sends matchId and tvNumber
       expect(qualActionsTest).toContain('handleTvAssign');
       expect(qualActionsTest).toContain('matchId');
       expect(qualActionsTest).toContain('tvNumber');
-      // TC-2616: handleBroadcastReflect calls broadcast PUT with player names
+      // TC-2616: handleBroadcastReflect calls broadcast PUT with player names; toast key checked
       expect(qualActionsTest).toContain('handleBroadcastReflect');
       expect(qualActionsTest).toContain('/broadcast');
-      expect(qualActionsTest).toContain('toast.success');
-      // TC-2617/TC-2618: toast.error on failure paths
-      expect(qualActionsTest).toContain('toast.error');
+      expect(qualActionsTest).toContain("'broadcastReflected'");
+      // TC-2617/TC-2618: toast.error with broadcastError key on failure paths
+      expect(qualActionsTest).toContain("'broadcastError'");
     });
   });
 });

--- a/smkc-score-app/__tests__/lib/hooks/useQualificationActions.test.ts
+++ b/smkc-score-app/__tests__/lib/hooks/useQualificationActions.test.ts
@@ -21,6 +21,11 @@ jest.mock('@/lib/client-logger', () => ({
   createLogger: jest.fn(() => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn() })),
 }));
 
+// Return i18n keys verbatim so toast assertions can target stable keys, not translation strings
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
 jest.mock('sonner', () => ({
   toast: {
     success: jest.fn(),
@@ -98,14 +103,14 @@ describe('useQualificationActions', () => {
         { qualificationId: 'q2', rankOverride: 2 },
       ];
 
-      let returnValue: boolean;
+      let returnValue: boolean | undefined;
       await act(async () => {
         returnValue = await result.current.handleBulkRankOverrideSave(updates);
       });
 
       expect(global.fetch).toHaveBeenCalledTimes(2);
       expect(refetch).toHaveBeenCalledTimes(1);
-      expect(returnValue!).toBe(true);
+      expect(returnValue).toBe(true);
     });
 
     it('TC-2614: stops on first failure, skips remaining updates, returns false', async () => {
@@ -125,7 +130,7 @@ describe('useQualificationActions', () => {
         { qualificationId: 'q3', rankOverride: 3 }, // should never be reached
       ];
 
-      let returnValue: boolean;
+      let returnValue: boolean | undefined;
       await act(async () => {
         returnValue = await result.current.handleBulkRankOverrideSave(updates);
       });
@@ -134,7 +139,7 @@ describe('useQualificationActions', () => {
       expect(global.fetch).toHaveBeenCalledTimes(2);
       expect(alertSpy).toHaveBeenCalledWith('Server error');
       expect(refetch).not.toHaveBeenCalled();
-      expect(returnValue!).toBe(false);
+      expect(returnValue).toBe(false);
     });
   });
 
@@ -167,7 +172,7 @@ describe('useQualificationActions', () => {
       (global.fetch as jest.Mock).mockResolvedValue({ ok: true } as Response);
       const { result } = makeHook();
 
-      let returnValue: boolean;
+      let returnValue: boolean | undefined;
       await act(async () => {
         returnValue = await result.current.handleBroadcastReflect('Alice', 'Bob');
       });
@@ -179,34 +184,34 @@ describe('useQualificationActions', () => {
           body: JSON.stringify({ player1Name: 'Alice', player2Name: 'Bob' }),
         }),
       );
-      expect(toast.success).toHaveBeenCalledWith('Broadcast updated');
-      expect(returnValue!).toBe(true);
+      expect(toast.success).toHaveBeenCalledWith('broadcastReflected');
+      expect(returnValue).toBe(true);
     });
 
     it('TC-2617: shows error toast and returns false on non-ok broadcast response', async () => {
       (global.fetch as jest.Mock).mockResolvedValue({ ok: false } as Response);
       const { result } = makeHook();
 
-      let returnValue: boolean;
+      let returnValue: boolean | undefined;
       await act(async () => {
         returnValue = await result.current.handleBroadcastReflect('Alice', 'Bob');
       });
 
-      expect(toast.error).toHaveBeenCalledWith('Broadcast failed');
-      expect(returnValue!).toBe(false);
+      expect(toast.error).toHaveBeenCalledWith('broadcastError');
+      expect(returnValue).toBe(false);
     });
 
     it('TC-2618: shows error toast and returns false on network failure', async () => {
       (global.fetch as jest.Mock).mockRejectedValue(new Error('Network error'));
       const { result } = makeHook();
 
-      let returnValue: boolean;
+      let returnValue: boolean | undefined;
       await act(async () => {
         returnValue = await result.current.handleBroadcastReflect('Alice', 'Bob');
       });
 
-      expect(toast.error).toHaveBeenCalledWith('Broadcast failed');
-      expect(returnValue!).toBe(false);
+      expect(toast.error).toHaveBeenCalledWith('broadcastError');
+      expect(returnValue).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **#2612**: `useQualificationActions.test.ts` の `let returnValue: boolean` を `boolean | undefined` に変更し、非nullアサーション演算子 `!` を除去（TC-2613/2614/2616–2618）
- **#2611**: `jest.mock('next-intl', ...)` でキーを返すモックを追加し、`toast.success('broadcastReflected')` / `toast.error('broadcastError')` でi18nキーベース検証に変更。翻訳文字列の変更でテストが壊れなくなる（TC-2616–2618）
- **#2610**: drift guard の実装詳細依存チェックを改善
  - `toContain('json.data')` → `toContain('data: { debugMode: true }')` （モック形状）
  - `toContain('cancelled')` → `toContain('cancels state update')` （it() 説明）

## Issues

Closes #2610
Closes #2611
Closes #2612

## Validation

- `useQualificationActions.test.ts`: TC-2611〜2618 全テスト通過確認（CI）
- `e2e-cases-drift.test.ts`: drift guard が更新されたテストを正しく追跡
- i18n キーベース検証により翻訳文字列変更への耐性が向上

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ab7stbWDSyxLdecCEqpfvY)_