### PR TITLE
test(drift-guard): add regex check for TC-2609 createSuccessResponse wrapper format (#2616)

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3960,6 +3960,9 @@ describe('E2E case drift coverage', () => {
       }
       // TC-2606 + TC-2609: verifies debugMode=true is asserted; stable substring avoids sensitivity to object-literal formatting
       expect(debugModeTest).toContain('debugMode: true');
+      // TC-2609: verifies TC-2609 tests the createSuccessResponse wrapped format { data: { debugMode } };
+      // regex is tolerant of whitespace differences around colons and braces
+      expect(debugModeTest).toMatch(/data\s*:\s*\{[^}]*debugMode\s*:\s*true/);
       // TC-2610: verifies cancellation of state update when unmounted; check behavior description, not internal var name
       expect(debugModeTest).toContain('unmount');
       expect(debugModeTest).toContain('cancels state update');


### PR DESCRIPTION
## Summary

- `e2e-cases-drift.test.ts` の TC-2605〜TC-2610 ドリフトガードに `toMatch` 正規表現を追加
- TC-2609 が `createSuccessResponse` の wrapped 形式 `{ data: { debugMode: true } }` を使っているかを確認
- `toContain('debugMode: true')` だけでは unwrapped 形式でもパスしてしまう問題を修正
- スペースの差異に対して robustな正規表現 `/data\s*:\s*\{[^}]*debugMode\s*:\s*true/` を使用

## Issues

Closes #2616

## Validation

- `npm test` 3666 tests passing (252 suites)
- TC-2605〜TC-2610 ドリフトガードテスト PASS を確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXwMKdKArKwLv619mAxTnR)_