### PR TITLE
test(drift-guard): add word boundary to TC-2609 data regex to prevent false positives

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3962,7 +3962,7 @@ describe('E2E case drift coverage', () => {
       expect(debugModeTest).toContain('debugMode: true');
       // TC-2609: verifies TC-2609 tests the createSuccessResponse wrapped format { data: { debugMode } };
       // regex is tolerant of whitespace differences around colons and braces
-      expect(debugModeTest).toMatch(/data\s*:\s*\{[^}]*debugMode\s*:\s*true/);
+      expect(debugModeTest).toMatch(/\bdata\s*:\s*\{[^}]*debugMode\s*:\s*true/);
       // TC-2610: verifies cancellation of state update when unmounted; check behavior description, not internal var name
       expect(debugModeTest).toContain('unmount');
       expect(debugModeTest).toContain('cancels state update');


### PR DESCRIPTION
## Summary

- `e2e-cases-drift.test.ts` の TC-2609 チェックで使用している正規表現 `/data\s*:\s*\{[^}]*debugMode\s*:\s*true/` に単語境界 `\b` を追加
- `\bdata\s*:\s*\{[^}]*debugMode\s*:\s*true/` とすることで `someData: { debugMode: true }` のようなプロパティ名末尾に `data` を含む場合の誤マッチを防止

## Issues

Closes #2618

## Validation

- `npm test` — 252 suites / 3666 tests green (27 skipped)
- TC-2609 drift-guard の 6 テスト全て PASS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZhhmgsmAaNiGgWwSrtQdu)_