### PR TITLE
test(drift-guard): restore TC-2626 POST check; fix TC-2609 duplicate

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3960,9 +3960,9 @@ describe('E2E case drift coverage', () => {
       }
       // TC-2606 + TC-2609: verifies debugMode=true is asserted; stable substring avoids sensitivity to object-literal formatting
       expect(debugModeTest).toContain('debugMode: true');
-      // TC-2609: verifies TC-2609 tests the createSuccessResponse wrapped format { data: { debugMode } };
-      // use toContain instead of a regex so nested braces in test fixtures don't break the guard
-      expect(debugModeTest).toContain('debugMode: true');
+      // TC-2609: verifies the test exercises the createSuccessResponse wrapper format { data: { debugMode: true } };
+      // use toContain on the full inline object so the check is distinct from the TC-2606 check above
+      expect(debugModeTest).toContain('data: { debugMode: true }');
       // TC-2610: verifies cancellation of state update when unmounted; check behavior description, not internal var name
       expect(debugModeTest).toContain('unmount');
       expect(debugModeTest).toContain('cancels state update');
@@ -4038,8 +4038,10 @@ describe('E2E case drift coverage', () => {
       // TC-2625: myMatches sorts incomplete before completed
       expect(participantMatchesTest).toContain('completed: true');
       expect(participantMatchesTest).toContain('myMatches[0].id');
-      // TC-2626: submitReport POSTs to correct endpoint; TC number above confirms test exists
+      // TC-2626: submitReport POSTs to correct endpoint; check URL and method string
       expect(participantMatchesTest).toContain('/report');
+      // toContain("'POST'") is stable across refactors — checks the method value, not call-site syntax
+      expect(participantMatchesTest).toContain("'POST'");
       // TC-2627: submitReport on non-ok → sets error and returns null
       expect(participantMatchesTest).toContain('Score invalid');
       expect(participantMatchesTest).toMatch(/expect\(returnValue\)\.toBeNull/);


### PR DESCRIPTION
## Summary

Two targeted drift-guard fixes — no source or test logic changes.

### #2629 — TC-2626 POST method check was removed in #2627
Restored as `toContain("'POST'")` — checks the method value string rather than the `=== 'POST'` call-site syntax. This is stable across quote-style or comparison-operator refactors while still catching if someone accidentally changes POST to PUT or GET.

### #2628 — Duplicate `debugMode: true` assertion after TC-2609 regex fix
The #2627 regex→toContain replacement left two identical `toContain('debugMode: true')` lines. The TC-2609 guard now uses `toContain('data: { debugMode: true }')` which:
- Is distinct from the TC-2606 check above it
- Specifically verifies the `createSuccessResponse` wrapper format (the real intent of TC-2609)

## Validation
- 377 drift-guard tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZhhmgsmAaNiGgWwSrtQdu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZhhmgsmAaNiGgWwSrtQdu)_