### PR TITLE
test(components): add TC-2643–2656 unit tests for RankCell and TieWarningBanner

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -4247,6 +4247,118 @@
 
 ---
 
+### TC-2643: RankCell — 非管理者は rankOverride なしのとき autoRank を表示する
+- **背景**: `RankCell` はランク表示セルと管理者向けインライン編集を統合したコンポーネント。非管理者は閲覧専用で編集ボタンが表示されない。
+- **手順**: `isAdmin=false`、`rankOverride=null`、`autoRank=3` で `RankCell` をレンダリングする。
+- **期待結果**: "3" が表示される。ボタン要素は存在しない。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+
+---
+
+### TC-2644: RankCell — 非管理者は rankOverride が設定されているときオーバーライドバッジを表示する
+- **背景**: 管理者が手動でランクを上書きした場合、非管理者にもアンバーバッジで通知する。autoRank は表示しない。
+- **手順**: `isAdmin=false`、`rankOverride=2`、`autoRank=5` でレンダリングする。
+- **期待結果**: "2" が表示される。"5" は表示されない。ボタンは存在しない。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+
+---
+
+### TC-2645: RankCell — 管理者は autoRank と編集ボタンを見る
+- **背景**: `isAdmin=true` のとき、ランク表示の横に鉛筆アイコン (Edit rank) ボタンが表示される。
+- **手順**: `isAdmin=true`、`rankOverride=null`、`autoRank=4` でレンダリングする。
+- **期待結果**: "4" と "Edit rank" ボタンが表示される。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+
+---
+
+### TC-2646: RankCell — 管理者はオーバーライドバッジと編集ボタンを見る
+- **背景**: オーバーライドがある場合も管理者は編集ボタンを持ち続け、再編集や削除が可能。
+- **手順**: `isAdmin=true`、`rankOverride=1`、`autoRank=3` でレンダリングする。
+- **期待結果**: "1" と "Edit rank" ボタンが表示される。"3" は表示されない。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+
+---
+
+### TC-2647: RankCell — 編集ボタンをクリックすると rankOverride=null のとき空文字の input が開く
+- **背景**: 既存オーバーライドがない場合、インライン入力は空で開く。clear ボタン (✕) は rankOverride=null 時は表示されない。
+- **手順**: `rankOverride=null` で編集ボタンをクリックする。
+- **期待結果**: number input が空文字値で表示される。✕ ボタンは存在しない。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+
+---
+
+### TC-2648: RankCell — 編集ボタンをクリックすると rankOverride の値で input が prefill される
+- **背景**: 既存オーバーライドを編集するとき、現在値を input に表示して修正しやすくする。✕ ボタンも表示される。
+- **手順**: `rankOverride=7` で編集ボタンをクリックする。
+- **期待結果**: input の値が "7"。✕ ボタンが表示される。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+
+---
+
+### TC-2649: RankCell — Enter キー押下で onSave が数値引数で呼ばれ編集モードが閉じる
+- **背景**: キーボード操作で素早くランクを確定できるよう、Enter キーで `commitSave()` を呼ぶ。
+- **手順**: 編集モードを開き、input に "5" を入力して Enter を押す。
+- **期待結果**: `onSave("qual-42", 5)` が呼ばれる。input が消え Edit rank ボタンが戻る。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+
+---
+
+### TC-2650: RankCell — ✓ ボタンクリックで onSave が呼ばれ編集モードが閉じる
+- **背景**: ✓ ボタン (commitSave) はマウス操作でランクを確定する代替手段。
+- **手順**: 編集モードを開き、"3" を入力して ✓ をクリックする。
+- **期待結果**: `onSave("qual-7", 3)` が呼ばれる。input が消える。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+
+---
+
+### TC-2651: RankCell — Escape キー押下で onSave を呼ばずに編集モードをキャンセルする
+- **背景**: Escape で変更を破棄して元の表示に戻る。onSave は呼ばれない。
+- **手順**: 編集モードを開き、"9" を入力して Escape を押す。
+- **期待結果**: `onSave` が呼ばれない。input が消え Edit rank ボタンが戻る。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+
+---
+
+### TC-2652: RankCell — ✕ ボタンクリックで onSave(null) が呼ばれてオーバーライドをクリアする
+- **背景**: ✕ ボタン (commitClear) はオーバーライドを削除して自動ランクに戻す。`rankOverride != null` のときのみ表示される。
+- **手順**: `rankOverride=3` で編集ボタンをクリックし、✕ をクリックする。
+- **期待結果**: `onSave("qual-99", null)` が呼ばれる。input が消える。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+
+---
+
+### TC-2653: TieWarningBanner — hasTies=false のとき何もレンダリングしない (管理者)
+- **背景**: `TieWarningBanner` は `hasTies` が false なら null を返し、上位から無条件に配置しても表示されないようにする。
+- **手順**: `hasTies=false`、`isAdmin=true` でレンダリングする。
+- **期待結果**: container.firstChild が null。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/tie-warning-banner.test.tsx
+
+---
+
+### TC-2654: TieWarningBanner — hasTies=false のとき何もレンダリングしない (非管理者)
+- **背景**: isAdmin の値に関係なく hasTies=false なら非表示。
+- **手順**: `hasTies=false`、`isAdmin=false` でレンダリングする。
+- **期待結果**: container.firstChild が null。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/tie-warning-banner.test.tsx
+
+---
+
+### TC-2655: TieWarningBanner — hasTies=true かつ isAdmin=true のとき管理者向けメッセージを表示する
+- **背景**: 管理者向けには sudden-death プレーオフの記録を促すメッセージを表示する。i18n キー `tiedRanksWarningAdmin` が使われる。
+- **手順**: `hasTies=true`、`isAdmin=true` でレンダリングする。useTranslations はキーをそのまま返すモックを使用。
+- **期待結果**: "tiedRanksWarningAdmin" が表示される。"tiedRanksWarningViewer" は表示されない。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/tie-warning-banner.test.tsx
+
+---
+
+### TC-2656: TieWarningBanner — hasTies=true かつ isAdmin=false のとき閲覧者向けメッセージを表示する
+- **背景**: 非管理者向けには "同着解決待ち" の通知メッセージを表示する。i18n キー `tiedRanksWarningViewer` が使われる。
+- **手順**: `hasTies=true`、`isAdmin=false` でレンダリングする。
+- **期待結果**: "tiedRanksWarningViewer" が表示される。"tiedRanksWarningAdmin" は表示されない。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/tie-warning-banner.test.tsx
+
+---
+
 ## E2Eテスト実行ガイド
 
 ### セッション管理（重要）

--- a/smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Unit tests for the RankCell component (TC-2643 through TC-2652).
+ *
+ * RankCell displays a rank number in a standings table, with admin-only
+ * inline editing to set or clear a rank override.
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { RankCell } from '@/components/tournament/rank-cell';
+
+const noop = jest.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  noop.mockClear();
+});
+
+describe('RankCell — view mode', () => {
+  it('TC-2643: non-admin sees auto rank when no override is set', () => {
+    render(
+      <RankCell
+        qualificationId="qual-1"
+        rankOverride={null}
+        autoRank={3}
+        isAdmin={false}
+        onSave={noop}
+      />,
+    );
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('TC-2644: non-admin sees amber override badge when rankOverride is set', () => {
+    render(
+      <RankCell
+        qualificationId="qual-1"
+        rankOverride={2}
+        autoRank={5}
+        isAdmin={false}
+        onSave={noop}
+      />,
+    );
+
+    // Override value is shown, not auto rank
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.queryByText('5')).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('TC-2645: admin sees auto rank and edit button', () => {
+    render(
+      <RankCell
+        qualificationId="qual-1"
+        rankOverride={null}
+        autoRank={4}
+        isAdmin={true}
+        onSave={noop}
+      />,
+    );
+
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit rank' })).toBeInTheDocument();
+  });
+
+  it('TC-2646: admin sees override badge and edit button when override exists', () => {
+    render(
+      <RankCell
+        qualificationId="qual-1"
+        rankOverride={1}
+        autoRank={3}
+        isAdmin={true}
+        onSave={noop}
+      />,
+    );
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.queryByText('3')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Edit rank' })).toBeInTheDocument();
+  });
+});
+
+describe('RankCell — edit mode', () => {
+  it('TC-2647: clicking edit opens input with empty string when no override exists', () => {
+    render(
+      <RankCell
+        qualificationId="qual-1"
+        rankOverride={null}
+        autoRank={4}
+        isAdmin={true}
+        onSave={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rank' }));
+
+    const input = screen.getByRole('spinbutton');
+    expect(input).toBeInTheDocument();
+    expect((input as HTMLInputElement).value).toBe('');
+    // Clear button must not appear when rankOverride is null
+    expect(screen.queryByRole('button', { name: /✕/ })).toBeNull();
+  });
+
+  it('TC-2648: clicking edit opens input prefilled with current override value', () => {
+    render(
+      <RankCell
+        qualificationId="qual-1"
+        rankOverride={7}
+        autoRank={3}
+        isAdmin={true}
+        onSave={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rank' }));
+
+    const input = screen.getByRole('spinbutton');
+    expect((input as HTMLInputElement).value).toBe('7');
+    // Clear button must appear when rankOverride is set
+    expect(screen.getByText('✕')).toBeInTheDocument();
+  });
+
+  it('TC-2649: pressing Enter calls onSave with parsed number and closes editor', async () => {
+    render(
+      <RankCell
+        qualificationId="qual-42"
+        rankOverride={null}
+        autoRank={2}
+        isAdmin={true}
+        onSave={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rank' }));
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '5' } });
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+
+    expect(noop).toHaveBeenCalledWith('qual-42', 5);
+    // After saving, edit mode closes and view mode is shown
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Edit rank' })).toBeInTheDocument();
+  });
+
+  it('TC-2650: clicking ✓ button calls onSave and closes editor', async () => {
+    render(
+      <RankCell
+        qualificationId="qual-7"
+        rankOverride={null}
+        autoRank={1}
+        isAdmin={true}
+        onSave={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rank' }));
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '3' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('✓'));
+    });
+
+    expect(noop).toHaveBeenCalledWith('qual-7', 3);
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+  });
+
+  it('TC-2651: pressing Escape cancels edit without calling onSave', () => {
+    render(
+      <RankCell
+        qualificationId="qual-1"
+        rankOverride={null}
+        autoRank={6}
+        isAdmin={true}
+        onSave={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rank' }));
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '9' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(noop).not.toHaveBeenCalled();
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Edit rank' })).toBeInTheDocument();
+  });
+
+  it('TC-2652: clicking ✕ button clears the override (calls onSave with null)', async () => {
+    render(
+      <RankCell
+        qualificationId="qual-99"
+        rankOverride={3}
+        autoRank={5}
+        isAdmin={true}
+        onSave={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rank' }));
+    expect(screen.getByText('✕')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('✕'));
+    });
+
+    expect(noop).toHaveBeenCalledWith('qual-99', null);
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+  });
+});

--- a/smkc-score-app/__tests__/components/tournament/tie-warning-banner.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/tie-warning-banner.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Unit tests for the TieWarningBanner component (TC-2653 through TC-2656).
+ *
+ * TieWarningBanner renders a yellow warning when tied ranks exist in a
+ * qualification group. Admins see a prompt to run a sudden-death playoff;
+ * viewers see a "pending resolution" notice.
+ */
+import { render, screen } from '@testing-library/react';
+import { TieWarningBanner } from '@/components/tournament/tie-warning-banner';
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+describe('TieWarningBanner', () => {
+  it('TC-2653: renders nothing when hasTies is false (admin)', () => {
+    const { container } = render(
+      <TieWarningBanner hasTies={false} isAdmin={true} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('TC-2654: renders nothing when hasTies is false (non-admin)', () => {
+    const { container } = render(
+      <TieWarningBanner hasTies={false} isAdmin={false} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('TC-2655: renders admin message when hasTies is true and isAdmin is true', () => {
+    render(<TieWarningBanner hasTies={true} isAdmin={true} />);
+
+    // useTranslations returns the i18n key — admin branch uses "tiedRanksWarningAdmin"
+    expect(screen.getByText('tiedRanksWarningAdmin')).toBeInTheDocument();
+    expect(screen.queryByText('tiedRanksWarningViewer')).toBeNull();
+  });
+
+  it('TC-2656: renders viewer message when hasTies is true and isAdmin is false', () => {
+    render(<TieWarningBanner hasTies={true} isAdmin={false} />);
+
+    // useTranslations returns the i18n key — non-admin branch uses "tiedRanksWarningViewer"
+    expect(screen.getByText('tiedRanksWarningViewer')).toBeInTheDocument();
+    expect(screen.queryByText('tiedRanksWarningAdmin')).toBeNull();
+  });
+});

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -4098,6 +4098,68 @@ describe('E2E case drift coverage', () => {
       expect(modePublishTest).toContain('updating).toBe(false)');
       expect(modePublishTest).toContain('Network error');
     });
+
+    it('documents TC-2643 through TC-2652 as RankCell unit tests', () => {
+      const rankCellTest = readRepoFile(
+        'smkc-score-app',
+        '__tests__',
+        'components',
+        'tournament',
+        'rank-cell.test.tsx',
+      );
+      for (const tc of [
+        'TC-2643', 'TC-2644', 'TC-2645', 'TC-2646',
+        'TC-2647', 'TC-2648', 'TC-2649', 'TC-2650',
+        'TC-2651', 'TC-2652',
+      ]) {
+        expect(rankCellTest).toContain(tc);
+      }
+      // TC-2643/TC-2644: non-admin view mode
+      expect(rankCellTest).toContain('isAdmin={false}');
+      expect(rankCellTest).toContain('queryByRole');
+      // TC-2645/TC-2646: admin view mode shows Edit rank button
+      expect(rankCellTest).toContain("Edit rank");
+      expect(rankCellTest).toContain('isAdmin={true}');
+      // TC-2647: empty input when no override
+      expect(rankCellTest).toContain("rankOverride={null}");
+      expect(rankCellTest).toContain('spinbutton');
+      // TC-2648: prefilled input when override exists
+      expect(rankCellTest).toContain('rankOverride={7}');
+      // TC-2649: Enter key save
+      expect(rankCellTest).toContain("key: 'Enter'");
+      // TC-2650: checkmark button save
+      expect(rankCellTest).toContain('✓');
+      // TC-2651: Escape cancel without onSave
+      expect(rankCellTest).toContain("key: 'Escape'");
+      expect(rankCellTest).toContain('not.toHaveBeenCalled');
+      // TC-2652: clear button sets override to null
+      expect(rankCellTest).toContain('✕');
+      expect(rankCellTest).toContain("null");
+    });
+
+    it('documents TC-2653 through TC-2656 as TieWarningBanner unit tests', () => {
+      const tieWarningTest = readRepoFile(
+        'smkc-score-app',
+        '__tests__',
+        'components',
+        'tournament',
+        'tie-warning-banner.test.tsx',
+      );
+      for (const tc of ['TC-2653', 'TC-2654', 'TC-2655', 'TC-2656']) {
+        expect(tieWarningTest).toContain(tc);
+      }
+      // TC-2653/TC-2654: hasTies=false returns null
+      expect(tieWarningTest).toContain('hasTies={false}');
+      expect(tieWarningTest).toContain('firstChild');
+      // TC-2655: admin message i18n key
+      expect(tieWarningTest).toContain('tiedRanksWarningAdmin');
+      expect(tieWarningTest).toContain('isAdmin={true}');
+      // TC-2656: viewer message i18n key
+      expect(tieWarningTest).toContain('tiedRanksWarningViewer');
+      expect(tieWarningTest).toContain('isAdmin={false}');
+      // next-intl mocked to return key as string
+      expect(tieWarningTest).toContain('useTranslations');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- **TC-2643–TC-2652** (`rank-cell.test.tsx`): 10 unit tests covering the `RankCell` component — previously untested despite being shared across all BM/MR/GP qualification pages for admin rank overrides.
  - Non-admin view: auto rank display, override amber badge (no edit button)
  - Admin view: edit button present in both auto and override states
  - Edit mode open: empty input when no override; prefilled when override exists; ✕ clear button only when override ≠ null
  - Save paths: Enter key, ✓ button click — both call `onSave` with parsed number and close editor
  - Cancel: Escape key discards change, `onSave` not called
  - Clear: ✕ button calls `onSave(qualificationId, null)` to restore auto rank

- **TC-2653–TC-2656** (`tie-warning-banner.test.tsx`): 4 unit tests covering `TieWarningBanner` — null render when `hasTies=false`, admin i18n key (`tiedRanksWarningAdmin`), viewer i18n key (`tiedRanksWarningViewer`).

- **Drift guards**: new `it()` blocks in `e2e-cases-drift.test.ts` assert both test files exist and contain each TC identifier plus key implementation strings.

- **E2E_TEST_CASES.md**: scenario descriptions added for TC-2643–2656.

## Validation

- All 14 new tests pass locally
- Full suite: **256 suites passed, 3681 tests green** (27 skipped, same as baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hDf35dN25NNKaffV4DXDf

---
_Generated by [Claude Code](https://claude.ai/code/session_012hDf35dN25NNKaffV4DXDf)_