### PR TITLE
test: resolve review-followup #2637 #2638 — TC-2659 behavioral test and scoped drift guard

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -4379,7 +4379,7 @@
 - **背景**: `commitSave` は `try/catch` なしで `onSave` を await するため、reject するとその後の `setIsEditing(false)` が実行されず編集モードが開いたままになる。この挙動はソースコードの静的検証で保証する（try/catch を追加するとこの保証が変わるため drift guard が検出する）。
 - **手順**: `rank-cell.tsx` の `commitSave` 実装に `try { ... await onSave } catch` が存在しないことを確認。
 - **期待結果**: `commitSave` の `onSave` 呼び出しが try/catch で囲まれていない。`setIsEditing(false)` が同関数内に存在する。
-- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+- **スクリプト**: n/a (structural drift guard) — smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts; 制御フロー検証は smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
 
 ---
 

--- a/smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
@@ -262,13 +262,43 @@ describe('RankCell — edge cases', () => {
     expect(screen.queryByRole('spinbutton')).toBeNull();
   });
 
-  it('TC-2659: commitSave has no try/catch — onSave rejection leaves editor open', () => {
-    // commitSave has no try/catch around `await onSave(...)`, so a rejection propagates
-    // and setIsEditing(false) is never reached — the editor stays open.
-    // Static source check is in e2e-cases-drift.test.ts (documents TC-2659 structural guard).
+  it('TC-2659: commitSave has no try/catch — setIsEditing(false) only runs after onSave resolves', async () => {
+    // With no try/catch in commitSave, setIsEditing(false) is only reached when onSave
+    // resolves. If onSave rejects, the error propagates and setIsEditing(false) is skipped
+    // — the editor stays open. The structural absence of try/catch is guarded in
+    // e2e-cases-drift.test.ts (TC-2659 drift guard).
     //
-    // This test documents the intent so the TC ID is registered and the drift guard in
-    // e2e-cases-drift.test.ts can assert the structural property via readRepoFile.
-    expect(true).toBe(true); // intentional no-op: structural assertion lives in drift guards
+    // Here we verify the control-flow invariant using a controlled promise:
+    // while onSave is in-flight the editor remains open; on success it closes.
+    let resolveOnSave!: () => void;
+    const controlledSave = jest.fn().mockImplementation(
+      () => new Promise<void>(resolve => { resolveOnSave = resolve; }),
+    );
+
+    render(
+      <RankCell
+        qualificationId="qual-reject"
+        rankOverride={null}
+        autoRank={3}
+        isAdmin={true}
+        onSave={controlledSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rank' }));
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '1' } });
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+
+    // commitSave is awaiting onSave — setIsEditing(false) not yet called → editor open
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+    expect(controlledSave).toHaveBeenCalledWith('qual-reject', 1);
+
+    // Resolve the save: setIsEditing(false) now runs and the editor closes
+    await act(async () => { resolveOnSave(); });
+    expect(screen.queryByRole('spinbutton')).toBeNull();
   });
 });

--- a/smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
@@ -277,7 +277,7 @@ describe('RankCell — edge cases', () => {
 
     render(
       <RankCell
-        qualificationId="qual-reject"
+        qualificationId="qual-pend"
         rankOverride={null}
         autoRank={3}
         isAdmin={true}
@@ -295,7 +295,7 @@ describe('RankCell — edge cases', () => {
 
     // commitSave is awaiting onSave — setIsEditing(false) not yet called → editor open
     expect(screen.getByRole('spinbutton')).toBeInTheDocument();
-    expect(controlledSave).toHaveBeenCalledWith('qual-reject', 1);
+    expect(controlledSave).toHaveBeenCalledWith('qual-pend', 1);
 
     // Resolve the save: setIsEditing(false) now runs and the editor closes
     await act(async () => { resolveOnSave(); });

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -4155,10 +4155,12 @@ describe('E2E case drift coverage', () => {
         'smkc-score-app', 'src', 'components', 'tournament', 'rank-cell.tsx',
       );
       expect(rankCellSrc).toContain('commitSave');
-      // The catch keyword must not appear in commitSave — not even in a comment starting "No try/catch"
-      // We check for 'catch (' as the functional pattern to avoid matching prose comments.
-      expect(rankCellSrc).not.toContain('catch (');
-      expect(rankCellSrc).toContain('setIsEditing(false)');
+      // Scope the catch-absence check to the commitSave function block only, so a
+      // legitimate try/catch elsewhere in rank-cell.tsx doesn't false-fail this guard.
+      const commitSaveBlock = rankCellSrc.match(/const commitSave[\s\S]*?\n  };/)?.[0] ?? '';
+      expect(commitSaveBlock).not.toBe(''); // sanity: function block must be present
+      expect(commitSaveBlock).not.toContain('catch (');
+      expect(commitSaveBlock).toContain('setIsEditing(false)');
       // The intentional design must be documented in source comments
       expect(rankCellSrc).toContain('No try/catch');
     });

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -4159,7 +4159,9 @@ describe('E2E case drift coverage', () => {
       // legitimate try/catch elsewhere in rank-cell.tsx doesn't false-fail this guard.
       const commitSaveBlock = rankCellSrc.match(/const commitSave[\s\S]*?\n  };/)?.[0] ?? '';
       expect(commitSaveBlock).not.toBe(''); // sanity: function block must be present
-      expect(commitSaveBlock).not.toContain('catch (');
+      // Use regex to catch both `catch (err)` and bare `catch {` (ES2019 optional binding).
+      // The comment "No try/catch:" in commitSave contains "catch" but not followed by ( or {.
+      expect(commitSaveBlock).not.toMatch(/\bcatch\s*[({]/);
       expect(commitSaveBlock).toContain('setIsEditing(false)');
       // The intentional design must be documented in source comments
       expect(rankCellSrc).toContain('No try/catch');


### PR DESCRIPTION
## Summary

- **rank-cell.test.tsx**: TC-2659のno-op `expect(true).toBe(true)` を実際の制御フロー検証テストに置き換え。controlled Promiseを使い「onSaveが解決するまでエディタが開いたまま、成功後にクローズ」を動的に検証。`qualificationId` を `"qual-pend"` にリネームし意図を明確化
- **e2e-cases-drift.test.ts**: TC-2659ドリフトガードの catch チェックを2段階改善：
  1. ファイル全体ではなく `commitSave` 関数ブロックのみにスコープ限定（正規表現で関数ブロックを抽出）
  2. `not.toContain('catch (')` → `not.toMatch(/\bcatch\s*[({]/)` に強化し ES2019 bare `catch {` も検出
- **E2E_TEST_CASES.md**: TC-2659のスクリプト欄を両テストファイルを参照するよう更新

## Issues

Closes #2637
Closes #2638

## Validation

- Full test suite: 256 test suites / 3685 tests PASS
- Cloudflare Workers: デプロイ成功 ✅