### PR TITLE
fix(test): strengthen TC-2547 drift guard from toContain to toContain('toBe(16)')

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3704,7 +3704,8 @@ describe('E2E case drift coverage', () => {
       expect(section).toContain('time-format.test.ts');
       expect(tfTest).toContain('TC-2547');
       expect(tfTest).toContain('155');
-      expect(tfTest).toContain('16');
+      // '16' は汎用的な数値リテラルなので toBe(16) の形式で確認し一意性を高める (#2545)
+      expect(tfTest).toContain('toBe(16)');
     });
 
     it('documents TC-2548 as msToCdmTime throwing for negative duration', () => {


### PR DESCRIPTION
## Summary

- Strengthens TC-2547 drift guard assertion from `toContain('16')` to `toContain('toBe(16)')` to prevent false positives where the number `16` appears in unrelated assertions

## Validation

- Changed 1 file: `smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts`
- More precise assertion guards against false-positive matches

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKWiX6LLgSPYQmmvFLRktU)_