### PR TITLE
feat(RankCell): add try/catch to commitSave/commitClear with inline error notification

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -4375,11 +4375,29 @@
 
 ---
 
-### TC-2659: RankCell — commitSave に try/catch がないため onSave reject で編集モードが維持される
-- **背景**: `commitSave` は `try/catch` なしで `onSave` を await するため、reject するとその後の `setIsEditing(false)` が実行されず編集モードが開いたままになる。この挙動はソースコードの静的検証で保証する（try/catch を追加するとこの保証が変わるため drift guard が検出する）。
-- **手順**: `rank-cell.tsx` の `commitSave` 実装に `try { ... await onSave } catch` が存在しないことを確認。
-- **期待結果**: `commitSave` の `onSave` 呼び出しが try/catch で囲まれていない。`setIsEditing(false)` が同関数内に存在する。
-- **スクリプト**: n/a (structural drift guard) — smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts; 制御フロー検証は smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+### TC-2659: RankCell — commitSave は onSave 成功時にエディタを閉じ、飛行中は開いたまま
+- **背景**: `commitSave` は `try/catch` で `onSave` を囲み、成功時のみ `setIsEditing(false)` を呼ぶ。in-flight 中はエディタが開いたままになる。
+- **手順**: 制御可能な Promise を onSave に渡し、resolve 前後のエディタ状態を確認。
+- **期待結果**: resolve 前はエディタが開いたまま。resolve 後はエディタが閉じる。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+
+### TC-2660: RankCell — onSave reject 時にインラインエラーメッセージを表示してエディタを維持する
+- **背景**: `commitSave` の try/catch は reject を捕捉し、`setSaveError` でエラーメッセージを表示する。ユーザーはメッセージを確認してリトライできる（`setIsEditing(false)` は呼ばれない）。
+- **手順**: reject する onSave を渡して Enter を押す。
+- **期待結果**: エディタが開いたままで `role="alert"` のエラーメッセージが表示される。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+
+### TC-2661: RankCell — 編集モードを再度開くと前回のエラーメッセージがクリアされる
+- **背景**: `openEdit` は `setSaveError(null)` を呼ぶため、前回の保存エラーが次回の編集に持ち越されない。
+- **手順**: onSave が reject した後、Escape で閉じ、再度編集ボタンをクリックする。
+- **期待結果**: エラーメッセージが表示されない（`role="alert"` 要素が存在しない）。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+
+### TC-2662: RankCell — commitClear も onSave reject 時にインラインエラーを表示してエディタを維持する
+- **背景**: `commitClear` も `commitSave` と同様の try/catch パターンで `setSaveError` を呼ぶ。
+- **手順**: reject する onSave と rankOverride=5 で RankCell をレンダリングし、✕ ボタンをクリックする。
+- **期待結果**: エディタが開いたままで `role="alert"` のエラーメッセージが表示される。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
 
 ---
 

--- a/smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/rank-cell.test.tsx
@@ -262,14 +262,9 @@ describe('RankCell — edge cases', () => {
     expect(screen.queryByRole('spinbutton')).toBeNull();
   });
 
-  it('TC-2659: commitSave has no try/catch — setIsEditing(false) only runs after onSave resolves', async () => {
-    // With no try/catch in commitSave, setIsEditing(false) is only reached when onSave
-    // resolves. If onSave rejects, the error propagates and setIsEditing(false) is skipped
-    // — the editor stays open. The structural absence of try/catch is guarded in
-    // e2e-cases-drift.test.ts (TC-2659 drift guard).
-    //
-    // Here we verify the control-flow invariant using a controlled promise:
-    // while onSave is in-flight the editor remains open; on success it closes.
+  it('TC-2659: commitSave closes editor on success and keeps it open while in-flight', async () => {
+    // With try/catch in commitSave, setIsEditing(false) is called only on success.
+    // While onSave is in-flight the editor stays open; after it resolves, the editor closes.
     let resolveOnSave!: () => void;
     const controlledSave = jest.fn().mockImplementation(
       () => new Promise<void>(resolve => { resolveOnSave = resolve; }),
@@ -302,55 +297,86 @@ describe('RankCell — edge cases', () => {
     expect(screen.queryByRole('spinbutton')).toBeNull();
   });
 
-  it('TC-2659 reject: onSave reject leaves editor open (no try/catch in commitSave)', async () => {
-    // Without try/catch in commitSave, a rejected onSave propagates without calling
-    // setIsEditing(false), so the editor stays open.
-    //
-    // The "reject path" is covered IMPLICITLY by two existing assertions:
-    //  1. Structural drift guard: e2e-cases-drift.test.ts TC-2659 verifies no try/catch exists
-    //  2. Resolve-path test above: setIsEditing(false) only runs after onSave RESOLVES
-    //
-    // Here we verify the in-flight invariant using a never-resolving/rejecting promise:
-    // while onSave is pending, the editor must stay open regardless of future outcome.
-    // (Directly triggering a floating-promise rejection would surface as an unhandled
-    // rejection in jest-circus even with try/catch, because the rejection occurs
-    // outside the awaitable scope of the event handler's callsite.)
-    let rejectOnSave!: (err: Error) => void;
-    const controlledSave = jest.fn().mockImplementation(
-      () => new Promise<void>((_, reject) => { rejectOnSave = reject; }),
-    );
+  it('TC-2660: commitSave shows inline error and keeps editor open when onSave rejects', async () => {
+    // try/catch in commitSave catches the rejection, shows an error message, and
+    // keeps the editor open so the user can see the message and retry.
+    const failingSave = jest.fn().mockRejectedValue(new Error('Network error'));
 
     render(
       <RankCell
-        qualificationId="qual-pend"
+        qualificationId="qual-err"
         rankOverride={null}
         autoRank={3}
         isAdmin={true}
-        onSave={controlledSave}
+        onSave={failingSave}
       />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit rank' }));
     const input = screen.getByRole('spinbutton');
-    fireEvent.change(input, { target: { value: '1' } });
+    fireEvent.change(input, { target: { value: '2' } });
 
-    // commitSave() is in-flight (awaiting onSave) — editor still open
     await act(async () => {
       fireEvent.keyDown(input, { key: 'Enter' });
     });
+
+    // Editor stays open
     expect(screen.getByRole('spinbutton')).toBeInTheDocument();
-    expect(controlledSave).toHaveBeenCalledWith('qual-pend', 1);
+    // Error message is shown
+    expect(screen.getByRole('alert')).toHaveTextContent('Network error');
+  });
 
-    // Prevent jest-circus from catching an unhandled rejection on test teardown:
-    // attach a no-op handler before triggering the reject.
-    const pendingRejection = controlledSave.mock.results[0].value as Promise<void>;
-    pendingRejection.catch(() => {});
-    rejectOnSave(new Error('save failed'));
+  it('TC-2661: error message is cleared when the editor is reopened', async () => {
+    // After a failed save, reopening the editor (openEdit) clears the previous error.
+    const failingSave = jest.fn()
+      .mockRejectedValueOnce(new Error('Server error'))
+      .mockResolvedValue(undefined);
 
-    // Give microtasks a chance to run (the rejection propagates through commitSave)
-    await Promise.resolve();
+    render(
+      <RankCell
+        qualificationId="qual-retry"
+        rankOverride={null}
+        autoRank={4}
+        isAdmin={true}
+        onSave={failingSave}
+      />,
+    );
 
-    // setIsEditing(false) was never reached → editor stays open
+    // First attempt → error
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rank' }));
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '1' } });
+    await act(async () => { fireEvent.keyDown(screen.getByRole('spinbutton'), { key: 'Enter' }); });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    // Press Escape to close editor
+    fireEvent.keyDown(screen.getByRole('spinbutton'), { key: 'Escape' });
+    // Reopen: error should be gone
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rank' }));
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('TC-2662: commitClear shows inline error and keeps editor open when onSave rejects', async () => {
+    // commitClear has the same try/catch pattern as commitSave.
+    const failingSave = jest.fn().mockRejectedValue(new Error('Clear failed'));
+
+    render(
+      <RankCell
+        qualificationId="qual-clear-err"
+        rankOverride={5}
+        autoRank={3}
+        isAdmin={true}
+        onSave={failingSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit rank' }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /✕/ }));
+    });
+
+    // Editor stays open
     expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+    // Error message is shown
+    expect(screen.getByRole('alert')).toHaveTextContent('Clear failed');
   });
 });

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -4099,7 +4099,7 @@ describe('E2E case drift coverage', () => {
       expect(modePublishTest).toContain('Network error');
     });
 
-    it('documents TC-2643 through TC-2659 as RankCell unit tests', () => {
+    it('documents TC-2643 through TC-2662 as RankCell unit tests', () => {
       const rankCellTest = readRepoFile(
         'smkc-score-app',
         '__tests__',
@@ -4111,6 +4111,7 @@ describe('E2E case drift coverage', () => {
         'TC-2643', 'TC-2644', 'TC-2645', 'TC-2646',
         'TC-2647', 'TC-2648', 'TC-2649', 'TC-2650',
         'TC-2651', 'TC-2652', 'TC-2657', 'TC-2658', 'TC-2659',
+        'TC-2660', 'TC-2661', 'TC-2662',
       ]) {
         expect(rankCellTest).toContain(tc);
       }
@@ -4143,28 +4144,26 @@ describe('E2E case drift coverage', () => {
       // TC-2658: rank 0 passes isNaN check
       expect(rankCellTest).toContain('qual-zero');
       expect(rankCellTest).toContain("isNaN");
-      // TC-2659: test documents intent; structural guard is in the block below
-      expect(rankCellTest).toContain('commitSave has no try/catch');
+      // TC-2660: error message shown on reject
+      expect(rankCellTest).toContain("getByRole('alert')");
+      // TC-2661: error cleared on reopen
+      expect(rankCellTest).toContain('queryByRole(\'alert\')');
     });
 
-    it('TC-2659: commitSave has no try/catch in rank-cell.tsx (structural drift guard)', () => {
-      // Verify the intentional absence of try/catch around onSave in commitSave.
-      // If a future refactor wraps onSave in try/catch+setIsEditing(false), the component
-      // behaviour changes (editor closes on error) and this guard flags the change for review.
+    it('TC-2659: commitSave has try/catch with inline error in rank-cell.tsx (structural drift guard)', () => {
+      // Verify try/catch is present in commitSave so that onSave rejections are caught
+      // and shown as inline error messages rather than propagating unhandled.
       const rankCellSrc = readRepoFile(
         'smkc-score-app', 'src', 'components', 'tournament', 'rank-cell.tsx',
       );
       expect(rankCellSrc).toContain('commitSave');
-      // Scope the catch-absence check to the commitSave function block only, so a
-      // legitimate try/catch elsewhere in rank-cell.tsx doesn't false-fail this guard.
+      // Scope the check to the commitSave function block only.
       const commitSaveBlock = rankCellSrc.match(/const commitSave[\s\S]*?\n\s*};/)?.[0] ?? '';
       expect(commitSaveBlock).not.toBe(''); // sanity: function block must be present
-      // Use regex to catch both `catch (err)` and bare `catch {` (ES2019 optional binding).
-      // The comment "No try/catch:" in commitSave contains "catch" but not followed by ( or {.
-      expect(commitSaveBlock).not.toMatch(/\bcatch\s*[({]/);
+      // try/catch must be present in commitSave for error handling
+      expect(commitSaveBlock).toMatch(/\bcatch\s*[({]/);
       expect(commitSaveBlock).toContain('setIsEditing(false)');
-      // The intentional design must be documented in source comments
-      expect(rankCellSrc).toContain('No try/catch');
+      expect(commitSaveBlock).toContain('setSaveError');
     });
 
     it('documents TC-2653 through TC-2656 as TieWarningBanner unit tests', () => {

--- a/smkc-score-app/src/components/tournament/rank-cell.tsx
+++ b/smkc-score-app/src/components/tournament/rank-cell.tsx
@@ -40,32 +40,44 @@ interface RankCellProps {
 export function RankCell({ qualificationId, rankOverride, autoRank, isAdmin, onSave }: RankCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState("");
+  // Inline error message shown when onSave rejects; null means no error.
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const openEdit = () => {
     setInputValue(rankOverride?.toString() ?? "");
+    setSaveError(null);
     setIsEditing(true);
   };
 
   const commitSave = async () => {
-    const v = parseInt(inputValue);
-    // No try/catch: if onSave rejects, the error propagates to the caller and
-    // setIsEditing(false) is never reached, keeping the editor open. This is
-    // intentional — the parent component or page-level error boundary handles
-    // network/server errors. Rank 0 is allowed through (isNaN(0) === false) and
-    // the API layer is responsible for enforcing minimum rank constraints.
-    await onSave(qualificationId, isNaN(v) ? null : v);
-    setIsEditing(false);
+    setSaveError(null);
+    try {
+      const v = parseInt(inputValue);
+      // Rank 0 is allowed through (isNaN(0) === false); the API layer enforces
+      // minimum rank constraints.
+      await onSave(qualificationId, isNaN(v) ? null : v);
+      setIsEditing(false);
+    } catch (err) {
+      // Keep the editor open so the user can retry after seeing the error.
+      setSaveError(err instanceof Error ? err.message : "保存に失敗しました");
+    }
   };
 
   const commitClear = async () => {
-    await onSave(qualificationId, null);
-    setIsEditing(false);
+    setSaveError(null);
+    try {
+      await onSave(qualificationId, null);
+      setIsEditing(false);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "保存に失敗しました");
+    }
   };
 
   if (isAdmin && isEditing) {
     return (
       /* Inline rank editor: number input + save/cancel/clear controls */
-      <div className="flex items-center gap-1">
+      <div className="flex flex-col gap-0.5">
+        <div className="flex items-center gap-1">
         <Input
           type="number"
           min={1}
@@ -96,6 +108,10 @@ export function RankCell({ qualificationId, rankOverride, autoRank, isAdmin, onS
           >
             ✕
           </Button>
+        )}
+        </div>
+        {saveError && (
+          <p className="text-xs text-destructive" role="alert">{saveError}</p>
         )}
       </div>
     );


### PR DESCRIPTION
## Summary

- `commitSave` and `commitClear` now wrap `onSave` in try/catch to catch rejections
- A `saveError` state displays an inline `role="alert"` message below the input when save fails
- The editor stays open on failure so the user can see the error and retry
- `openEdit` clears `saveError` so stale errors don't carry over to the next edit session

## Issues

Closes #2643
Closes #2644

## New Test Cases

- **TC-2659** (updated): commitSave closes editor on success, stays open while in-flight
- **TC-2660**: onSave reject shows inline error (`role="alert"`) and keeps editor open
- **TC-2661**: Error cleared when editor is reopened via `openEdit`
- **TC-2662**: `commitClear` also shows inline error on onSave reject

## Validation

- All 3688 tests pass (256 suites, 0 failures)
- Drift guard updated: TC-2659 now asserts try/catch IS present in commitSave
- E2E_TEST_CASES.md updated with TC-2659 revision and TC-2660–TC-2662 additions

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKWiX6LLgSPYQmmvFLRktU)_