### PR TITLE
fix/test: resolve #2650 #2652, add TC-2663–2673 component unit tests

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -4401,6 +4401,94 @@
 
 ---
 
+### TC-2663: ModePublishSwitch — 非公開状態で "unpublishMode" バッジを表示する
+- **背景**: `isPublic=false` のとき、スイッチの隣に "unpublishMode" (i18nキー) バッジが表示される。
+- **手順**: `useModePublish` を `isPublic: false` でモックし、`ModePublishSwitch` をレンダリングする。
+- **期待結果**: "unpublishMode" テキストが表示され、"publishMode" は表示されない。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/mode-publish-switch.test.tsx
+
+---
+
+### TC-2664: ModePublishSwitch — 公開状態で "publishMode" バッジを表示する
+- **背景**: `isPublic=true` のとき、スイッチの隣に "publishMode" バッジが表示される。
+- **手順**: `useModePublish` を `isPublic: true` でモックし、`ModePublishSwitch` をレンダリングする。
+- **期待結果**: "publishMode" テキストが表示され、"unpublishMode" は表示されない。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/mode-publish-switch.test.tsx
+
+---
+
+### TC-2665: ModePublishSwitch — loading=true のとき Switch が無効化される
+- **背景**: 初回フェッチ中はトグル不可にして二重操作を防ぐ。
+- **手順**: `useModePublish` を `loading: true` でモックし、`ModePublishSwitch` をレンダリングする。
+- **期待結果**: `role="switch"` 要素が `disabled` 属性を持つ。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/mode-publish-switch.test.tsx
+
+---
+
+### TC-2666: ModePublishSwitch — updating=true のとき Switch が無効化される
+- **背景**: PUT リクエスト処理中はトグルを受け付けない。
+- **手順**: `useModePublish` を `updating: true` でモックし、`ModePublishSwitch` をレンダリングする。
+- **期待結果**: `role="switch"` 要素が `disabled` 属性を持つ。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/mode-publish-switch.test.tsx
+
+---
+
+### TC-2667: ModePublishSwitch — Switch クリックで toggle() が呼ばれる
+- **背景**: Switch の `onCheckedChange` が `useModePublish` の `toggle` に紐づいている。
+- **手順**: `ModePublishSwitch` をレンダリングし、`role="switch"` をクリックする。
+- **期待結果**: `toggle` モック関数が1回呼ばれる。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/mode-publish-switch.test.tsx
+
+---
+
+### TC-2668: ModePublishSwitch — aria-label が modeLabelKey と現在の公開状態を含む
+- **背景**: スクリーンリーダー向けに `aria-label` が「{モード名}: {公開状態}」の形式で設定される。
+- **手順**: `modeLabelKey="battleMode"` で `ModePublishSwitch` をレンダリングする (非公開状態)。
+- **期待結果**: `aria-label` が `"battleMode: unpublishMode"` になる。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/mode-publish-switch.test.tsx
+
+---
+
+### TC-2669: TaParticipantTimeInputRow — courseAbbr ラベルがレンダリングされる
+- **背景**: 各コースの入力行に略称ラベルを表示し、どのコースの入力かを明示する。
+- **手順**: `courseAbbr="MKS"` で `TaParticipantTimeInputRow` をレンダリングする。
+- **期待結果**: "MKS" テキストが表示される。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/ta-participant-time-input-row.test.tsx
+
+---
+
+### TC-2670: TaParticipantTimeInputRow — onChange が courseAbbr と新しい値で呼ばれる
+- **背景**: 入力変更時に `onChange(courseAbbr, value)` を呼ぶことで、親コンポーネントがどのコースの値かを識別できる。
+- **手順**: 入力フィールドに値を入力する。
+- **期待結果**: `onChange` が `('MKS', 入力値)` で呼ばれる。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/ta-participant-time-input-row.test.tsx
+
+---
+
+### TC-2671: TaParticipantTimeInputRow — onBlur が courseAbbr で呼ばれる
+- **背景**: フォーカスアウト時に `onBlur(courseAbbr)` でバリデーションや保存をトリガーする。
+- **手順**: 入力フィールドをブラーする。
+- **期待結果**: `onBlur` が `'MKS'` で呼ばれる。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/ta-participant-time-input-row.test.tsx
+
+---
+
+### TC-2672: TaParticipantTimeInputRow — disabled=true のとき入力が無効化される
+- **背景**: TA 凍結後や管理者専用入力フィールドでは入力を無効化する。
+- **手順**: `disabled={true}` で `TaParticipantTimeInputRow` をレンダリングする。
+- **期待結果**: テキストボックスが `disabled` 属性を持つ。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/ta-participant-time-input-row.test.tsx
+
+---
+
+### TC-2673: TaParticipantTimeInputRow — value/placeholder/timeInputProps がスプレッドされる
+- **背景**: `timeInputProps` のスプレッドで `id`・`maxLength` 等をフォワードできる。
+- **手順**: `value`・`placeholder`・`timeInputProps: { id: 'time-mks', maxLength: 8 }` を渡す。
+- **期待結果**: input の value・placeholder が一致し、id が `'time-mks'` になる。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/ta-participant-time-input-row.test.tsx
+
+---
+
 ## E2Eテスト実行ガイド
 
 ### セッション管理（重要）

--- a/smkc-score-app/__tests__/components/tournament/mode-publish-switch.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/mode-publish-switch.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Unit tests for the ModePublishSwitch component (TC-2663 through TC-2668).
+ *
+ * ModePublishSwitch is the per-mode publish toggle rendered on each mode page.
+ * It wraps useModePublish and shows a badge reflecting the current publish state.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ModePublishSwitch } from '@/components/tournament/mode-publish-switch';
+
+const toggleMock = jest.fn();
+
+// Default state: not published, not loading/updating
+const defaultPublishState = {
+  isPublic: false,
+  toggle: toggleMock,
+  updating: false,
+  loading: false,
+};
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+jest.mock('@/hooks/use-mode-publish', () => ({
+  useModePublish: jest.fn(),
+}));
+
+// Helpers
+import { useModePublish } from '@/hooks/use-mode-publish';
+const mockUseModePublish = useModePublish as jest.Mock;
+
+beforeEach(() => {
+  toggleMock.mockClear();
+  mockUseModePublish.mockReturnValue(defaultPublishState);
+});
+
+describe('ModePublishSwitch', () => {
+  it('TC-2663: shows unpublishMode badge when isPublic is false', () => {
+    render(
+      <ModePublishSwitch
+        tournamentId="t-1"
+        mode="BM"
+        modeLabelKey="battleMode"
+      />,
+    );
+
+    // useTranslations returns the key as-is
+    expect(screen.getByText('unpublishMode')).toBeInTheDocument();
+    expect(screen.queryByText('publishMode')).toBeNull();
+  });
+
+  it('TC-2664: shows publishMode badge when isPublic is true', () => {
+    mockUseModePublish.mockReturnValue({ ...defaultPublishState, isPublic: true });
+
+    render(
+      <ModePublishSwitch
+        tournamentId="t-1"
+        mode="BM"
+        modeLabelKey="battleMode"
+      />,
+    );
+
+    expect(screen.getByText('publishMode')).toBeInTheDocument();
+    expect(screen.queryByText('unpublishMode')).toBeNull();
+  });
+
+  it('TC-2665: switch is disabled while loading', () => {
+    mockUseModePublish.mockReturnValue({ ...defaultPublishState, loading: true });
+
+    render(
+      <ModePublishSwitch
+        tournamentId="t-1"
+        mode="BM"
+        modeLabelKey="battleMode"
+      />,
+    );
+
+    // Switch renders as a button with role="switch"
+    const switchEl = screen.getByRole('switch');
+    expect(switchEl).toBeDisabled();
+  });
+
+  it('TC-2666: switch is disabled while updating', () => {
+    mockUseModePublish.mockReturnValue({ ...defaultPublishState, updating: true });
+
+    render(
+      <ModePublishSwitch
+        tournamentId="t-1"
+        mode="BM"
+        modeLabelKey="battleMode"
+      />,
+    );
+
+    expect(screen.getByRole('switch')).toBeDisabled();
+  });
+
+  it('TC-2667: clicking switch calls toggle()', () => {
+    render(
+      <ModePublishSwitch
+        tournamentId="t-1"
+        mode="BM"
+        modeLabelKey="battleMode"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('switch'));
+
+    expect(toggleMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('TC-2668: switch aria-label includes modeLabelKey and current state key', () => {
+    render(
+      <ModePublishSwitch
+        tournamentId="t-1"
+        mode="BM"
+        modeLabelKey="battleMode"
+      />,
+    );
+
+    // aria-label = "${tc(modeLabelKey)}: ${stateLabel}"
+    // useTranslations mock returns the key, so: "battleMode: unpublishMode"
+    const switchEl = screen.getByRole('switch');
+    expect(switchEl).toHaveAttribute('aria-label', 'battleMode: unpublishMode');
+  });
+});

--- a/smkc-score-app/__tests__/components/tournament/ta-participant-time-input-row.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/ta-participant-time-input-row.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Unit tests for the TaParticipantTimeInputRow component (TC-2669 through TC-2673).
+ *
+ * TaParticipantTimeInputRow is a memoized row component used in the TA
+ * (Time Attack) qualification page for each course time entry. It forwards
+ * timeInputProps onto the input and fires onChange/onBlur with the courseAbbr.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { TaParticipantTimeInputRow } from '@/components/tournament/ta-participant-time-input-row';
+
+const onChangeMock = jest.fn();
+const onBlurMock = jest.fn();
+
+const defaultProps = {
+  courseAbbr: 'MKS',
+  value: '',
+  placeholder: '0\'00"000',
+  disabled: false,
+  inputClassName: 'input-cls',
+  timeInputProps: { id: 'time-mks', maxLength: 8 } as React.InputHTMLAttributes<HTMLInputElement>,
+  onChange: onChangeMock,
+  onBlur: onBlurMock,
+};
+
+beforeEach(() => {
+  onChangeMock.mockClear();
+  onBlurMock.mockClear();
+});
+
+describe('TaParticipantTimeInputRow', () => {
+  it('TC-2669: renders course label with courseAbbr', () => {
+    render(<TaParticipantTimeInputRow {...defaultProps} />);
+
+    expect(screen.getByText('MKS')).toBeInTheDocument();
+  });
+
+  it('TC-2670: onChange fires with courseAbbr and new value', () => {
+    render(<TaParticipantTimeInputRow {...defaultProps} />);
+
+    const timeValue = "1'23\"456";
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: timeValue } });
+
+    expect(onChangeMock).toHaveBeenCalledTimes(1);
+    expect(onChangeMock).toHaveBeenCalledWith('MKS', timeValue);
+  });
+
+  it('TC-2671: onBlur fires with courseAbbr when input loses focus', () => {
+    render(<TaParticipantTimeInputRow {...defaultProps} />);
+
+    fireEvent.blur(screen.getByRole('textbox'));
+
+    expect(onBlurMock).toHaveBeenCalledTimes(1);
+    expect(onBlurMock).toHaveBeenCalledWith('MKS');
+  });
+
+  it('TC-2672: input is disabled when disabled prop is true', () => {
+    render(<TaParticipantTimeInputRow {...defaultProps} disabled={true} />);
+
+    expect(screen.getByRole('textbox')).toBeDisabled();
+  });
+
+  it('TC-2673: input shows value and placeholder from props and spreads timeInputProps', () => {
+    const timeValue = "1'23\"456";
+    const timePlaceholder = "mm'ss\"mmm";
+    render(
+      <TaParticipantTimeInputRow
+        {...defaultProps}
+        value={timeValue}
+        placeholder={timePlaceholder}
+      />,
+    );
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toBe(timeValue);
+    expect(input.placeholder).toBe(timePlaceholder);
+    // timeInputProps spread: id is forwarded
+    expect(input.id).toBe('time-mks');
+  });
+});

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -3542,7 +3542,7 @@ describe('E2E case drift coverage', () => {
     const dbRetryTest = readRepoFile('smkc-score-app', '__tests__', 'lib', 'db-read-retry.test.ts');
     expect(section).toContain('db-read-retry.test.ts');
     expect(dbRetryTest).toContain('TC-2518');
-    expect(dbRetryTest).toContain('toHaveBeenCalledTimes(1)');
+    expect(dbRetryTest).toContain('onRetry).toHaveBeenCalledTimes(1)');
     expect(dbRetryTest).toContain('always-fails');
   });
 
@@ -4188,6 +4188,59 @@ describe('E2E case drift coverage', () => {
       expect(tieWarningTest).toContain('isAdmin={false}');
       // next-intl mocked to return key as string
       expect(tieWarningTest).toContain('useTranslations');
+    });
+
+    it('documents TC-2663 through TC-2668 as ModePublishSwitch unit tests', () => {
+      const mpsTest = readRepoFile(
+        'smkc-score-app',
+        '__tests__',
+        'components',
+        'tournament',
+        'mode-publish-switch.test.tsx',
+      );
+      for (const tc of ['TC-2663', 'TC-2664', 'TC-2665', 'TC-2666', 'TC-2667', 'TC-2668']) {
+        expect(mpsTest).toContain(tc);
+      }
+      // TC-2663: unpublishMode badge
+      expect(mpsTest).toContain('unpublishMode');
+      // TC-2664: publishMode badge
+      expect(mpsTest).toContain('publishMode');
+      // TC-2665/TC-2666: disabled when loading or updating
+      expect(mpsTest).toContain('loading: true');
+      expect(mpsTest).toContain('updating: true');
+      expect(mpsTest).toContain('toBeDisabled');
+      // TC-2667: toggle called on click
+      expect(mpsTest).toContain('toggleMock');
+      // TC-2668: aria-label
+      expect(mpsTest).toContain('aria-label');
+      // useModePublish is mocked
+      expect(mpsTest).toContain('useModePublish');
+    });
+
+    it('documents TC-2669 through TC-2673 as TaParticipantTimeInputRow unit tests', () => {
+      const taRowTest = readRepoFile(
+        'smkc-score-app',
+        '__tests__',
+        'components',
+        'tournament',
+        'ta-participant-time-input-row.test.tsx',
+      );
+      for (const tc of ['TC-2669', 'TC-2670', 'TC-2671', 'TC-2672', 'TC-2673']) {
+        expect(taRowTest).toContain(tc);
+      }
+      // TC-2669: courseAbbr label
+      expect(taRowTest).toContain('MKS');
+      // TC-2670: onChange with courseAbbr
+      expect(taRowTest).toContain('onChangeMock');
+      expect(taRowTest).toContain("'MKS'");
+      // TC-2671: onBlur with courseAbbr
+      expect(taRowTest).toContain('onBlurMock');
+      // TC-2672: disabled
+      expect(taRowTest).toContain('disabled={true}');
+      expect(taRowTest).toContain('toBeDisabled');
+      // TC-2673: timeInputProps spread
+      expect(taRowTest).toContain('timeInputProps');
+      expect(taRowTest).toContain('time-mks');
     });
   });
 });

--- a/smkc-score-app/src/components/tournament/rank-cell.tsx
+++ b/smkc-score-app/src/components/tournament/rank-cell.tsx
@@ -78,37 +78,37 @@ export function RankCell({ qualificationId, rankOverride, autoRank, isAdmin, onS
       /* Inline rank editor: number input + save/cancel/clear controls */
       <div className="flex flex-col gap-0.5">
         <div className="flex items-center gap-1">
-        <Input
-          type="number"
-          min={1}
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          className="w-14 h-7 text-center text-sm p-1"
-          onKeyDown={(e) => {
-            if (e.key === "Enter") commitSave();
-            if (e.key === "Escape") setIsEditing(false);
-          }}
-          autoFocus
-        />
-        <Button
-          size="sm"
-          variant="ghost"
-          className="h-7 px-1 text-xs"
-          onClick={commitSave}
-        >
-          ✓
-        </Button>
-        {rankOverride != null && (
-          /* Clear button: removes override and restores automatic rank */
+          <Input
+            type="number"
+            min={1}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            className="w-14 h-7 text-center text-sm p-1"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitSave();
+              if (e.key === "Escape") setIsEditing(false);
+            }}
+            autoFocus
+          />
           <Button
             size="sm"
             variant="ghost"
-            className="h-7 px-1 text-xs text-destructive"
-            onClick={commitClear}
+            className="h-7 px-1 text-xs"
+            onClick={commitSave}
           >
-            ✕
+            ✓
           </Button>
-        )}
+          {rankOverride != null && (
+            /* Clear button: removes override and restores automatic rank */
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 px-1 text-xs text-destructive"
+              onClick={commitClear}
+            >
+              ✕
+            </Button>
+          )}
         </div>
         {saveError && (
           <p className="text-xs text-destructive" role="alert">{saveError}</p>


### PR DESCRIPTION
## Summary

- **#2652 fix**: `rank-cell.tsx` — `flex-col` ラッパー追加後の子要素インデント不整合を修正。`flex items-center gap-1` 内の `Input`・Save/Escape/Clear `Button` を 2 スペース追加インデント。
- **#2650 fix**: `e2e-cases-drift.test.ts` — TC-2518 drift guard の `toContain('toHaveBeenCalledTimes(1)')` を `toContain('onRetry).toHaveBeenCalledTimes(1)')` に強化。TC-2515 の `operation.toHaveBeenCalledTimes(1)` と重複する文字列を排除し、onRetry スパイ固有のアサーションに変更。
- **TC-2663–2668** (`mode-publish-switch.test.tsx`): `ModePublishSwitch` コンポーネントの新規ユニットテスト（未テストだった）。バッジ表示・disabled 状態・toggle 呼び出し・aria-label を検証。
- **TC-2669–2673** (`ta-participant-time-input-row.test.tsx`): `TaParticipantTimeInputRow` コンポーネントの新規ユニットテスト（未テストだった）。ラベル表示・onChange/onBlur コールバック・disabled 状態・props スプレッドを検証。
- **E2E_TEST_CASES.md** & **e2e-cases-drift.test.ts**: TC-2663–2673 のシナリオ説明と drift guard を追加。

## Issues

Closes #2650
Closes #2652

## Validation

- 全 3701 テスト PASS (258 suites, 0 failures)
- rank-cell.tsx 機能への影響なし（インデント修正のみ）
- TC-2518 drift guard がより固有な文字列を検証するため False Positive を防止


---
_Generated by [Claude Code](https://claude.ai/code/session_01477p2xBbpJCexxSGejzBTT)_