### PR TITLE
test: migrate fireEvent → userEvent.setup() in TC-2667/2670/2671

### DIFF
--- a/smkc-score-app/__tests__/components/tournament/mode-publish-switch.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/mode-publish-switch.test.tsx
@@ -6,7 +6,8 @@
  * ModePublishSwitch is the per-mode publish toggle rendered on each mode page.
  * It wraps useModePublish and shows a badge reflecting the current publish state.
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ModePublishSwitch } from '@/components/tournament/mode-publish-switch';
 
 const toggleMock = jest.fn();
@@ -96,7 +97,12 @@ describe('ModePublishSwitch', () => {
     expect(screen.getByRole('switch')).toBeDisabled();
   });
 
-  it('TC-2667: clicking switch calls toggle()', () => {
+  it('TC-2667: clicking switch calls toggle()', async () => {
+    // userEvent is preferred over fireEvent for Radix UI Switch, which relies
+    // on pointer events internally — userEvent fires the full pointer-event
+    // sequence (pointerdown → mousedown → pointerup → mouseup → click) so the
+    // test is resilient to future internal event-handling changes.
+    const user = userEvent.setup();
     render(
       <ModePublishSwitch
         tournamentId="t-1"
@@ -105,7 +111,7 @@ describe('ModePublishSwitch', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('switch'));
+    await user.click(screen.getByRole('switch'));
 
     expect(toggleMock).toHaveBeenCalledTimes(1);
   });

--- a/smkc-score-app/__tests__/components/tournament/ta-participant-time-input-row.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/ta-participant-time-input-row.test.tsx
@@ -7,7 +7,8 @@
  * (Time Attack) qualification page for each course time entry. It forwards
  * timeInputProps onto the input and fires onChange/onBlur with the courseAbbr.
  */
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { TaParticipantTimeInputRow } from '@/components/tournament/ta-participant-time-input-row';
 
 const onChangeMock = jest.fn();
@@ -36,20 +37,29 @@ describe('TaParticipantTimeInputRow', () => {
     expect(screen.getByText('MKS')).toBeInTheDocument();
   });
 
-  it('TC-2670: onChange fires with courseAbbr and new value', () => {
+  it('TC-2670: onChange fires with courseAbbr and new value', async () => {
+    // userEvent.type fires a realistic keystroke sequence (keydown → keypress →
+    // input → keyup) rather than a single synthetic change event.  For a
+    // controlled input whose value prop is not updated by the mock, each
+    // character triggers one onChange call.  We type a single character so the
+    // assertion on call count and forwarded value remain unambiguous.
+    const user = userEvent.setup();
     render(<TaParticipantTimeInputRow {...defaultProps} />);
 
-    const timeValue = "1'23\"456";
-    fireEvent.change(screen.getByRole('textbox'), { target: { value: timeValue } });
+    await user.type(screen.getByRole('textbox'), '1');
 
     expect(onChangeMock).toHaveBeenCalledTimes(1);
-    expect(onChangeMock).toHaveBeenCalledWith('MKS', timeValue);
+    expect(onChangeMock).toHaveBeenCalledWith('MKS', '1');
   });
 
-  it('TC-2671: onBlur fires with courseAbbr when input loses focus', () => {
+  it('TC-2671: onBlur fires with courseAbbr when input loses focus', async () => {
+    // userEvent.tab() shifts focus away from the input, generating the same
+    // blur/focusout sequence a real user would trigger with the keyboard.
+    const user = userEvent.setup();
     render(<TaParticipantTimeInputRow {...defaultProps} />);
 
-    fireEvent.blur(screen.getByRole('textbox'));
+    await user.click(screen.getByRole('textbox'));
+    await user.tab();
 
     expect(onBlurMock).toHaveBeenCalledTimes(1);
     expect(onBlurMock).toHaveBeenCalledWith('MKS');

--- a/smkc-score-app/package-lock.json
+++ b/smkc-score-app/package-lock.json
@@ -46,6 +46,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/bcryptjs": "^2.4.6",
         "@types/jest": "^29.5.12",
         "@types/node": "^20",
@@ -7639,6 +7640,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/smkc-score-app/package.json
+++ b/smkc-score-app/package.json
@@ -88,6 +88,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/bcryptjs": "^2.4.6",
     "@types/jest": "^29.5.12",
     "@types/node": "^20",


### PR DESCRIPTION
## Summary

- `@testing-library/user-event` v14 を devDependency として追加
- **TC-2667** (`ModePublishSwitch`): `fireEvent.click` → `userEvent.setup()` + `await user.click()`
  - Radix UI Switch は内部でポインターイベントシーケンスを使うため、`userEvent` で実際のブラウザ操作に近いイベント列を再現
- **TC-2670** (`TaParticipantTimeInputRow`): `fireEvent.change` → `userEvent.setup()` + `await user.type('1')`
  - controlled input (mock が value を更新しない) では `user.type()` はキーストローク毎に onChange を呼ぶため、単一文字を入力してコール数・引数の検証を明確化
- **TC-2671**: `fireEvent.blur` → `user.click()` + `await user.tab()`
  - キーボードユーザーが実際に発生させる blur/focusout シーケンスを再現

## Issues

Closes #2654

## Validation

```
Test Suites: 1 skipped, 258 passed, 258 of 259 total
Tests:       27 skipped, 3701 passed, 3728 total
```

対象 2 ファイル (`mode-publish-switch.test.tsx`, `ta-participant-time-input-row.test.tsx`) ともに全 TC がパス。

---
_Generated by [Claude Code](https://claude.ai/code/session_01XtqinAxqtJnxa5NQEAfZyS)_