### PR TITLE
test(TC-2674): add useState-wrapper test for full time-format string onChange forwarding (#2656)

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -4489,6 +4489,14 @@
 
 ---
 
+### TC-2674: TaParticipantTimeInputRow — フル時間フォーマット文字列の onChange 転送を useState ラッパーで検証
+- **背景**: TC-2670 は controlled input の制約から単一文字のみテストしているが、実際のユースケースである `"1'23\"456"` のような複数文字の時間フォーマット文字列の入力を検証する必要がある。`useState` ラッパーで value を更新することで、各キーストロークが正しく蓄積され、最終的な onChange 呼び出しが完全な文字列を受け取ることを確認する。
+- **手順**: `useState` でラップした `TaParticipantTimeInputRow` に `user.type` で `"1'23\"456"` を入力する。
+- **期待結果**: 最後の `onChange` 呼び出しが `('MKS', "1'23\"456")` で呼ばれる。
+- **スクリプト**: n/a (unit/static coverage) — smkc-score-app/__tests__/components/tournament/ta-participant-time-input-row.test.tsx
+
+---
+
 ## E2Eテスト実行ガイド
 
 ### セッション管理（重要）

--- a/smkc-score-app/__tests__/components/tournament/ta-participant-time-input-row.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/ta-participant-time-input-row.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  *
- * Unit tests for the TaParticipantTimeInputRow component (TC-2669 through TC-2673).
+ * Unit tests for the TaParticipantTimeInputRow component (TC-2669 through TC-2674).
  *
  * TaParticipantTimeInputRow is a memoized row component used in the TA
  * (Time Attack) qualification page for each course time entry. It forwards
@@ -9,6 +9,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { TaParticipantTimeInputRow } from '@/components/tournament/ta-participant-time-input-row';
 
 const onChangeMock = jest.fn();
@@ -87,5 +88,36 @@ describe('TaParticipantTimeInputRow', () => {
     expect(input.placeholder).toBe(timePlaceholder);
     // timeInputProps spread: id is forwarded
     expect(input.id).toBe('time-mks');
+  });
+
+  it('TC-2674: onChange receives full time format string via controlled wrapper', async () => {
+    // TC-2670 only types a single character because the mock does not update the
+    // value prop, so each keystroke overwrites the same empty input.  This test
+    // uses a useState wrapper that actually updates the controlled value on every
+    // onChange call, allowing userEvent.type to accumulate characters and
+    // confirming that the complete time-format string "1'23\"456" is forwarded.
+    function ControlledWrapper() {
+      const [value, setValue] = useState('');
+      const handleChange = (course: string, val: string) => {
+        setValue(val);
+        onChangeMock(course, val);
+      };
+      return (
+        <TaParticipantTimeInputRow
+          {...defaultProps}
+          value={value}
+          onChange={handleChange}
+        />
+      );
+    }
+
+    const user = userEvent.setup();
+    render(<ControlledWrapper />);
+
+    await user.type(screen.getByRole('textbox'), "1'23\"456");
+
+    // 8 characters typed → 8 onChange calls; last call receives the full accumulated string.
+    expect(onChangeMock).toHaveBeenCalledTimes(8);
+    expect(onChangeMock).toHaveBeenLastCalledWith('MKS', "1'23\"456");
   });
 });

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -4217,7 +4217,7 @@ describe('E2E case drift coverage', () => {
       expect(mpsTest).toContain('useModePublish');
     });
 
-    it('documents TC-2669 through TC-2673 as TaParticipantTimeInputRow unit tests', () => {
+    it('documents TC-2669 through TC-2674 as TaParticipantTimeInputRow unit tests', () => {
       const taRowTest = readRepoFile(
         'smkc-score-app',
         '__tests__',
@@ -4225,7 +4225,7 @@ describe('E2E case drift coverage', () => {
         'tournament',
         'ta-participant-time-input-row.test.tsx',
       );
-      for (const tc of ['TC-2669', 'TC-2670', 'TC-2671', 'TC-2672', 'TC-2673']) {
+      for (const tc of ['TC-2669', 'TC-2670', 'TC-2671', 'TC-2672', 'TC-2673', 'TC-2674']) {
         expect(taRowTest).toContain(tc);
       }
       // TC-2669: courseAbbr label
@@ -4241,6 +4241,10 @@ describe('E2E case drift coverage', () => {
       // TC-2673: timeInputProps spread
       expect(taRowTest).toContain('timeInputProps');
       expect(taRowTest).toContain('time-mks');
+      // TC-2674: full time-format string via useState wrapper
+      expect(taRowTest).toContain('ControlledWrapper');
+      expect(taRowTest).toContain('useState');
+      expect(taRowTest).toContain("1'23");
     });
   });
 });


### PR DESCRIPTION
## Summary

- TC-2674を追加: `useState`ラッパーコンポーネントを使ってフル時間フォーマット文字列`"1'23\"456"`のonChange転送を検証
- TC-2670は controlled input の制約から単一文字のみテストしているが、TC-2674では state が更新されるラッパーで各キーストロークが正しく蓄積されることを確認
- `toHaveBeenCalledTimes(8)` アサーションを追加してサイレントトランケーションを検出
- `e2e-cases-drift.test.ts`のドリフトガードとE2E_TEST_CASES.mdにTC-2674を追記

## Issues

Closes #2656

## Validation

```
Tests: 388 passed (TC-2669〜TC-2674 + drift guard 382 tests)
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoCmkqjZGwS19N9Cqu1zAC)_