### PR TITLE
test(debug-fill-button): migrate global.fetch direct assignment to jest.spyOn pattern

### DIFF
--- a/smkc-score-app/__tests__/components/tournament/debug-fill-button.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/debug-fill-button.test.tsx
@@ -6,10 +6,8 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { DebugFillButton } from "@/components/tournament/debug-fill-button";
 
 describe("DebugFillButton", () => {
-  const originalFetch = global.fetch;
-
   afterEach(() => {
-    global.fetch = originalFetch;
+    // jest.spyOn allows jest.restoreAllMocks() to fully reset fetch without manual originalFetch tracking
     jest.restoreAllMocks();
   });
 
@@ -22,7 +20,7 @@ describe("DebugFillButton", () => {
 
   it("TC-2688: shows 実行中… while the fetch is in-flight", async () => {
     let resolve!: (r: Response) => void;
-    global.fetch = jest.fn(
+    jest.spyOn(global, "fetch").mockImplementation(
       () =>
         new Promise<Response>((res) => {
           resolve = res;
@@ -43,7 +41,7 @@ describe("DebugFillButton", () => {
 
   it("TC-2689: prevents duplicate clicks while a request is in-flight", async () => {
     let resolve!: (r: Response) => void;
-    global.fetch = jest.fn(
+    jest.spyOn(global, "fetch").mockImplementation(
       () =>
         new Promise<Response>((res) => {
           resolve = res;
@@ -66,7 +64,7 @@ describe("DebugFillButton", () => {
   });
 
   it("TC-2690: calls the correct debug-fill endpoint on click", async () => {
-    global.fetch = jest.fn().mockResolvedValue(
+    jest.spyOn(global, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ filled: 3, skipped: 0 }), { status: 200 }),
     );
 
@@ -82,7 +80,7 @@ describe("DebugFillButton", () => {
   });
 
   it("TC-2691: shows success status with filled/skipped counts", async () => {
-    global.fetch = jest.fn().mockResolvedValue(
+    jest.spyOn(global, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ filled: 12, skipped: 3 }), { status: 200 }),
     );
 
@@ -95,7 +93,7 @@ describe("DebugFillButton", () => {
   });
 
   it("TC-2692: calls onFilled callback after successful API response", async () => {
-    global.fetch = jest.fn().mockResolvedValue(
+    jest.spyOn(global, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ filled: 5, skipped: 0 }), { status: 200 }),
     );
     const onFilled = jest.fn();
@@ -107,7 +105,7 @@ describe("DebugFillButton", () => {
   });
 
   it("TC-2693: shows failure message with server error text on non-ok response", async () => {
-    global.fetch = jest.fn().mockResolvedValue(
+    jest.spyOn(global, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ error: "Not enough players" }), { status: 400 }),
     );
 
@@ -120,7 +118,7 @@ describe("DebugFillButton", () => {
   });
 
   it("TC-2694: shows error message and re-enables button when fetch throws", async () => {
-    global.fetch = jest.fn().mockRejectedValue(new Error("Network down"));
+    jest.spyOn(global, "fetch").mockRejectedValue(new Error("Network down"));
 
     render(<DebugFillButton tournamentId="t-1" mode="gp" />);
     fireEvent.click(screen.getByRole("button"));
@@ -132,7 +130,7 @@ describe("DebugFillButton", () => {
   });
 
   it("TC-2695: shows 0 件 when filled/skipped fields are missing from the response", async () => {
-    global.fetch = jest.fn().mockResolvedValue(
+    jest.spyOn(global, "fetch").mockResolvedValue(
       new Response(JSON.stringify({}), { status: 200 }),
     );
 


### PR DESCRIPTION
## Summary

- `debug-fill-button.test.tsx` の `global.fetch = jest.fn()` 直接代入を `jest.spyOn(global, 'fetch')` パターンに統一
- `jest.spyOn` に移行することで `jest.restoreAllMocks()` が自動的にスパイをリストアし、手動の `originalFetch` 変数と `global.fetch = originalFetch` の復元処理が不要に
- `afterEach` がシンプルになり、テスト間の副作用リスクを排除

## Issues

Closes #2659

## Validation

- 全9テスト (TC-2687〜TC-2695) がパス
- `jest.restoreAllMocks()` によるfetch自動リストアを確認
- `expect(global.fetch).toHaveBeenCalledTimes(1)` 等のアサーションはspyOn後も有効

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVR7EbvqM12yFyWPpRkb89)_