### PR TITLE
refactor(AuthHeader): replace .animate-pulse selector with data-testid in TC-2696

### DIFF
--- a/smkc-score-app/__tests__/components/AuthHeader.test.tsx
+++ b/smkc-score-app/__tests__/components/AuthHeader.test.tsx
@@ -26,13 +26,13 @@ describe("AuthHeader", () => {
   it("TC-2696: shows skeleton while session is loading, no interactive elements", () => {
     mockUseSession.mockReturnValue({ data: null, status: "loading" });
 
-    const { container } = render(<AuthHeader />);
+    render(<AuthHeader />);
 
     // Loading state must not expose premature auth state (no buttons or links)
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
     // Skeleton must be aria-hidden so screen readers skip it during load
-    const skeleton = container.querySelector(".animate-pulse");
+    const skeleton = screen.getByTestId("auth-skeleton");
     expect(skeleton).toBeInTheDocument();
     expect(skeleton).toHaveAttribute("aria-hidden", "true");
   });

--- a/smkc-score-app/src/components/AuthHeader.tsx
+++ b/smkc-score-app/src/components/AuthHeader.tsx
@@ -26,7 +26,7 @@ export function AuthHeader() {
 
   /* Show nothing during session loading to avoid flash of incorrect state */
   if (status === 'loading') {
-    return <div className="w-20 h-5 bg-muted animate-pulse rounded" aria-hidden="true" />;
+    return <div className="w-20 h-5 bg-muted animate-pulse rounded" aria-hidden="true" data-testid="auth-skeleton" />;
   }
 
   if (session) {


### PR DESCRIPTION
## Summary

- `AuthHeader.tsx`: skeleton div に `data-testid="auth-skeleton"` を追加
- `AuthHeader.test.tsx` TC-2696: `container.querySelector(".animate-pulse")` → `screen.getByTestId("auth-skeleton")` に変更 (closes #2665)

Tailwind クラス名への依存を排除し、テストを実装詳細から切り離す。

## Test plan
- [ ] `node_modules/.bin/jest __tests__/components/AuthHeader.test.tsx` が 9/9 PASS
- [ ] `data-testid` を削除した場合に TC-2696 が FAIL することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YVR7EbvqM12yFyWPpRkb89

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVR7EbvqM12yFyWPpRkb89)_