### PR TITLE
test: fix review-followup issues #2671 #2672 #2673 — drift guard specificity, spy restore, Date unification

### DIFF
--- a/smkc-score-app/__tests__/components/ui/update-indicator.test.tsx
+++ b/smkc-score-app/__tests__/components/ui/update-indicator.test.tsx
@@ -16,6 +16,7 @@ beforeEach(() => {
 afterEach(() => {
   jest.runOnlyPendingTimers();
   jest.useRealTimers();
+  jest.restoreAllMocks();
 });
 
 describe('UpdateIndicator — polling badge', () => {
@@ -39,8 +40,7 @@ describe('UpdateIndicator — time display', () => {
   });
 
   it('TC-2734: shows seconds-ago when lastUpdated is < 60s in the past', () => {
-    const now = new Date();
-    const tenSecondsAgo = new Date(now.getTime() - 10_000);
+    const tenSecondsAgo = new Date(Date.now() - 10_000);
     render(<UpdateIndicator lastUpdated={tenSecondsAgo} isPolling={false} />);
     expect(screen.getByText(/Last updated:.*\ds ago/)).toBeInTheDocument();
   });

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -4381,8 +4381,8 @@ describe('E2E case drift coverage', () => {
       ]) {
         expect(spinnerTest).toContain(tc);
       }
-      // TC-2719: role="status"
-      expect(spinnerTest).toContain('role="status"');
+      // TC-2719: getByRole('status') asserts the element has role="status"
+      expect(spinnerTest).toContain("getByRole('status')");
       // TC-2720: aria-live="polite"
       expect(spinnerTest).toContain('aria-live');
       // TC-2721: aria-label="Loading"


### PR DESCRIPTION
## Summary

Fix three review-followup issues in test files for UI components:

- **#2671**: Unify `Date` creation style in `update-indicator.test.tsx` — TC-2734 now uses `new Date(Date.now() - N)` consistently with TC-2735/2736
- **#2672**: Add `jest.restoreAllMocks()` to `afterEach` in `update-indicator.test.tsx` — ensures `clearIntervalSpy` in TC-2738 is always restored even when assertions fail mid-test
- **#2673**: Fix `e2e-cases-drift.test.ts` TC-2719 drift guard — replace `toContain('role="status"')` (which matched the `it()` description string) with `toContain("getByRole('status')")` (which matches the actual assertion code only)

## Issues

Closes #2671
Closes #2672
Closes #2673

## Validation

- `npm test` — 3776 tests pass, 0 failures (266 suites passed, 1 skipped by design)
- Changed files: `update-indicator.test.tsx`, `e2e-cases-drift.test.ts`
- No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M15QimifZ9jh2EvKt9qoJu

---
_Generated by [Claude Code](https://claude.ai/code/session_01M15QimifZ9jh2EvKt9qoJu)_