### PR TITLE
fix(export): move resolveTournamentId inside try/catch to prevent unhandled 500

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -540,6 +540,16 @@
 - **期待結果**: エラー alert が表示され、ボタンは disabled 解除かつ `aria-busy=false` になる。再クリックで `/export?format=cdm` リクエストが再送される。
 - **スクリプト**: tc-all.js TC-361
 
+## TC-362: Export API 不正IDに対する構造化エラーレスポンス
+- **URL**: GET /api/tournaments/INVALID_FORMAT_ID/export
+- **authRequired**: false (エラーはID解決前に返る)
+- **手順**:
+  1. `https` モジュールでブラウザ外から `GET /api/tournaments/INVALID_FORMAT_ID/export` を直接リクエスト
+  2. HTTPステータスコードを確認
+  3. レスポンスボディのContent-Typeを確認
+- **期待結果**: HTTPステータス 500 で `{ success: false, error: "..." }` 形式のJSON が返り、HTML 500エラーページにならない
+- **背景**: resolveTournamentId が try 外で呼ばれると不正IDのDB同時エラーで未ハンドル例外になるバグ修正 (#2675)
+
 ## TC-201: 各モードページのデータ読み込み確認
 - **URL**: /tournaments/[id]/ta, /bm, /mr, /gp
 - **authRequired**: true (admin)

--- a/smkc-score-app/__mocks__/lib/prisma.ts
+++ b/smkc-score-app/__mocks__/lib/prisma.ts
@@ -14,6 +14,7 @@ const mockPrisma = {
   tournament: {
     update: jest.fn(),
     findMany: jest.fn(),
+    findFirst: jest.fn(),
     findUnique: jest.fn(),
     deleteMany: jest.fn(),
   },

--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -1332,6 +1332,30 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       expect(loggerMock.error).toHaveBeenCalled();
     });
 
+    // Regression: resolveTournamentId was previously called OUTSIDE the try/catch.
+    // An identifier that fails the slug/UUID format check causes resolveTournamentId to
+    // throw when there is also a DB connectivity error. The throw must be caught and
+    // returned as a structured 500, not left as an unhandled exception (which would
+    // surface as a raw Next.js 500 HTML page and skip the error-response JSON body).
+    it('should return structured 500 when resolveTournamentId throws (invalid format + DB error)', async () => {
+      // Use an identifier that fails both TOURNAMENT_SLUG_REGEX and UUID_REGEX so
+      // resolveTournamentId's internal catch will re-throw after a DB error.
+      const badId = 'INVALID_FORMAT_ID';
+      (prisma.tournament.findFirst as jest.Mock).mockRejectedValue(new Error('D1 connection error'));
+
+      const request = new MockNextRequest(`http://localhost:3000/api/tournaments/${badId}/export`);
+      const params = Promise.resolve({ id: badId });
+      const result = await GET(request, { params });
+
+      expect(result.status).toBe(500);
+      expect(result.data).toEqual(expect.objectContaining({ success: false }));
+      // Logger should capture the error with the raw id as tournamentId fallback
+      expect(loggerMock.error).toHaveBeenCalledWith('Failed to export tournament', {
+        error: expect.any(Error),
+        tournamentId: badId,
+      });
+    });
+
     it('should handle tournament with all empty data', async () => {
       const mockTournament = {
         id: 't1',

--- a/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
+++ b/smkc-score-app/src/app/api/tournaments/[id]/export/route.ts
@@ -273,10 +273,16 @@ export async function GET(
   // Logger created inside function for proper test mocking support
   const logger = createLogger('tournament-export-api');
   const { id } = await params;
-  const tournamentId = await resolveTournamentId(id);
   const exportFormat = new URL(request.url).searchParams.get("format");
+  // Use raw id as fallback so the catch-block logger always has a tournamentId,
+  // even if resolveTournamentId throws before assigning.
+  let tournamentId = id;
 
   try {
+    // Resolve inside try so identifier-validation errors from resolveTournamentId
+    // (e.g. malformed id combined with a DB connectivity failure) are returned as
+    // a structured 500 instead of an unhandled exception that crashes the handler.
+    tournamentId = await resolveTournamentId(id);
     if (exportFormat === "cdm") {
       const session = await auth();
       if (!session?.user) {


### PR DESCRIPTION
## Summary

- Moves `resolveTournamentId(id)` **inside** the route's `try/catch` block to prevent an unhandled exception from surfacing as a raw Next.js HTML 500 page
- When a tournament identifier fails the slug/UUID format check **and** a DB connectivity error occurs simultaneously, `resolveTournamentId` re-throws — previously this bypassed the structured `createErrorResponse` path entirely
- Adds a `let tournamentId = id` fallback before `try` so the `catch` logger always has a readable ID even when `resolveTournamentId` itself throws
- Adds `tournament.findFirst` to the global Prisma mock (was missing, so `resolveTournamentId` silently short-circuited in every existing test)
- Adds regression unit test: invalid-format ID + simulated DB error → structured `{ success: false }` JSON 500 (not unhandled crash)
- Adds TC-362 to `E2E_TEST_CASES.md`

## Issues

Closes #2675

## Validation

- All 3777 unit tests pass (`npm test -- --ci --forceExit`)
- `npm run lint` reports 0 errors (warnings only, pre-existing)
- The new regression test (`resolveTournamentId throws → structured 500`) passes with the fix and would fail without it

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9zz5ukkiP21UyLwStQfhV)_