### PR TITLE
docs(TC-362): fix inaccurate authRequired comment explanation

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -542,7 +542,7 @@
 
 ## TC-362: Export API 不正IDに対する構造化エラーレスポンス
 - **URL**: GET /api/tournaments/INVALID_FORMAT_ID/export
-- **authRequired**: false (エラーはID解決前に返る)
+- **authRequired**: false (auth チェックは resolveTournamentId より後に行われるため不要)
 - **手順**:
   1. `https` モジュールでブラウザ外から `GET /api/tournaments/INVALID_FORMAT_ID/export` を直接リクエスト
   2. HTTPステータスコードを確認


### PR DESCRIPTION
## Summary

- TC-362 の `authRequired` コメントの説明が不正確だったため修正。
- `(エラーはID解決前に返る)` → `(auth チェックは resolveTournamentId より後に行われるため不要)`
- #2676 の修正により `resolveTournamentId` は `try` ブロック **内** で呼ばれるため、「ID解決前」という説明は誤り。正確な理由は「auth チェックが resolveTournamentId より後にある」こと。

## Issues

Closes #2677

## Validation

- ドキュメント修正のみ（コード変更なし）
- E2E_TEST_CASES.md TC-362 の `authRequired` 説明文を #2677 の修正案に従って更新済み

---
_Generated by [Claude Code](https://claude.ai/code/session_019skQxzi5AtnBdacQ6L53J5)_