### PR TITLE
test(e2e): add TC-362 and TC-363 to tc-all.js

### DIFF
--- a/E2E_TEST_CASES.md
+++ b/E2E_TEST_CASES.md
@@ -545,10 +545,23 @@
 - **authRequired**: false (auth チェックは resolveTournamentId より後に行われるため不要)
 - **手順**:
   1. `https` モジュールでブラウザ外から `GET /api/tournaments/INVALID_FORMAT_ID/export` を直接リクエスト
-  2. HTTPステータスコードを確認
-  3. レスポンスボディのContent-Typeを確認
-- **期待結果**: HTTPステータス 500 で `{ success: false, error: "..." }` 形式のJSON が返り、HTML 500エラーページにならない
+  2. HTTPステータスコードを確認 (4xx or 5xx)
+  3. レスポンスボディの Content-Type が `application/json` であることを確認
+  4. レスポンスボディが `{ success: false, error: "..." }` 形式であることを確認
+- **期待結果**: HTTP 4xx/5xx で `{ success: false, error: "..." }` 形式の JSON が返り、HTML エラーページにならない。プレビュー環境 (DB 疎通あり) では 404、DB エラー時は 500 となるが、いずれも JSON であること
 - **背景**: resolveTournamentId が try 外で呼ばれると不正IDのDB同時エラーで未ハンドル例外になるバグ修正 (#2675)
+- **スクリプト**: tc-all.js TC-362
+
+## TC-363: CDM Export — 非認証アクセスは 401 JSON を返す
+- **URL**: GET /api/tournaments/[id]/export?format=cdm
+- **authRequired**: false (テスト自体は非認証で実行)
+- **手順**:
+  1. `https` モジュールでブラウザ外から `GET /api/tournaments/:id/export?format=cdm` を直接リクエスト (セッションなし)
+  2. HTTP ステータスコードを確認
+  3. レスポンスボディを確認
+- **期待結果**: HTTP 401 で `{ success: false, error: "..." }` 形式の JSON が返る。HTML リダイレクトや HTML エラーページにならない
+- **背景**: CDM エクスポートは管理者専用。未認証リクエストが 401 JSON で拒否されることをセキュリティテストとして確認する
+- **スクリプト**: tc-all.js TC-363
 
 ## TC-201: 各モードページのデータ読み込み確認
 - **URL**: /tournaments/[id]/ta, /bm, /mr, /gp

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -368,6 +368,8 @@ describe('E2E case drift coverage', () => {
     ['TC-352', tcAll],
     ['TC-356', tcAll],
     ['TC-357', tcAll],
+    ['TC-362', tcAll],
+    ['TC-363', tcAll],
     ['TC-702', tcGp],
     ['TC-717', tcGp],
     ['TC-722', tcGp],

--- a/smkc-score-app/e2e/tc-all.js
+++ b/smkc-score-app/e2e/tc-all.js
@@ -3841,6 +3841,77 @@ async function main() {
     }
   }
 
+  // TC-362: Export API 不正IDに対する構造化エラーレスポンス
+  // Verifies that a malformed tournament ID returns a structured JSON error
+  // (success:false) instead of an HTML error page. Accepts 4xx or 5xx as valid
+  // error status — the key invariant is JSON body, not a specific status code,
+  // because in preview (DB accessible) resolveTournamentId returns the raw ID
+  // and findUnique returns null → 404, while in production with a DB error it
+  // throws → 500. Both paths must return JSON, never an HTML error page.
+  {
+    try {
+      const tc362 = await new Promise((resolve) => {
+        let rawBody = '';
+        const req = https.get(`${BASE}/api/tournaments/INVALID_FORMAT_ID/export`, (res) => {
+          const ct = res.headers['content-type'] || '';
+          res.on('data', (chunk) => { rawBody += chunk; });
+          res.on('end', () => {
+            const statusOk = res.statusCode >= 400;
+            const isJson = ct.includes('application/json');
+            let bodyOk = false;
+            try {
+              const parsed = JSON.parse(rawBody);
+              bodyOk = parsed.success === false && typeof parsed.error === 'string';
+            } catch { /* non-JSON body */ }
+            resolve({ pass: statusOk && isJson && bodyOk, status: res.statusCode, ct, body: rawBody.slice(0, 200) });
+          });
+        });
+        req.on('error', (err) => resolve({ pass: false, error: err.message }));
+        req.setTimeout(10000, () => { req.destroy(); resolve({ pass: false, error: 'timeout' }); });
+      });
+      log('TC-362', tc362.pass ? 'PASS' : 'FAIL',
+        !tc362.pass ? `status=${tc362.status} ct=${tc362.ct} body=${tc362.body ?? tc362.error}` : '');
+    } catch (err) {
+      log('TC-362', 'FAIL', err instanceof Error ? err.message : 'TC-362 threw');
+    }
+  }
+
+  // TC-363: CDM Export — unauthenticated request returns 401 JSON (security test)
+  // Verifies that ?format=cdm is admin-only and rejects unauthenticated https
+  // requests with a structured JSON 401, not an HTML redirect or error page.
+  {
+    const tc363Tid = sharedFixture?.tournamentId ?? TID;
+    if (tc363Tid) {
+      try {
+        const tc363 = await new Promise((resolve) => {
+          let rawBody = '';
+          const req = https.get(`${BASE}/api/tournaments/${tc363Tid}/export?format=cdm`, (res) => {
+            const ct = res.headers['content-type'] || '';
+            res.on('data', (chunk) => { rawBody += chunk; });
+            res.on('end', () => {
+              const is401 = res.statusCode === 401;
+              const isJson = ct.includes('application/json');
+              let bodyOk = false;
+              try {
+                const parsed = JSON.parse(rawBody);
+                bodyOk = parsed.success === false;
+              } catch { /* non-JSON body */ }
+              resolve({ pass: is401 && isJson && bodyOk, status: res.statusCode, ct, body: rawBody.slice(0, 200) });
+            });
+          });
+          req.on('error', (err) => resolve({ pass: false, error: err.message }));
+          req.setTimeout(10000, () => { req.destroy(); resolve({ pass: false, error: 'timeout' }); });
+        });
+        log('TC-363', tc363.pass ? 'PASS' : 'FAIL',
+          !tc363.pass ? `status=${tc363.status} ct=${tc363.ct} body=${tc363.body ?? tc363.error}` : '');
+      } catch (err) {
+        log('TC-363', 'FAIL', err instanceof Error ? err.message : 'TC-363 threw');
+      }
+    } else {
+      log('TC-363', 'SKIP', 'No tournament ID available');
+    }
+  }
+
   // TC-348: Character stats API — admin gets stats shape, non-admin gets 403
   {
     const statsPid = sharedFixture?.playerIds?.[0];


### PR DESCRIPTION
## Summary

- **TC-362 スクリプト化**: `INVALID_FORMAT_ID` に対する Export API の構造化エラーレスポンスを E2E スクリプトで検証。`https` モジュールでブラウザ外から GET し、4xx/5xx かつ JSON (`success:false`) が返ることを確認。#2676 のリグレッション回避テスト。
- **TC-363 新規追加**: CDM Export の非認証アクセス (セキュリティテスト)。未認証 https リクエストが HTTP 401 JSON (`success:false`) で拒否されることを確認。
- **drift guard**: `e2e-cases-drift.test.ts` に TC-362 / TC-363 エントリを追加し、E2E_TEST_CASES.md との乖離を検知。

## Issues

なし (E2Eカバレッジ改善)

## Validation

- `e2e-cases-drift.test.ts` がローカルでPASS
- TC-362: E2E_TEST_CASES.md に `**スクリプト**: tc-all.js TC-362` 追記、期待結果を 4xx/5xx + JSON に更新
- TC-363: E2E_TEST_CASES.md に新規エントリ追加 + tc-all.js にスクリプト追加

---
_Generated by [Claude Code](https://claude.ai/code/session_019skQxzi5AtnBdacQ6L53J5)_