### PR TITLE
refactor(test): remove fragile implementation-scan from drift guard (#2694)

### DIFF
--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -4616,9 +4616,9 @@ describe('E2E case drift coverage', () => {
       expect(driftTest).toContain("it('TC-2818:");
       expect(driftTest).toContain("it('TC-2819:");
       expect(driftTest).toContain("it('TC-2820:");
-      // TC-2820: guard throws RangeError — check guard condition, not JSDoc comment
+      // TC-2820: behavioral test (tcRange(...).toThrow(RangeError)) is the stronger guarantee;
+      // checking implementation details like 'if (start > end)' is fragile if tcRange moves files.
       expect(driftTest).toContain('RangeError');
-      expect(driftTest).toContain('if (start > end)');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Removes `expect(driftTest).toContain('if (start > end)')` from the TC-2818–2820 drift guard
- This check was self-referential: it scanned `e2e-cases-drift.test.ts` itself, so it would silently pass even if `tcRange` were moved to another file and the RangeError guard were deleted
- TC-2820's behavioral test (`expect(() => tcRange(...)).toThrow(RangeError)`) is a stronger guarantee and makes the file-content scan redundant

Closes #2694

## Test plan

- [x] All 400 drift-guard tests still pass (`npx jest --testPathPattern="e2e-cases-drift"`)
- [x] No test logic was removed — only the fragile `toContain('if (start > end)')` assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCt4vQy6iUtUZ41aTqnZwF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCt4vQy6iUtUZ41aTqnZwF)_