### PR TITLE
test: resolve #2701 #2702 — userEvent.click in TC-2851, nested describe for AlertTitle/AlertDescription

### DIFF
--- a/smkc-score-app/__tests__/components/ui/alert.test.tsx
+++ b/smkc-score-app/__tests__/components/ui/alert.test.tsx
@@ -31,29 +31,33 @@ describe('Alert', () => {
     expect(screen.getByRole('alert')).toHaveClass('border-l-destructive');
   });
 
-  it('TC-2857: AlertTitle renders as an h5 element', () => {
-    render(<Alert><AlertTitle>Warning</AlertTitle></Alert>);
-    const title = screen.getByText('Warning');
-    expect(title.tagName).toBe('H5');
+  describe('AlertTitle', () => {
+    it('TC-2857: renders as an h5 element', () => {
+      render(<Alert><AlertTitle>Warning</AlertTitle></Alert>);
+      const title = screen.getByText('Warning');
+      expect(title.tagName).toBe('H5');
+    });
+
+    it('TC-2858: renders children', () => {
+      render(<Alert><AlertTitle>Score saved</AlertTitle></Alert>);
+      expect(screen.getByText('Score saved')).toBeInTheDocument();
+    });
+
+    it('TC-2859: forwards custom className', () => {
+      render(<Alert><AlertTitle className="title-class">T</AlertTitle></Alert>);
+      expect(screen.getByText('T')).toHaveClass('title-class');
+    });
   });
 
-  it('TC-2858: AlertTitle renders children', () => {
-    render(<Alert><AlertTitle>Score saved</AlertTitle></Alert>);
-    expect(screen.getByText('Score saved')).toBeInTheDocument();
-  });
+  describe('AlertDescription', () => {
+    it('TC-2860: renders children', () => {
+      render(<Alert><AlertDescription>Details here</AlertDescription></Alert>);
+      expect(screen.getByText('Details here')).toBeInTheDocument();
+    });
 
-  it('TC-2859: AlertTitle forwards custom className', () => {
-    render(<Alert><AlertTitle className="title-class">T</AlertTitle></Alert>);
-    expect(screen.getByText('T')).toHaveClass('title-class');
-  });
-
-  it('TC-2860: AlertDescription renders children', () => {
-    render(<Alert><AlertDescription>Details here</AlertDescription></Alert>);
-    expect(screen.getByText('Details here')).toBeInTheDocument();
-  });
-
-  it('TC-2861: AlertDescription forwards custom className', () => {
-    render(<Alert><AlertDescription className="desc-class">D</AlertDescription></Alert>);
-    expect(screen.getByText('D')).toHaveClass('desc-class');
+    it('TC-2861: forwards custom className', () => {
+      render(<Alert><AlertDescription className="desc-class">D</AlertDescription></Alert>);
+      expect(screen.getByText('D')).toHaveClass('desc-class');
+    });
   });
 });

--- a/smkc-score-app/__tests__/components/ui/checkbox.test.tsx
+++ b/smkc-score-app/__tests__/components/ui/checkbox.test.tsx
@@ -2,7 +2,8 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Checkbox } from '@/components/ui/checkbox';
 
 describe('Checkbox', () => {
@@ -31,10 +32,11 @@ describe('Checkbox', () => {
     expect(screen.getByTestId('cb')).toHaveAttribute('data-state', 'checked');
   });
 
-  it('TC-2851: calls onCheckedChange when clicked', () => {
+  it('TC-2851: calls onCheckedChange when clicked', async () => {
+    const user = userEvent.setup();
     const onCheckedChange = jest.fn();
     render(<Checkbox data-testid="cb" onCheckedChange={onCheckedChange} />);
-    fireEvent.click(screen.getByTestId('cb'));
+    await user.click(screen.getByTestId('cb'));
     expect(onCheckedChange).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- **#2701**: `checkbox.test.tsx` TC-2851 の `fireEvent.click` を `userEvent.setup()` / `await user.click()` に変更。Radix UI コンポーネントで mousedown→mouseup→click の順序発火を正確に再現する。
- **#2702**: `alert.test.tsx` の TC-2857–2859 (AlertTitle) と TC-2860–2861 (AlertDescription) を `describe('AlertTitle')` / `describe('AlertDescription')` の入れ子ブロックに分割。テスト出力の可読性と失敗時の特定を改善する。

## Issues

Closes #2701
Closes #2702

## Validation

- `npm test` 全スイート通過 (277 passed, 1 skipped)
- ドリフトガード (`e2e-cases-drift.test.ts`) が TC 番号・アサーション文字列を引き続き検出できることを確認済み

---
_Generated by [Claude Code](https://claude.ai/code/session_014KyfVmtiJWPRQCrQEPLtkz)_