### PR TITLE
test: fix TC-2877 placement and improve TC-2894/2897 to role assertions

### DIFF
--- a/smkc-score-app/__tests__/components/ui/alert-dialog.test.tsx
+++ b/smkc-score-app/__tests__/components/ui/alert-dialog.test.tsx
@@ -99,7 +99,9 @@ describe('AlertDialog Components', () => {
       expect(overlay).toBeInTheDocument();
       expect(overlay).toHaveClass('fixed', 'inset-0', 'z-50', 'paddock-overlay');
     });
+  });
 
+  describe('AlertDialogContent', () => {
     it('TC-2877: AlertDialogContent にカスタム className が転送される', () => {
       render(
         <AlertDialog open={true}>
@@ -116,9 +118,7 @@ describe('AlertDialog Components', () => {
       const content = screen.getByRole('alertdialog');
       expect(content).toHaveClass('custom-content');
     });
-  });
 
-  describe('AlertDialogContent', () => {
     it('TC-2878: children をレンダリングする', () => {
       render(
         <AlertDialog open={true}>
@@ -385,21 +385,18 @@ describe('AlertDialog Components', () => {
       expect(screen.getByText('Action Button')).toBeInTheDocument();
     });
 
-    it('TC-2894: button 要素としてレンダリングされる', () => {
+    it('TC-2894: button ロールを持つ', () => {
       render(
         <AlertDialog open={true}>
           <AlertDialogPortal>
             <AlertDialogContent>
-              <AlertDialogAction data-testid="action">
-                Action
-              </AlertDialogAction>
+              <AlertDialogAction>Action</AlertDialogAction>
             </AlertDialogContent>
           </AlertDialogPortal>
         </AlertDialog>
       );
 
-      const action = screen.getByTestId('action');
-      expect(action.tagName).toBe('BUTTON');
+      expect(screen.getByRole('button', { name: 'Action' })).toBeInTheDocument();
     });
 
     it('TC-2895: カスタム className が転送される', () => {
@@ -435,21 +432,18 @@ describe('AlertDialog Components', () => {
       expect(screen.getByText('Cancel Button')).toBeInTheDocument();
     });
 
-    it('TC-2897: button 要素としてレンダリングされる', () => {
+    it('TC-2897: button ロールを持つ', () => {
       render(
         <AlertDialog open={true}>
           <AlertDialogPortal>
             <AlertDialogContent>
-              <AlertDialogCancel data-testid="cancel">
-                Cancel
-              </AlertDialogCancel>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
             </AlertDialogContent>
           </AlertDialogPortal>
         </AlertDialog>
       );
 
-      const cancel = screen.getByTestId('cancel');
-      expect(cancel.tagName).toBe('BUTTON');
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
     });
 
     it('TC-2898: mt-2/sm:mt-0 モバイルレイアウトクラスを持つ', () => {

--- a/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
+++ b/smkc-score-app/__tests__/docs/e2e-cases-drift.test.ts
@@ -4803,6 +4803,8 @@ describe('E2E case drift coverage', () => {
       // TC-2891: description typography classes
       expect(alertDialogTest).toContain('font-mono');
       expect(alertDialogTest).toContain('text-muted-foreground');
+      // TC-2894/TC-2897: button role (accessibility-oriented assertion)
+      expect(alertDialogTest).toContain("getByRole('button'");
       // TC-2898: cancel mobile margin
       expect(alertDialogTest).toContain('mt-2');
       expect(alertDialogTest).toContain('sm:mt-0');


### PR DESCRIPTION
## Summary

- **TC-2877** (#2705): moved from `describe('AlertDialogOverlay')` to `describe('AlertDialogContent')` where it belongs — the test body renders and checks `AlertDialogContent` className forwarding, not the overlay
- **TC-2894 / TC-2897** (#2706): replaced `expect(el.tagName).toBe('BUTTON')` with `screen.getByRole('button', { name: '...' })` for accessibility-oriented assertions that survive `asChild` implementation changes
- **drift guard**: added `getByRole('button')` string assertion so the accessibility approach is enforced going forward

Fixes #2705, #2706.

## Test plan
- [x] `__tests__/components/ui/alert-dialog.test.tsx` — 30 tests pass
- [x] `__tests__/docs/e2e-cases-drift.test.ts` — drift guard passes
- [x] Full suite: 3946 tests pass (277 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KyfVmtiJWPRQCrQEPLtkz

---
_Generated by [Claude Code](https://claude.ai/code/session_014KyfVmtiJWPRQCrQEPLtkz)_