### PR TITLE
test: restore global.fetch teardown, fix TC-2913, add TC-2920–2928 group-utils tests

### DIFF
--- a/smkc-score-app/__tests__/components/tournament/ta-elimination-phase.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/ta-elimination-phase.test.tsx
@@ -68,6 +68,16 @@ function makeEntry(overrides: {
   };
 }
 
+let originalFetch: typeof global.fetch;
+
+beforeAll(() => {
+  originalFetch = global.fetch;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
 beforeEach(() => {
   jest.useFakeTimers();
   jest.clearAllMocks();
@@ -84,9 +94,9 @@ afterEach(() => {
 describe('TAEliminationPhase — loading', () => {
   it('TC-2913: renders animated skeleton divs while fetch is pending', () => {
     global.fetch = jest.fn().mockReturnValue(new Promise(() => {}));
-    render(<TAEliminationPhase {...defaultProps} />);
+    const { container } = render(<TAEliminationPhase {...defaultProps} />);
     // Loading state renders animate-pulse placeholder divs before data arrives
-    expect(document.querySelector('.animate-pulse')).toBeInTheDocument();
+    expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
     // No h1 heading rendered during initial loading
     expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

### review-followup fixes (#2709, #2710)
- `beforeAll`/`afterAll` で `global.fetch` を保存・復元し、テストスイート間の汚染を防止 (#2710)
- TC-2913: `document.querySelector('.animate-pulse')` を `render()` 戻り値の `container.querySelector()` に置換 (#2709)

### 未カバー領域テスト追加 (TC-2920–TC-2928)
- `recommendGroupCount` のしきい値テスト: 0/15名→2グループ、16-23名→3グループ、24名以上→4グループ (TC-2920–TC-2923)
- `assignGroupsBySeeding` の蛇行配置パターン §10.2 (TC-2924)
- seeding なしプレイヤーが末尾配置されること (TC-2925)
- groupCount が [2,4] 範囲外でもクランプされること (TC-2926)
- 空配列入力で空配列が返ること (TC-2927)
- 元の配列を変更しない純粋関数契約 (TC-2928)
- drift guard で TC-2920–2928 を保護

## Issues

Closes #2709
Closes #2710

## Validation

- `ta-elimination-phase.test.tsx` 全7テスト PASS
- `group-setup-dialog.test.ts` 全21テスト PASS (旧6 + 新9 + TC-1007 static x6)
- `e2e-cases-drift.test.ts` 全432テスト PASS