### PR TITLE
test(TC-2931/2932): replace CSS-class assertion with data-variant; name button in TC-2932

### DIFF
--- a/smkc-score-app/__tests__/components/tournament/group-setup-dialog.test.tsx
+++ b/smkc-score-app/__tests__/components/tournament/group-setup-dialog.test.tsx
@@ -64,23 +64,24 @@ describe("GroupSetupDialog", () => {
       <GroupSetupDialog {...defaultProps} existingAssignments={[]} />,
     );
     const newBtn = screen.getByRole("button", { name: /Setup Groups/i });
-    // default variant has bg-primary class
-    expect(newBtn.className).toMatch(/bg-primary/);
+    // Use data-variant instead of CSS class names to avoid coupling to shadcn/Tailwind internals
+    expect(newBtn).toHaveAttribute("data-variant", "default");
 
     const existing: SetupPlayer[] = [{ playerId: "p1", group: "A" }];
     rerender(<GroupSetupDialog {...defaultProps} existingAssignments={existing} />);
     const editBtn = screen.getByRole("button", { name: /Edit Groups/i });
-    // outline variant has border-input or bg-background class (no bg-primary)
-    expect(editBtn.className).not.toMatch(/\bbg-primary\b/);
+    expect(editBtn).toHaveAttribute("data-variant", "outline");
   });
 
-  it("TC-2932: renders for all supported modes without errors", () => {
+  it("TC-2932: renders trigger button for all supported modes without errors", () => {
+    // defaultProps has existingAssignments: [] so the trigger button reads "Setup Groups"
     const modes: Array<"bm" | "mr" | "gp"> = ["bm", "mr", "gp"];
     for (const mode of modes) {
       const { unmount } = render(
         <GroupSetupDialog {...defaultProps} mode={mode} />,
       );
-      expect(screen.getByRole("button")).toBeInTheDocument();
+      // Named query avoids ambiguity when additional buttons are added to the component
+      expect(screen.getByRole("button", { name: /Setup Groups/i })).toBeInTheDocument();
       unmount();
     }
   });

--- a/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
+++ b/smkc-score-app/src/components/tournament/group-setup-dialog.tsx
@@ -186,6 +186,7 @@ export function GroupSetupDialog({
       <DialogTrigger asChild>
         <Button
           variant={hasExistingQualifications ? "outline" : "default"}
+          data-variant={hasExistingQualifications ? "outline" : "default"}
         >
           {hasExistingQualifications ? tc("editGroups") : tc("setupGroups")}
         </Button>


### PR DESCRIPTION
## Summary

- **TC-2931** (#2716): CSS class assertions (`bg-primary`) removed in favour of a `data-variant` attribute on the trigger Button. Eliminates coupling to shadcn/ui or Tailwind internals — style refactors no longer break this test.
- **TC-2932** (#2717): Bare `getByRole("button")` replaced with `getByRole("button", { name: /Setup Groups/i })`. Prevents `TestingLibraryElementError: Found multiple elements` if the component gains more buttons later.
- Component change: one-liner `data-variant` prop added to the `<DialogTrigger>` Button, mirroring the `variant` value so tests have a stable selector.

## Issues

Closes #2716
Closes #2717

## Validation

- `npx jest --no-coverage --testPathPattern="group-setup-dialog"` → 9/9 pass
- Full suite: 278 test suites pass, 3941 tests pass, 27 pre-existing skips — no regressions

---
_Generated by [Claude Code](https://claude.ai/code/session_0166NqFscnL7oQci3pjGyU6B)_