### PR TITLE
[codex] Fix CDM export invalid TT phase times

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -1757,5 +1757,72 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
         expect.objectContaining({ category: 'bmQualifications', droppedCount: 1 }),
       );
     });
+
+    it('should still export when a TT phase round contains an invalid timeMs', async () => {
+      setupRealTemplateMock();
+      const mockTournament = {
+        id: 't-invalid-tt-time',
+        name: 'Invalid TT Time Test',
+        date: new Date('2024-01-15'),
+        bmQualifications: [],
+        mrQualifications: [],
+        gpQualifications: [],
+        bmMatches: [],
+        mrMatches: [],
+        gpMatches: [],
+        ttEntries: [
+          {
+            player: { id: 'p1', name: 'Alice', nickname: 'Alice' },
+            playerId: 'p1',
+            stage: 'qualification',
+            seeding: 1,
+            lives: 0,
+            eliminated: false,
+            totalTime: 5000,
+            qualificationPoints: 2,
+            rank: 1,
+          },
+          {
+            player: { id: 'p2', name: 'Bob', nickname: 'Bob' },
+            playerId: 'p2',
+            stage: 'qualification',
+            seeding: 2,
+            lives: 0,
+            eliminated: false,
+            totalTime: 6000,
+            qualificationPoints: 1,
+            rank: 2,
+          },
+        ],
+        ttPhaseRounds: [
+          {
+            phase: 'phase1',
+            roundNumber: 1,
+            course: 'MC1',
+            results: [
+              { playerId: 'p1', timeMs: -1 },
+              { playerId: 'p2', timeMs: 6000 },
+            ],
+            eliminatedIds: ['p1'],
+            livesReset: false,
+          },
+        ],
+      };
+      (prisma.tournament.findUnique as jest.Mock).mockResolvedValue(mockTournament);
+
+      const request = new MockNextRequest('http://localhost:3000/api/tournaments/t-invalid-tt-time/export?format=cdm');
+      const params = Promise.resolve({ id: 't-invalid-tt-time' });
+      const result = await GET(request, { params });
+
+      expect(result.status).toBe(200);
+      expect(result.data).toBeInstanceOf(Uint8Array);
+      expect(loggerMock.error).not.toHaveBeenCalledWith(
+        'Failed to export tournament',
+        expect.anything(),
+      );
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        'TT Finals phase1 round 1: invalid timeMs for player p1; treating as missing time',
+      );
+    });
   });
 });

--- a/smkc-score-app/src/lib/cdm-export/fill/tt-lives-replay.ts
+++ b/smkc-score-app/src/lib/cdm-export/fill/tt-lives-replay.ts
@@ -157,7 +157,11 @@ export function replayTTFinals(data: CdmTournamentData): TTFinalsReplayRound[] {
       break;
     }
 
-    const results = parseRoundResults(round.results);
+    const results = parseRoundResults(round.results, {
+      logger,
+      phase,
+      roundNumber: round.roundNumber,
+    });
     // Participants restricted to the known universe: a result for an unknown id
     // cannot be placed on the sheet, so it is ignored (and warned) rather than
     // silently shifting row positions.
@@ -421,7 +425,14 @@ function stableSort<T>(items: T[], key: (item: T) => number): T[] {
 }
 
 /** Parse a TTPhaseRound.results JSON value into typed rows (defensive). */
-function parseRoundResults(raw: unknown): ResultRow[] {
+function parseRoundResults(
+  raw: unknown,
+  context?: {
+    logger: ReturnType<typeof createLogger>;
+    phase: FinalsPhase;
+    roundNumber: number;
+  },
+): ResultRow[] {
   if (!Array.isArray(raw)) return [];
   const rows: ResultRow[] = [];
   for (const item of raw) {
@@ -429,9 +440,18 @@ function parseRoundResults(raw: unknown): ResultRow[] {
       const playerId = (item as { playerId: unknown }).playerId;
       const timeMs = (item as { timeMs?: unknown }).timeMs;
       if (typeof playerId === "string") {
+        const usableTime =
+          typeof timeMs === "number" && Number.isFinite(timeMs) && timeMs >= 0
+            ? timeMs
+            : null;
+        if (timeMs !== undefined && timeMs !== null && usableTime === null) {
+          context?.logger.warn(
+            `TT Finals ${context.phase} round ${context.roundNumber}: invalid timeMs for player ${playerId}; treating as missing time`,
+          );
+        }
         rows.push({
           playerId,
-          timeMs: typeof timeMs === "number" ? timeMs : null,
+          timeMs: usableTime,
         });
       }
     }


### PR DESCRIPTION
## Summary

- Treat invalid TT phase-round `timeMs` values as missing CDM TT Finals times instead of throwing during workbook generation.
- Log the affected phase, round, and player so operators can find bad persisted data.
- Add route-level regression coverage with the real CDM template to prove CDM export still returns an `.xlsm`.

## Root Cause

CDM TT Finals replay accepted any numeric `timeMs` from `ttPhaseRounds.results`. A negative or non-finite value later reached `msToCdmTime`, which throws by design for invalid durations. That exception bubbled through the export route and surfaced to admins as an HTTP 500.

## Validation

- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/export/route.test.ts' --runInBand`
- `npm test -- --runTestsByPath __tests__/lib/cdm-export/fill/tt-finals.test.ts __tests__/lib/cdm-export/fill/tt-lives-replay.test.ts --runInBand`
