### PR TITLE
fix(cdm-export): スピル子セルのキャッシュ削除でトーナメント結果が反映されない問題を修正

### DIFF
--- a/smkc-score-app/__tests__/lib/cdm-export/index.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/index.test.ts
@@ -220,6 +220,64 @@ describe("generateCdmWorkbook — patched input cells (8-player)", () => {
   });
 });
 
+describe("generateCdmWorkbook — no CDM2025 template data renders anywhere", () => {
+  // Distinctive nicknames baked into the real template's CDM2025 roster (verified
+  // against xl/sharedStrings.xml). They reach the visible cells two ways: as
+  // dynamic-array spill children (t="str" cached values, no <f>) on the
+  // formula-driven sheets, and as static t="s" references in the BM/MR Finals
+  // seed list. A correct export must leave NONE of them as a rendered value.
+  const STALE_NICKNAMES = [
+    "Bluh", "Drew", "Sami", "Ale", "Zarkov", "Kasmo", "Jarmou",
+    "Patrick", "Geo", "Champix", "Onwa", "Moll", "Antistar",
+  ];
+
+  // Match one <c> element: self-closing form first + lazy attribute run so a
+  // self-closing cell cannot swallow the next cell up to its </c>.
+  const CELL_RE = /<c\b[^>]*?\/>|<c\b[^>]*?>[\s\S]*?<\/c>/g;
+
+  /** Collect any cell on any worksheet that renders a stale CDM2025 nickname. */
+  function staleNameOffenders(out: Uint8Array): string[] {
+    const outParts = parts(out);
+    // Resolve the shared-string table to dereference t="s" cells.
+    const ss = strFromU8(outParts["xl/sharedStrings.xml"]);
+    const sharedStrings = [...ss.matchAll(/<si>([\s\S]*?)<\/si>/g)].map((m) =>
+      [...m[1].matchAll(/<t[^>]*>([\s\S]*?)<\/t>/g)].map((t) => t[1]).join(""),
+    );
+    const stale = new Set(STALE_NICKNAMES);
+    const offenders: string[] = [];
+    for (const path of Object.keys(outParts)) {
+      if (!/^xl\/worksheets\/sheet\d+\.xml$/.test(path)) continue;
+      const xml = strFromU8(outParts[path]);
+      for (const cell of xml.match(CELL_RE) ?? []) {
+        if (cell.includes("<f")) continue; // formulas are kept; only values matter
+        const t = /\bt="([^"]*)"/.exec(cell)?.[1];
+        let text = "";
+        if (t === "s") {
+          const idx = Number(/<v>(\d+)<\/v>/.exec(cell)?.[1] ?? "-1");
+          text = sharedStrings[idx] ?? "";
+        } else if (t === "inlineStr") {
+          text = [...cell.matchAll(/<t[^>]*>([\s\S]*?)<\/t>/g)].map((m) => m[1]).join("");
+        } else if (t === "str") {
+          text = /<v>([\s\S]*?)<\/v>/.exec(cell)?.[1] ?? "";
+        }
+        if (stale.has(text)) {
+          offenders.push(`${path} ${/\br="([^"]*)"/.exec(cell)?.[1]}=${text}`);
+        }
+      }
+    }
+    return offenders;
+  }
+
+  // Both export shapes must be clean: the degraded-8 path (spill children +
+  // overwrite/strip) and the faithful-24 playoff path (typed seed list).
+  it.each([
+    ["8-player degraded", eightPlayerFixture],
+    ["24-player playoff", twentyFourPlayoffFixture],
+  ])("renders no CDM2025 roster nickname on any sheet (%s)", (_label, fixture) => {
+    expect(staleNameOffenders(generateCdmWorkbook(loadTemplate(), fixture()))).toEqual([]);
+  });
+});
+
 describe("generateCdmWorkbook — patched input cells (24-player playoff)", () => {
   const out = generateCdmWorkbook(loadTemplate(), twentyFourPlayoffFixture());
   const ttQual = readSheet(out, "TT Qualifications");

--- a/smkc-score-app/__tests__/lib/cdm-export/xlsx-zip-patcher.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/xlsx-zip-patcher.test.ts
@@ -55,7 +55,7 @@ describe("patchCdmWorkbook — no-op pass-through fidelity", () => {
   const out = patchCdmWorkbook(loadTemplate(), []);
   const outParts = parts(out);
 
-  it("preserves every part except workbook.xml, content types and workbook rels", () => {
+  it("preserves every non-worksheet part except workbook.xml, content types and workbook rels", () => {
     const allowedToDiffer = new Set([
       "xl/workbook.xml",
       "[Content_Types].xml",
@@ -66,6 +66,13 @@ describe("patchCdmWorkbook — no-op pass-through fidelity", () => {
     for (const path of Object.keys(originalParts)) {
       if (removed.has(path)) continue; // expected to be gone
       if (allowedToDiffer.has(path)) continue; // checked individually below
+      // Worksheet XML is now expected to differ even on a no-op patch: stale
+      // CDM2025 cached formula AND dynamic-array spill-child values are stripped
+      // from EVERY sheet so no template-era data can render before recalc. The
+      // irreplaceable parts the old SheetJS exporter destroyed (tables, richData,
+      // media, styles, sharedStrings, metadata, …) must still pass through
+      // byte-for-byte, which is what this loop guards.
+      if (/^xl\/worksheets\/sheet\d+\.xml$/.test(path)) continue;
       expect(outParts[path]).toBeDefined();
       expect(bytesEqual(outParts[path], originalParts[path])).toBe(true);
     }
@@ -85,14 +92,24 @@ describe("patchCdmWorkbook — no-op pass-through fidelity", () => {
     ).toBe(true);
   });
 
-  it("keeps all 12 worksheet xml parts byte-identical when nothing is written", () => {
+  it("keeps all 12 worksheet parts but strips their stale cached values", () => {
     const sheets = Object.keys(originalParts).filter((p) =>
       /^xl\/worksheets\/sheet\d+\.xml$/.test(p)
     );
     expect(sheets.length).toBe(12);
-    for (const sheet of sheets) {
-      expect(bytesEqual(outParts[sheet], originalParts[sheet])).toBe(true);
-    }
+    for (const sheet of sheets) expect(outParts[sheet]).toBeDefined();
+
+    // Overall Ranking (sheet12) is never written by the fill map, yet it must no
+    // longer carry the CDM2025 roster: the SORT(UNIQUE(Registration[Nickname]))
+    // anchor formula survives, but the names it spilled (B3..B61, t="str" cells
+    // with no <f>) are cleared so Excel re-spills the new tournament's players.
+    const overall = strFromU8(outParts["xl/worksheets/sheet12.xml"]);
+    expect(overall).toContain(
+      "_xlfn._xlws.SORT(_xlfn.UNIQUE(Registration[Nickname]))",
+    );
+    expect(overall).not.toContain("<v>Bluh</v>");
+    expect(overall).not.toContain("<v>Drew</v>");
+    expect(overall).not.toContain("<v>Sami</v>");
   });
 
   it("adds full-recalculation attributes to calcPr in workbook.xml", () => {
@@ -186,6 +203,51 @@ describe("patchCdmWorkbook — real cell writes", () => {
     // The B2 array formula text must be gone; a styled shell remains.
     expect(sheet12).not.toContain("_xlfn._xlws.SORT(_xlfn.UNIQUE(Registration[Nickname]))");
     expect(sheet12).toContain('<c r="B2" s="32"/>');
+  });
+
+  it("strips stale cached values from dynamic-array spill child cells", () => {
+    // Overall Ranking (sheet12) is never written by the fill map. Its B column is
+    // the spill of SORT(UNIQUE(Registration[Nickname])) anchored at B2; the
+    // template persists the CDM2025 spill children (B3..B61) as t="str" cells with
+    // NO <f> of their own, e.g. <c r="B7" s="32" t="str"><v>Bluh</v></c>. The old
+    // strip only touched cells containing <f>, so those names survived and Excel
+    // rendered the stale CDM2025 roster. A no-op patch must already remove them.
+    const out = patchCdmWorkbook(loadTemplate(), []);
+    const overall = readSheet(out, "xl/worksheets/sheet12.xml");
+    expect(overall).not.toContain("<v>Bluh</v>");
+    expect(overall).not.toContain("<v>Drew</v>");
+    expect(overall).not.toContain("<v>Sami</v>");
+    // The spill ANCHOR formula must remain intact — only its cached value is gone.
+    expect(overall).toContain(
+      "_xlfn._xlws.SORT(_xlfn.UNIQUE(Registration[Nickname]))",
+    );
+  });
+
+  it("strips spill children on a touched sheet too (TT Qualifications)", () => {
+    // TT Qualifications (sheet3) B2:B48 / F2:F48 spill FILTER/SORT of the roster.
+    // Writing an input cell makes the sheet "touched"; the spill children must be
+    // cleared on that path as well, not just on untouched sheets.
+    const out = patchCdmWorkbook(loadTemplate(), [
+      { sheet: "TT Qualifications", ref: "G2", op: "number", value: 11034 },
+    ]);
+    const ttQual = readSheet(out, "xl/worksheets/sheet3.xml");
+    expect(ttQual).not.toContain("<v>Bluh</v>");
+    expect(ttQual).not.toContain("<v>Drew</v>");
+    expect(ttQual).not.toContain("<v>Sami</v>");
+    // The input we wrote must OUTLIVE the strip — G2 is a plain input cell, not a
+    // spill child, so clearing spill ranges must not touch it.
+    expect(ttQual).toContain('<c r="G2" s="45"><v>11034</v></c>');
+  });
+
+  it("throws when a value is written into a dynamic-array spill cell", () => {
+    // Overall Ranking B2 anchors SORT(UNIQUE(Registration[Nickname])) with spill
+    // ref B2:B61, so B5 is a spill CHILD (no <f> of its own). Writing a value
+    // there is fill/template drift: it would be silently erased by the spill-range
+    // strip, so the patcher must reject it — symmetric with the anchor guard above.
+    const writes: CdmCellWrite[] = [
+      { sheet: "Overall Ranking", ref: "B5", op: "inlineString", value: "X" },
+    ];
+    expect(() => patchCdmWorkbook(loadTemplate(), writes)).toThrow(/B5/);
   });
 
   it("throws on an unknown sheet name", () => {

--- a/smkc-score-app/src/lib/cdm-export/xlsx-zip-patcher.ts
+++ b/smkc-score-app/src/lib/cdm-export/xlsx-zip-patcher.ts
@@ -15,22 +15,27 @@
  *  2. patch ONLY the input cells of the touched worksheets via SheetXmlPatcher,
  *     which rewrites just the changed <c>/<row> regions and reproduces every
  *     other byte of the sheet verbatim;
- *  3. drop formula cached values from touched sheets, force a full recalculation
- *     on open and drop the now-stale calcChain so Excel rebuilds the dependency
- *     order itself;
+ *  3. drop stale cached results from EVERY worksheet (touched or not) — both
+ *     formula cells AND the dynamic-array spill children those formulas populate
+ *     (cells with no <f> of their own; see stripFormulaCachedValues) — then force
+ *     a full recalculation on open and drop the now-stale calcChain so Excel
+ *     rebuilds the dependency order and re-spills the values itself;
  *  4. pass through EVERY other part (tables, richData, media, styles, metadata,
  *     sharedStrings, printerSettings, customXml, docProps, ...) byte-for-byte,
  *     keeping the original zip entry order so a diff against the template shows
- *     only the three parts we intentionally edit.
+ *     only the worksheets plus the three calc-control parts we intentionally edit.
  *
- * The only parts that may differ from the template after a no-op patch are:
+ * The parts that may differ from the template after a no-op patch are:
+ *   - xl/worksheets/sheet*.xml (stale cached formula/spill values removed; the
+ *     formulas, styles and structure are otherwise byte-preserved)
  *   - xl/workbook.xml          (calcPr gains fullCalcOnLoad="1")
  *   - [Content_Types].xml      (calcChain Override removed)
  *   - xl/_rels/workbook.xml.rels (calcChain Relationship removed)
- * and xl/calcChain.xml is removed entirely.
+ * and xl/calcChain.xml is removed entirely. Every other (non-worksheet) part is
+ * byte-identical — that fidelity is what the old SheetJS exporter could not keep.
  */
 import { unzipSync, zipSync, strFromU8, strToU8 } from "fflate";
-import type { CdmCellWrite, CdmSheetName } from "@/lib/cdm-export/types";
+import type { CdmCellWrite } from "@/lib/cdm-export/types";
 import { SheetXmlPatcher } from "@/lib/cdm-export/sheet-xml-patcher";
 
 /** OOXML part path of the worksheet relationship Content-Type filter. */
@@ -120,8 +125,8 @@ function upsertAttr(attrs: string, name: string, value: string): string {
 
 /**
  * Add the recalculation attributes to <calcPr>, idempotently. With the calcChain
- * gone and touched-sheet formula caches removed, this tells Excel to rebuild
- * the dynamic-array formula web on first open.
+ * gone and every sheet's formula and spill-child caches removed, this tells Excel
+ * to rebuild the dynamic-array formula web on first open.
  */
 function ensureFullRecalculation(workbookXml: string): string {
   const calcPrMatch = /<calcPr\b([^>]*)\/>/.exec(workbookXml);
@@ -150,15 +155,128 @@ function ensureFullRecalculation(workbookXml: string): string {
   throw new Error("patchCdmWorkbook: workbook.xml has neither <calcPr> nor <sheets>");
 }
 
+/** A rectangular cell range (1-based, inclusive on both corners). */
+interface CellRange {
+  minCol: number;
+  maxCol: number;
+  minRow: number;
+  maxRow: number;
+}
+
+/** Convert column letters ("A", "B", … "AA") to a 1-based column number. */
+function columnLettersToNumber(letters: string): number {
+  let col = 0;
+  for (let i = 0; i < letters.length; i++) {
+    col = col * 26 + (letters.charCodeAt(i) - 64);
+  }
+  return col;
+}
+
+/** Parse an A1 ref ("B12") into 1-based {col,row}, or undefined if malformed. */
+function parseA1(ref: string): { col: number; row: number } | undefined {
+  const m = /^([A-Za-z]+)(\d+)$/.exec(ref);
+  if (!m) return undefined;
+  return { col: columnLettersToNumber(m[1].toUpperCase()), row: Number(m[2]) };
+}
+
+/** Parse an A1 range ("B2:B48" or a bare single cell "B2") into a CellRange. */
+function parseRange(ref: string): CellRange | undefined {
+  const [a, b] = ref.split(":");
+  const start = parseA1(a);
+  const end = b ? parseA1(b) : start;
+  if (!start || !end) return undefined;
+  return {
+    minCol: Math.min(start.col, end.col),
+    maxCol: Math.max(start.col, end.col),
+    minRow: Math.min(start.row, end.row),
+    maxRow: Math.max(start.row, end.row),
+  };
+}
+
+/**
+ * Collect the spill range of every dynamic-array formula in a worksheet.
+ *
+ * A dynamic-array (spill) formula stores its `<f>` ONLY in its anchor cell, as
+ * `<c r="B2"…><f t="array" ref="B2:B48">…</f><v>…</v></c>`. The cells it spills
+ * into (B3..B48) are persisted as plain cached cells with NO `<f>` of their own,
+ * e.g. `<c r="B4" s="44" t="str"><v>Bluh</v></c>`. Those spill *children* are the
+ * ones that carry the CDM2025 names/scores (FILTER/SORT/UNIQUE of
+ * Registration[Nickname], cross-sheet XLOOKUPs, …), yet they hold no `<f>` and so
+ * escape a naïve "does the cell contain <f>?" strip. We collect the anchors' ref
+ * ranges here so {@link stripFormulaCachedValues} can clear the children too.
+ *
+ * Only `t="array"` formulas declare a spill (a stale value to drop). Shared
+ * formulas (`t="shared"`) also carry a `ref`, but their member cells each keep
+ * their own `<f t="shared" si=…>` and are already handled by the in-cell `<f>`
+ * test, so they are deliberately excluded here.
+ */
+function collectSpillRanges(sheetXml: string): CellRange[] {
+  const ranges: CellRange[] = [];
+  const fTagRe = /<f\b([^>]*)>/g;
+  let m: RegExpExecArray | null;
+  while ((m = fTagRe.exec(sheetXml)) !== null) {
+    const attrs = m[1];
+    if (!/\bt="array"/.test(attrs)) continue;
+    const refMatch = /\bref="([^"]*)"/.exec(attrs);
+    if (!refMatch) continue;
+    const range = parseRange(refMatch[1]);
+    if (range) ranges.push(range);
+  }
+  return ranges;
+}
+
+/** Is the A1 ref inside any of the given ranges? */
+function isWithinAnyRange(ref: string, ranges: CellRange[]): boolean {
+  if (ranges.length === 0) return false;
+  const cell = parseA1(ref);
+  if (!cell) return false;
+  for (const r of ranges) {
+    if (
+      cell.col >= r.minCol &&
+      cell.col <= r.maxCol &&
+      cell.row >= r.minRow &&
+      cell.row <= r.maxRow
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Remove stale cached formula values from a worksheet XML string while keeping
  * formulas, styles and rich-value metadata intact. The CDM template ships with
  * CDM2025 cached results in formula cells; generated workbooks must not show
- * those names/scores while Excel is deciding when to recalculate.
+ * those names/scores while Excel is deciding when to recalculate. Applied to
+ * every worksheet in the package — the never-written sheets (Overall Ranking,
+ * TT for Scoub, Parameters) carry just as much stale CDM2025 data as the ones
+ * we patch, so leaving their caches would let those template-era values render
+ * until the post-open recalculation catches up.
+ *
+ * Two kinds of cached values are dropped:
+ *  1. cells that contain an `<f>` (ordinary, shared or array-anchor formulas);
+ *  2. dynamic-array SPILL CHILDREN — cells with no `<f>` of their own that sit
+ *     inside an anchor's spill `ref` range. These hold the bulk of the visible
+ *     CDM2025 roster (the FILTER/SORT/UNIQUE spills) and, because a non-empty
+ *     spill range also blocks Excel from re-spilling fresh values on open, must
+ *     be cleared so the anchor can repopulate them. See {@link collectSpillRanges}.
  */
 function stripFormulaCachedValues(sheetXml: string): string {
-  return sheetXml.replace(/<c\b[^>]*(?:\/>|>[\s\S]*?<\/c>)/g, (cell) => {
-    if (!cell.includes("<f")) return cell;
+  const spillRanges = collectSpillRanges(sheetXml);
+  // Match one <c> element at a time. The self-closing form is listed FIRST and
+  // both forms use a lazy attribute run (`[^>]*?`); otherwise a self-closing cell
+  // (<c r=".." t="s"/>) would greedily swallow the following cells up to the next
+  // </c>, and the per-cell ref/spill test below would then key off only the
+  // leading cell — silently skipping any spill child caught inside that span.
+  return sheetXml.replace(/<c\b[^>]*?\/>|<c\b[^>]*?>[\s\S]*?<\/c>/g, (cell) => {
+    if (!cell.includes("<f")) {
+      // Not a formula cell. Only strip it when it is a spill child of some
+      // dynamic-array anchor; a true input/static cell must keep its value.
+      // The cell's own address is the first r="…" in the element (a `ref="…"`
+      // on a nested <f> is excluded by the \b word boundary before r).
+      const refMatch = /\br="([^"]*)"/.exec(cell);
+      if (!refMatch || !isWithinAnyRange(refMatch[1], spillRanges)) return cell;
+    }
     return cell
       .replace(/<v(?:\s*\/|>[\s\S]*?<\/v>)/g, "")
       .replace(/<is>[\s\S]*?<\/is>/g, "");
@@ -215,9 +333,11 @@ export function patchCdmWorkbook(
 
   const sheetPathByName = buildSheetPathResolver(workbookXml, workbookRelsXml);
 
-  // Group writes by sheet, preserving their relative order within a sheet so
-  // last-write-wins is honoured by SheetXmlPatcher.
-  const writesBySheet = new Map<CdmSheetName, CdmCellWrite[]>();
+  // Group writes by the resolved part PATH (not the sheet name), preserving
+  // their relative order within a sheet so last-write-wins is honoured by
+  // SheetXmlPatcher. Keying by path lets the single strip loop below find a
+  // sheet's writes without a separate "touched" bookkeeping set.
+  const writesByPath = new Map<string, CdmCellWrite[]>();
   for (const write of writes) {
     const path = sheetPathByName.get(write.sheet);
     if (!path) {
@@ -225,31 +345,69 @@ export function patchCdmWorkbook(
         `patchCdmWorkbook: unknown sheet name "${write.sheet}" — not present in workbook.xml`
       );
     }
-    const list = writesBySheet.get(write.sheet);
+    const list = writesByPath.get(path);
     if (list) {
       list.push(write);
     } else {
-      writesBySheet.set(write.sheet, [write]);
+      writesByPath.set(path, [write]);
     }
   }
 
-  // Patch each touched worksheet's XML in place within the parts map. The map
-  // still holds verbatim bytes for everything else, which is what guarantees
-  // byte-fidelity of the untouched parts.
-  for (const [sheet, sheetWrites] of writesBySheet) {
-    const path = sheetPathByName.get(sheet)!;
+  // Process EVERY worksheet the workbook declares, whether or not it receives
+  // cell writes. The CDM template ships with CDM2025 computed results cached
+  // inside formula cells AND inside their dynamic-array spill children, and on
+  // the sheets the exporter never writes to (Overall Ranking, TT for Scoub,
+  // Parameters — see design §3.6) those caches would otherwise survive
+  // unchanged. fullCalcOnLoad rebuilds the values once Excel recalculates, but
+  // until it does Excel renders the stale template-era names/scores — exactly
+  // the "only some sheets update" symptom. We therefore strip every worksheet's
+  // caches, touched or not, so nothing can show a pre-computed template value on
+  // open. A single pass over all paths keeps "stripped exactly once" structural.
+  for (const path of new Set(sheetPathByName.values())) {
     const sheetBytes = parts[path];
     if (!sheetBytes) {
       throw new Error(`patchCdmWorkbook: worksheet part "${path}" not found in package`);
     }
-    const patcher = new SheetXmlPatcher(strFromU8(sheetBytes));
-    for (const write of sheetWrites) {
-      // CdmCellWrite is CdmCellOp & { sheet, ref }; SheetXmlPatcher.apply takes
-      // the op shape, so we pass the write through (the extra sheet/ref fields
-      // are ignored by the discriminated-union switch).
-      patcher.apply(write.ref, write);
+    let sheetXml = strFromU8(sheetBytes);
+
+    const sheetWrites = writesByPath.get(path);
+    if (sheetWrites) {
+      // Symmetric drift guard: SheetXmlPatcher already throws when a value op
+      // lands on a formula ANCHOR (a cell with its own <f>). A value op aimed at
+      // a dynamic-array SPILL CHILD (no <f> of its own) would NOT throw there,
+      // yet the strip below clears that whole spill range — silently erasing the
+      // write. That is the same fill/template drift the anchor guard rejects, so
+      // we reject it here too rather than lose data quietly. Computed on the
+      // pre-patch XML because value ops never alter anchors (they would throw).
+      const spillRanges = collectSpillRanges(sheetXml);
+      for (const write of sheetWrites) {
+        if (
+          (write.op === "number" || write.op === "inlineString") &&
+          isWithinAnyRange(write.ref, spillRanges)
+        ) {
+          throw new Error(
+            `patchCdmWorkbook: refusing to write a value into the dynamic-array ` +
+              `spill cell ${write.sheet}!${write.ref}; the fill map disagrees with the template`
+          );
+        }
+      }
+
+      const patcher = new SheetXmlPatcher(sheetXml);
+      for (const write of sheetWrites) {
+        // CdmCellWrite is CdmCellOp & { sheet, ref }; SheetXmlPatcher.apply takes
+        // the op shape, so we pass the write through (the extra sheet/ref fields
+        // are ignored by the discriminated-union switch).
+        patcher.apply(write.ref, write);
+      }
+      sheetXml = patcher.serialize();
     }
-    parts[path] = strToU8(stripFormulaCachedValues(patcher.serialize()));
+
+    // Strip on the post-patch XML so spill ranges reflect any anchors an
+    // overwrite/strip op removed: a cell whose <f t="array"> was overwritten is
+    // no longer in a range, so its freshly written value is preserved. (The only
+    // anchors the degraded bracket modes strip are single-cell, so no multi-cell
+    // anchor is ever orphaned mid-spill; revisit this if that ever changes.)
+    parts[path] = strToU8(stripFormulaCachedValues(sheetXml));
   }
 
   // Force recalculation on open and remove the stale calc chain.


### PR DESCRIPTION
## 症状

CDMエクスポートのExcelを**デスクトップExcelで開いても、トーナメント結果に書き換わらず古いCDM2025の選手名が残る**。

## 原因（実測で特定）

エクスポーターは入力セルだけ書き込み、順位・ランキング等の結果は Excel の動的配列数式（`SORT`/`FILTER`/`UNIQUE`/`XLOOKUP`）に再計算させる設計です。古い値が出ないよう数式キャッシュを削除して `fullCalcOnLoad` で再計算させますが、削除対象が **`<f>` を持つセルだけ** でした。

動的配列数式は **アンカーセルにしか `<f>` を持たず**、展開先の**スピル子セルは数式を持たずキャッシュ値だけ**を保持します:

```xml
<c r="B2" ...><f t="array" ref="B2:B61">_xlfn._xlws.SORT(_xlfn.UNIQUE(Registration[Nickname]))</f><v>...</v></c>
<c r="B7" s="32" t="str"><v>Bluh</v></c>   <!-- スピル子: <f> なし、strip 対象外だった -->
```

このため Overall Ranking・各予選シート・TT 等に2025年の名前が残存。さらにスピル範囲に値が居座ると Excel が再スピルできず、開いても古い表示が残り続けていました。

## 修正

`stripFormulaCachedValues` を拡張し、各シートの動的配列アンカー範囲（`<f t="array" ref="…">`）を解析して、**範囲内の全セル（=スピル子）のキャッシュ値も削除**。文字列だけでなく**数値スピル子（古いスコア・タイム）**も解消します。スピル範囲が空になることで Excel が開いた時に新トーナメントの結果を再スピルします。

あわせて:
- **対称ドリフトガード**: スピル子への `number`/`inlineString` 書き込みを throw（既存の「数式アンカーへの書き込みは throw」と対称化。範囲stripで暗黙に消えるのを防止）
- touched/untouched の二重ループを全worksheet1パスに統合（簡潔化）
- 自己終了セルが次の `</c>` まで貪欲マッチする正規表現バグを修正
- 古くなったコメント更新、未使用import除去

## テスト

- 入力セルが strip 後も保持されること
- スピル子への値書き込みが throw すること
- `generateCdmWorkbook` のフル出力を全12シート走査し、既知のCDM2025ニックネームが値として残らないこと（**degraded-8 / faithful-24 両パス**）

検証: cdm-export 214 + エクスポートルート/e2e cdm 含め **264テストパス**、tsc/eslint クリーン。tdd-test-reviewer による2回のレビュー（指摘→修正→再レビュー）で全指摘クリア、約24,000書き込みの監査でガード除外ケースの到達不能性も確認済み。

## 未確認

XMLレベルで「全シートで古い値ゼロ＋数式・再計算フラグ健在＋入力保持」を実測。**実デスクトップExcelでの再計算描画は未検証**のため、マージ・デプロイ後にプレビュー環境の実ファイルで順位・ランキングが新トーナメント内容に再計算されることの確認を推奨します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
