### PR TITLE
fix(cdm-export): materialize finals bracket names

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -382,6 +382,11 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       // (S6 = XLOOKUP(T6,...)); the faithful path must leave the formula intact,
       // while stripping the stale template cached value.
       expect(sheet.S6).toBeUndefined();
+      // The visible bracket names are materialized from the match record so the
+      // export does not render an empty tournament table while waiting for Excel
+      // to recalculate stripped formula caches.
+      expect(sheet.T5.v).toBe('W1');
+      expect(sheet.T6.v).toBe('W2');
       // winners_r1[0] is a completed 4-2: slot1 score in V5, slot2 score in V6.
       expect(sheet.V5.v).toBe(4);
       expect(sheet.V6.v).toBe(2);
@@ -392,8 +397,10 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       expect(typeof sheet.B3.v).toBe('string');
       // GP finals use the same geometry (driver points written as scores).
       expect(workbook.Sheets['GP Finals'].S5.v).toBe(1);
+      expect(workbook.Sheets['GP Finals'].T5.v).toBe('W1');
       expect(workbook.Sheets['GP Finals'].V5.v).toBe(4);
       expect(workbook.Sheets['MR Finals'].S5.v).toBe(1);
+      expect(workbook.Sheets['MR Finals'].T5.v).toBe('W1');
     });
 
     it('should write the Main Hub player rows for exactly 60 players', async () => {

--- a/smkc-score-app/__tests__/lib/cdm-export/fill/finals.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/fill/finals.test.ts
@@ -4,8 +4,9 @@
  * The Finals sheet is a formula-driven 24-player double-elimination bracket. The
  * fill map reconstructs each slot's B-position from the app match records (no DB
  * seed column) using the canonical structures in double-elimination.ts, writes
- * only the typed seed cells + score cells in faithful mode, and value-overwrites
- * the degraded 16-/8-player brackets the template formulas cannot represent.
+ * typed seed cells + visible name/score cells in faithful mode, and
+ * value-overwrites the degraded 16-/8-player brackets the template formulas
+ * cannot represent.
  *
  * Ground truth for cell coordinates is the verified template dump
  * /tmp/cdm-analysis/sheet2025/sheet_BM_Finals.txt; the B-position map below was
@@ -193,10 +194,15 @@ describe("buildFinalsWrites — faithful 24-player bracket", () => {
     expectUntouched(map, "L6");
   });
 
-  it("never writes a name/advancement formula cell (faithful path)", () => {
-    for (const ref of ["F5", "T5", "T6", "M6", "AA7", "AV19", "BC47"]) {
-      expectUntouched(map, ref);
-    }
+  it("writes visible match names from the app record in faithful path", () => {
+    expect(map.get("F5")).toMatchObject({ op: "overwriteString", value: "B23" });
+    expect(map.get("F6")).toMatchObject({ op: "overwriteString", value: "B22" });
+    expect(map.get("M5")).toMatchObject({ op: "overwriteString", value: "B13" });
+    expect(map.get("M6")).toMatchObject({ op: "overwriteString", value: "B23" });
+    expect(map.get("T5")).toMatchObject({ op: "overwriteString", value: "B1" });
+    expect(map.get("T6")).toMatchObject({ op: "overwriteString", value: "B13" });
+    // Downstream matches that do not yet exist are still left alone.
+    for (const ref of ["AA7", "AV19", "BC47"]) expectUntouched(map, ref);
   });
 
   it("writes scores by identity resolution into the slot the template expects", () => {
@@ -240,6 +246,9 @@ describe("buildFinalsWrites — losers_final slot reversal (faithful)", () => {
       mk({ matchNumber: 29, stage: "finals", round: "losers_final", p1: 201, p2: 102, s1: 1, s2: 4 }),
     ];
     const map = indexWrites(buildFinalsWrites(emptyData({ bmMatches: matches }), "bm"), "BM Finals");
+    // Names are written under the same template slot order as the scores.
+    expect(map.get("BC47")).toMatchObject({ op: "overwriteString", value: "B102" });
+    expect(map.get("BC48")).toMatchObject({ op: "overwriteString", value: "B201" });
     // bp102 (WF loser, app player2, score 4) -> template slot1 score cell BE47.
     expectNumber(map, "BE47", 4);
     // bp201 (LSF winner, app player1, score 1) -> template slot2 score cell BE48.

--- a/smkc-score-app/docs/cdm-export-design.md
+++ b/smkc-score-app/docs/cdm-export-design.md
@@ -165,8 +165,11 @@ UBF=AM(39), GF1=AT(46), GF2=BA(53)。下段 LB は R/Y/AF/AM/AT/BA の rows 41..
   - winners_r1: idx 0,2,4,6 は S{row} のみ（slot2 は `Winner of B2,k` 数式）、
     idx 1,3,5,7 は S{row},S{row+1}
 - スコアは **同一性解決**で書く（3.4.1）。
-- 名前列（F/M/T/AA/AH/AO/AV/BC）・進出数式・最終順位ブロック（BG/BH/BI）・
-  "First to"・Arena ヘッダ・B32/B33 は非接触。
+- 名前列（F/M/T/AA/AH/AO/AV/BC）はテンプレート上は数式だが、生成直後や
+  保護ビューなどで再計算が遅れてもトーナメント表が空欄にならないよう、
+  **実 match record の player1/player2 を同一性解決した現在値で書く**。スコアと同じく
+  losers_final の反転などテンプレートの slot 意味論に従う。
+- 進出数式・最終順位ブロック（BG/BH/BI）・"First to"・Arena ヘッダ・B32/B33 は非接触。
 - TV 番号はテンプレートに該当セルが無いため**書かない**。
 - GF reset 不要時はスコアをクリアするだけ（数式が空欄処理）。
 

--- a/smkc-score-app/src/lib/cdm-export/fill/finals.ts
+++ b/smkc-score-app/src/lib/cdm-export/fill/finals.ts
@@ -8,7 +8,9 @@
  *   - typed seed cells (offset +1 in each match block) — a B-position number.
  *   - score cells (offset +4) — the two players' scores for that match.
  * Everything else (name XLOOKUPs, "Winner of N" advancement, final standings) is
- * a formula the export must NOT touch on the faithful path. See
+ * a formula in the template, but the export writes the current match-record
+ * names into used bracket slots so downloaded workbooks show the correct
+ * tournament table even before or without an Excel recalculation. See
  * docs/cdm-export-design.md §3.4 and finals-slot-semantics.ts.
  *
  * The DB stores no seed column, so we reconstruct each slot's B-position by
@@ -514,6 +516,68 @@ function writeMatchScores(
   builder.setNumberOrClear(scoreRefs[1], scoreFor(match, mode, 1));
 }
 
+/**
+ * Write the visible player names for one app match. Faithful CDM templates can
+ * derive these cells by formula, but stripped template caches plus protected or
+ * delayed recalculation can otherwise render an empty bracket. We use the same
+ * slot semantics as score resolution so rows like losers_final still land under
+ * the template's expected slot order.
+ */
+function writeMatchNames(
+  builder: FinalsWriteBuilder,
+  round: string,
+  matchIndex: number,
+  match: CdmMatch,
+  byRound: Map<string, CdmMatch[]>,
+  mode: CdmVersusMode,
+  recon: Reconstruction,
+): void {
+  const nameRefs = [0, 1].map((slotIndex) =>
+    slotCells(round, matchIndex, slotIndex)?.nameRef ?? null,
+  );
+  if (!nameRefs[0] || !nameRefs[1]) {
+    logger.warn("Finals match has no slot geometry; skipping names", {
+      mode,
+      round,
+      matchIndex,
+    });
+    return;
+  }
+  const resolvedNameRefs = [nameRefs[0], nameRefs[1]] as const;
+
+  const expected: Array<CdmPlayer | null> = [null, null];
+  for (const slotIndex of [0, 1]) {
+    const semantics = getSlotSemantics(round, matchIndex, slotIndex);
+    expected[slotIndex] = semantics
+      ? resolveSlotPlayer(semantics, round, matchIndex, slotIndex, byRound, mode, recon)
+      : null;
+  }
+
+  const byPlayerId = new Map<string, number>();
+  let resolvedBoth = true;
+  for (const slotIndex of [0, 1]) {
+    const player = expected[slotIndex];
+    if (player && (player.id === match.player1.id || player.id === match.player2.id)) {
+      byPlayerId.set(player.id, slotIndex);
+    } else {
+      resolvedBoth = false;
+    }
+  }
+
+  if (resolvedBoth && byPlayerId.size === 2) {
+    for (const player of [match.player1, match.player2]) {
+      const targetSlot = byPlayerId.get(player.id)!;
+      builder.overwriteString(resolvedNameRefs[targetSlot], player.nickname);
+    }
+    return;
+  }
+
+  // Same fallback as score writes: preserve the app record's p1/p2 order when
+  // the computed slot semantics cannot be reconciled with manually edited data.
+  builder.overwriteString(resolvedNameRefs[0], match.player1.nickname);
+  builder.overwriteString(resolvedNameRefs[1], match.player2.nickname);
+}
+
 /* ------------------------------------------------------------------ *
  * Typed seed-cell writing (faithful 24).
  * ------------------------------------------------------------------ */
@@ -696,6 +760,7 @@ function buildFaithfulOr16(
     clearAllScores(builder, ALL_FINALS_ROUNDS);
     writeTypedSeedCells(builder, recon);
     writeSeedList(builder, recon.bPositionPlayers, FULL_SEED_COUNT, mode);
+    writeAllNames(builder, byRound, mode, recon);
     writeAllScores(builder, byRound, mode, recon);
     return builder.build();
   }
@@ -786,6 +851,22 @@ function writeAllScores(
   }
 }
 
+/** Write visible names for every resolvable match across all faithful rounds. */
+function writeAllNames(
+  builder: FinalsWriteBuilder,
+  byRound: Map<string, CdmMatch[]>,
+  mode: CdmVersusMode,
+  recon: Reconstruction,
+): void {
+  for (const [round, list] of byRound) {
+    if (!FINALS_BRACKET_SLOTS[round]) continue;
+    list.forEach((match, matchIndex) => {
+      if (matchIndex >= FINALS_BRACKET_SLOTS[round].length) return;
+      writeMatchNames(builder, round, matchIndex, match, byRound, mode, recon);
+    });
+  }
+}
+
 /* ------------------------------------------------------------------ *
  * Mode: degraded 16-player (no playoff).
  *
@@ -859,6 +940,7 @@ function build16Player(
     }
   });
 
+  writeAllNames(builder, byRound, mode, recon);
   writeAllScores(builder, byRound, mode, recon);
   return builder.build();
 }


### PR DESCRIPTION
## Summary

- Materialize BM/MR/GP Finals bracket player names from the app match records instead of leaving those visible cells entirely dependent on Excel recalculation.
- Reuse the existing finals slot-semantics resolution so names follow the same template slot order as scores, including losers-final reversal.
- Update CDM export design docs and add unit + route integration coverage proving generated `.xlsm` files retain visible Finals names after template cache stripping.

## Root Cause

After stripping stale CDM 2025 formula and spill-child caches, Finals name cells could render blank until Excel recalculated the workbook. In protected-view, delayed-recalc, or other non-recalc paths, that made brackets look empty or broken even though seed/score inputs had been written.

## Validation

- `npm test -- --runTestsByPath __tests__/lib/cdm-export/fill/finals.test.ts '__tests__/app/api/tournaments/[id]/export/route.test.ts' --runInBand`
- `npm test -- --runTestsByPath __tests__/lib/cdm-export/xlsx-zip-patcher.test.ts __tests__/lib/cdm-export/time-format.test.ts __tests__/lib/cdm-export/fill/finals.test.ts __tests__/lib/cdm-export/fill/tt-qualifications.test.ts __tests__/lib/cdm-export/fill/tt-finals.test.ts __tests__/lib/cdm-export/fill/tt-lives-replay.test.ts __tests__/lib/cdm-export/fill/qualifications.test.ts __tests__/lib/cdm-export/fill/finals-slot-semantics.test.ts __tests__/lib/cdm-export/fill/sheet-player-order.test.ts __tests__/lib/cdm-export/fill/main-hub.test.ts __tests__/lib/cdm-export/index.test.ts __tests__/lib/cdm-export/sheet-xml-patcher.test.ts --runInBand`
- `npm test -- --runTestsByPath '__tests__/app/api/tournaments/[id]/export/route.test.ts' __tests__/docs/e2e-cases-drift.test.ts --runInBand`
- `npm run build`
- `git diff --check`
