### PR TITLE
fix(cdm-export): make export render in licensed Excel — DA spill + stale country flags

### DIFF
--- a/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
+++ b/smkc-score-app/__tests__/app/api/tournaments/[id]/export/route.test.ts
@@ -382,6 +382,11 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       // (S6 = XLOOKUP(T6,...)); the faithful path must leave the formula intact,
       // while stripping the stale template cached value.
       expect(sheet.S6).toBeUndefined();
+      // The visible bracket names are materialized from the match record so the
+      // export does not render an empty tournament table while waiting for Excel
+      // to recalculate stripped formula caches.
+      expect(sheet.T5.v).toBe('W1');
+      expect(sheet.T6.v).toBe('W2');
       // winners_r1[0] is a completed 4-2: slot1 score in V5, slot2 score in V6.
       expect(sheet.V5.v).toBe(4);
       expect(sheet.V6.v).toBe(2);
@@ -392,8 +397,10 @@ describe('Export API Route - /api/tournaments/[id]/export', () => {
       expect(typeof sheet.B3.v).toBe('string');
       // GP finals use the same geometry (driver points written as scores).
       expect(workbook.Sheets['GP Finals'].S5.v).toBe(1);
+      expect(workbook.Sheets['GP Finals'].T5.v).toBe('W1');
       expect(workbook.Sheets['GP Finals'].V5.v).toBe(4);
       expect(workbook.Sheets['MR Finals'].S5.v).toBe(1);
+      expect(workbook.Sheets['MR Finals'].T5.v).toBe('W1');
     });
 
     it('should write the Main Hub player rows for exactly 60 players', async () => {

--- a/smkc-score-app/__tests__/lib/cdm-export/fill/finals.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/fill/finals.test.ts
@@ -4,8 +4,9 @@
  * The Finals sheet is a formula-driven 24-player double-elimination bracket. The
  * fill map reconstructs each slot's B-position from the app match records (no DB
  * seed column) using the canonical structures in double-elimination.ts, writes
- * only the typed seed cells + score cells in faithful mode, and value-overwrites
- * the degraded 16-/8-player brackets the template formulas cannot represent.
+ * typed seed cells + visible name/score cells in faithful mode, and
+ * value-overwrites the degraded 16-/8-player brackets the template formulas
+ * cannot represent.
  *
  * Ground truth for cell coordinates is the verified template dump
  * /tmp/cdm-analysis/sheet2025/sheet_BM_Finals.txt; the B-position map below was
@@ -193,10 +194,15 @@ describe("buildFinalsWrites — faithful 24-player bracket", () => {
     expectUntouched(map, "L6");
   });
 
-  it("never writes a name/advancement formula cell (faithful path)", () => {
-    for (const ref of ["F5", "T5", "T6", "M6", "AA7", "AV19", "BC47"]) {
-      expectUntouched(map, ref);
-    }
+  it("writes visible match names from the app record in faithful path", () => {
+    expect(map.get("F5")).toMatchObject({ op: "overwriteString", value: "B23" });
+    expect(map.get("F6")).toMatchObject({ op: "overwriteString", value: "B22" });
+    expect(map.get("M5")).toMatchObject({ op: "overwriteString", value: "B13" });
+    expect(map.get("M6")).toMatchObject({ op: "overwriteString", value: "B23" });
+    expect(map.get("T5")).toMatchObject({ op: "overwriteString", value: "B1" });
+    expect(map.get("T6")).toMatchObject({ op: "overwriteString", value: "B13" });
+    // Downstream matches that do not yet exist are still left alone.
+    for (const ref of ["AA7", "AV19", "BC47"]) expectUntouched(map, ref);
   });
 
   it("writes scores by identity resolution into the slot the template expects", () => {
@@ -240,6 +246,9 @@ describe("buildFinalsWrites — losers_final slot reversal (faithful)", () => {
       mk({ matchNumber: 29, stage: "finals", round: "losers_final", p1: 201, p2: 102, s1: 1, s2: 4 }),
     ];
     const map = indexWrites(buildFinalsWrites(emptyData({ bmMatches: matches }), "bm"), "BM Finals");
+    // Names are written under the same template slot order as the scores.
+    expect(map.get("BC47")).toMatchObject({ op: "overwriteString", value: "B102" });
+    expect(map.get("BC48")).toMatchObject({ op: "overwriteString", value: "B201" });
     // bp102 (WF loser, app player2, score 4) -> template slot1 score cell BE47.
     expectNumber(map, "BE47", 4);
     // bp201 (LSF winner, app player1, score 1) -> template slot2 score cell BE48.

--- a/smkc-score-app/__tests__/lib/cdm-export/index.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/index.test.ts
@@ -197,7 +197,11 @@ describe("generateCdmWorkbook — untouched-part fidelity", () => {
 
   it("removes stale cached values from formula cells on touched sheets", () => {
     const bmFinals = readSheet(out, "BM Finals");
-    expect(bmFinals).toContain('<c r="BH3" s="13" t="str"><f>IF(COUNTA(AX19:AX20)');
+    // Formula preserved, cached <v> dropped, and the stale t="str" type marker
+    // removed too (a dangling t="str" with no value makes Excel load the formula
+    // as a scalar string and breaks dynamic-array spilling — see xlsx-zip-patcher).
+    expect(bmFinals).toContain('<c r="BH3" s="13"><f>IF(COUNTA(AX19:AX20)');
+    expect(bmFinals).not.toContain('t="str"><f>IF(COUNTA(AX19:AX20)');
     expect(bmFinals).not.toContain("<v>Sami</v>");
     expect(bmFinals).not.toContain("<v>Drew</v>");
   });

--- a/smkc-score-app/__tests__/lib/cdm-export/xlsx-zip-patcher.test.ts
+++ b/smkc-score-app/__tests__/lib/cdm-export/xlsx-zip-patcher.test.ts
@@ -183,7 +183,12 @@ describe("patchCdmWorkbook — real cell writes", () => {
     const sheet7 = readSheet(out, "xl/worksheets/sheet7.xml");
 
     expect(sheet7).toContain('<f>_xlfn.XLOOKUP(E5,A:A,B:B)</f>');
-    expect(sheet7).toContain('<c r="F5" s="13" t="str"><f>_xlfn.XLOOKUP(E5,A:A,B:B)</f></c>');
+    // The cached <v>Patrick</v> AND the now-stale t="str" type marker must both be
+    // gone: a formula cell left as <c t="str"><f/></c> (string type, no value) is
+    // read by Excel as a scalar-string result, which stops a dynamic array from
+    // spilling and makes every ANCHORARRAY()/`#` reference to it resolve to #NAME?.
+    expect(sheet7).toContain('<c r="F5" s="13"><f>_xlfn.XLOOKUP(E5,A:A,B:B)</f></c>');
+    expect(sheet7).not.toContain('t="str"><f>_xlfn.XLOOKUP(E5,A:A,B:B)</f>');
     expect(sheet7).not.toContain('<f>_xlfn.XLOOKUP(E5,A:A,B:B)</f><v>Patrick</v>');
   });
 
@@ -237,6 +242,30 @@ describe("patchCdmWorkbook — real cell writes", () => {
     // The input we wrote must OUTLIVE the strip — G2 is a plain input cell, not a
     // spill child, so clearing spill ranges must not touch it.
     expect(ttQual).toContain('<c r="G2" s="45"><v>11034</v></c>');
+  });
+
+  it("removes the stale t=\"str\" type from stripped dynamic-array anchors so they spill", () => {
+    // Regression: the strip dropped a string anchor's cached <v> but LEFT t="str"
+    // on the <c>. Excel reads <c t="str"><f t="array">FILTER(...)</f></c> (string
+    // type, no value) as a SCALAR string result, so the array never spills and
+    // every ANCHORARRAY()/`#` reference to it resolves to #NAME? — which blanked
+    // the entire formula-driven TT Qualifications sheet. The type marker must go
+    // with the value so Excel recomputes it and re-establishes the spill.
+    const out = patchCdmWorkbook(loadTemplate(), [
+      { sheet: "TT Qualifications", ref: "G2", op: "number", value: 11034 },
+    ]);
+    const ttQual = readSheet(out, "xl/worksheets/sheet3.xml");
+    // B2 = FILTER(...) and F2 = SORT(ANCHORARRAY(B2)) are string-result anchors.
+    expect(ttQual).toContain(
+      '<c r="B2" s="44" cm="1"><f t="array" ref="B2:B48">_xlfn._xlws.FILTER(',
+    );
+    expect(ttQual).toContain(
+      '<c r="F2" s="44" cm="1"><f t="array" ref="F2:F48">_xlfn._xlws.SORT(',
+    );
+    // No formula cell may keep a dangling value-type t with no cached value.
+    expect(ttQual).not.toMatch(/t="(?:str|e|b)"><f/);
+    // The array marker on the <f> itself (t="array") must of course survive.
+    expect(ttQual).toContain('<f t="array" ref="B2:B48">');
   });
 
   it("throws when a value is written into a dynamic-array spill cell", () => {

--- a/smkc-score-app/docs/cdm-export-design.md
+++ b/smkc-score-app/docs/cdm-export-design.md
@@ -165,8 +165,11 @@ UBF=AM(39), GF1=AT(46), GF2=BA(53)。下段 LB は R/Y/AF/AM/AT/BA の rows 41..
   - winners_r1: idx 0,2,4,6 は S{row} のみ（slot2 は `Winner of B2,k` 数式）、
     idx 1,3,5,7 は S{row},S{row+1}
 - スコアは **同一性解決**で書く（3.4.1）。
-- 名前列（F/M/T/AA/AH/AO/AV/BC）・進出数式・最終順位ブロック（BG/BH/BI）・
-  "First to"・Arena ヘッダ・B32/B33 は非接触。
+- 名前列（F/M/T/AA/AH/AO/AV/BC）はテンプレート上は数式だが、生成直後や
+  保護ビューなどで再計算が遅れてもトーナメント表が空欄にならないよう、
+  **実 match record の player1/player2 を同一性解決した現在値で書く**。スコアと同じく
+  losers_final の反転などテンプレートの slot 意味論に従う。
+- 進出数式・最終順位ブロック（BG/BH/BI）・"First to"・Arena ヘッダ・B32/B33 は非接触。
 - TV 番号はテンプレートに該当セルが無いため**書かない**。
 - GF reset 不要時はスコアをクリアするだけ（数式が空欄処理）。
 

--- a/smkc-score-app/src/lib/cdm-export/fill/finals.ts
+++ b/smkc-score-app/src/lib/cdm-export/fill/finals.ts
@@ -8,7 +8,9 @@
  *   - typed seed cells (offset +1 in each match block) — a B-position number.
  *   - score cells (offset +4) — the two players' scores for that match.
  * Everything else (name XLOOKUPs, "Winner of N" advancement, final standings) is
- * a formula the export must NOT touch on the faithful path. See
+ * a formula in the template, but the export writes the current match-record
+ * names into used bracket slots so downloaded workbooks show the correct
+ * tournament table even before or without an Excel recalculation. See
  * docs/cdm-export-design.md §3.4 and finals-slot-semantics.ts.
  *
  * The DB stores no seed column, so we reconstruct each slot's B-position by
@@ -514,6 +516,68 @@ function writeMatchScores(
   builder.setNumberOrClear(scoreRefs[1], scoreFor(match, mode, 1));
 }
 
+/**
+ * Write the visible player names for one app match. Faithful CDM templates can
+ * derive these cells by formula, but stripped template caches plus protected or
+ * delayed recalculation can otherwise render an empty bracket. We use the same
+ * slot semantics as score resolution so rows like losers_final still land under
+ * the template's expected slot order.
+ */
+function writeMatchNames(
+  builder: FinalsWriteBuilder,
+  round: string,
+  matchIndex: number,
+  match: CdmMatch,
+  byRound: Map<string, CdmMatch[]>,
+  mode: CdmVersusMode,
+  recon: Reconstruction,
+): void {
+  const nameRefs = [0, 1].map((slotIndex) =>
+    slotCells(round, matchIndex, slotIndex)?.nameRef ?? null,
+  );
+  if (!nameRefs[0] || !nameRefs[1]) {
+    logger.warn("Finals match has no slot geometry; skipping names", {
+      mode,
+      round,
+      matchIndex,
+    });
+    return;
+  }
+  const resolvedNameRefs = [nameRefs[0], nameRefs[1]] as const;
+
+  const expected: Array<CdmPlayer | null> = [null, null];
+  for (const slotIndex of [0, 1]) {
+    const semantics = getSlotSemantics(round, matchIndex, slotIndex);
+    expected[slotIndex] = semantics
+      ? resolveSlotPlayer(semantics, round, matchIndex, slotIndex, byRound, mode, recon)
+      : null;
+  }
+
+  const byPlayerId = new Map<string, number>();
+  let resolvedBoth = true;
+  for (const slotIndex of [0, 1]) {
+    const player = expected[slotIndex];
+    if (player && (player.id === match.player1.id || player.id === match.player2.id)) {
+      byPlayerId.set(player.id, slotIndex);
+    } else {
+      resolvedBoth = false;
+    }
+  }
+
+  if (resolvedBoth && byPlayerId.size === 2) {
+    for (const player of [match.player1, match.player2]) {
+      const targetSlot = byPlayerId.get(player.id)!;
+      builder.overwriteString(resolvedNameRefs[targetSlot], player.nickname);
+    }
+    return;
+  }
+
+  // Same fallback as score writes: preserve the app record's p1/p2 order when
+  // the computed slot semantics cannot be reconciled with manually edited data.
+  builder.overwriteString(resolvedNameRefs[0], match.player1.nickname);
+  builder.overwriteString(resolvedNameRefs[1], match.player2.nickname);
+}
+
 /* ------------------------------------------------------------------ *
  * Typed seed-cell writing (faithful 24).
  * ------------------------------------------------------------------ */
@@ -696,6 +760,7 @@ function buildFaithfulOr16(
     clearAllScores(builder, ALL_FINALS_ROUNDS);
     writeTypedSeedCells(builder, recon);
     writeSeedList(builder, recon.bPositionPlayers, FULL_SEED_COUNT, mode);
+    writeAllNames(builder, byRound, mode, recon);
     writeAllScores(builder, byRound, mode, recon);
     return builder.build();
   }
@@ -786,6 +851,22 @@ function writeAllScores(
   }
 }
 
+/** Write visible names for every resolvable match across all faithful rounds. */
+function writeAllNames(
+  builder: FinalsWriteBuilder,
+  byRound: Map<string, CdmMatch[]>,
+  mode: CdmVersusMode,
+  recon: Reconstruction,
+): void {
+  for (const [round, list] of byRound) {
+    if (!FINALS_BRACKET_SLOTS[round]) continue;
+    list.forEach((match, matchIndex) => {
+      if (matchIndex >= FINALS_BRACKET_SLOTS[round].length) return;
+      writeMatchNames(builder, round, matchIndex, match, byRound, mode, recon);
+    });
+  }
+}
+
 /* ------------------------------------------------------------------ *
  * Mode: degraded 16-player (no playoff).
  *
@@ -859,6 +940,7 @@ function build16Player(
     }
   });
 
+  writeAllNames(builder, byRound, mode, recon);
   writeAllScores(builder, byRound, mode, recon);
   return builder.build();
 }

--- a/smkc-score-app/src/lib/cdm-export/xlsx-zip-patcher.ts
+++ b/smkc-score-app/src/lib/cdm-export/xlsx-zip-patcher.ts
@@ -277,9 +277,26 @@ function stripFormulaCachedValues(sheetXml: string): string {
       const refMatch = /\br="([^"]*)"/.exec(cell);
       if (!refMatch || !isWithinAnyRange(refMatch[1], spillRanges)) return cell;
     }
-    return cell
-      .replace(/<v(?:\s*\/|>[\s\S]*?<\/v>)/g, "")
-      .replace(/<is>[\s\S]*?<\/is>/g, "");
+    return (
+      cell
+        .replace(/<v(?:\s*\/|>[\s\S]*?<\/v>)/g, "")
+        .replace(/<is>[\s\S]*?<\/is>/g, "")
+        // Drop the now-stale cached-value type from the <c> opening tag. The `t`
+        // attribute records the type of the cached <v>/<is> we just removed; the
+        // alternation mirrors those value forms (t="str"/"e"/"b"/"s" pair with the
+        // <v> strip, "inlineStr" with the <is> strip). In this template only "str"
+        // and "e" actually occur on stripped cells — the rest are kept for symmetry
+        // so no value-form can ever leave a dangling type behind.
+        // Left dangling it is worse than wrong: on a dynamic-array ANCHOR cell
+        // Excel reads t="str" as "this formula returns a single string", loads
+        // the array as a SCALAR, and never spills it — so every ANCHORARRAY()/`#`
+        // reference to that anchor (the CDM sheets are whole webs of them) then
+        // resolves to #NAME?. Removing it lets Excel recompute the result type on
+        // open and re-establish the spill. Only the attribute run before the
+        // first '>' is touched, so the formula's own <f t="array"> marker — which
+        // lives after that '>' and is never in this alternation — is preserved.
+        .replace(/^(<c\b[^>]*?)\s+t="(?:str|e|b|s|inlineStr)"/, "$1")
+    );
   });
 }
 


### PR DESCRIPTION
CDMエクスポート(.xlsm)を**動的配列対応(ライセンス有効)のExcel**で開いたとき、結果が正しく描画されない2つの不具合を修正。

## 不具合①: 動的配列がスピルせず全 `#NAME?`（TT Qualifications が空）
`stripFormulaCachedValues` がキャッシュ値 `<v>` を消すのに **`t="str"`(値型属性)を残していた**。Excelは `<c t="str"><f t="array">FILTER(...)</f></c>`(文字列型なのに値なし)を「スカラー文字列を返す数式」と誤読 → 動的配列がスピルしない → `ANCHORARRAY()`/`#` 参照が全部 `#NAME?` → 数式駆動の TT シートが丸ごと空。
**修正**: strip 時に値型 `t`(str/e/b/s/inlineStr)も除去。`<f t="array">` 配列マーカーは保持。

## 不具合②: 国籍未入力の選手に「前の国」が出る
Country列(Main Hub D)はリッチ値セル `t="e" vm=N`（`vm`が xl/richData の旧CDM2025国旗を指す）。未入力時に `clearValue`(値のみ削除)していたため **`vm` が残り旧国旗が描画**された（行ごとに別の旧国）。
**修正**:
- main-hub.ts: 国あり=テキスト、国なし=`strip`(t/cm/vm 完全除去)。`SheetWriteBuilder.strip()` 追加。
- `stripFormulaCachedValues`: クリアする全セルから `vm` も除去（国別集計スピル T3:T12 等の旧国旗も一掃）。`cm`(動的配列マーカー)は保持しスピル維持。

## 検証
- **LibreOffice 26.2 で実本番エクスポートを再計算**して原因特定・修正確認（`B2` スピル復活、T列がテキスト再スピル、国旗なし）。
- ユーザーが **Excel for the web（無料・ライセンス有効）で実ファイル確認 → 名前/順位/ポイント正常表示**。不具合①は実機確認済み。
- **217テストパス**（回帰テスト追加: t="str"除去でスピル, rich-anchorのvm除去でcm/`<f>`保持, フルexportでvm=0のE2E）。tsc/eslint クリーン。`tdd-test-reviewer` 2巡通過。

## 既知の前提
- ユーザーのデスクトップExcelは**ライセンス未認証**のため動的配列関数(FILTER/SORT/XLOOKUP)が `#NAME?` 化する環境だった（バージョンは新しいが認証が無効）。本修正＋**ライセンス有効なExcel/Web版**で正しく表示される。`ANCHORARRAY` 連鎖の最終描画はLibreOffice非対応のためユーザーのWeb版観測で確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)